### PR TITLE
Add build to byte and native compile seed7-mode.el

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,103 @@
+# YAML FILE: build.yml
+#
+# Purpose   : Automated build control.
+# Created   : Wednesday, May 27 2026.
+# Author    : Pierre Rouleau <prouleau001@gmail.com>
+# Time-stamp: <2026-05-27 22:48:57 EDT, updated by Pierre Rouleau>
+# ----------------------------------------------------------------------------
+# Module Description
+# ------------------
+#
+# This byte-compiles and native-compiles the seed7-mode code over several
+# versions of Emacs in several OS to ensure that the code builds without any
+# error and warnings in all supported versions.
+#
+# The build is controlled by a GNU Make script invoked by 'make all'.
+# The script byte-compiles the file and if Emasc supports native compilation
+# it native-compiles the file too.
+
+# ----------------------------------------------------------------------------
+# Dependencies
+# ------------
+#
+# - Github actions
+# - Github Action for Emacs: https://github.com/marketplace/actions/set-up-emacs
+#   - This uses Nix.  Since Nix does not support Windows, this prevents running
+#     the tests under Windows, unfortunately.
+#
+# Note that costly tests are currently disabled since I'm trying to only use
+# what is free from Github.
+
+
+# ----------------------------------------------------------------------------
+# Code
+# ----
+#
+#
+name: Build
+on:
+  push:
+    branches:
+      - master # Run only on 'push' for the main branch.
+    paths-ignore:
+      - '**.pdf'
+      - '**.rst'
+      - '.gitignore'
+  pull_request:
+    branches:
+      - '**' # Run 'pull-request' for all branches.
+    paths-ignore:
+      - '**.pdf'
+      - '**.rst'
+      - '.gitignore'
+
+
+jobs:
+  build:
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          # Ubuntu Linux runs several Emacs versions: 26,1 to 30.1
+          - os: ubuntu-latest
+            emacs_version: '26.1'
+          - os: ubuntu-latest
+            emacs_version: '26.2'
+          - os: ubuntu-latest
+            emacs_version: '26.3'
+          - os: ubuntu-latest
+            emacs_version: '27.1'
+          - os: ubuntu-latest
+            emacs_version: '28.1'
+          - os: ubuntu-latest
+            emacs_version: '29.4'
+          - os: ubuntu-latest
+            emacs_version: '30.1'
+          # On macOS, I did not find anything to test on Emacs 26 running on Intel-based macOS
+          # So the tests start at Emacs 27.1 running on the only Intel macOS I have found.
+          # However, the large costs too much and I am disabling it..
+          # I am currently testing Emacs 26.3 on a local image.
+          # - os: macos-14-large
+          #   emacs_version: '27.1'
+          - os: macos-latest
+            emacs_version: '28.1'
+          - os: macos-latest
+            emacs_version: '29.4'
+          - os: macos-latest
+            emacs_version: '30.1'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Run build
+        run: make all
+
+# ----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,82 @@
+# MAKEFILE FILE: Makefile
+#
+# Purpose   : Run seed7-mode tests.
+# Created   : Friday, July 11 2025.
+# Author    : Pierre Rouleau <prouleau001@gmail.com>
+# Time-stamp: <2026-05-27 22:51:18 EDT, updated by Pierre Rouleau>
+
+# ----------------------------------------------------------------------------
+# Module Description
+# ------------------
+#
+# Controls byte and native compilation of all Emacs Lisp files used by the
+# Seed7 support.  The build only succeeds when all compilations succeed with
+# no error and no warning.
+
+# ----------------------------------------------------------------------------
+# Dependencies
+# ------------
+#
+# - GNU Make, Emacs.
+
+
+# ----------------------------------------------------------------------------
+# Code
+# ----
+#
+#
+
+# ----------------------------------------------------------------------------
+# Portable makefile
+.POSIX:
+
+# -----------------------------------------------------------------------------
+# allow overriding the Emacs binary at the command line
+EMACS ?= emacs
+
+# Note: the above macro allows the following use of make with
+# other Emacs binaries:
+#
+#    make clean
+#    make EMACS=emacs-26.1 pel test
+#    make clean
+#    make EMACS=emacs-24.3 pel test
+
+# ----------------------------------------------------------------------------
+# Define abilities of Emacs - native compilation.
+
+EMACS_NATIVE_COMP_AVAILABLE := $(shell $(EMACS) --batch --eval '(when \
+                                                                  (and (fboundp (quote native-comp-available-p)) \
+                                                                       (native-comp-available-p)) \
+                                                                    (princ "yes"))')
+
+# -----------------------------------------------------------------------------
+# Identify the files used in the package.
+
+EL_FILES := seed7-mode.el
+
+# ELC_FILES list the PEL .elc files
+ELC_FILES := $(subst .el,.elc,$(EL_FILES))
+
+# ----------------------------------------------------------------------------
+# RULES:  to byte-compile the Emacs-Lisp source code files
+
+# Single .el file byte-compile to .elc rule
+.SUFFIXES: .el .elc
+
+ifeq ($(EMACS_NATIVE_COMP_AVAILABLE), yes)
+.el.elc:
+	$(EMACS) -Q --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile $<
+	$(EMACS) -Q --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-native-compile $<
+else
+.el.elc:
+	$(EMACS) -Q --batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile $<
+endif
+
+
+# ----------------------------------------------------------------------------
+# Targets
+
+all: $(ELC_FILES)
+
+# ----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ EMACS_NATIVE_COMP_AVAILABLE := $(shell $(EMACS) --batch --eval '(when \
 
 EL_FILES := seed7-mode.el
 
