### PR TITLE
Refactor: add seed7--run and seed7--parse-diagnostics

### DIFF
--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1024
+;; Package-Version: 20260602.1146
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -482,7 +482,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T14:24:49+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T15:46:59+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -571,6 +571,8 @@ You may:
 - Specify the program name with an absolute path.
 - Specify compiler options after the program name if necessary.
 
+IMPORTANT NOTE: see7-mode expects this tool to print diagnostics on stdout.
+
 The name of the source code file is appended to the end of that line.
 Note that the s7check is part of the example programs located inside
 the Seed7 prg directory.  Compile the prg/s7check.sd7 with s7c to create
@@ -586,6 +588,8 @@ You may:
 - Specify the program name without a path if it is in the PATH of your shell.
 - Specify the program name with an absolute path.
 - Specify compiler options after the program name if necessary.
+
+IMPORTANT NOTE: see7-mode expects this tool to print diagnostics on stderr.
 
 The name of the source code file is appended to the end of that line."
   :group 'seed7
@@ -6451,26 +6455,43 @@ See also: `seed7-check-or-compile'."
          stderr-text
          diagnostics
          exit-code)
-    (unless (and program (file-executable-p program))
-      (user-error "\
+    (unwind-protect
+        (progn
+          (unless (and program (file-executable-p program))
+            (user-error "\
 Program specified by `%s' not found or not executable: %s
 Verify the value of `%s'."
-                  (if compile "seed7-compiler" "seed7-checker")
-                  raw-program
-                  (if compile "seed7-compiler" "seed7-checker")))
-    ;; Execute program - get exit code
-    (setq exit-code (seed7--run program args stdout-buf stderr-buf
-                                (format "(from `%s' = %S"
-                                        (if compile "seed7-compiler"
-                                          "seed7-checker")
-                                        cmd-string)))
-    ;; - remember stderr text
-    (with-current-buffer stderr-buf
-      (setq stderr-text (buffer-string)))
-    (kill-buffer stderr-buf)
-    ;; - extract diagnostics from stdout
-    (setq diagnostics (seed7--parse-diagnostics compile stdout-buf))
-    (kill-buffer stdout-buf)
+                        (if compile "seed7-compiler" "seed7-checker")
+                        raw-program
+                        (if compile "seed7-compiler" "seed7-checker")))
+          ;; Execute program - get exit code
+          (setq exit-code (seed7--run program args stdout-buf stderr-buf
+                                      (format "(from `%s' = %S)"
+                                              (if compile "seed7-compiler"
+                                                "seed7-checker")
+                                              cmd-string)))
+          ;; The s7c compiler program emits diagnostics on stderr.
+          ;; The s7check static checker emits diagnostics on stdout.
+          ;; - Extract stderr text
+          (with-current-buffer stderr-buf
+            (setq stderr-text (buffer-string)))
+          ;; - When analyzing keep the stdout as is: the content of
+          ;;   stderr in stderr-text.
+          (when compile
+            ;; - When compiling append the content of stderr to stdout,
+            ;;   analyze that and set the stderr-text to empty string.
+            (with-current-buffer stdout-buf
+              (goto-char (point-max))
+              (insert stderr-text))
+            (setq stderr-text ""))
+          ;; - extract diagnostics from stdout
+          (setq diagnostics (seed7--parse-diagnostics compile stdout-buf))
+          ;; - return exit code, diagnostics and stderr text
+          (list exit-code diagnostics stderr-text))
+      (when (buffer-live-p stderr-buf)
+        (kill-buffer stderr-buf))
+      (when (buffer-live-p stdout-buf)
+        (kill-buffer stdout-buf)))
     ;; - return exit code, diagnostics and stderr text
     (list exit-code diagnostics stderr-text)))
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1704
+;; Package-Version: 20260602.1712
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -505,7 +505,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T21:04:18+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T21:12:17+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6427,7 +6427,7 @@ Return a list (in source order) of plists, each with the keys:
               ;; s7c summary footer ("N errors found") - skip entirely.
               nil)
              (in-error
-              ;; Continuation / context line - accumulate non blank
+              ;; Continuation / context line - accumulate non-blank
               (unless (string-blank-p line)
                 (push line context-lines)))))
           (forward-line 1))
@@ -6475,8 +6475,7 @@ used to set `default-directory' for the subprocess."
           (setq diagnostics
                 (seed7--parse-diagnostics compile stdout-buf)))
       ;; Cleanup: always kill scratch buffers.
-      (unless compile
-        (when (buffer-live-p stderr-buf) (kill-buffer stderr-buf)))
+      (when (buffer-live-p stderr-buf) (kill-buffer stderr-buf))
       (when (buffer-live-p stdout-buf) (kill-buffer stdout-buf)))
     (list exit-code diagnostics stderr-text)))
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1420
+;; Package-Version: 20260602.1500
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -482,7 +482,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T18:20:34+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T19:00:06+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6412,6 +6412,14 @@ Return a list (in source order) of plists, each with the keys:
         (flush-current))
       (nreverse diagnostics))))
 
+(defun seed7--expand-args (args)
+  "Expand any leading ~ from the arguments."
+  (mapcar (lambda (a)
+            (if (string-prefix-p "~" a)
+                (expand-file-name a)
+              a))
+          args))
+
 (defun seed7-check-file (file-name &optional compile)
   "Run static check or compilation on FILE-NAME without using the shell.
 
@@ -6456,11 +6464,7 @@ See also: `seed7-check-or-compile'."
                        (if (file-name-directory raw-program)
                            (executable-find (expand-file-name raw-program))
                          (executable-find raw-program))))
-         (args    (append (mapcar (lambda (a)
-                                    (if (string-prefix-p "~" a)
-                                        (expand-file-name a)
-                                      a))
-                                  (cdr cmd-parts))
+         (args    (append (seed7--expand-args (cdr cmd-parts))
                           (list (expand-file-name file-name)))))
     ;; Guard: fail fast before allocating any buffers.
     (unless program

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1550
+;; Package-Version: 20260602.1617
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -485,7 +485,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T19:50:02+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T20:17:53+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2502,7 +2502,7 @@ Use inside a `cond' clause to emphasize the check FCT."
 
 (defun seed7--plural-s (n)
   "Return \"s\" if N is larger than 1, \"\" otherwise."
-  (if (> n 1) "s" ""))
+  (if (= n 1) "" "s"))
 
 (defun seed7--run (program args stdout-buffer
                            &optional stderr-buffer context-msg)
@@ -2516,7 +2516,7 @@ Use inside a `cond' clause to emphasize the check FCT."
 If execution of PROGRAM signals fails, the function issues a user-error that
 ends with the CONTEXT-MSG.
 
-Return the exit code of the PROGRAM execution.."
+Return the exit code of the PROGRAM execution."
   ;; Create a temporary file to hold the stderr output safely
   (let ((temp-stderr-file (when stderr-buffer
                             (make-temp-file "emacs-seed7-mode-stderr-"))))
@@ -2535,7 +2535,7 @@ Return the exit code of the PROGRAM execution.."
                    (user-error "\
 seed7: cannot run \"%s\"%s: %s"
                                program
-                               (if  context-msg
+                               (if context-msg
                                    (format "  with %s" context-msg)
                                  "")
                                (error-message-string err))))))
