### PR TITLE
Improve robustness of xref support

### DIFF
--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260530.0942
+;; Package-Version: 20260530.1015
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -480,7 +480,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-05-30T13:42:41+0000 W22-6"
+(defconst seed7-mode-version-timestamp "2026-05-30T14:15:33+0000 W22-6"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -553,7 +553,7 @@ To disable this behaviour turn this user-option off."
   "When non-nil, Seed7 navigation commands print a success message.
 If you do not want these navigation success messages printed set this to
 nil.  Setting it to nil does not prevent user error messages to show up
-when the navigation commands fails."
+when the navigation commands fail."
   :group 'seed7
   :type 'boolean
   :safe #'booleanp)
@@ -5479,7 +5479,7 @@ then deactivates it (to prevent the area to limit searches)."
     (seed7-indent-line)))
 
 (defun seed7-fill ()
-  "Refill/justify comment and string paragraph, re-indent current code block."
+  "Refill/justify comment or string paragraph, or re-indent current code block."
   (interactive)
   (if (or (seed7-inside-comment-p)
           (seed7-inside-string-p))
@@ -5534,7 +5534,7 @@ Also add tempo marker at each of these locations."
   "Insert the code template for a procedure declaration.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   ;; insert a template with a temporary name N to allow auto-indent to work.
   (insert "const proc: N (A) is func\n local\n V\n begin\n C\n end func;")
@@ -5551,7 +5551,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert the code template for a function declaration.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   ;; Insert template with N & T markers for name and type to allow auto-indent
   ;; to work, then remove them and leave point at the function name.
@@ -5569,7 +5569,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert the code template for a short function declaration.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "const func T: N (A) is\n return R;")
   (forward-line -1)
@@ -5584,7 +5584,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert the code template for an enumeration declaration.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "const type: T is new enum\n V,\n end enum;")
   (forward-line -2)
@@ -5600,7 +5600,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert the code template for a structure declaration.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "const type: T is new struct\n var V: N is v;\n end struct;")
   (forward-line -2)
@@ -5616,7 +5616,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert an if statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "if C then\n A\n end if;" )
   (forward-line -2)
@@ -5632,7 +5632,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert an if statement with an else clause.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "if C then\n A\n else\n B\n end if;" )
   (forward-line -4)
@@ -5650,7 +5650,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert an if statement with an elsif clause.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "if C then\n A\n elsif C then\n B\n end if;" )
   (forward-line -4)
@@ -5670,7 +5670,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert an if statement with an elsif and an else clause.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "if C then\n A\n elsif C then\n B\n else\n C\n end if;")
   (forward-line -6)
@@ -5692,7 +5692,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a case statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "case V of\n when C:\n E\n end case;")
   (forward-line -3)
@@ -5710,7 +5710,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for I range N to M do\n E\n end for;")
   (forward-line -2)
@@ -5726,7 +5726,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for-until statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for V range N to N until C do\n E\n end for;")
   (forward-line -2)
@@ -5742,7 +5742,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for-step statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for V range N to N step N do\n E\n end for;")
   (forward-line -2)
@@ -5758,7 +5758,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for-each statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for V range L do\n E\n end for;")
   (forward-line -2)
@@ -5774,7 +5774,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for-each-until statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for V range L until C do\n E\n end for;")
   (forward-line -2)
@@ -5790,7 +5790,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for-each-key statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for V key I range L do\n E\n end for;")
   (forward-line -2)
@@ -5806,7 +5806,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for-each-key-until statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for V key I range L until C do\n E\n end for;")
   (forward-line -2)
@@ -5822,7 +5822,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for-key statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for key I range L do\n E\n end for;")
   (forward-line -2)
@@ -5838,7 +5838,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a for-key-until statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "for key I range L until C do\n E\n end for;")
   (forward-line -2)
@@ -5854,7 +5854,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a repeat statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "repeat\n E\n until C;")
   (seed7-to-indent)
@@ -5871,7 +5871,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a while statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "while C do\n E\n end while;")
   (forward-line -2)
@@ -5888,7 +5888,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a block handler statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "block\n E\n exception\n catch X:\n H\n end block;")
   (forward-line -4)
@@ -5908,7 +5908,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a global block statement.
 Leave point at condition position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "global\n E\n end global;")
   (forward-line -1)
