### PR TITLE
Fix excessive indentation of sibling catch statement

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -123,7 +123,7 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
 
 ** Bug Fixes
 
-- Fix *excessive indentation of sibling catch statements*.  Issue reported by /barankegnu/
+- Fix *excessive indentation of sibling catch and error statements*.  Issue reported by /barankegnu/
   in [[https://github.com/pierre-rouleau/seed7-mode/issues/79][bug-79]].
 
 - Fix *seed7-line-inside-parens-pair*: was using the wrong variable for

--- a/NEWS
+++ b/NEWS
@@ -123,6 +123,9 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
 
 ** Bug Fixes
 
+- Fix *excessive indentation of sibling catch statements*.  Issue reported by /barankegnu/
+  in [[https://github.com/pierre-rouleau/seed7-mode/issues/79][bug-79]].
+
 - Fix *seed7-line-inside-parens-pair*: was using the wrong variable for
   the line-beginning position.
 

--- a/reports/bug-79.sd7
+++ b/reports/bug-79.sd7
@@ -1,0 +1,70 @@
+# SEED7 FILE: bug-79.sd7
+#
+# Purpose   : The catch block.
+# Created   : Friday, June 12 2026.
+# ----------------------------------------------------------------------------
+# Module Description
+# ------------------
+#
+# Reported by barankegnu
+#
+# Also, when you press "tab" in a line with "catch", the auto-completion with
+# spaces is incorrect, because it looks like this (it's a part of my source
+# code):
+
+# block
+#   configFile := open(configPath, "r");
+# exception
+#   catch MEMORY_ERROR:
+#     write("\n\tREAD_DATA_FROM_FILE->OPEN->MEMORY_ERROR\n\n");
+#     exit(PROGRAM);
+#     catch RANGE_ERROR:
+#       write("\n\tREAD_DATA_FROM_FILE->OPEN->RANGE_ERROR\n\n");
+#       exit(PROGRAM);
+#   end block;
+#
+#
+
+# Correct variant is:
+#
+# block
+#   configFile := open(configPath, "r");
+# exception
+#   catch MEMORY_ERROR:
+#     write("\n\tREAD_DATA_FROM_FILE->OPEN->MEMORY_ERROR\n\n");
+#     exit(PROGRAM);
+#   catch RANGE_ERROR:
+#     write("\n\tREAD_DATA_FROM_FILE->OPEN->RANGE_ERROR\n\n");
+#     exit(PROGRAM);
+# end block;
+
+# ----------------------------------------------------------------------------
+# Code
+# ----
+#
+#
+block
+  configFile := open(configPath, "r");
+exception
+  catch MEMORY_ERROR:
+    write("\n\tREAD_DATA_FROM_FILE->OPEN->MEMORY_ERROR\n\n");
+    exit(PROGRAM);
+    catch RANGE_ERROR:
+      write("\n\tREAD_DATA_FROM_FILE->OPEN->RANGE_ERROR\n\n");
+      exit(PROGRAM);
+  end block;
+
+# Correct variant is:
+
+block
+  configFile := open(configPath, "r");
+exception
+  catch MEMORY_ERROR:
+    write("\n\tREAD_DATA_FROM_FILE->OPEN->MEMORY_ERROR\n\n");
+    exit(PROGRAM);
+  catch RANGE_ERROR:
+    write("\n\tREAD_DATA_FROM_FILE->OPEN->RANGE_ERROR\n\n");
+    exit(PROGRAM);
+end block;
+
+# ----------------------------------------------------------------------------

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260612.1544
+;; Package-Version: 20260612.1603
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -543,7 +543,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-12T19:44:34+0000 W24-5"
+(defconst seed7-mode-version-timestamp "2026-06-12T20:03:32+0000 W24-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -4955,12 +4955,18 @@ Move point."
         seed7-indent-width
       ;; Other lines are indented by 2 levels
       (* 2 seed7-indent-width)))
+
    ((string= header "catch ")
-    (if (string-prefix-p "end block" first-text)
-        ;; end block lines up with block, 1 indentation level less than catch
-        (- seed7-indent-width)
+    (cond
+     ((string-prefix-p "end block" first-text)
+      ;; end block lines up with block, 1 indentation level less than catch
+      (- seed7-indent-width))
+     ((string-match-p "\\`catch[[:blank:]]" first-text)
+      ;; A sibling catch clause lines up with the previous catch (offset 0)
+      0)
+     (t
       ;; Other lines are indented by 1 level relative to catch
-      seed7-indent-width))
+      seed7-indent-width)))
 
    ;;-- repeat - until
    ((string= header "repeat")

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260612.1603
+;; Package-Version: 20260612.1631
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -543,7 +543,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-12T20:03:32+0000 W24-5"
+(defconst seed7-mode-version-timestamp "2026-06-12T20:31:07+0000 W24-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -4950,7 +4950,8 @@ Move point."
       ;; Other lines are indented
       seed7-indent-width))
    ((string= header "exception")
-    (if (string-match-p "\\`catch[[:blank:]]" first-text)
+    (if (or (string-match-p "\\`catch[[:blank:]]" first-text)
+            (string-match-p "\\`error[[:blank:]]" first-text))
         ;; catch is indented one level from exception
         seed7-indent-width
       ;; Other lines are indented by 2 levels
@@ -4961,8 +4962,10 @@ Move point."
      ((string-prefix-p "end block" first-text)
       ;; end block lines up with block, 1 indentation level less than catch
       (- seed7-indent-width))
+     ;; A sibling catch or error clause lines up with the previous one (offset 0)
      ((string-match-p "\\`catch[[:blank:]]" first-text)
-      ;; A sibling catch clause lines up with the previous catch (offset 0)
+      0)
+     ((string-match-p "\\`error[[:blank:]]" first-text)
       0)
      (t
       ;; Other lines are indented by 1 level relative to catch


### PR DESCRIPTION
As reported by Issue #79

* The `seed7--indent-offset-for` logic did not take the possibility of multiple catch siblings.  Now it does.  This prevents the extra indentation level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed excessive indentation of sibling catch statements in exception handling blocks. When multiple catch clauses were added to an exception handler, they were being incorrectly nested under the first catch instead of remaining at the same indentation level as their counterparts.

* **Chores**
  * Updated package version timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->