@@ -6426,19 +6426,20 @@ Return a list (in source order) of plists, each with the keys:
 
 (defun seed7--run-and-parse (program args cmd-string compile file-name)
   "Run PROGRAM with ARGS and return (EXIT-CODE DIAGNOSTICS STDERR-TEXT).
-CMD-STRING is the original command string (for error messages).
-COMPILE and FILE-NAME are passed to `seed7--parse-diagnostics'.
-Buffers are allocated locally and always freed via `unwind-protect'."
+
+If COMPILE is non-nil, use `seed7-compiler' (s7c) to compile the file
+specified by FILE-NAME; otherwise use `seed7-checker' (s7check) to perform a
+static check."
   (let* ((stdout-buf        (generate-new-buffer " *seed7-check-output*"))
-         (stderr-buf        (generate-new-buffer " *seed7-check-stderr*"))
+         (stderr-buf        (unless compile
+                              (generate-new-buffer " *seed7-check-stderr*")))
          (default-directory (file-name-directory (expand-file-name file-name)))
          stderr-text diagnostics exit-code)
     (unwind-protect
         ;; Run compiler/checker
         (progn
           (setq exit-code
-                (seed7--run program args stdout-buf
-                            (unless compile stderr-buf)
+                (seed7--run program args stdout-buf stderr-buf
                             (format "(from `%s' = %S)"
                                     (if compile "seed7-compiler" "seed7-checker")
                                     cmd-string)))
@@ -6450,7 +6451,8 @@ Buffers are allocated locally and always freed via `unwind-protect'."
           (setq diagnostics
                 (seed7--parse-diagnostics compile stdout-buf)))
       ;; Cleanup: always kill scratch buffers.
-      (when (buffer-live-p stderr-buf) (kill-buffer stderr-buf))
+      (unless compile
+        (when (buffer-live-p stderr-buf) (kill-buffer stderr-buf)))
       (when (buffer-live-p stdout-buf) (kill-buffer stdout-buf)))
     (list exit-code diagnostics stderr-text)))
 
@@ -6473,7 +6475,9 @@ Returns a (EXIT-CODE DIAGNOSTICS STDERR) where:
     :message - diagnostic message text string
     :context - list of continuation/context strings that followed the
                diagnostic line in the tool's output (may be nil).
-  STDERR     - a string corresponding to the program stderr.
+  STDERR     - a string corresponding to the program stderr, or an empty
+               string when COMPILE is non-nil (the compiler's stderr is
+               merged into the parsed diagnostic stream instead).
 
 The DIAGNOSTICS list is nil when no diagnostics are found.
 
@@ -6665,7 +6669,7 @@ or nil when no diagnostics are found."
         (goto-char (point-min)))
       (display-buffer out-buf)
       ;; -- Show and return diagnostics count ----------------------
-      (message end-msg)
+      (message "%s" end-msg)
       diags)))
 
 ;; ---------------------------------------------------------------------------

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260601.1817
+;; Package-Version: 20260602.1014
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -482,7 +482,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-01T22:17:30+0000 W23-1"
+(defconst seed7-mode-version-timestamp "2026-06-02T14:14:37+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2493,6 +2493,10 @@ Use inside a `cond' clause to emphasize the check FCT."
 ;;* Seed7 Utilities
 ;;  ===============
 
+(defun seed7--plural-s (n)
+  "Return \"s\" if N is larger than 1, \"\" otherwise."
+  (if (> n 1) "s" ""))
+
 (defun seed7--run (program args stdout-buffer stderr-buffer
                            &optional context-msg)
   "Run PROGRAM with ARGS synchronously.
@@ -2525,7 +2529,7 @@ seed7: cannot run \"%s\"%s: %s"
             (insert-file-contents temp-stderr-file))
           ;; Normalise: call-process returns a string when killed by a signal.
           (unless (integerp exit-code)
-              (setq exit-code 1))
+            (setq exit-code 1))
           ;; Return the exit code of the process
           exit-code)
       ;; delete temp file even if the process or insertion fails
@@ -2985,8 +2989,8 @@ Arguments:
 - DIRECTION: symbol: either forward or backward."
   (format "There's no %sSeed7 function%s or procedure%s found %s!"
           (if (= n 1) "" (format "%d " n))
-          (if (= n 1) "" "s")
-          (if (= n 1) "" "s")
+          (seed7--plural-s n)
+          (seed7--plural-s n)
           (if (eq direction 'forward) "below" "above")))
 
 
@@ -6512,17 +6516,39 @@ or nil when no diagnostics are found."
     ;;
     ;; -- Build command, execute and extract result information
     (let* ((cmd        (if compile seed7-compiler seed7-checker))
+           (pgm        (file-name-nondirectory (car (string-split cmd))))
+           (operation  (if compile "compilation" "check"))
            (dir        (file-name-directory file))
            ;; Record time *around* the checker invocation
            (t0          (current-time))
            (result      (seed7-check-file file compile))
            (exit-code   (nth 0 result))
-           (errors      (nth 1 result))
+           (diags       (nth 1 result))
            (stderr-text (nth 2 result))
            (t1          (current-time))
            (duration    (float-time (time-subtract t1 t0)))
-           (n-errors    (length errors))
-           (out-buf     (get-buffer-create "*seed7-errors*")))
+           (n-diags     (length diags))
+           (out-buf     (get-buffer-create "*seed7-errors*"))
+           ;; Format result message
+           (err-msg     (when (and stderr-text
+                                   (not (string-blank-p stderr-text)))
+                          (format "\nSTDERR:\n%s\n" stderr-text)))
+           (end-msg (format "%s: %s"
+                            pgm
+                            (cond
+                             (diags (format "%d error%s found%s"
+                                            n-diags
+                                            (seed7--plural-s n-diags)
+                                            (or err-msg "")))
+                             (err-msg (format "%s with exit code %d%s"
+                                              operation
+                                              exit-code
+                                              (or err-msg "")))
+                             ((not (zerop exit-code))
+                              (format "%s with exit code %d"
+                                      operation
+                                      exit-code))
+                             (t "no errors found")))))
       ;;
       ;; -- Format the output -----------------------------------------------
       (with-current-buffer out-buf
@@ -6535,13 +6561,9 @@ or nil when no diagnostics are found."
           (insert (format "-*- mode: compilation; default-directory: %S -*-\n"
                           dir))
           (insert (format "%s %s\n\n" cmd file))
-          ;; -- stderr-text -------------------------
-          (when (and stderr-text
-                     (not (string-blank-p stderr-text)))
-            (insert (format "\nSTDERR:\n%s\n" stderr-text)))
           ;; -- Diagnostics -------------------------
-          (if errors
-              (dolist (e errors)
+          (if diags
+              (dolist (e diags)
                 ;; Format the GNU-style anchor line according to the tool used.
                 ;; compilation-mode recognises both FILENAME:LINE: and
                 ;; FILENAME:LINE:COL: forms via its built-in `gnu' regexp entry.
@@ -6564,7 +6586,7 @@ or nil when no diagnostics are found."
                   (insert ctx "\n"))
                 ;; Blank line between diagnostics for readability.
                 (insert "\n"))
-            (insert "seed7: no errors found\n"))
+            (insert end-msg))
           ;; -- Footer ------------------------------
           (insert (format "\nCompilation finished at %s, duration %.2f s\n"
                           (format-time-string "%a %b %e %H:%M:%S" t1)
@@ -6578,7 +6600,7 @@ or nil when no diagnostics are found."
         ;;   versions of Emacs may not have them.  If they are defined, then
         ;;   update the modeline, otherwise leave it alone.
         (when (boundp 'compilation-num-errors-found)
-          (setq-local compilation-num-errors-found   n-errors)
+          (setq-local compilation-num-errors-found n-diags)
           ;; The current Seed7 tools emit no warning and no information hints.
           ;; If future versions of Seed7 emit them the following should be
           ;; extracted.
@@ -6595,7 +6617,7 @@ or nil when no diagnostics are found."
                                            'compilation-mode-line-fail))
                        " ["
                        ;; error count - red bold (compilation-mode-line-fail)
-                       (propertize (number-to-string n-errors)
+                       (propertize (number-to-string n-diags)
                                    'face 'compilation-mode-line-fail)
                        ;; warning count - orange bold (compilation-mode-line-run
                        ;;                 inherits compilation-warning)
@@ -6607,13 +6629,9 @@ or nil when no diagnostics are found."
                        "]")))
         (goto-char (point-min)))
       (display-buffer out-buf)
-      ;; -- Show and return diagnostics -------------------------------------
-      (if errors
-          (message "seed7: %d error%s found"
-                   n-errors
-                   (if (> n-errors 1) "s" ""))
-        (message "seed7: no errors found"))
-      errors)))
+      ;; -- Show and return diagnostics count ----------------------
+      (message end-msg)
+      diags)))
 
 ;; ---------------------------------------------------------------------------
 ;;* Seed7 Cross Reference
@@ -7486,12 +7504,12 @@ current Emacs session without restarting Emacs."
                        registered
                        invalid-count
                        duplicate-count
-                       (if (= 1 (+ invalid-count duplicate-count)) "" "s"))
+                       (seed7--plural-s (+ invalid-count duplicate-count)))
                :warning)
             (unless quietly
               (message "seed7-mode: abbrev table rebuilt: %d abbreviation%s registered."
                        registered
-                       (if (= registered 1) "" "s")))))))))
+                       (seed7--plural-s registered)))))))))
 
 ;; Build the table once at package load time using the initial values.
 (seed7-rebuild-abbrev-table 'quietly)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260601.1032
+;; Package-Version: 20260601.1817
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -251,6 +251,8 @@
 ;; - Seed7 Speedbar Support
 ;; - Seed7 Low-level Macros
 ;;   . `seed7--set'
+;; - Seed7 Utilities
+;;   . `seed7--run'
 ;; - Seed7 Code Navigation
 ;;   - Seed7 Comment and String Identification Macros and Functions
 ;;     . `seed7--point-in-code-p'
@@ -480,7 +482,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-01T14:32:25+0000 W23-1"
+(defconst seed7-mode-version-timestamp "2026-06-01T22:17:30+0000 W23-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2486,6 +2488,49 @@ Note: the default style for all Seed7 buffers is controlled by the
   "Set VAR with result of FCT call and return it.
 Use inside a `cond' clause to emphasize the check FCT."
   `(setq ,var ,fct))
+
+;; ---------------------------------------------------------------------------
+;;* Seed7 Utilities
+;;  ===============
+
+(defun seed7--run (program args stdout-buffer stderr-buffer
+                           &optional context-msg)
+  "Run PROGRAM with ARGS synchronously.
+
+Directs stdout to STDOUT-BUFFER and stderr to STDERR-BUFFER.
+Return the exit code."
+  ;; Create a temporary file to hold the stderr output safely
+  (let ((temp-stderr-file (make-temp-file "emacs-seed7-mode-stderr-")))
+    ;; Clear previous contents of both buffers
+    (with-current-buffer stdout-buffer (erase-buffer))
+    (with-current-buffer stderr-buffer (erase-buffer))
+    (unwind-protect
+        (let* ((dest (list stdout-buffer temp-stderr-file))
+               (exit-code
+                (condition-case err
+                    (apply #'call-process program nil dest nil args)
+                  (error
+                   (user-error "\
+seed7: cannot run \"%s\"%s: %s"
+                               program
+                               (if  context-msg
+                                   (format "  with %s" context-msg)
+                                 "")
+                               (error-message-string err))))))
+
+          ;; Read the collected stderr file back into the target stderr buffer
+          (with-current-buffer stderr-buffer
+            (unless (integerp exit-code)
+              (insert (format "Error: %S\n" exit-code)))
+            (insert-file-contents temp-stderr-file))
+          ;; Normalise: call-process returns a string when killed by a signal.
+          (unless (integerp exit-code)
+              (setq exit-code 1))
+          ;; Return the exit code of the process
+          exit-code)
+      ;; delete temp file even if the process or insertion fails
+      (when (file-exists-p temp-stderr-file)
+        (delete-file temp-stderr-file)))))
 
 ;; ---------------------------------------------------------------------------
 ;;* Seed7 Code Navigation
@@ -6274,13 +6319,87 @@ Header lines (\"SEED7 COMPILER Version ...\", \"Source: ...\",
 \"Compiling the program ...\") and the footer (\"N errors found\")
 do NOT match this pattern and are therefore skipped during parsing.")
 
+
+(defun seed7--parse-diagnostics (compile s7c-out-buf)
+  "Parse s7c/s7check diagnostics from text in S7C-OUT-BUF.
+
+If COMPILE is non-nil, parse  `seed7-compiler' (s7c) output;
+otherwise parse `seed7-checker' (s7check) output.
+
+Return a list (in source order) of plists, each with the keys:
+    :file    - absolute source filename string
+    :line    - line number as an integer
+    :column  - column number as an integer, 1-based (s7c only; nil for s7check)
+    :code    - symbolic error code string (s7check only, e.g. \"NO_MATCH\");
+               nil when the compiler (s7c) is used
+    :message - diagnostic message text string
+    :context - list of continuation/context strings that followed the
+               diagnostic line in the tool's output (may be nil)."
+  (with-current-buffer s7c-out-buf
+    (goto-char (point-min))
+    (let ((diag-re    (if compile
+                          seed7--compiler-diagnostic-regexp
+                        seed7--checker-diagnostic-regexp))
+          ;; Regexp to recognise (and discard) the s7c summary footer line.
+          ;; e.g. "64 errors found" - must not be accumulated as context.
+          ;; Only relevant for s7c output; s7check produces no such footer.
+          (footer-re  "^[0-9]+ errors? found$")
+          ;; other local variables that are all initialized to nil
+          diagnostics cur-file cur-line cur-col cur-code cur-message
+          context-lines in-error)
+      (cl-flet ((flush-current ()
+                  "Push the accumulated diagnostic (if any) onto results."
+                  (when in-error
+                    (push (list :file    cur-file
+                                :line    cur-line
+                                :column  cur-col
+                                :code    cur-code
+                                :message cur-message
+                                :context (nreverse context-lines))
+                          diagnostics)
+                    (setq in-error      nil
+                          context-lines nil))))
+        (while (not (eobp))
+          (let ((line (buffer-substring-no-properties
+                       (line-beginning-position)
+                       (line-end-position))))
+            (cond
+             ((string-match diag-re line)
+              ;; New diagnostic - flush previous, start fresh.
+              (flush-current)
+              (setq in-error      t
+                    cur-file      (match-string 1 line)
+                    cur-line      (string-to-number (match-string 2 line))
+                    context-lines nil)
+              (if compile
+                  ;; s7c: group 3 = column, group 4 = message, no code
+                  (setq cur-col     (string-to-number (match-string 3 line))
+                        cur-code    nil
+                        cur-message (match-string 4 line))
+                ;; s7check: group 3 = code, group 4 = message, no column
+                (setq cur-col     nil
+                      cur-code    (match-string 3 line)
+                      cur-message (match-string 4 line))))
+             ((and compile (string-match footer-re line))
+              ;; s7c summary footer ("N errors found") - skip entirely.
+              nil)
+             (in-error
+              ;; Continuation / context line - accumulate non blank
+              (unless (string-blank-p line)
+                (push line context-lines)))))
+          (forward-line 1))
+        ;; Flush the final diagnostic (if any).
+        (flush-current))
+      (nreverse diagnostics))))
+
 (defun seed7-check-file (file-name &optional compile)
   "Run static check or compilation on FILE-NAME without using the shell.
+
 If COMPILE is non-nil, use `seed7-compiler' (s7c) to compile the file;
 otherwise use `seed7-checker' (s7check) to perform a static check.
 
 Invokes the tool directly via `call-process' (no /bin/sh involved).
-Returns a cons cell (EXIT-CODE . DIAGNOSTICS) where:
+Returns a (EXIT-CODE DIAGNOSTICS STDERR) where:
   EXIT-CODE   - integer exit status returned by the tool, or 1 when the
                 process was terminated by a signal.
   DIAGNOSTICS - list (in source order) of plists, each with the keys:
@@ -6291,7 +6410,8 @@ Returns a cons cell (EXIT-CODE . DIAGNOSTICS) where:
                nil when the compiler (s7c) is used
     :message - diagnostic message text string
     :context - list of continuation/context strings that followed the
-               diagnostic line in the tool's output (may be nil)
+               diagnostic line in the tool's output (may be nil).
+  STDERR     - a string corresponding to the program stderr.
 
 The DIAGNOSTICS list is nil when no diagnostics are found.
 
@@ -6316,21 +6436,16 @@ See also: `seed7-check-or-compile'."
                                (executable-find (expand-file-name raw-program))
                              (executable-find raw-program))))
          (args        (append (mapcar (lambda (a)
-                                       (if (string-prefix-p "~" a)
-                                           (expand-file-name a)
-                                         a))
+                                        (if (string-prefix-p "~" a)
+                                            (expand-file-name a)
+                                          a))
                                       (cdr cmd-parts))
                               (list (expand-file-name file-name))))
-         (diag-re    (if compile
-                         seed7--compiler-diagnostic-regexp
-                       seed7--checker-diagnostic-regexp))
-         ;; Regexp to recognise (and discard) the s7c summary footer line.
-         ;; e.g. "64 errors found" - must not be accumulated as context.
-         ;; Only relevant for s7c output; s7check produces no such footer.
-         (footer-re  "^[0-9]+ errors? found$")
-         (out-buf    (generate-new-buffer " *seed7-check-output*"))
+         (stdout-buf    (generate-new-buffer " *seed7-check-output*"))
+         (stderr-buf    (generate-new-buffer " *seed7-check-stderr*"))
          (default-directory (file-name-directory (expand-file-name file-name)))
-         results
+         stderr-text
+         diagnostics
          exit-code)
     (unless (and program (file-executable-p program))
       (user-error "\
@@ -6339,73 +6454,21 @@ Verify the value of `%s'."
                   (if compile "seed7-compiler" "seed7-checker")
                   raw-program
                   (if compile "seed7-compiler" "seed7-checker")))
-    (unwind-protect
-        (progn
-          (setq exit-code
-                (condition-case err
-                   ;; `program' is the fully resolved executable path, so
-                   ;; tilde paths and symlinks are handled correctly and no
-                   ;; shell is involved.
-                    (apply #'call-process program nil out-buf nil args)
-                  (file-error
-                   (user-error
-                    "seed7: cannot run \"%s\" (from `%s' = %S): %s"
-                    program
-                    (if compile "seed7-compiler" "seed7-checker")
-                    cmd-string
-                    (error-message-string err)))))
-          ;; Normalise: call-process returns a string when killed by a signal.
-          (unless (integerp exit-code)
-            (setq exit-code 1))
-          (with-current-buffer out-buf
-            (goto-char (point-min))
-            (let (cur-file cur-line cur-col cur-code cur-message
-                  context-lines in-error)
-              (cl-flet ((flush-current ()
-                          "Push the accumulated diagnostic (if any) onto results."
-                          (when in-error
-                            (push (list :file    cur-file
-                                        :line    cur-line
-                                        :column  cur-col
-                                        :code    cur-code
-                                        :message cur-message
-                                        :context (nreverse context-lines))
-                                  results)
-                            (setq in-error      nil
-                                  context-lines nil))))
-                (while (not (eobp))
-                  (let ((line (buffer-substring-no-properties
-                               (line-beginning-position)
-                               (line-end-position))))
-                    (cond
-                     ((string-match diag-re line)
-                      ;; New diagnostic - flush previous, start fresh.
-                      (flush-current)
-                      (setq in-error      t
-                            cur-file      (match-string 1 line)
-                            cur-line      (string-to-number (match-string 2 line))
-                            context-lines nil)
-                      (if compile
-                          ;; s7c: group 3 = column, group 4 = message, no code
-                          (setq cur-col     (string-to-number (match-string 3 line))
-                                cur-code    nil
-                                cur-message (match-string 4 line))
-                        ;; s7check: group 3 = code, group 4 = message, no column
-                        (setq cur-col     nil
-                              cur-code    (match-string 3 line)
-                              cur-message (match-string 4 line))))
-                     ((and compile (string-match footer-re line))
-                      ;; s7c summary footer ("N errors found") - skip entirely.
-                      nil)
-                     (in-error
-                      ;; Continuation / context line - accumulate non blank
-                      (unless (string-blank-p line)
-                        (push line context-lines)))))
-                  (forward-line 1))
-                ;; Flush the final diagnostic (if any).
-                (flush-current))))
-          (cons exit-code (nreverse results)))
-      (kill-buffer out-buf))))
+    ;; Execute program - get exit code
+    (setq exit-code (seed7--run program args stdout-buf stderr-buf
+                                (format "(from `%s' = %S"
+                                        (if compile "seed7-compiler"
+                                          "seed7-checker")
+                                        cmd-string)))
+    ;; - remember stderr text
+    (with-current-buffer stderr-buf
+      (setq stderr-text (buffer-string)))
+    (kill-buffer stderr-buf)
+    ;; - extract diagnostics from stdout
+    (setq diagnostics (seed7--parse-diagnostics compile stdout-buf))
+    (kill-buffer stdout-buf)
+    ;; - return exit code, diagnostics and stderr text
+    (list exit-code diagnostics stderr-text)))
 
 (defun seed7-check-or-compile (&optional compile)
   "Check or compile the current Seed7 buffer's file and show diagnostics.
@@ -6451,14 +6514,15 @@ or nil when no diagnostics are found."
     (let* ((cmd        (if compile seed7-compiler seed7-checker))
            (dir        (file-name-directory file))
            ;; Record time *around* the checker invocation
-           (t0         (current-time))
-           (result     (seed7-check-file file compile))
-           (exit-code  (car result))
-           (errors     (cdr result))
-           (t1         (current-time))
-           (duration   (float-time (time-subtract t1 t0)))
-           (n-errors   (length errors))
-           (out-buf    (get-buffer-create "*seed7-errors*")))
+           (t0          (current-time))
+           (result      (seed7-check-file file compile))
+           (exit-code   (nth 0 result))
+           (errors      (nth 1 result))
+           (stderr-text (nth 2 result))
+           (t1          (current-time))
+           (duration    (float-time (time-subtract t1 t0)))
+           (n-errors    (length errors))
+           (out-buf     (get-buffer-create "*seed7-errors*")))
       ;;
       ;; -- Format the output -----------------------------------------------
       (with-current-buffer out-buf
@@ -6471,6 +6535,10 @@ or nil when no diagnostics are found."
           (insert (format "-*- mode: compilation; default-directory: %S -*-\n"
                           dir))
           (insert (format "%s %s\n\n" cmd file))
+          ;; -- stderr-text -------------------------
+          (when (and stderr-text
+                     (not (string-blank-p stderr-text)))
+            (insert (format "\nSTDERR:\n%s\n" stderr-text)))
           ;; -- Diagnostics -------------------------
           (if errors
               (dolist (e errors)
@@ -6539,7 +6607,7 @@ or nil when no diagnostics are found."
                        "]")))
         (goto-char (point-min)))
       (display-buffer out-buf)
-      ;; -- Show and return results -----------------------------------------
+      ;; -- Show and return diagnostics -------------------------------------
       (if errors
           (message "seed7: %d error%s found"
                    n-errors

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1014
+;; Package-Version: 20260602.1024
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -482,7 +482,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T14:14:37+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T14:24:49+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6516,7 +6516,7 @@ or nil when no diagnostics are found."
     ;;
     ;; -- Build command, execute and extract result information
     (let* ((cmd        (if compile seed7-compiler seed7-checker))
-           (pgm        (file-name-nondirectory (car (string-split cmd))))
+           (pgm        (file-name-nondirectory (car (split-string cmd))))
            (operation  (if compile "compilation" "check"))
            (dir        (file-name-directory file))
            ;; Record time *around* the checker invocation

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1146
+;; Package-Version: 20260602.1420
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -482,7 +482,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T15:46:59+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T18:20:34+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2501,19 +2501,30 @@ Use inside a `cond' clause to emphasize the check FCT."
   "Return \"s\" if N is larger than 1, \"\" otherwise."
   (if (> n 1) "s" ""))
 
-(defun seed7--run (program args stdout-buffer stderr-buffer
-                           &optional context-msg)
+(defun seed7--run (program args stdout-buffer
+                           &optional stderr-buffer context-msg)
   "Run PROGRAM with ARGS synchronously.
 
-Directs stdout to STDOUT-BUFFER and stderr to STDERR-BUFFER.
-Return the exit code."
+- If STDERR-BUFFER is nil: collect PROGRAM output from stdout and stderr in
+  STDOUT-BUFFER.
+- if STDERR-BUFFER is non-nil it must be a buffer; the stdout and stderr
+  streams of PROGRAM are collected separately.
+
+If execution of PROGRAM signals fails, the function issues a user-error that
+ends with the CONTEXT-MSG.
+
+Return the exit code of the PROGRAM execution.."
   ;; Create a temporary file to hold the stderr output safely
-  (let ((temp-stderr-file (make-temp-file "emacs-seed7-mode-stderr-")))
+  (let ((temp-stderr-file (when stderr-buffer
+                            (make-temp-file "emacs-seed7-mode-stderr-"))))
     ;; Clear previous contents of both buffers
     (with-current-buffer stdout-buffer (erase-buffer))
-    (with-current-buffer stderr-buffer (erase-buffer))
+    (when stderr-buffer
+      (with-current-buffer stderr-buffer (erase-buffer)))
     (unwind-protect
-        (let* ((dest (list stdout-buffer temp-stderr-file))
+        (let* ((dest (if stderr-buffer
+                         (list stdout-buffer temp-stderr-file)
+                       stdout-buffer))
                (exit-code
                 (condition-case err
                     (apply #'call-process program nil dest nil args)
@@ -2525,19 +2536,20 @@ seed7: cannot run \"%s\"%s: %s"
                                    (format "  with %s" context-msg)
                                  "")
                                (error-message-string err))))))
-
-          ;; Read the collected stderr file back into the target stderr buffer
-          (with-current-buffer stderr-buffer
-            (unless (integerp exit-code)
-              (insert (format "Error: %S\n" exit-code)))
-            (insert-file-contents temp-stderr-file))
+          ;; When used, read the collected stderr file back into the target
+          ;; stderr buffer.
+          (when stderr-buffer
+            (with-current-buffer stderr-buffer
+              (unless (integerp exit-code)
+                (insert (format "Error: %S\n" exit-code)))
+              (insert-file-contents temp-stderr-file)))
           ;; Normalise: call-process returns a string when killed by a signal.
           (unless (integerp exit-code)
             (setq exit-code 1))
           ;; Return the exit code of the process
           exit-code)
-      ;; delete temp file even if the process or insertion fails
-      (when (file-exists-p temp-stderr-file)
+      ;; When used, delete temp file even if the process or insertion fails.
+      (when (and stderr-buffer (file-exists-p temp-stderr-file))
         (delete-file temp-stderr-file)))))
 
 ;; ---------------------------------------------------------------------------
@@ -6433,67 +6445,67 @@ non-nil) cannot be found or is not executable.  In that case verify the
 value of the corresponding user-option.
 
 See also: `seed7-check-or-compile'."
-  (let* ((cmd-string (if compile seed7-compiler seed7-checker))
+  (let* ((cmd-string         (if compile seed7-compiler seed7-checker))
+         (user-option-name   (if compile "seed7-compiler" "seed7-checker"))
          (cmd-parts  (split-string-and-unquote cmd-string))
          (raw-program (car cmd-parts))
          ;; Resolve the executable: when a directory component is present
          ;; (e.g. "~/bin/s7check"), ;; expand ~ before searching exec-path
          ;; so tilde paths are honoured.
-         (program     (and raw-program
-                           (if (file-name-directory raw-program)
-                               (executable-find (expand-file-name raw-program))
-                             (executable-find raw-program))))
-         (args        (append (mapcar (lambda (a)
-                                        (if (string-prefix-p "~" a)
-                                            (expand-file-name a)
-                                          a))
-                                      (cdr cmd-parts))
-                              (list (expand-file-name file-name))))
-         (stdout-buf    (generate-new-buffer " *seed7-check-output*"))
-         (stderr-buf    (generate-new-buffer " *seed7-check-stderr*"))
-         (default-directory (file-name-directory (expand-file-name file-name)))
-         stderr-text
-         diagnostics
-         exit-code)
-    (unwind-protect
-        (progn
-          (unless (and program (file-executable-p program))
-            (user-error "\
-Program specified by `%s' not found or not executable: %s
+         (program (and raw-program
+                       (if (file-name-directory raw-program)
+                           (executable-find (expand-file-name raw-program))
+                         (executable-find raw-program))))
+         (args    (append (mapcar (lambda (a)
+                                    (if (string-prefix-p "~" a)
+                                        (expand-file-name a)
+                                      a))
+                                  (cdr cmd-parts))
+                          (list (expand-file-name file-name)))))
+    ;; Guard: fail fast before allocating any buffers.
+    (unless program
+      (user-error "Program specified by `%s' not found or not executable: %s
 Verify the value of `%s'."
-                        (if compile "seed7-compiler" "seed7-checker")
-                        raw-program
-                        (if compile "seed7-compiler" "seed7-checker")))
-          ;; Execute program - get exit code
-          (setq exit-code (seed7--run program args stdout-buf stderr-buf
-                                      (format "(from `%s' = %S)"
-                                              (if compile "seed7-compiler"
-                                                "seed7-checker")
-                                              cmd-string)))
-          ;; The s7c compiler program emits diagnostics on stderr.
-          ;; The s7check static checker emits diagnostics on stdout.
-          ;; - Extract stderr text
-          (with-current-buffer stderr-buf
-            (setq stderr-text (buffer-string)))
-          ;; - When analyzing keep the stdout as is: the content of
-          ;;   stderr in stderr-text.
-          (when compile
-            ;; - When compiling append the content of stderr to stdout,
-            ;;   analyze that and set the stderr-text to empty string.
-            (with-current-buffer stdout-buf
-              (goto-char (point-max))
-              (insert stderr-text))
-            (setq stderr-text ""))
-          ;; - extract diagnostics from stdout
-          (setq diagnostics (seed7--parse-diagnostics compile stdout-buf))
-          ;; - return exit code, diagnostics and stderr text
-          (list exit-code diagnostics stderr-text))
-      (when (buffer-live-p stderr-buf)
-        (kill-buffer stderr-buf))
-      (when (buffer-live-p stdout-buf)
-        (kill-buffer stdout-buf)))
-    ;; - return exit code, diagnostics and stderr text
-    (list exit-code diagnostics stderr-text)))
+                  user-option-name raw-program user-option-name))
+    (let* ((stdout-buf (generate-new-buffer " *seed7-check-output*"))
+           (stderr-buf (generate-new-buffer " *seed7-check-stderr*"))
+           stderr-text
+           diagnostics
+           exit-code
+           (default-directory (file-name-directory (expand-file-name
+                                                    file-name))))
+      (unwind-protect
+          (progn
+            ;; Execute program - get exit code
+            ;; - The s7c compiler program emits diagnostics on stderr;
+            ;;   - accumulate everything in the stdout-buf.
+            ;; - The s7check static checker emits diagnostics on stdout;
+            ;;   - accumulate diagnostics in stdout-buffer and errors in a
+            ;;     separate stderr-buffer.
+            (setq exit-code (seed7--run program args stdout-buf
+                                        (unless compile stderr-buf)
+                                        (format "(from `%s' = %S)"
+                                                (if compile "seed7-compiler"
+                                                  "seed7-checker")
+                                                cmd-string)))
+            (if compile
+                ;; when compiling all output is in stdout-buffer
+                (setq stderr-text "")
+              ;; when analyzing the stdout holds only diagnostics and stderr
+              ;; holds the error stream; stores it in stderr-text
+              (with-current-buffer stderr-buf
+                (setq stderr-text (buffer-string))))
+            ;; - extract diagnostics from stdout
+            (setq diagnostics (seed7--parse-diagnostics compile stdout-buf))
+            ;; - return exit code, diagnostics and stderr text
+            (list exit-code diagnostics stderr-text))
+        ;; Cleanup: always kill scratch buffers.
+        (when (buffer-live-p stderr-buf)
+          (kill-buffer stderr-buf))
+        (when (buffer-live-p stdout-buf)
+          (kill-buffer stdout-buf)))
+      ;; - return exit code, diagnostics and stderr text
+      (list exit-code diagnostics stderr-text))))
 
 (defun seed7-check-or-compile (&optional compile)
   "Check or compile the current Seed7 buffer's file and show diagnostics.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1523
+;; Package-Version: 20260602.1550
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -420,6 +420,9 @@
 ;;       . `seed7--indent-lines'
 ;; - Seed7 Compilation
 ;;   * `seed7-check-or-compile'
+;;     . `seed7-check-file'
+;;       . `seed7--expand-args'
+;;       . `seed7--run-and-parse'
 ;; - Seed7 Cross Reference
 ;;    > `seed7--xref-backend'
 ;;    + `xref-backend-identifier-at-point'
@@ -482,7 +485,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T19:23:26+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T19:50:02+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6416,9 +6419,10 @@ Return a list (in source order) of plists, each with the keys:
   "Expand any leading ~ from the arguments."
   (let ((updated-args nil))
     (dolist (arg args (nreverse updated-args))
-      (if (string-prefix-p "~" arg)
-          (push (expand-file-name arg) updated-args)
-        arg))))
+      (push (if (string-prefix-p "~" arg)
+                (expand-file-name arg)
+              arg)
+            updated-args))))
 
 (defun seed7--run-and-parse (program args cmd-string compile file-name)
   "Run PROGRAM with ARGS and return (EXIT-CODE DIAGNOSTICS STDERR-TEXT).
@@ -6563,7 +6567,7 @@ or nil when no diagnostics are found."
            ;; Format result message
            (err-msg     (when (and stderr-text
                                    (not (string-blank-p stderr-text)))
-                          (format "\nSTDERR:\n%s\n" stderr-text)))
+                          (format "\nSTDERR: %s" stderr-text)))
            (end-msg (format "%s: %s"
                             pgm
                             (cond

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1500
+;; Package-Version: 20260602.1514
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -482,7 +482,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T19:00:06+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T19:14:14+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6414,11 +6414,11 @@ Return a list (in source order) of plists, each with the keys:
 
 (defun seed7--expand-args (args)
   "Expand any leading ~ from the arguments."
-  (mapcar (lambda (a)
-            (if (string-prefix-p "~" a)
-                (expand-file-name a)
-              a))
-          args))
+  (let ((updated-args nil))
+    (dolist (arg args (nreverse updated-args))
+      (if (string-prefix-p "~" arg)
+          (push (expand-file-name arg) updated-args)
+        arg))))
 
 (defun seed7-check-file (file-name &optional compile)
   "Run static check or compilation on FILE-NAME without using the shell.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1712
+;; Package-Version: 20260602.1727
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -505,7 +505,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T21:12:17+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T21:27:25+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2530,7 +2530,7 @@ Use inside a `cond' clause to emphasize the check FCT."
 
 - If STDERR-BUFFER is nil: collect PROGRAM output from stdout and stderr in
   STDOUT-BUFFER.
-- if STDERR-BUFFER is non-nil it must be a buffer; the stdout and stderr
+- If STDERR-BUFFER is non-nil, it must be a buffer; the stdout and stderr
   streams of PROGRAM are collected separately.
 
 If execution of PROGRAM fails (e.g. the OS cannot start it), the
@@ -6447,6 +6447,7 @@ Return a list (in source order) of plists, each with the keys:
 (defun seed7--run-and-parse (program args cmd-string compile file-name)
   "Run PROGRAM with ARGS and return (EXIT-CODE DIAGNOSTICS STDERR-TEXT).
 
+CMD-STRING is the original command string (used verbatim in error messages).
 COMPILE non-nil identifies a compilation operation (s7c); nil identifies
 a static check (s7check).  When COMPILE is non-nil, STDERR-TEXT in the
 result is always \"\", because s7c emits diagnostics on stderr and they
@@ -6486,7 +6487,7 @@ If COMPILE is non-nil, use `seed7-compiler' (s7c) to compile the file;
 otherwise use `seed7-checker' (s7check) to perform a static check.
 
 Invokes the tool directly via `call-process' (no /bin/sh involved).
-Returns a (EXIT-CODE DIAGNOSTICS STDERR) where:
+Returns a list (EXIT-CODE DIAGNOSTICS STDERR) where:
   EXIT-CODE   - integer exit status returned by the tool, or 1 when the
                 process was terminated by a signal.
   DIAGNOSTICS - list (in source order) of plists, each with the keys:

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1818
+;; Package-Version: 20260602.1826
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -505,7 +505,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T22:18:09+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T22:26:54+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2540,7 +2540,8 @@ error message; when nil the message ends with the OS error description.
 Return the exit code of the PROGRAM execution as an integer.
 When the process is killed by a signal, `call-process' returns a string;
 this function normalises it to 1."
-  ;; Create a temporary file to hold the stderr output safely
+  ;; When stderr capture is required, create a temporary file to hold the
+  ;; output.
   (let ((temp-stderr-file (when stderr-buffer
                             (make-temp-file "emacs-seed7-mode-stderr-"))))
     ;; Clear previous contents of both buffers

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1727
+;; Package-Version: 20260602.1747
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -505,7 +505,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T21:27:25+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T21:47:04+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -592,7 +592,7 @@ by default.
 You may:
 - Specify the program name without a path if it is in the PATH of your shell.
 - Specify the program name with an absolute path.
-- Specify compiler options after the program name if necessary.
+- Specify static checker options after the program name if necessary.
 
 IMPORTANT NOTE: seed7-mode expects this tool to print diagnostics on stdout.
 
@@ -2533,8 +2533,9 @@ Use inside a `cond' clause to emphasize the check FCT."
 - If STDERR-BUFFER is non-nil, it must be a buffer; the stdout and stderr
   streams of PROGRAM are collected separately.
 
-If execution of PROGRAM fails (e.g. the OS cannot start it), the
-function issues a user-error that ends with the CONTEXT-MSG.
++If execution of PROGRAM fails (e.g. the OS cannot start it), the function
++issues a `user-error'.  When CONTEXT-MSG is non-nil it is appended to the
++error message; when nil the message ends with the OS error description.
 
 Return the exit code of the PROGRAM execution."
   ;; Create a temporary file to hold the stderr output safely
@@ -6363,8 +6364,8 @@ Header lines (\"SEED7 COMPILER Version ...\", \"Source: ...\",
 do NOT match this pattern and are therefore skipped during parsing.")
 
 
-(defun seed7--parse-diagnostics (compile s7c-out-buf)
-  "Parse s7c/s7check diagnostics from text in S7C-OUT-BUF.
+(defun seed7--parse-diagnostics (compile out-buf)
+  "Parse s7c/s7check diagnostics from text in OUT-BUF.
 
 If COMPILE is non-nil, parse `seed7-compiler' (s7c) output;
 otherwise parse `seed7-checker' (s7check) output.
@@ -6378,7 +6379,7 @@ Return a list (in source order) of plists, each with the keys:
     :message - diagnostic message text string
     :context - list of continuation/context strings that followed the
                diagnostic line in the tool's output (may be nil)."
-  (with-current-buffer s7c-out-buf
+  (with-current-buffer out-buf
     (goto-char (point-min))
     (let ((diag-re    (if compile
                           seed7--compiler-diagnostic-regexp
@@ -6436,13 +6437,13 @@ Return a list (in source order) of plists, each with the keys:
       (nreverse diagnostics))))
 
 (defun seed7--expand-args (args)
-  "Expand any leading ~ from the arguments."
-  (let ((updated-args nil))
-    (dolist (arg args (nreverse updated-args))
-      (push (if (string-prefix-p "~" arg)
+  "Return a copy of ARGS with any element whose name starts with `~' expanded.
+Other elements are returned unchanged."
+  (mapcar (lambda (arg)
+            (if (string-prefix-p "~" arg)
                 (expand-file-name arg)
-              arg)
-            updated-args))))
+              arg))
+          args))
 
 (defun seed7--run-and-parse (program args cmd-string compile file-name)
   "Run PROGRAM with ARGS and return (EXIT-CODE DIAGNOSTICS STDERR-TEXT).
@@ -6607,7 +6608,7 @@ or nil when no diagnostics are found."
                              (err-msg (format "%s with exit code %d%s"
                                               operation
                                               exit-code
-                                              (or err-msg "")))
+                                              err-msg))
                              ((not (zerop exit-code))
                               (format "%s with exit code %d"
                                       operation

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1617
+;; Package-Version: 20260602.1640
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -252,6 +252,7 @@
 ;; - Seed7 Low-level Macros
 ;;   . `seed7--set'
 ;; - Seed7 Utilities
+;;   . `seed7--plural-s'
 ;;   . `seed7--run'
 ;; - Seed7 Code Navigation
 ;;   - Seed7 Comment and String Identification Macros and Functions
@@ -485,7 +486,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T20:17:53+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T20:40:33+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -574,7 +575,7 @@ You may:
 - Specify the program name with an absolute path.
 - Specify compiler options after the program name if necessary.
 
-IMPORTANT NOTE: see7-mode expects this tool to print diagnostics on stdout.
+IMPORTANT NOTE: seed7-mode expects this tool to print diagnostics on stdout.
 
 The name of the source code file is appended to the end of that line.
 Note that the s7check is part of the example programs located inside
@@ -592,7 +593,7 @@ You may:
 - Specify the program name with an absolute path.
 - Specify compiler options after the program name if necessary.
 
-IMPORTANT NOTE: see7-mode expects this tool to print diagnostics on stderr.
+IMPORTANT NOTE: seed7-mode expects this tool to print diagnostics on stderr.
 
 The name of the source code file is appended to the end of that line."
   :group 'seed7
@@ -2501,7 +2502,7 @@ Use inside a `cond' clause to emphasize the check FCT."
 ;;  ===============
 
 (defun seed7--plural-s (n)
-  "Return \"s\" if N is larger than 1, \"\" otherwise."
+  "Return \"s\" if N is not equal to 1, \"\" otherwise."
   (if (= n 1) "" "s"))
 
 (defun seed7--run (program args stdout-buffer
@@ -2513,8 +2514,8 @@ Use inside a `cond' clause to emphasize the check FCT."
 - if STDERR-BUFFER is non-nil it must be a buffer; the stdout and stderr
   streams of PROGRAM are collected separately.
 
-If execution of PROGRAM signals fails, the function issues a user-error that
-ends with the CONTEXT-MSG.
+If execution of PROGRAM fails (e.g. the OS cannot start it), the
+function issues a user-error that ends with the CONTEXT-MSG.
 
 Return the exit code of the PROGRAM execution."
   ;; Create a temporary file to hold the stderr output safely
@@ -6427,9 +6428,11 @@ Return a list (in source order) of plists, each with the keys:
 (defun seed7--run-and-parse (program args cmd-string compile file-name)
   "Run PROGRAM with ARGS and return (EXIT-CODE DIAGNOSTICS STDERR-TEXT).
 
-If COMPILE is non-nil, use `seed7-compiler' (s7c) to compile the file
-specified by FILE-NAME; otherwise use `seed7-checker' (s7check) to perform a
-static check."
+CMD-STRING is the original command string used in error messages.
+COMPILE no-nil identifies a compilation operation, nil identifies a static
+check operation.
+The FILE-NAME identifies the name of the file to compile or static check by
+PROGRAM."
   (let* ((stdout-buf        (generate-new-buffer " *seed7-check-output*"))
          (stderr-buf        (unless compile
                               (generate-new-buffer " *seed7-check-stderr*")))
@@ -6496,7 +6499,7 @@ See also: `seed7-check-or-compile'."
          (cmd-parts  (split-string-and-unquote cmd-string))
          (raw-program (car cmd-parts))
          ;; Resolve the executable: when a directory component is present
-         ;; (e.g. "~/bin/s7check"), ;; expand ~ before searching exec-path
+         ;; (e.g. "~/bin/s7check"), expand ~ before searching exec-path
          ;; so tilde paths are honoured.
          (program (and raw-program
                        (if (file-name-directory raw-program)
@@ -6555,7 +6558,8 @@ or nil when no diagnostics are found."
     ;;
     ;; -- Build command, execute and extract result information
     (let* ((cmd        (if compile seed7-compiler seed7-checker))
-           (pgm        (file-name-nondirectory (car (split-string cmd))))
+           (pgm        (file-name-nondirectory
+                        (car (split-string-and-unquote cmd))))
            (operation  (if compile "compilation" "check"))
            (dir        (file-name-directory file))
            ;; Record time *around* the checker invocation

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1747
+;; Package-Version: 20260602.1800
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -505,7 +505,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T21:47:04+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T22:00:05+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2533,9 +2533,9 @@ Use inside a `cond' clause to emphasize the check FCT."
 - If STDERR-BUFFER is non-nil, it must be a buffer; the stdout and stderr
   streams of PROGRAM are collected separately.
 
-+If execution of PROGRAM fails (e.g. the OS cannot start it), the function
-+issues a `user-error'.  When CONTEXT-MSG is non-nil it is appended to the
-+error message; when nil the message ends with the OS error description.
+If execution of PROGRAM fails (e.g. the OS cannot start it), the function
+issues a `user-error'.  When CONTEXT-MSG is non-nil it is appended to the
+error message; when nil the message ends with the OS error description.
 
 Return the exit code of the PROGRAM execution."
   ;; Create a temporary file to hold the stderr output safely
@@ -6384,10 +6384,6 @@ Return a list (in source order) of plists, each with the keys:
     (let ((diag-re    (if compile
                           seed7--compiler-diagnostic-regexp
                         seed7--checker-diagnostic-regexp))
-          ;; Regexp to recognise (and discard) the s7c summary footer line.
-          ;; e.g. "64 errors found" - must not be accumulated as context.
-          ;; Only relevant for s7c output; s7check produces no such footer.
-          (footer-re  "^[0-9]+ errors? found$")
           ;; other local variables that are all initialized to nil
           diagnostics cur-file cur-line cur-col cur-code cur-message
           context-lines in-error)
@@ -6408,6 +6404,7 @@ Return a list (in source order) of plists, each with the keys:
                        (line-beginning-position)
                        (line-end-position))))
             (cond
+             ;;
              ((string-match diag-re line)
               ;; New diagnostic - flush previous, start fresh.
               (flush-current)
@@ -6424,9 +6421,14 @@ Return a list (in source order) of plists, each with the keys:
                 (setq cur-col     nil
                       cur-code    (match-string 3 line)
                       cur-message (match-string 4 line))))
-             ((and compile (string-match footer-re line))
+             ;;
+             ;; Regexp to recognise (and discard) the s7c summary footer line.
+             ;; e.g. "64 errors found" - must not be accumulated as context.
+             ;; Only relevant for s7c output; s7check produces no such footer.
+             ((and compile (string-match "^[0-9]+ errors? found$"  line))
               ;; s7c summary footer ("N errors found") - skip entirely.
               nil)
+             ;;
              (in-error
               ;; Continuation / context line - accumulate non-blank
               (unless (string-blank-p line)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1640
+;; Package-Version: 20260602.1704
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -205,6 +205,8 @@
 ;; of sections.
 ;;
 ;; - Version Info
+;;   . `seed7-mode-version'
+;;   * `seed7-mode-customize'
 ;; - Seed7 Customization
 ;; - Seed7 Keyword Regexp
 ;;   - Seed7 Tokens
@@ -234,6 +236,8 @@
 ;;   - Seed7 Block Processing Regexp
 ;;   - Seed7 Procedure/Function Parameters Regexp
 ;;   - Seed7 Procedure/Function Regexp
+;;     . `seed7-func-beg-of-decl-re-fmt'
+;;     . `seed7--procfunc-beg-of-decl-re-fmt'
 ;; - Seed7 iMenu Support Regexp
 ;;   - Seed7 Procedure/Function iMenu Regexp
 ;;   - Seed7 Enum/Structure iMenu Regexp
@@ -264,7 +268,9 @@
 ;;       . `seed7--inside-string-p'
 ;;   - Seed7 Code Search Functions
 ;;     . `seed7-re-search-forward'
+;;     . `seed7-re-search-forward-closest'
 ;;     . `seed7-re-search-backward'
+;;     . `seed7-re-search-backward-closest'
 ;;   - Seed7 Skipping Comments
 ;;     . `seed7-skip-comment-backward'
 ;;     . `seed7-skip-comment-forward'
@@ -302,8 +308,13 @@
 ;;       . `seed7--start-regexp-for'
 ;;         . `seed7--type-regexp'
 ;; - Seed7 iMenu Support
+;;   . `seed7--setup-imenu'
+;;   . `seed7--refresh-imenu'
+;;   * `seed7-toggle-menu-callable-list'
+;;   * `seed7-toggle-menu-sorting'
 ;; - Seed7 Code Marking
 ;;   * `seed7-mark-defun'
+;;   . `seed7-lines-in-defun'
 ;; - Seed7 Indentation
 ;;   - Seed7 Indentation Customization
 ;;   - Seed7 Indentation Utility Macros
@@ -312,6 +323,7 @@
 ;;     - Seed7 Indentation Base utilities
 ;;       . `seed7-blank-line-p'
 ;;       . `seed7-indent-step-for-column'
+;;       . `seed7-current-line-number'
 ;;       . `seed7-current-line-start-inside-comment-p'
 ;;         o `seed7-inside-comment-p'
 ;;         . `seed7-to-indent'
@@ -363,6 +375,7 @@
 ;;     . `seed7-line-inside-nested-parens-pairs'
 ;;     . `seed7-line-inside-nested-parens-pairs-column'
 ;;     . `seed7-indentation-of-previous-non-string-line'
+;;     . `seed7-line-is-procfunc-beg-of-decl'
 ;;     . `seed7-line-is-defun-end'
 ;;       o `seed7-line-starts-with-any'
 ;;         o `seed7-line-starts-with'
@@ -424,6 +437,7 @@
 ;;     . `seed7-check-file'
 ;;       . `seed7--expand-args'
 ;;       . `seed7--run-and-parse'
+;;         . `seed7--parse-diagnostics'
 ;; - Seed7 Cross Reference
 ;;    > `seed7--xref-backend'
 ;;    + `xref-backend-identifier-at-point'
@@ -441,9 +455,14 @@
 ;;            . `seed7--xref-in-list'
 ;;            . `seed7--signature-from'
 ;;              . `seed7--signature-at'
+;;    + `xref-backend-completions'
+;;      . `seed7--xref-identifiers'
+;;        . `seed7--procfun-identifiers'
+;;        . `seed7--list-of-terms'
 ;;        . `seed7--make-xref-from-file-loc'
 ;; - Seed7 Completion Support
 ;; - Seed7 Abbreviation Support
+;;   * `seed7-rebuild-abbrev-table'
 ;; - Seed7 Key Map
 ;; - Seed7 Menu
 ;; - Seed7 Major Mode
@@ -486,7 +505,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T20:40:33+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T21:04:18+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6347,7 +6366,7 @@ do NOT match this pattern and are therefore skipped during parsing.")
 (defun seed7--parse-diagnostics (compile s7c-out-buf)
   "Parse s7c/s7check diagnostics from text in S7C-OUT-BUF.
 
-If COMPILE is non-nil, parse  `seed7-compiler' (s7c) output;
+If COMPILE is non-nil, parse `seed7-compiler' (s7c) output;
 otherwise parse `seed7-checker' (s7check) output.
 
 Return a list (in source order) of plists, each with the keys:
@@ -6428,11 +6447,13 @@ Return a list (in source order) of plists, each with the keys:
 (defun seed7--run-and-parse (program args cmd-string compile file-name)
   "Run PROGRAM with ARGS and return (EXIT-CODE DIAGNOSTICS STDERR-TEXT).
 
-CMD-STRING is the original command string used in error messages.
-COMPILE no-nil identifies a compilation operation, nil identifies a static
-check operation.
-The FILE-NAME identifies the name of the file to compile or static check by
-PROGRAM."
+COMPILE non-nil identifies a compilation operation (s7c); nil identifies
+a static check (s7check).  When COMPILE is non-nil, STDERR-TEXT in the
+result is always \"\", because s7c emits diagnostics on stderr and they
+are parsed directly from the combined stdout+stderr stream.  When COMPILE
+is nil, STDERR-TEXT holds any text the checker emitted on stderr.
+FILE-NAME is the path of the source file passed to PROGRAM; it is also
+used to set `default-directory' for the subprocess."
   (let* ((stdout-buf        (generate-new-buffer " *seed7-check-output*"))
          (stderr-buf        (unless compile
                               (generate-new-buffer " *seed7-check-stderr*")))
@@ -6662,10 +6683,9 @@ or nil when no diagnostics are found."
                        ;; error count - red bold (compilation-mode-line-fail)
                        (propertize (number-to-string n-diags)
                                    'face 'compilation-mode-line-fail)
-                       ;; warning count - orange bold (compilation-mode-line-run
-                       ;;                 inherits compilation-warning)
+                       ;; warning count
                        " "
-                       (propertize "0" 'face 'compilation-mode-line-run)
+                       (propertize "0" 'face 'compilation-warning)
                        ;; info count - green bold (compilation-mode-line-exit)
                        " "
                        (propertize "0" 'face 'compilation-mode-line-exit)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1800
+;; Package-Version: 20260602.1818
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -505,7 +505,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T22:00:05+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T22:18:09+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2537,7 +2537,9 @@ If execution of PROGRAM fails (e.g. the OS cannot start it), the function
 issues a `user-error'.  When CONTEXT-MSG is non-nil it is appended to the
 error message; when nil the message ends with the OS error description.
 
-Return the exit code of the PROGRAM execution."
+Return the exit code of the PROGRAM execution as an integer.
+When the process is killed by a signal, `call-process' returns a string;
+this function normalises it to 1."
   ;; Create a temporary file to hold the stderr output safely
   (let ((temp-stderr-file (when stderr-buffer
                             (make-temp-file "emacs-seed7-mode-stderr-"))))
@@ -6475,7 +6477,6 @@ used to set `default-directory' for the subprocess."
               (setq stderr-text "")
             (with-current-buffer stderr-buf
               (setq stderr-text (buffer-string))))
-          ;; End with setq — value of unwind-protect is discarded anyway.
           (setq diagnostics
                 (seed7--parse-diagnostics compile stdout-buf)))
       ;; Cleanup: always kill scratch buffers.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260602.1514
+;; Package-Version: 20260602.1523
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -482,7 +482,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-02T19:14:14+0000 W23-2"
+(defconst seed7-mode-version-timestamp "2026-06-02T19:23:26+0000 W23-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6420,6 +6420,36 @@ Return a list (in source order) of plists, each with the keys:
           (push (expand-file-name arg) updated-args)
         arg))))
 
+(defun seed7--run-and-parse (program args cmd-string compile file-name)
+  "Run PROGRAM with ARGS and return (EXIT-CODE DIAGNOSTICS STDERR-TEXT).
+CMD-STRING is the original command string (for error messages).
+COMPILE and FILE-NAME are passed to `seed7--parse-diagnostics'.
+Buffers are allocated locally and always freed via `unwind-protect'."
+  (let* ((stdout-buf        (generate-new-buffer " *seed7-check-output*"))
+         (stderr-buf        (generate-new-buffer " *seed7-check-stderr*"))
+         (default-directory (file-name-directory (expand-file-name file-name)))
+         stderr-text diagnostics exit-code)
+    (unwind-protect
+        ;; Run compiler/checker
+        (progn
+          (setq exit-code
+                (seed7--run program args stdout-buf
+                            (unless compile stderr-buf)
+                            (format "(from `%s' = %S)"
+                                    (if compile "seed7-compiler" "seed7-checker")
+                                    cmd-string)))
+          (if compile
+              (setq stderr-text "")
+            (with-current-buffer stderr-buf
+              (setq stderr-text (buffer-string))))
+          ;; End with setq — value of unwind-protect is discarded anyway.
+          (setq diagnostics
+                (seed7--parse-diagnostics compile stdout-buf)))
+      ;; Cleanup: always kill scratch buffers.
+      (when (buffer-live-p stderr-buf) (kill-buffer stderr-buf))
+      (when (buffer-live-p stdout-buf) (kill-buffer stdout-buf)))
+    (list exit-code diagnostics stderr-text)))
+
 (defun seed7-check-file (file-name &optional compile)
   "Run static check or compilation on FILE-NAME without using the shell.
 
@@ -6463,53 +6493,17 @@ See also: `seed7-check-or-compile'."
          (program (and raw-program
                        (if (file-name-directory raw-program)
                            (executable-find (expand-file-name raw-program))
-                         (executable-find raw-program))))
-         (args    (append (seed7--expand-args (cdr cmd-parts))
-                          (list (expand-file-name file-name)))))
+                         (executable-find raw-program)))))
     ;; Guard: fail fast before allocating any buffers.
     (unless program
       (user-error "Program specified by `%s' not found or not executable: %s
 Verify the value of `%s'."
                   user-option-name raw-program user-option-name))
-    (let* ((stdout-buf (generate-new-buffer " *seed7-check-output*"))
-           (stderr-buf (generate-new-buffer " *seed7-check-stderr*"))
-           stderr-text
-           diagnostics
-           exit-code
-           (default-directory (file-name-directory (expand-file-name
-                                                    file-name))))
-      (unwind-protect
-          (progn
-            ;; Execute program - get exit code
-            ;; - The s7c compiler program emits diagnostics on stderr;
-            ;;   - accumulate everything in the stdout-buf.
-            ;; - The s7check static checker emits diagnostics on stdout;
-            ;;   - accumulate diagnostics in stdout-buffer and errors in a
-            ;;     separate stderr-buffer.
-            (setq exit-code (seed7--run program args stdout-buf
-                                        (unless compile stderr-buf)
-                                        (format "(from `%s' = %S)"
-                                                (if compile "seed7-compiler"
-                                                  "seed7-checker")
-                                                cmd-string)))
-            (if compile
-                ;; when compiling all output is in stdout-buffer
-                (setq stderr-text "")
-              ;; when analyzing the stdout holds only diagnostics and stderr
-              ;; holds the error stream; stores it in stderr-text
-              (with-current-buffer stderr-buf
-                (setq stderr-text (buffer-string))))
-            ;; - extract diagnostics from stdout
-            (setq diagnostics (seed7--parse-diagnostics compile stdout-buf))
-            ;; - return exit code, diagnostics and stderr text
-            (list exit-code diagnostics stderr-text))
-        ;; Cleanup: always kill scratch buffers.
-        (when (buffer-live-p stderr-buf)
-          (kill-buffer stderr-buf))
-        (when (buffer-live-p stdout-buf)
-          (kill-buffer stdout-buf)))
-      ;; - return exit code, diagnostics and stderr text
-      (list exit-code diagnostics stderr-text))))
+    ;; Run compiler or checker and return results
+    (seed7--run-and-parse program
+                          (append (seed7--expand-args (cdr cmd-parts))
+                                  (list (expand-file-name file-name)))
+                          cmd-string compile file-name)))
 
 (defun seed7-check-or-compile (&optional compile)
   "Check or compile the current Seed7 buffer's file and show diagnostics.


### PR DESCRIPTION
* Add seed7--run that executes the command in a process and deals with error conditions.
* Add seed7--parse-diagnostics that parses the output of s7c and s7check and extracts each diagnostic.  This allows testing this parsing from examples.

These two new functions are now used by the code that perform compilation or static checking of the Seed7 code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities for pluralized UI text, safer execution/capture of the Seed7 tool, argument expansion, and combined run+parse reporting.

* **Refactor**
  * Reworked the compile/diagnostics pipeline to return unified exit/diagnostics/stderr results and produce source-ordered diagnostics.

* **Bug Fixes**
  * Reliably capture and surface stderr, fix diagnostics counting and mode-line error display, and ensure temporary/scratch cleanup.

* **Documentation**
  * Clarified which tool emits diagnostics to stdout vs stderr.

* **Chores**
  * Updated package version timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->