@@ -5924,7 +5924,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a variable declaration.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "var T: N is V;")
   (seed7-to-indent)
@@ -5937,7 +5937,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert a constant declaration.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "const T: N is V;")
   (seed7-to-indent)
@@ -5950,7 +5950,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert declaration of in parameter.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "in T: N")
   (backward-char 1)
@@ -5962,7 +5962,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert declaration of invar parameter.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "in var T: N")
   (backward-char 1)
@@ -5974,7 +5974,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert declaration of inout parameter.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "inout T: N")
   (backward-char 1)
@@ -5986,7 +5986,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert declaration of ref parameter.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "ref T: N")
   (backward-char 1)
@@ -5998,7 +5998,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert declaration of value parameter.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "val T: N")
   (backward-char 1)
@@ -6010,7 +6010,7 @@ and \\[tempo-forward-mark] to move to previous one."
   "Insert declaration of call by name parameter.
 Leave point at first position to fill.
 Use \\[tempo-forward-mark] to move to next position to fill,
-and \\[tempo-forward-mark] to move to previous one."
+and \\[tempo-backward-mark] to move to previous one."
   (interactive "*")
   (insert "in func T: N")
   (backward-char 1)
@@ -6544,7 +6544,7 @@ or nil when no diagnostics are found."
 ;; of the program.
 ;;
 ;; Once this is done, you will be able to use the various xref commands with
-;; the xref front-end of your choice, the default being xref own front-end,
+;; the xref front-end of your choice, the default being xref's own front-end,
 ;; but also with the helm, ivy or other xref front-ends.
 
 (defvar-local seed7---xref-buffer nil
@@ -6572,7 +6572,9 @@ user-option."
          (xref-cmd (car-safe xref-uo-list))
          (xref-executable-name (and
                                 xref-cmd
-                                (executable-find (expand-file-name xref-cmd)))))
+                                (if (file-name-directory xref-cmd)
+                                    (executable-find (expand-file-name xref-cmd))
+                                  (executable-find xref-cmd)))))
     (if (and xref-executable-name
              (file-executable-p xref-executable-name))
         (let* ((sd7-source-fname-with-path
@@ -6638,7 +6640,7 @@ user-option."
                                seed7-xref))))
                       ;; The command is not a s7 command but something else.
                       ;; We know the first word is a valid executable, just
-                      ;; proceed by setting pre-pending the cdr of seed7-xref
+                      ;; proceed by setting prepending the cdr of seed7-xref
                       ;; list.
                       (when (> (length xref-uo-list) 1)
                         (setq args (append (cdr xref-uo-list) args))))
@@ -6647,12 +6649,19 @@ user-option."
                            xref-executable-name
                            nil outbuf nil
                            args)))))
