### PR TITLE
Add limit on execution time

### DIFF
--- a/.github/workflows/build-apt-brew.yml
+++ b/.github/workflows/build-apt-brew.yml
@@ -53,7 +53,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    strategy:
+    timeout-minutes: 10
+   strategy:
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,6 +51,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container:
       image: silex/emacs:${{ matrix.emacs_version }}
     strategy:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,7 +3,7 @@
 # Purpose   : build for Windows.
 # Created   : Thursday, May 28 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-28 12:40:38 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-06-17 11:46:43 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -50,6 +50,7 @@ on:
 jobs:
   build-windows:
     runs-on: windows-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +65,7 @@ jobs:
 
       - name: Setup Emacs ${{ matrix.emacs_version }}
         uses: jcs090218/setup-emacs@master
+        timeout-minutes: 8
         with:
           version: ${{ matrix.emacs_version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@
 # Purpose   : Automated build control.
 # Created   : Wednesday, May 27 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-05-28 14:05:21 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-06-17 11:45:30 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -60,6 +60,7 @@ jobs:
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         include:
@@ -100,6 +101,7 @@ jobs:
 
       - name: Setup Emacs
         uses: purcell/setup-emacs@master
+        timeout-minutes: 8
         with:
           version: ${{ matrix.emacs_version }}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented execution timeout limits across all continuous integration build workflows to enhance build reliability and consistency. Updated build configurations for Apt/Brew, Docker, Windows, and standard build environments with timeout constraints to ensure builds complete reliably within expected timeframes, prevent indefinite process hangs, and improve overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->