-# ELC_FILES used for this project.=
-ELC_FILES := $(subst .el,.elc,$(EL _FILES))=
+# ELC_FILES used for this project.
+ELC_FILES := $(subst .el,.elc,$(EL _FILES))
 
 # ----------------------------------------------------------------------------
 # RULES:  to byte-compile the Emacs-Lisp source code files

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 # Purpose   : Run seed7-mode tests.
 # Created   : Friday, July 11 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-27 22:51:18 EDT, updated by Pierre Rouleau>
 
 # ----------------------------------------------------------------------------
 # Module Description
@@ -55,8 +54,8 @@ EMACS_NATIVE_COMP_AVAILABLE := $(shell $(EMACS) --batch --eval '(when \
 
 EL_FILES := seed7-mode.el
 
-# ELC_FILES list the PEL .elc files
-ELC_FILES := $(subst .el,.elc,$(EL_FILES))
+# ELC_FILES used for this project.=
+ELC_FILES := $(subst .el,.elc,$(EL _FILES))=
 
 # ----------------------------------------------------------------------------
 # RULES:  to byte-compile the Emacs-Lisp source code files

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260527.2255
+;; Package-Version: 20260527.2300
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -459,6 +459,8 @@
 ;;                        ;      `outline-heading-end-regexp',
 (require 'xref)           ; use: `xref-make', 'xref-make-file-location'
 (require 'cl-lib)         ; use: `cl-flet'
+(require 'compile)        ; use: `compilation-num-warnings-found',
+;;                        ;      `compilation-num-infos-found'
 
 ;;; --------------------------------------------------------------------------
 ;;; Code:
@@ -474,7 +476,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-05-28T02:55:37+0000 W22-4"
+(defconst seed7-mode-version-timestamp "2026-05-28T03:00:37+0000 W22-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6313,11 +6315,6 @@ See also: `seed7-check-or-compile'."
                 (flush-current))))
           (cons exit-code (nreverse results)))
       (kill-buffer out-buf))))
-
-;; Declare variables to prevent warnings
-(defvar compilation-num-errors-found)
-(defvar compilation-num-warnings-found)
-(defvar mode-line-process)
 
 (defun seed7-check-or-compile (&optional compile)
   "Check or compile the current Seed7 buffer's file and show diagnostics.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260527.1706
+;; Package-Version: 20260527.2255
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -474,7 +474,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-05-27T21:06:07+0000 W22-3"
+(defconst seed7-mode-version-timestamp "2026-05-28T02:55:37+0000 W22-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6313,6 +6313,11 @@ See also: `seed7-check-or-compile'."
                 (flush-current))))
           (cons exit-code (nreverse results)))
       (kill-buffer out-buf))))
+
+;; Declare variables to prevent warnings
+(defvar compilation-num-errors-found)
+(defvar compilation-num-warnings-found)
+(defvar mode-line-process)
 
 (defun seed7-check-or-compile (&optional compile)
   "Check or compile the current Seed7 buffer's file and show diagnostics.


### PR DESCRIPTION
* Perform the build in several versions of Emacs on Linux and macOS
* Succeeds only if there are no error and no warning detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated build pipeline that runs on code changes and pull requests, verifying compatibility across multiple Emacs versions and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->