-            (unless (zerop exit-code)
+            (cond
+             ((not (integerp exit-code))
+              (user-error
+               "seed7-xref tool was terminated: %s.\nCommand: %s\nOutput:\n%s"
+               exit-code
+               seed7-xref
+               (with-current-buffer outbuf (buffer-string))))
+             ((not (zerop exit-code))
               (user-error
                "seed7-xref tool exited with status %d.\nCommand: %s\nOutput:\n%s"
                exit-code
                seed7-xref
-               (with-current-buffer outbuf (buffer-string))))))
+               (with-current-buffer outbuf (buffer-string)))))))
       (user-error "\
 The seed7-xref user-option does not identify an executable file: %s
 Please update!"
@@ -6958,9 +6967,8 @@ This implements `xref-backend-identifier-at-point' for Seed7 buffers."
 
 (defun seed7--make-xref-from-file-loc (elems)
   "Create an xref object pointing to the given file location.
-ELEMS is a list holding: file, line, and column point to the location of
-the xref, desc, the last element,  describes it."
-  (xref-make (nth 3 elems)               ; desc
+ELEMS is a list (FILE LINE COLUMN DESC), where DESC describes the xref target."
+  (xref-make (nth 3 elems)              ; desc
              (xref-make-file-location (nth 0 elems)
                                       (nth 1 elems)
                                       (nth 2 elems))))
@@ -7050,7 +7058,7 @@ The list has no duplicate and is unsorted."
     identifiers))
 
 (defun seed7--procfun-identifiers ()
-  "Return (unsorted) list of all identifiers of function or procedure."
+  "Return (unsorted) list of all identifiers of current function or procedure."
   (save-excursion
     (let ((identifiers nil)
           (callable-start nil)
@@ -7090,7 +7098,7 @@ The list has no duplicate and is unsorted."
   "When non-nil, install Seed7’s local abbrev table in seed7-mode buffers.
 
 This does not enable `abbrev-mode'; enable `abbrev-mode' separately to expand
-abbreviations
+abbreviations.
 
 NOTE: After changing in a session execute `seed7-rebuild-abbrev-table'
 to activate the change."
@@ -7261,7 +7269,7 @@ the default list are intentionally left without the prefix to show what they
 would look like, but they are disabled because bare-word abbreviations expand
 too aggressively in normal editing.
 
-Make sure you have no duplication of keywords if you edit the list.
+Make sure you have no duplication of abbreviation keys if you edit the list.
 
 NOTE: After changing in a session execute `seed7-rebuild-abbrev-table'
 to activate the change."

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260530.1113
+;; Package-Version: 20260530.1223
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -480,7 +480,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-05-30T15:13:11+0000 W22-6"
+(defconst seed7-mode-version-timestamp "2026-05-30T16:23:58+0000 W22-6"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -592,17 +592,15 @@ The name of the source code file is appended to the end of that line."
 ;;** Seed7 Cross Reference
 
 (defcustom seed7-xref
-  (format "s7 %stools/s7xref.sd7"
+  (combine-and-quote-strings
+   (list "s7"
+         (expand-file-name
+          "tools/s7xref.sd7"
           (file-name-directory
-           (or
-            ;; normal case: seed7-mode is on load path
-            (locate-library "seed7-mode")
-            ;; if user is just editing it, and it's in a buffer use that.
-            ;; Note that in that case the s7xref.sd7 may not be installed.
-            (when-let (buf (get-buffer "seed7-mode.el"))
-              (buffer-file-name buf))
-            ;; otherwise use a default
-            (format "%s/utils/" user-emacs-directory))))
+           (or (locate-library "seed7-mode")
+               (when-let (buf (get-buffer "seed7-mode.el"))
+                 (buffer-file-name buf))
+               (expand-file-name "utils/" user-emacs-directory))))))
   "Seed7 cross reference builder command line.
 
 The command line must identify the Seed7 cross reference builder,
@@ -629,8 +627,9 @@ The ~ character, if you use it, is expanded to identify your HOME
 directory.
 
 The default value attempts to locate `seed7-mode' from Emacs
-`load-path'.  If this fails it uses the utils directory inside your
-`user-emacs-directory'.
+`load-path'.  If this fails it uses the utils/tools directory inside
+your `user-emacs-directory'.
+
 Modify this value if `seed7-mode' is not in your Emacs load path
 and the default path is not appropriate."
   :group 'seed7
@@ -6532,18 +6531,17 @@ or nil when no diagnostics are found."
 ;;* Seed7 Cross Reference
 ;;  =====================
 ;;
-;; The `seed7-mode` supports the xref framework introduced in Emacs 25: the
-;; code implements an xref framework compliant back-end using the s7xref Seed7
-;; program that parses Seed7 program and library files to extract all required
-;; information about global variable, functions and procedures which includes
-;; all operators (both word and special operators).
+;; The `seed7-mode' supports the xref framework introduced in Emacs 25: the
+;; code implements an xref-framework-compliant backend using the s7xref Seed7
+;; program that parses Seed7 program files and library files to extract all
+;; required information about global variables, functions and procedures which
+;; includes all operators (both word and special operators).
 ;;
 ;; Therefore to use this feature you must have the Seed7 compiler and
-;; interpreter installed in your system and the s7xref.sd7 file available in
+;; interpreter installed on your system and the s7xref.sd7 file available in
 ;; the seed7-mode/tools directory installed.  You can use it as is with the s7
 ;; interpreter or compile it with the s7c compiler.  The `seed7-xref' user
-;; option must identify the appropriate information that will allow execution
-;; of the program.
+;; option must identify the command used to execute the program.
 ;;
 ;; Once this is done, you will be able to use the various xref commands with
 ;; the xref front-end of your choice, the default being xref's own front-end,
@@ -6570,6 +6568,8 @@ Each line holds 3 tab-separated elements:
 
 This uses the Seed7 cross reference tool identified by the `seed7-xref'
 user-option."
+  (unless buffer-file-name
+    (user-error "Buffer is not visiting a file"))
   (let* ((xref-uo-list (split-string-and-unquote seed7-xref))
          (xref-cmd (car-safe xref-uo-list))
          (xref-executable-name (and
@@ -6620,30 +6620,33 @@ user-option."
                         ;; file name to args.
                         (progn
                           (setq xref-uo-list (cdr xref-uo-list))
-                          (let ((sd7-script-fn
-                                 (expand-file-name (car-safe xref-uo-list))))
-                            (if (and sd7-script-fn
-                                     (file-exists-p sd7-script-fn))
-                                (progn
-                                  ;; remove script filename from the list
-                                  (setq xref-uo-list (cdr-safe xref-uo-list))
-                                  ;; prepend scripts args if any
-                                  (when xref-uo-list
-                                    (setq args (append xref-uo-list args)))
-                                  ;; then prepend script file-name
-                                  (setq args
-                                        (append (list sd7-script-fn) args)))
-                              (user-error
-                               "Invalid seed7-xref: %s\nseed7-xref = %s"
-                               (if sd7-script-fn
-                                   (format "Can't find script: %s"
-                                           sd7-script-fn)
-                                 "No Seed7 file identified after s7 interpreter.")
-                               seed7-xref))))
+                          (let ((script (car-safe xref-uo-list)))
+                            (unless script
+                              (user-error "\
+Invalid seed7-xref: No Seed7 file identified after s7 interpreter.
+seed7-xref = %s"
+                                          seed7-xref))
+                            (let ((sd7-script-fn
+                                   (expand-file-name script)))
+                              (if (and sd7-script-fn
+                                       (file-exists-p sd7-script-fn))
+                                  (progn
+                                    ;; remove script filename from the list
+                                    (setq xref-uo-list (cdr-safe xref-uo-list))
+                                    ;; prepend scripts args if any
+                                    (when xref-uo-list
+                                      (setq args (append xref-uo-list args)))
+                                    ;; then prepend script file-name
+                                    (setq args
+                                          (append (list sd7-script-fn) args)))
+                                (user-error
+                                 "Invalid seed7-xref: %s\nseed7-xref = %s"
+                                 (format "Can't find script: %s"
+                                         sd7-script-fn)
+                                 seed7-xref)))))
                       ;; The command is not a s7 command but something else.
                       ;; We know the first word is a valid executable, just
-                      ;; proceed by setting prepending the cdr of seed7-xref
-                      ;; list.
+                      ;; proceed by prepending the cdr of seed7-uo-xref list.
                       (when (> (length xref-uo-list) 1)
                         (setq args (append (cdr xref-uo-list) args))))
                     ;; Execute the command with appropriate arguments.
@@ -6663,7 +6666,11 @@ user-option."
                "seed7-xref tool exited with status %d.\nCommand: %s\nOutput:\n%s"
                exit-code
                seed7-xref
-               (with-current-buffer outbuf (buffer-string)))))))
+               (with-current-buffer outbuf (buffer-string))))
+             (t
+              (when (buffer-modified-p)
+                (message "\
+seed7-xref: buffer has unsaved changes; xref results may be stale"))))))
       (user-error "\
 The seed7-xref user-option does not identify an executable file: %s
 Please update!"

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260530.1015
+;; Package-Version: 20260530.1113
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -480,7 +480,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-05-30T14:15:33+0000 W22-6"
+(defconst seed7-mode-version-timestamp "2026-05-30T15:13:11+0000 W22-6"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2576,25 +2576,26 @@ Return position of the closest match end, nil if nothing found.
 After returning, match data reflects the regexp that produced the closest
 match."
   (let* ((candidates nil)
-         (closest-position-beg.end.regexp
+         (closest-beg.end.match-data
           (dolist (regexp regexps (car-safe
                                    (sort
                                     (seq-filter #'identity candidates)
                                     ;; sort by start position (the nearest)
                                     (lambda (a b) (< (nth 0 a) (nth 0 b))))))
             (save-excursion
-              (when-let ((end (seed7-re-search-forward regexp)))
-                ;; Store (start-of-match end-of-match regexp).
-                ;; seed7-re-search-forward returns point-after-match (end);
+              (when (seed7-re-search-forward regexp)
+                ;; Store (start-of-match-pos end-of-match-pos match-data).
+                ;; seed7-re-search-forward returns end-of-match-pos
                 ;; match-beginning 0 is the true match start.
-                (push (list (match-beginning 0) end regexp) candidates))))))
-    (when closest-position-beg.end.regexp
+                (push (list (match-beginning 0) (match-end 0) (match-data))
+                      candidates))))))
+    (when closest-beg.end.match-data
       ;; restore match start pos
-      (goto-char  (nth 0 closest-position-beg.end.regexp))
+      (goto-char  (nth 0 closest-beg.end.match-data))
       ;; restore the match data by searching again without moving
-      (looking-at (nth 2 closest-position-beg.end.regexp))
+      (set-match-data (nth 2 closest-beg.end.match-data))
       ;; set point to end of match and return it
-      (goto-char (nth 1 closest-position-beg.end.regexp)))))
+      (goto-char (nth 1 closest-beg.end.match-data)))))
 
 (defun seed7-re-search-backward (regexp &optional bound)
   "Search for REGEXP inside code.  Skip comment and strings.
@@ -2632,7 +2633,7 @@ After returning, match data reflects the regexp that produced the closest
 match."
   ;; search with all regexp in the regexps list.
   (let* ((candidates nil)
-         (closest-position-beg.end.regexp
+         (closest-beg.end.match-data
           (dolist (regexp regexps (car-safe
                                    (sort
                                     (seq-filter #'identity candidates)
@@ -2640,19 +2641,20 @@ match."
                                     (lambda (a b) (> (nth 1 a) (nth 1 b))))))
             ;; For each search, store the begin/end positions and the regexp
             (save-excursion
-              (when-let ((end (seed7-re-search-backward regexp)))
-                (push (list (match-beginning 0) (match-end 0) regexp) candidates))))))
+              (when (seed7-re-search-backward regexp)
+                (push (list (match-beginning 0) (match-end 0) (match-data))
+                      candidates))))))
     ;; If something is found, restore the global match data that corresponds
     ;; to the regexp that finds the closest position and return the requested
     ;; position
-    (when closest-position-beg.end.regexp
+    (when closest-beg.end.match-data
       ;; restore match start pos
-      (goto-char  (nth 0 closest-position-beg.end.regexp))
+      (goto-char  (nth 0 closest-beg.end.match-data))
       ;; restore the match data by searching again without moving
-      (looking-at (nth 2 closest-position-beg.end.regexp))
+      (set-match-data (nth 2 closest-beg.end.match-data))
       ;; set point and return position of the requested end
       (goto-char (nth (if get-end-pos 1 0)
-                      closest-position-beg.end.regexp)))))
+                      closest-beg.end.match-data)))))
 
 
 ;;** Seed7 Skipping Comments
@@ -6690,24 +6692,29 @@ Please update!"
 
 (defun seed7--signature-from (filename line column)
   "Return Seed7 element signature for element in FILENAME at LINE, COLUMN."
-  (with-temp-buffer
-    (insert-file-contents filename)
-    (goto-char (point-min))
-    (forward-line (1- line))
-    (forward-char column)
-    (seed7--signature-at)))
+  (condition-case err
+      (with-temp-buffer
+        (insert-file-contents filename)
+        (goto-char (point-min))
+        (forward-line (1- line))
+        (forward-char column)
+        (seed7--signature-at))
+    (file-error
+     (format "<xref: cannot read %s: %s>"
+             filename (error-message-string err)))))
 
-(defun seed7--xref-in-list (list filename lineno)
-  "Return t if FILENAME @ LINENO is inside LIST.  Return nil otherwise."
+(defun seed7--xref-in-list (entries filename lineno)
+  "Return t if FILENAME @ LINENO is inside list of ENTRIES.
+Return nil otherwise."
   (let ((found nil)
-        (entry (car-safe list)))
+        (entry (car-safe entries)))
     (while (and entry
                 (not found))
       (when (and (string= (nth 0 entry) filename)
                  (eq (nth 1 entry) lineno))
         (setq found t))
-      (setq list (cdr-safe list))
-      (setq entry (car-safe list)))
+      (setq entries (cdr-safe entries))
+      (setq entry (car-safe entries)))
     found))
 
 (defun seed7--symbol-definition-areas-for-block (block-spec)
@@ -7094,7 +7101,7 @@ The list has no duplicate and is unsorted."
 ;;* Seed7 Abbreviation Support
 ;;  ==========================
 
-(defcustom  seed7-support-abbrev-mode t
+(defcustom seed7-support-abbrev-mode t
   "When non-nil, install Seed7’s local abbrev table in seed7-mode buffers.
 
 This does not enable `abbrev-mode'; enable `abbrev-mode' separately to expand

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260529.1924
+;; Package-Version: 20260530.0942
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -480,7 +480,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-05-29T23:24:20+0000 W22-5"
+(defconst seed7-mode-version-timestamp "2026-05-30T13:42:41+0000 W22-6"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -599,7 +599,8 @@ The name of the source code file is appended to the end of that line."
             (locate-library "seed7-mode")
             ;; if user is just editing it, and it's in a buffer use that.
             ;; Note that in that case the s7xref.sd7 may not be installed.
-            (buffer-file-name (get-buffer "seed7-mode.el"))
+            (when-let (buf (get-buffer "seed7-mode.el"))
+              (buffer-file-name buf))
             ;; otherwise use a default
             (format "%s/utils/" user-emacs-directory))))
   "Seed7 cross reference builder command line.
