### PR TITLE
Document the seed7-run-program command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -993,7 +993,7 @@ Running Seed7 Program inside Emacs
 
                                            - Prompt you for the program's command line arguments.
                                              Type them followed by ``RET``.
-                                           - If the current Seed7 buffer is not saved prompts for saving
+                                           - If the current Seed7 buffer is not saved, it prompts for saving
                                              the latest changes to the file.
                                            - Perform static analysis of the content of the file. Display
                                              all errors found inside a ``*seed7-errors*`` buffer which
@@ -1006,11 +1006,19 @@ Running Seed7 Program inside Emacs
 
                                              - The interactive window showing the
                                                ``*seed7-run: <BASENAME>*`` buffer and operating in the
-                                               ``seed7-run-mode``..
+                                               ``seed7-run-mode``.
 
                                                - This shows the program's stdout stream.
                                                - Takes input when you type the ``RET`` key.
                                                - Stop the program by typing ``C-c C-c``.
+
+                                             - A special mode window  showing the
+                                               ``*seed7-run-stderr <BASENAME>*`` buffer that displays
+                                               what the program prints to the stderr stream.
+
+                                           The ``<BASENAME>`` part of the buffer name corresponds to the
+                                           basename of the Seed7 file.  You may run several See7
+                                           programs simultaneously, the window name identifies each one.
 = ============================ =========== =============================================================
 
 .. ---------------------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -1012,6 +1012,7 @@ Running Seed7 Program inside Emacs
                                                - Takes input when you type the ``RET`` key.
                                                - Stop the program by typing ``C-c C-c``.
 = ============================ =========== =============================================================
+
 .. ---------------------------------------------------------------------------
 
 Compatibility

--- a/README.rst
+++ b/README.rst
@@ -979,12 +979,48 @@ Comment Management Commands
                                              customizable user-options.
 = ============================ =========== =============================================================
 
+Running Seed7 Program inside Emacs
+----------------------------------
+
+= ============================ =========== =============================================================
+. Function                     Key Binding Description
+= ============================ =========== =============================================================
+. seed7-run-program            ``C-c C-r`` Run the Seed7 program visited in the current buffer.
+
+                                           Execute this command in a ``seed7-mode`` buffer to run the
+                                           Seed7 program via the Seed7 interpreter.
+                                           This does the following:
+
+                                           - Prompt you for the program's command line arguments.
+                                             Type them followed by ``RET``.
+                                           - If the current Seed7 buffer is not saved prompts for saving
+                                             the latest changes to the file.
+                                           - Perform static analysis of the content of the file. Display
+                                             all errors found inside a ``*seed7-errors*`` buffer which
+                                             allows you to jump to the location of each error.
+                                           - If no error is found then it runs the program with the
+                                             Seed7 interpreter using the command line identified by the
+                                             **seed7-interpreter** customizable user-option which defaults
+                                             to "s7".
+                                           - Open 2 windows:
+
+                                             - The interactive window showing the
+                                               ``*seed7-run: <BASENAME>*`` buffer and operating in the
+                                               ``seed7-run-mode``..
+
+                                               - This shows the program's stdout stream.
+                                               - Takes input when you type the ``RET`` key.
+                                               - Stop the program by typing ``C-c C-c``.
+= ============================ =========== =============================================================
+.. ---------------------------------------------------------------------------
+
 Compatibility
 =============
 
 The seed7-mode is compatible with:
 
-- Emacs 25.1 and later.
+- Emacs 25.1 and later on any platform supported by Seed7 (including Linux,
+  macOS and Windows).
 - Emacs `comment-dwim`_ command.  The recommended key binding for it is ``M-;``
 - Emacs `which-function-mode`_, when active shows the name of the current Seed7 function or procedure in the
   mode line. It also works with Seed7 actions and forward declarations.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260605.0843
+;; Package-Version: 20260605.0938
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -442,7 +442,6 @@
 ;;   - Seed7 Run – process filters and sentinel
 ;;   * `seed7-run-program'
 ;;     . `seed7--run-program-filter'
-;;     . `seed7--run-stderr-filter'
 ;;     . `seed7--run-sentinel'
 ;;   - Seed7 Run – interactive input commands
 ;;     . `seed7-run-send-input'
@@ -516,7 +515,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-05T12:43:02+0000 W23-5"
+(defconst seed7-mode-version-timestamp "2026-06-05T13:38:02+0000 W23-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6754,7 +6753,6 @@ or nil when no diagnostics are found."
 ;;
 ;;  * `seed7-run-program'
 ;;    - `seed7--run-program-filter'
-;;    - `seed7--run-stderr-filter'
 ;;    - `seed7--run-sentinel'
 ;;    - `seed7-run-send-input'
 ;;    - `seed7-run-interrupt'

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260604.1031
+;; Package-Version: 20260605.0843
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -438,6 +438,17 @@
 ;;       . `seed7--expand-args'
 ;;       . `seed7--run-and-parse'
 ;;         . `seed7--parse-diagnostics'
+;; - Seed7 Run Program
+;;   - Seed7 Run – process filters and sentinel
+;;   * `seed7-run-program'
+;;     . `seed7--run-program-filter'
+;;     . `seed7--run-stderr-filter'
+;;     . `seed7--run-sentinel'
+;;   - Seed7 Run – interactive input commands
+;;     . `seed7-run-send-input'
+;;     . `seed7-run-interrupt'
+;;   - Seed7 Run – run-buffer major mode
+;;     * `seed7-run-mode'
 ;; - Seed7 Cross Reference
 ;;    > `seed7--xref-backend'
 ;;    + `xref-backend-identifier-at-point'
@@ -505,7 +516,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-04T14:31:23+0000 W23-4"
+(defconst seed7-mode-version-timestamp "2026-06-05T12:43:02+0000 W23-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed guide for running Seed7 programs directly in Emacs with features including command-line arguments, automatic buffer saving, static analysis, and process management.
  * Expanded compatibility documentation to include Emacs 25.1+ support across all platforms and integration with related packages.

* **Chores**
  * Updated version metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->