### PR TITLE
Add a (manual) builder for Windows

### DIFF
--- a/.github/workflows/build-apt-brew.yml
+++ b/.github/workflows/build-apt-brew.yml
@@ -41,8 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu — each image ships a different Emacs generation via apt-get
-          - os: ubuntu-20.04    # ships Emacs 26.3
+          # Ubuntu — use only supported hosted runner labels
+          # - os: ubuntu-20.04    # ships Emacs 26.3, but GitHub retired it on Apr 15.2025
           - os: ubuntu-22.04    # ships Emacs 27.1
           - os: ubuntu-24.04    # ships Emacs 29.x
           # macOS — Homebrew installs the latest stable Emacs

--- a/.github/workflows/build-apt-brew.yml
+++ b/.github/workflows/build-apt-brew.yml
@@ -1,0 +1,71 @@
+# YAML FILE: build-manual-apt-brew.yml
+#
+# Purpose   : Manual build using native package managers (apt-get / Homebrew).
+# Created   : Wednesday, May 28 2026.
+# Author    : Pierre Rouleau <prouleau001@gmail.com>
+# ----------------------------------------------------------------------------
+# Module Description
+# ------------------
+#
+# Installs Emacs via the OS native package manager — no Nix, no external
+# Emacs action.  Emacs versions obtained are those shipped by each distro
+# release:
+#
+#   ubuntu-20.04  → Emacs 26.3
+#   ubuntu-22.04  → Emacs 27.1
+#   ubuntu-24.04  → Emacs 29.x
+#   macos-latest  → Emacs via Homebrew (latest stable, currently 30.x)
+#
+# The workflow is triggered only manually (workflow_dispatch).
+#
+# ----------------------------------------------------------------------------
+# Dependencies
+# ------------
+#
+# - GitHub Actions (actions/checkout)
+# - apt-get (Ubuntu), Homebrew (macOS)
+
+# ----------------------------------------------------------------------------
+# Code
+# ----
+
+name: Build (apt-get / Homebrew - manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Ubuntu — each image ships a different Emacs generation via apt-get
+          - os: ubuntu-20.04    # ships Emacs 26.3
+          - os: ubuntu-22.04    # ships Emacs 27.1
+          - os: ubuntu-24.04    # ships Emacs 29.x
+          # macOS — Homebrew installs the latest stable Emacs
+          - os: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Emacs (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends emacs-nox
+          emacs --version
+
+      - name: Install Emacs (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install emacs
+          emacs --version
+
+      - name: Compile
+        run: make all
+
+# ----------------------------------------------------------------------------

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,66 @@
+# YAML FILE: build-manual-docker.yml
+#
+# Purpose   : Manual build using silex/emacs Docker images (Nix-free).
+# Created   : Wednesday, May 28 2026.
+# Author    : Pierre Rouleau <prouleau001@gmail.com>
+# ----------------------------------------------------------------------------
+# Module Description
+# ------------------
+#
+# Runs each job inside a silex/emacs Docker container, one per Emacs version.
+# This approach is completely Nix-free and gives precise version control
+# (same versions as the Nix-based build.yml).
+#
+# Limitation: Docker containers are only supported on Linux runners; macOS
+# is not covered by this workflow.
+#
+# The workflow is triggered only manually (workflow_dispatch).
+#
+# ----------------------------------------------------------------------------
+# Dependencies
+# ------------
+#
+# - GitHub Actions (actions/checkout)
+# - Docker Hub image: silex/emacs  (https://hub.docker.com/r/silex/emacs)
+
+# ----------------------------------------------------------------------------
+# Code
+# ----
+
+name: Build (Docker/silex - manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: silex/emacs:${{ matrix.emacs_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - '26.1'
+          - '26.3'
+          - '27.1'
+          - '28.1'
+          - '29.4'
+          - '30.1'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Verify Emacs version
+        run: emacs --version
+
+      - name: Install make
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends make
+
+      - name: Compile
+        run: make all
+
+# ----------------------------------------------------------------------------

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,66 @@
+# YAML FILE: build-windows.yml
+#
+# Purpose   : build for Windows.
+# Created   : Thursday, May 28 2026.
+# Author    : Pierre Rouleau <prouleau001@gmail.com>
+# Time-stamp: <2026-05-28 08:57:58 EDT, updated by Pierre Rouleau>
+# ----------------------------------------------------------------------------
+# Module Description
+# ------------------
+#
+# - This workflow is triggered only manually (workflow_dispatch).
+# - Uses jcs090218/setup-emacs which supports Linux, macOS, and Windows.
+# - Compilation step uses bash (Git Bash) so GNU Make POSIX shell recipes work.
+
+# ----------------------------------------------------------------------------
+# Dependencies
+# ------------
+#
+
+# ----------------------------------------------------------------------------
+# Code
+# ----
+#
+#
+
+name: Build (Windows - manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_tests:
+        description: 'Run ERT tests after compilation (may fail; see known issues)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - '28.1'
+          - '29.4'
+          - '30.1'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Emacs ${{ matrix.emacs_version }}
+        uses: jcs090218/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Verify Emacs
+        shell: bash
+        run: emacs --version
+
+      - name: Compile
+        shell: bash
+        run: make all
+
+
+# ----------------------------------------------------------------------------

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,7 +3,7 @@
 # Purpose   : build for Windows.
 # Created   : Thursday, May 28 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-28 08:57:58 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-28 09:06:54 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -27,12 +27,7 @@ name: Build (Windows - manual)
 
 on:
   workflow_dispatch:
-    inputs:
-      run_tests:
-        description: 'Run ERT tests after compilation (may fail; see known issues)'
-        required: false
-        default: false
-        type: boolean
+
 
 jobs:
   build-windows:
@@ -47,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@<40-char-commit-sha>
 
       - name: Setup Emacs ${{ matrix.emacs_version }}
-        uses: jcs090218/setup-emacs@master
+        uses: jcs090218/setup-emacs@<40-char-commit-sha>
         with:
           version: ${{ matrix.emacs_version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@
 # Purpose   : Automated build control.
 # Created   : Wednesday, May 27 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-27 22:48:57 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-28 09:17:13 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Emacs
         uses: purcell/setup-emacs@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@
 # Purpose   : Automated build control.
 # Created   : Wednesday, May 27 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-28 09:59:47 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-28 10:51:08 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -43,7 +43,7 @@ on:
   #
   # push:
   #   branches:
-  #     - master # Run only on 'push' for the main branch.
+  #     - main # Run only on 'push' for the main branch.
   #   paths-ignore:
   #     - '**.pdf'
   #     - '**.rst'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@
 # Purpose   : Automated build control.
 # Created   : Wednesday, May 27 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-28 09:17:13 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-05-28 09:59:47 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -36,20 +36,25 @@
 #
 name: Build
 on:
-  push:
-    branches:
-      - master # Run only on 'push' for the main branch.
-    paths-ignore:
-      - '**.pdf'
-      - '**.rst'
-      - '.gitignore'
-  pull_request:
-    branches:
-      - '**' # Run 'pull-request' for all branches.
-    paths-ignore:
-      - '**.pdf'
-      - '**.rst'
-      - '.gitignore'
+  workflow_dispatch:    # ← allows manual "Run workflow" button in the Actions UI
+
+  # Disable automatic execution until upstream issue is fixed
+  # (see https://github.com/purcell/setup-emacs/issues/58).
+  #
+  # push:
+  #   branches:
+  #     - master # Run only on 'push' for the main branch.
+  #   paths-ignore:
+  #     - '**.pdf'
+  #     - '**.rst'
+  #     - '.gitignore'
+  # pull_request:
+  #   branches:
+  #     - '**' # Run 'pull-request' for all branches.
+  #   paths-ignore:
+  #     - '**.pdf'
+  #     - '**.rst'
+  #     - '.gitignore'
 
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added manually triggered build workflows for Windows, Linux/macOS (apt/Homebrew), and Docker to run project builds across multiple Emacs versions.
  * Converted main build to manual dispatch and updated the repository checkout action to a newer version to streamline manual CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->