@@ -2598,9 +2599,11 @@ match."
 (defun seed7-re-search-backward (regexp &optional bound)
   "Search for REGEXP inside code.  Skip comment and strings.
 The optional second argument BOUND is a buffer position that bounds
-  the search.  The match found must not end after that position.  A
-  value of nil means search to the end of the accessible portion of
-  the buffer.
+the search.
+
+The match found must not begin before that position. A nil value means
+search to the beginning of the accessible portion of the buffer.
+
 Return found position or nil if nothing found.
 Move point."
   (let ((found-pos nil)
@@ -6565,8 +6568,11 @@ Each line holds 3 tab-separated elements:
 
 This uses the Seed7 cross reference tool identified by the `seed7-xref'
 user-option."
-  (let* ((xref-uo-list (split-string seed7-xref))
-         (xref-executable-name (executable-find (car-safe xref-uo-list))))
+  (let* ((xref-uo-list (split-string-and-unquote seed7-xref))
+         (xref-cmd (car-safe xref-uo-list))
+         (xref-executable-name (and
+                                xref-cmd
+                                (executable-find (expand-file-name xref-cmd)))))
     (if (and xref-executable-name
              (file-executable-p xref-executable-name))
         (let* ((sd7-source-fname-with-path
@@ -6585,51 +6591,68 @@ user-option."
           ;; In case the command was executed before, erase prior content
           (with-current-buffer outbuf
             (erase-buffer))
-          (if (eq (length xref-uo-list) 1)
-              ;; seed7-xref is just 1 word, the name of the xref program
-              (call-process xref-executable-name
-                            nil outbuf nil
-                            sd7-source-fname-with-path)
-            ;; seed7-xref has more than 1 word.  The first word is the program,
-            ;; and the following words are its arguments.  For instance the
-            ;; program name could be s7 and the next word a Seed7 source file to
-            ;; interpret.  And there could be other options.  Pass them all to
-            ;; the `call-process' as args.
-            ;; Since we do not use the shell, the file paths *must* be expanded.
-            (let ((args (list sd7-source-fname-with-path)))
-              (if (string= (file-name-nondirectory (car xref-uo-list)) "s7")
-                  ;; If Seed7 interpreter is used, ensure that the second element
-                  ;; is a fully expanded file name that exists.  If it exists
-                  ;; prepend the fully expanded file name to args.
-                  (progn
-                    (setq xref-uo-list (cdr xref-uo-list))
-                    (let ((sd7-script-fn
-                           (expand-file-name (car-safe xref-uo-list))))
-                      (if (and sd7-script-fn (file-exists-p sd7-script-fn))
-                          (progn
-                            ;; remove script filename from the list
-                            (setq xref-uo-list (cdr-safe xref-uo-list))
-                            ;; prepend scripts args if any
-                            (when xref-uo-list
-                              (setq args (append xref-uo-list args)))
-                            ;; then prepend script file-name
-                            (setq args (append (list sd7-script-fn) args)))
-                        (user-error
-                         "Invalid seed7-xref: %s\nseed7-xref = %s"
-                         (if sd7-script-fn
-                             (format "Can't find script: %s" sd7-script-fn)
-                           "No Seed7 file identified after s7 interpreter.")
-                         seed7-xref))))
-                ;; The command is not a s7 command but something else.
-                ;; We know the first word is a valid executable, just proceed
-                ;; by setting pre-pending the cdr of seed7-xref list.
-                (when (> (length xref-uo-list) 1)
-                  (setq args (append (cdr xref-uo-list) args))))
-              ;; Execute the command with appropriate arguments.
-              (apply #'call-process
-                     xref-executable-name
-                     nil outbuf nil
-                     args))))
+          (let
+              ((exit-code
+                (if (eq (length xref-uo-list) 1)
+                    ;; seed7-xref is just 1 word, the name of the xref program
+                    (call-process xref-executable-name
+                                  nil outbuf nil
+                                  sd7-source-fname-with-path)
+                  ;; seed7-xref has more than 1 word.  The first word is the
+                  ;; program, and the following words are its arguments.  For
+                  ;; instance the program name could be s7 and the next word a
+                  ;; Seed7 source file to interpret.  And there could be other
+                  ;; options.  Pass them all to the `call-process' as args.
+                  ;;
+                  ;; Since we do not use the shell, the file paths *must* be
+                  ;; expanded.
+                  (let ((args (list sd7-source-fname-with-path)))
+                    (if (string= (file-name-nondirectory
+                                  (car xref-uo-list))
+                                 "s7")
+                        ;; If Seed7 interpreter is used, ensure that the
+                        ;; second element is a fully expanded file name that
+                        ;; exists.  If it exists prepend the fully expanded
+                        ;; file name to args.
+                        (progn
+                          (setq xref-uo-list (cdr xref-uo-list))
+                          (let ((sd7-script-fn
+                                 (expand-file-name (car-safe xref-uo-list))))
+                            (if (and sd7-script-fn
+                                     (file-exists-p sd7-script-fn))
+                                (progn
+                                  ;; remove script filename from the list
+                                  (setq xref-uo-list (cdr-safe xref-uo-list))
+                                  ;; prepend scripts args if any
+                                  (when xref-uo-list
+                                    (setq args (append xref-uo-list args)))
+                                  ;; then prepend script file-name
+                                  (setq args
+                                        (append (list sd7-script-fn) args)))
+                              (user-error
+                               "Invalid seed7-xref: %s\nseed7-xref = %s"
+                               (if sd7-script-fn
+                                   (format "Can't find script: %s"
+                                           sd7-script-fn)
+                                 "No Seed7 file identified after s7 interpreter.")
+                               seed7-xref))))
+                      ;; The command is not a s7 command but something else.
+                      ;; We know the first word is a valid executable, just
+                      ;; proceed by setting pre-pending the cdr of seed7-xref
+                      ;; list.
+                      (when (> (length xref-uo-list) 1)
+                        (setq args (append (cdr xref-uo-list) args))))
+                    ;; Execute the command with appropriate arguments.
+                    (apply #'call-process
+                           xref-executable-name
+                           nil outbuf nil
+                           args)))))
+            (unless (zerop exit-code)
+              (user-error
+               "seed7-xref tool exited with status %d.\nCommand: %s\nOutput:\n%s"
+               exit-code
+               seed7-xref
+               (with-current-buffer outbuf (buffer-string))))))
       (user-error "\
 The seed7-xref user-option does not identify an executable file: %s
 Please update!"


### PR DESCRIPTION
* seed7-xref fallback could fail and use current buffer's file. That's fixed.
* seed7-xref ~ in path is now honoured by seed7--build-xref which expands it.
* seed7--build-xref command line parsing now handle spaces in paths
* seed7--build-xref no longer ignore a failing xref tool exit code and reports the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust cross-reference file reading with clearer error messages when referenced files cannot be read.
  * Improved match-selection behavior for nearest-result searches and restoration of match data after positioning.

* **Improvements**
  * Enhanced parsing and execution of cross-reference commands with explicit arg construction, better executable/script validation, and explicit error reporting for bad exits.
  * Warnings when xref buffers have unsaved changes.

* **Refactor**
  * Search helpers and xref-building logic reorganized for more reliable match and command handling.

* **Chores**
  * Updated package/version metadata and refreshed docstrings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->