### PR TITLE
Investigating the much longer startup time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ ALL_TEST_FILES := tests/ert-tests/seed7-test-arrays-01.el \
                   tests/ert-tests/seed7-test-mark-defun-01.el \
                   tests/ert-tests/seed7-test-nav-array-01.el \
                   tests/ert-tests/seed7-test-nav-final-pos-01.el \
-                  tests/ert-tests/seed7-test-nav-nested-01.el
+                  tests/ert-tests/seed7-test-nav-nested-01.el \
+                  tests/ert-tests/seed7-test-syntax-propertize-01.el
 
 ALL_TEST_PASSED := $(ALL_TEST_FILES:.el=.el.test-passed)
 
@@ -265,12 +266,12 @@ endif
 # ----------------------
 
 
-tests/ert-tests/seed7-test-arrays-01.el.test-passed:        seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-arrays-01.elc
-tests/ert-tests/seed7-test-mark-defun-01.el.test-passed:    seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-mark-defun-01.el
-tests/ert-tests/seed7-test-nav-array-01.el.test-passed:     seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-array-01.elc
-tests/ert-tests/seed7-test-nav-final-pos-01.el.test-passed: seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-final-pos-01.elc
-tests/ert-tests/seed7-test-nav-nested-01.el.test-passed:    seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-nested-01.elc
-
+tests/ert-tests/seed7-test-arrays-01.el.test-passed:             seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-arrays-01.elc
+tests/ert-tests/seed7-test-mark-defun-01.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-mark-defun-01.el
+tests/ert-tests/seed7-test-nav-array-01.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-array-01.elc
+tests/ert-tests/seed7-test-nav-final-pos-01.el.test-passed:      seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-final-pos-01.elc
+tests/ert-tests/seed7-test-nav-nested-01.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-nested-01.elc
+tests/ert-tests/seed7-test-syntax-propertize-01.el.test-passed:  seed7-mode.elc tests/ert-tests/pel-ert.elc  tests/ert-tests/seed7-test-syntax-propertize-01.el
 #tests/ert-tests/seed7-test-sets-01.el.test-passed:          seed7-mode.elc tests/ert-tests/seed7-test-sets-01.elc
 
 # ----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ ELC_FILES := $(subst .el,.elc,$(EL_FILES))
 ALL_TEST_FILES := tests/ert-tests/seed7-test-arrays-01.el \
                   tests/ert-tests/seed7-test-mark-defun-01.el \
                   tests/ert-tests/seed7-test-nav-array-01.el \
+                  tests/ert-tests/seed7-test-nav-final-pos-01.el \
                   tests/ert-tests/seed7-test-nav-nested-01.el
 
 ALL_TEST_PASSED := $(ALL_TEST_FILES:.el=.el.test-passed)
@@ -267,6 +268,7 @@ endif
 tests/ert-tests/seed7-test-arrays-01.el.test-passed:        seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-arrays-01.elc
 tests/ert-tests/seed7-test-mark-defun-01.el.test-passed:    seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-mark-defun-01.el
 tests/ert-tests/seed7-test-nav-array-01.el.test-passed:     seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-array-01.elc
+tests/ert-tests/seed7-test-nav-final-pos-01.el.test-passed: seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-final-pos-01.elc
 tests/ert-tests/seed7-test-nav-nested-01.el.test-passed:    seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-nested-01.elc
 
 #tests/ert-tests/seed7-test-sets-01.el.test-passed:          seed7-mode.elc tests/ert-tests/seed7-test-sets-01.elc

--- a/NEWS
+++ b/NEWS
@@ -193,6 +193,11 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
 - Prevent possible out-of-bounds buffer positions (*1+*, *1-*) inside
   *seed7-calc-indent* when operating at buffer edges.
 
+- Fix massive rendering slowdown regression introduced with the first version
+  of the code that supported imenu/Speedbar reporting of the nested function
+  lineage display.  The new implementation is much faster and display of
+  nested function lineage no longer impacts performance.
+
 ** Build / CI
 
 - GitHub Actions workflows added for multi-platform byte and native

--- a/README.rst
+++ b/README.rst
@@ -1365,9 +1365,11 @@ it will download the new version of the files and byte-compile ``seed7-mode.el``
 Future
 ======
 
-This package is stable enough to be useful but is not perfect yet.
-It is not yet available under MELPA; I did not get enough feedback
-for potential areas to improve.
+This package is stable enough to be useful and is still evolving
+with performance improvements and new features.
+I am planing more cleanup and broader test coverage before proposing it
+to MELPA.
+
 However, you can easily install it as described above.
 
 Any help, questions, suggestions are welcome!

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260619.0752
+;; Package-Version: 20260619.0841
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -534,7 +534,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-19T11:52:25+0000 W25-5"
+(defconst seed7-mode-version-timestamp "2026-06-19T12:41:52+0000 W25-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3614,6 +3614,7 @@ Move inside the current if inside one, to the next if outside one.
   (let* ((n (prefix-numeric-value n))
          (original-pos (point))  (found-candidate nil)
          (final-pos nil)         (found-pos nil)
+         (long-body-final-pos nil)
          (item-name nil)         (item-name2 nil)
          (item-type nil)         (item-type2 nil)
          (tail-type nil)         (tail-type2 nil)
@@ -3625,7 +3626,8 @@ Move inside the current if inside one, to the next if outside one.
           (dotimes (_ n)
             (setq found-candidate nil
                   final-pos nil
-                  found-pos nil)
+                  found-pos nil
+                  long-body-final-pos nil)
             ;; Search for all possible function/procedure end.
             ;; - Retain the one that is closest to point.
 
@@ -3683,6 +3685,7 @@ Move inside the current if inside one, to the next if outside one.
                           item-name (substring-no-properties (match-string seed7-procfunc-regexp-item-name-group))
                           tail-type (substring-no-properties (match-string seed7-procfunc-regexp-tail-type-group))
                           top-block-name top-block-name2
+                          long-body-final-pos matched-end-pos
                           final-pos matched-end-pos
                           found-candidate t)))))
             ;; -- Search for next short function. ----------------------------
@@ -3698,15 +3701,13 @@ Move inside the current if inside one, to the next if outside one.
                             item-name2 (substring-no-properties (match-string seed7-procfunc-regexp-item-name-group))
                             tail-type2 (substring-no-properties (match-string seed7-procfunc-regexp-tail-type-group)))
                       t)
-                   ;; Reject this candidate only when it is nested inside the
-                   ;; outer long-body callable already captured (final-pos is
-                   ;; set and short-func-decl-pos falls strictly between
-                   ;; original-pos and final-pos).  When no outer end has been
-                   ;; found yet (final-pos is nil), the short function is a
-                   ;; top-level sibling/successor and must be accepted.
-                   (not (and final-pos
-                             short-func-decl-pos
-                             (< original-pos short-func-decl-pos final-pos)))
+                    ;; Reject this candidate only when it is nested inside the
+                    ;; outer long-body callable already captured
+                    ;; When no outer end has been found yet (long-body-final-pos is nil),
+                    ;; the short function is a top-level sibling/successor and must be accepted.
+                    (not (and long-body-final-pos
+                              short-func-decl-pos
+                              (< original-pos short-func-decl-pos long-body-final-pos)))
                     (seed7-re-search-forward seed7-short-func-end-regexp)
                     (eq (point) found-pos)
                     (or (not final-pos)
@@ -3732,9 +3733,9 @@ Move inside the current if inside one, to the next if outside one.
                              tail-type2 (substring-no-properties (match-string seed7-procfunc-regexp-tail-type-group)))
                        t)
                      ;; Reject if nested inside the outer long-body callable already found
-                     (not (and final-pos
+                     (not (and long-body-final-pos
                                fwd-decl-pos
-                               (< original-pos fwd-decl-pos final-pos)))
+                               (< original-pos fwd-decl-pos long-body-final-pos)))
                      (seed7-re-search-forward seed7-forward-declaration-end-regexp)
                      (eq (point) found-pos)
                      (or (not final-pos)
@@ -3760,9 +3761,9 @@ Move inside the current if inside one, to the next if outside one.
                              tail-type2 (substring-no-properties (match-string seed7-procfunc-regexp-tail-type-group)))
                        t)
                      ;; Reject if nested inside the outer long-body callable already found
-                     (not (and final-pos
+                     (not (and long-body-final-pos
                                action-decl-pos
-                               (< original-pos action-decl-pos final-pos)))
+                               (< original-pos action-decl-pos long-body-final-pos)))
                      (seed7-re-search-forward seed7-procfunc-forward-or-action-declaration-re)
                      (eq (point) found-pos)
                      (or (not final-pos)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260619.0841
+;; Package-Version: 20260619.0939
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -534,7 +534,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-19T12:41:52+0000 W25-5"
+(defconst seed7-mode-version-timestamp "2026-06-19T13:39:12+0000 W25-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -4744,44 +4744,58 @@ Results are in document order."
 Non-callable entries (Enum, Interface, Struct) are listed under their own
 category sub-menu using their simple names.
 
-Callable entries (proc/func) use fully-qualified names built by
-`seed7--qualified-name-at-pos', so nested callables appear as
-\"parent:child:grand_child\" instead of just \"grand_child\".  This drives
-both imenu and Speedbar.  The flag
-`seed7--menu-list-functions-and-procedures-together' controls whether
-procedures and functions share a single \"Callable\" sub-menu or are split
-into separate \"Procedure\" / \"Function\" sub-menus."
+Callable entries (proc/func) use fully-qualified names so nested callables
+appear as \"parent:child:grand_child\".  The nesting stack is maintained by
+a single O(n) forward pass: only long-body callables (tail-type \"func\")
+push a frame; `end func;' pops one frame.  Short-body callables
+\(tail-type \"return\"), forward declarations, and action declarations are
+added to the index as leaves without pushing to the stack.
+
+The flag `seed7--menu-list-functions-and-procedures-together' controls
+whether procedures and functions share a single \"Callable\" sub-menu or are
+split into separate \"Procedure\" / \"Function\" sub-menus."
   (let ((procs      '())
         (funcs      '())
+        ;; Nesting stack: each element is (name . decl-pos).
+        ;; Only long-body callables (tail-type "func") are pushed here;
+        ;; short-body, forward, and action declarations are NOT pushed.
+        (stack      '())
         (enums      (seed7--imenu-index-for-regexp seed7-enum-regexp-4imenu      1))
         (interfaces (seed7--imenu-index-for-regexp seed7-interface-regexp-4imenu 1))
         (structs    (seed7--imenu-index-for-regexp seed7-struct-regexp-4imenu    1)))
-    ;; Single pass over the buffer: collect all callable declarations.
     (save-excursion
       (goto-char (point-min))
-      (while (seed7-re-search-forward seed7-procfunc-regexp)
-        (let* ((decl-pos (match-beginning 0))
-               (bare-name (match-string-no-properties
-                           seed7-procfunc-regexp-item-name-group))
-               (item-type (match-string-no-properties
-                           seed7-procfunc-regexp-item-type-group))
-               (is-proc   (string= item-type "proc"))
-               ;; Get the fully-qualified name (handles nesting).
-               (qname    (save-excursion
-                           (goto-char decl-pos)
-                           (seed7--qualified-name-at-pos)))
-               (menu-name
-                (cond
-                 ((not qname) bare-name)
-                 ((or (string= qname bare-name)
-                      (string-suffix-p (concat ":" bare-name) qname))
-                  qname)
-                 (t
-                  (concat qname ":" bare-name)))))
-          (if is-proc
-              (push (cons menu-name decl-pos) procs)
-            (push (cons menu-name decl-pos) funcs)))))
-    ;; Restore document order (we pushed, so lists are reversed).
+      ;; Combine both patterns in one search.  When `end func;' matches,
+      ;; the callable name group (G3) is nil — use that to dispatch.
+      (while (seed7-re-search-forward
+              (concat seed7-procfunc-regexp "\\|" seed7-procfunc-end-regexp))
+        (if (not (match-string seed7-procfunc-regexp-item-name-group))
+            ;; `end func;' matched — pop one level.
+            ;; Both proc and func long bodies close with `end func;'.
+            (when stack (pop stack))
+          ;; Callable declaration matched.
+          (let* ((name      (match-string-no-properties
+                             seed7-procfunc-regexp-item-name-group))
+                 (item-type (match-string-no-properties
+                             seed7-procfunc-regexp-item-type-group))
+                 (tail-type (match-string-no-properties
+                             seed7-procfunc-regexp-tail-type-group))
+                 (is-proc      (string= item-type "proc"))
+                 ;; Only "func" tail introduces a long body closed by `end func;'.
+                 ;; "return", "forward;", "action ...", "DYNAMIC;" are all leaves.
+                 (is-long-body (string= tail-type "func"))
+                 (decl-pos  (match-beginning 0))
+                 ;; Build qualified name from the current nesting stack.
+                 (qname     (if stack
+                                (concat (mapconcat #'car (reverse stack) ":") ":" name)
+                              name)))
+            ;; Only long-body callables open a new nesting level.
+            (when is-long-body
+              (push (cons name decl-pos) stack))
+            (if is-proc
+                (push (cons qname decl-pos) procs)
+              (push (cons qname decl-pos) funcs))))))
+    ;; Restore document order (push reverses the lists).
     (setq procs (nreverse procs)
           funcs (nreverse funcs))
     ;; Assemble the final index alist.
@@ -4790,7 +4804,7 @@ into separate \"Procedure\" / \"Function\" sub-menus."
       (when interfaces (push (cons "Interface" interfaces) index))
       (when enums      (push (cons "Enum"      enums)      index))
       (if seed7--menu-list-functions-and-procedures-together
-          ;; Merge procs + funcs into one list, sorted by document position.
+          ;; Merge procs + funcs into one list sorted by document position.
           (let ((callables (sort (append procs funcs)
                                  (lambda (a b) (< (cdr a) (cdr b))))))
             (when callables

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260618.2340
+;; Package-Version: 20260619.0752
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -534,7 +534,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-19T03:40:10+0000 W25-5"
+(defconst seed7-mode-version-timestamp "2026-06-19T11:52:25+0000 W25-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -784,8 +784,6 @@ Inside a non-capturing group.")
 
 ;; --
 ;; Note: Ensure that something like 0_ is not matched by seed7-name-identifier-nc-re
-
-
 (defconst seed7-name-identifier-fmt "\\(%s[[:alpha:]][[:alnum:]_]*\\|_[[:alnum:]_]+\\)"
   ;; Note: the regexp has 2 branches but the first character on each differs:
   ;; this means that the regexp engine does not need to backtrack.
@@ -3708,8 +3706,7 @@ Move inside the current if inside one, to the next if outside one.
                    ;; top-level sibling/successor and must be accepted.
                    (not (and final-pos
                              short-func-decl-pos
-                             (> short-func-decl-pos original-pos)
-                             (< short-func-decl-pos final-pos)))
+                             (< original-pos short-func-decl-pos final-pos)))
                     (seed7-re-search-forward seed7-short-func-end-regexp)
                     (eq (point) found-pos)
                     (or (not final-pos)
@@ -3722,48 +3719,60 @@ Move inside the current if inside one, to the next if outside one.
                        top-block-name top-block-name2))))
             ;; -- Search for next forward declaration. -----------------------
             (save-excursion
-              (when
-                  (and
-                   (setq found-pos
-                         (seed7-re-search-forward seed7-forward-declaration-end-regexp)
-                         top-block-name2 (seed7-top-block-name))
-                   (when (seed7-re-search-backward seed7-procfunc-regexp)
-                     (setq item-type2 (substring-no-properties (match-string seed7-procfunc-regexp-item-type-group))
-                           item-name2 (substring-no-properties (match-string seed7-procfunc-regexp-item-name-group))
-                           tail-type2 (substring-no-properties (match-string seed7-procfunc-regexp-tail-type-group)))
-                     t)
-                   (seed7-re-search-forward seed7-forward-declaration-end-regexp)
-                   (eq (point) found-pos)
-                   (or (not final-pos)
-                       (< found-pos final-pos)))
-                (setq final-pos found-pos
-                      found-candidate t
-                      item-name item-name2
-                      item-type item-type2
-                      tail-type tail-type2
-                      top-block-name top-block-name2)))
+              (let (fwd-decl-pos)
+                (when
+                    (and
+                     (setq found-pos
+                           (seed7-re-search-forward seed7-forward-declaration-end-regexp)
+                           top-block-name2 (seed7-top-block-name))
+                     (when (seed7-re-search-backward seed7-procfunc-regexp)
+                       (setq fwd-decl-pos (point)
+                             item-type2 (substring-no-properties (match-string seed7-procfunc-regexp-item-type-group))
+                             item-name2 (substring-no-properties (match-string seed7-procfunc-regexp-item-name-group))
+                             tail-type2 (substring-no-properties (match-string seed7-procfunc-regexp-tail-type-group)))
+                       t)
+                     ;; Reject if nested inside the outer long-body callable already found
+                     (not (and final-pos
+                               fwd-decl-pos
+                               (< original-pos fwd-decl-pos final-pos)))
+                     (seed7-re-search-forward seed7-forward-declaration-end-regexp)
+                     (eq (point) found-pos)
+                     (or (not final-pos)
+                         (< found-pos final-pos)))
+                  (setq final-pos found-pos
+                        found-candidate t
+                        item-name item-name2
+                        item-type item-type2
+                        tail-type tail-type2
+                        top-block-name top-block-name2))))
             ;; -- Search for next function implementation declaration. -------
             (save-excursion
-              (when
-                  (and
-                   (setq found-pos
-                         (seed7-re-search-forward seed7-procfunc-forward-or-action-declaration-re)
-                         top-block-name2 (seed7-top-block-name))
-                   (when (seed7-re-search-backward seed7-procfunc-regexp)
-                     (setq item-type2 (substring-no-properties (match-string seed7-procfunc-regexp-item-type-group))
-                           item-name2 (substring-no-properties (match-string seed7-procfunc-regexp-item-name-group))
-                           tail-type2 (substring-no-properties (match-string seed7-procfunc-regexp-tail-type-group)))
-                     t)
-                   (seed7-re-search-forward seed7-procfunc-forward-or-action-declaration-re)
-                   (eq (point) found-pos)
-                   (or (not final-pos)
-                       (< found-pos final-pos)))
-                (setq final-pos found-pos
-                      found-candidate t
-                      item-name item-name2
-                      item-type item-type2
-                      tail-type tail-type2
-                      top-block-name top-block-name2)))
+              (let (action-decl-pos)
+                (when
+                    (and
+                     (setq found-pos
+                           (seed7-re-search-forward seed7-procfunc-forward-or-action-declaration-re)
+                           top-block-name2 (seed7-top-block-name))
+                     (when (seed7-re-search-backward seed7-procfunc-regexp)
+                       (setq action-decl-pos (point)
+                             item-type2 (substring-no-properties (match-string seed7-procfunc-regexp-item-type-group))
+                             item-name2 (substring-no-properties (match-string seed7-procfunc-regexp-item-name-group))
+                             tail-type2 (substring-no-properties (match-string seed7-procfunc-regexp-tail-type-group)))
+                       t)
+                     ;; Reject if nested inside the outer long-body callable already found
+                     (not (and final-pos
+                               action-decl-pos
+                               (< original-pos action-decl-pos final-pos)))
+                     (seed7-re-search-forward seed7-procfunc-forward-or-action-declaration-re)
+                     (eq (point) found-pos)
+                     (or (not final-pos)
+                         (< found-pos final-pos)))
+                  (setq final-pos found-pos
+                        found-candidate t
+                        item-name item-name2
+                        item-type item-type2
+                        tail-type tail-type2
+                        top-block-name top-block-name2))))
             ;; --
             (if found-candidate
                 ;; move to the end of first function to allow next search in loop

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260618.1057
+;; Package-Version: 20260618.1553
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -534,7 +534,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-18T14:57:26+0000 W25-4"
+(defconst seed7-mode-version-timestamp "2026-06-18T19:53:07+0000 W25-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2088,22 +2088,25 @@ Group 3: - \"func\" for proc or function that ends with \"end func\".
 ;;** Seed7 Mode Syntax Propertize Function
 ;;   -------------------------------------
 
-(defconst seed7-char-literal-re
+(defconst seed7-char-literal-re-no-comments
   (format
-   "\\(?:\\(?:[[:digit:]]\\(#\\)[[:alnum:]]\\)\\|\\(\\(?:'\\\\''\\)\\|\\(?:'.'\\)\\|\\(?:'\\\\[abefnrtv\"A-Z\\\\]'\\)\\|\\(?:%s\\)\\)\\)\\|\\((\\*\\)\\|\\(\\*)\\)"
-   ;; (----(----------------------------------)----(--------------------------------------------------------------------------------)--)-----(------)-----(------)
+   "\\(?:\\(?:[[:digit:]]\\(#\\)[[:alnum:]]\\)\\|\\(\\(?:'\\\\''\\)\\|\\(?:'.'\\)\\|\\(?:'\\\\[abefnrtv\"A-Z\\\\]'\\)\\|\\(?:%s\\)\\)\\)"
+   ;; (----(----------------------------------)----(--------------------------------------------------------------------------------)--)
    ;;                      (---)                   (-----------------------------------------------------------------------------------)
-   ;;                                                 (-----------)     (-------)     (-----------------------------)     (------)           (------)     (------)
-   ;;                      G1                      G2                                  backslash-character                   %s              G3           G4
+   ;;                                                 (-----------)     (-------)     (-----------------------------)     (------)
+   ;;                      G1                      G2                                  backslash-character                   %s
    ;; format argument number:                                                                                                 1
    ;;
    ;; G1: #
    ;; G2: single quote character expression
-   ;; G3: opening block comment: (*
-   ;; G4: closing block comment: *)
    ;; backslash characters: \a, \b... :standard named escape letters, including \e for the Escape character.
    ;; backslash characters: \A .. \Z  : standard Seed7 control characters: Ctrl-A .. Ctrl-Z
-   seed7-any-valid-char-integer-semicolon-re))
+   seed7-any-valid-char-integer-semicolon-re)
+  "Regexp for # and char literals only — no block-comment delimiters.")
+
+(defconst seed7-block-comment-delim-re "(\\*\\|\\*)"
+  "Regexp matching the two-character Seed7 block-comment delimiters.
+Matches either the opening `(*' or the closing `*)'.")
 
 ;; Emacs supports two-character comment delimiters via "style b"
 ;; syntax text properties. The characters of each delimiter are
@@ -2135,36 +2138,33 @@ Handle four cases:
   (with-silent-modifications
     (save-excursion
       (save-match-data
+        ;; Loop 1: handle # and char literals (fires only at [[:digit:]] and ')
         (goto-char start)
-        (while (re-search-forward seed7-char-literal-re end t)
+        (while (re-search-forward seed7-char-literal-re-no-comments end t)
           (cond
-           ;; deal with '#'
-           ((match-beginning 1)
+           ((match-beginning 1)         ; # number-base separator
             (put-text-property (match-beginning 1) (match-end 1)
                                'syntax-table (string-to-syntax "_")))
-
-           ;; Deal with single quoted character expression
-           ((match-beginning 2)
+           ((match-beginning 2)         ; single-quoted char literal
             (put-text-property (match-beginning 2) (1+ (match-beginning 2))
                                'syntax-table '(7 . ?'))
-            (put-text-property (1- (match-end 2))  (match-end 2)
-                               'syntax-table '(7 . ?')))
-
-           ;; Mark (* as a two-character comment-start (style b).
-           ;; Override the paren-open syntax on '(' for this occurrence.
-           ((match-beginning 3)
-            (put-text-property (match-beginning 3) (1+ (match-beginning 3))
-                               'syntax-table (string-to-syntax "< 1bn"))
-            (put-text-property (1+ (match-beginning 3)) (match-end 3)
-                               'syntax-table (string-to-syntax "< 2bn")))
-
-           ;; Mark *) as a two-character comment-end (style b).
-           ;; Override the paren-close syntax on ')' for this occurrence.
-           ((match-beginning 4)
-            (put-text-property (match-beginning 4) (1+ (match-beginning 4))
-                               'syntax-table (string-to-syntax "> 3bn"))
-            (put-text-property (1+ (match-beginning 4)) (match-end 4)
-                               'syntax-table (string-to-syntax "> 4bn")))))))))
+            (put-text-property (1- (match-end 2)) (match-end 2)
+                               'syntax-table '(7 . ?')))))
+        ;; Loop 2: handle (* and *) — use simple two-char search, no 35-branch alternation
+        (goto-char start)
+        (while (re-search-forward seed7-block-comment-delim-re end t)
+          (let ((beg (match-beginning 0)))
+            (if (eq (char-after beg) ?\()
+                (progn                  ; (* opener
+                  (put-text-property beg (1+ beg)
+                                     'syntax-table (string-to-syntax "< 1bn"))
+                  (put-text-property (1+ beg) (+ beg 2)
+                                     'syntax-table (string-to-syntax "< 2bn")))
+              (progn                    ; *) closer
+                (put-text-property beg (1+ beg)
+                                   'syntax-table (string-to-syntax "> 3bn"))
+                (put-text-property (1+ beg) (+ beg 2)
+                                   'syntax-table (string-to-syntax "> 4bn"))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;;* Seed7 Faces
@@ -2558,9 +2558,8 @@ Please update your code to use the new name before this deadline."
    ;; `*)' genuinely closes a `(* ... *)' block comment and not when
    ;; those two characters appear elsewhere (e.g. inside a string).
    (list "\\*)"
-         '(0 (when (save-excursion
-                     (goto-char (match-beginning 0))
-                     (nth 4 (syntax-ppss)))
+         '(0 (when (equal (get-text-property (match-beginning 0) 'syntax-table)
+                          (string-to-syntax "> 3bn"))
                font-lock-comment-face)
              t)))
   "Associates regexp to a regexp group and a face to render it.")

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260618.1553
+;; Package-Version: 20260618.1618
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -534,7 +534,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-18T19:53:07+0000 W25-4"
+(defconst seed7-mode-version-timestamp "2026-06-18T20:18:35+0000 W25-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2124,21 +2124,20 @@ Matches either the opening `(*' or the closing `*)'.")
 ;; Each syntax-entry code ends with 'n' because Seed7 (* *) style
 ;; comments can be nested.
 
-
 (defun seed7-mode-syntax-propertize (start end)
   "Apply syntax-table text properties between START and END.
 
-Handle four cases:
+Handle two cases:
 - the `#' number-base separator,
-- single-quoted character literals,
-- the `(*' and
-- the `*)' two-characters block-comment delimiters."
+- single-quoted character literals.
+
+The `(*' and `*)' block-comment delimiters are handled entirely by
+the style-a entries in `seed7-mode-syntax-table' (`\"()1n\"', `\". 23\"',
+`\")(4n\"') via Emacs's C-level scanner; no text properties are needed."
   ;; See:  (info "(elisp)Syntax Properties")
-  ;;
   (with-silent-modifications
     (save-excursion
       (save-match-data
-        ;; Loop 1: handle # and char literals (fires only at [[:digit:]] and ')
         (goto-char start)
         (while (re-search-forward seed7-char-literal-re-no-comments end t)
           (cond
@@ -2149,22 +2148,7 @@ Handle four cases:
             (put-text-property (match-beginning 2) (1+ (match-beginning 2))
                                'syntax-table '(7 . ?'))
             (put-text-property (1- (match-end 2)) (match-end 2)
-                               'syntax-table '(7 . ?')))))
-        ;; Loop 2: handle (* and *) — use simple two-char search, no 35-branch alternation
-        (goto-char start)
-        (while (re-search-forward seed7-block-comment-delim-re end t)
-          (let ((beg (match-beginning 0)))
-            (if (eq (char-after beg) ?\()
-                (progn                  ; (* opener
-                  (put-text-property beg (1+ beg)
-                                     'syntax-table (string-to-syntax "< 1bn"))
-                  (put-text-property (1+ beg) (+ beg 2)
-                                     'syntax-table (string-to-syntax "< 2bn")))
-              (progn                    ; *) closer
-                (put-text-property beg (1+ beg)
-                                   'syntax-table (string-to-syntax "> 3bn"))
-                (put-text-property (1+ beg) (+ beg 2)
-                                   'syntax-table (string-to-syntax "> 4bn"))))))))))
+                               'syntax-table '(7 . ?')))))))))
 
 ;; ---------------------------------------------------------------------------
 ;;* Seed7 Faces
@@ -2541,27 +2525,7 @@ Please update your code to use the new name before this deadline."
 
    ;; other low priority characters
    ;; [ TODO 2025-07-09, by Pierre Rouleau: check if any missing and improve control of ..]
-   (cons "[[:print:]]\\(\\(?:~\\)\\|\\(?:\\.\\.\\)\\)[[:print:]]"   (list 1 ''font-lock-keyword-face))
-
-   ;; Fontify the `*)' block-comment end delimiter entirely with
-   ;; `font-lock-comment-face'.
-   ;;
-   ;; Syntactic fontification applies `font-lock-comment-delimiter-face'
-   ;; to `*' (syntax property "> 3bn": first char of style-b comment-end)
-   ;; and leaves `)' ("> 4bn": second char) with no face, because
-   ;; `syntax-ppss' at the `)' position already reports "outside comment"
-   ;; — the comment was fully closed by the complete `*)' pair.
-   ;;
-   ;; This rule overrides both characters to `font-lock-comment-face',
-   ;; consistent with the interior of the block.  The
-   ;; `(nth 4 (syntax-ppss ...))' guard ensures the rule fires only when
-   ;; `*)' genuinely closes a `(* ... *)' block comment and not when
-   ;; those two characters appear elsewhere (e.g. inside a string).
-   (list "\\*)"
-         '(0 (when (equal (get-text-property (match-beginning 0) 'syntax-table)
-                          (string-to-syntax "> 3bn"))
-               font-lock-comment-face)
-             t)))
+   (cons "[[:print:]]\\(\\(?:~\\)\\|\\(?:\\.\\.\\)\\)[[:print:]]"   (list 1 ''font-lock-keyword-face)))
   "Associates regexp to a regexp group and a face to render it.")
 
 ;; ---------------------------------------------------------------------------

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260618.1618
+;; Package-Version: 20260618.2340
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -534,7 +534,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-18T20:18:35+0000 W25-4"
+(defconst seed7-mode-version-timestamp "2026-06-19T03:40:10+0000 W25-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -784,15 +784,19 @@ Inside a non-capturing group.")
 
 ;; --
 ;; Note: Ensure that something like 0_ is not matched by seed7-name-identifier-nc-re
-(defconst seed7-name-identifier-nc-re
-  "\\(?:[[:alpha:]_][[:alnum:]_]+\\)\\|\\(?:[[:alpha:]][[:alnum:]]*_*\\)"
+
+
+(defconst seed7-name-identifier-fmt "\\(%s[[:alpha:]][[:alnum:]_]*\\|_[[:alnum:]_]+\\)"
+  ;; Note: the regexp has 2 branches but the first character on each differs:
+  ;; this means that the regexp engine does not need to backtrack.
+  ;; Backtracking can be expensive, so it is avoided.
+  "A complete, valid name identifier.  Format string.")
+
+(defconst seed7-name-identifier-nc-re (format seed7-name-identifier-fmt "?:")
   "A complete, valid name identifier.  No capturing group.")
 
-(defconst seed7-name-identifier-re
-  (format "\\(%s\\)"
-          seed7-name-identifier-nc-re)
-  "A complete, valid name identifier.
-Group 1: identifier : 1 word")
+(defconst seed7-name-identifier-re (format seed7-name-identifier-fmt "")
+  "A complete, valid name identifier. Group 1: identifier : 1 word")
 
 ;; --
 (defconst seed7--open-paren-regexp
@@ -2127,17 +2131,17 @@ Matches either the opening `(*' or the closing `*)'.")
 (defun seed7-mode-syntax-propertize (start end)
   "Apply syntax-table text properties between START and END.
 
-Handle two cases:
+Handle four cases:
 - the `#' number-base separator,
-- single-quoted character literals.
-
-The `(*' and `*)' block-comment delimiters are handled entirely by
-the style-a entries in `seed7-mode-syntax-table' (`\"()1n\"', `\". 23\"',
-`\")(4n\"') via Emacs's C-level scanner; no text properties are needed."
+- single-quoted character literals,
+- the `(*' two-character block-comment opener,
+- the `*)' two-character block-comment closer."
   ;; See:  (info "(elisp)Syntax Properties")
   (with-silent-modifications
     (save-excursion
       (save-match-data
+        ;; Loop 1: `#' and single-quoted char literals.
+        ;; Fires only at [[:digit:]] and `'' — rare in a Seed7 file.
         (goto-char start)
         (while (re-search-forward seed7-char-literal-re-no-comments end t)
           (cond
@@ -2148,7 +2152,24 @@ the style-a entries in `seed7-mode-syntax-table' (`\"()1n\"', `\". 23\"',
             (put-text-property (match-beginning 2) (1+ (match-beginning 2))
                                'syntax-table '(7 . ?'))
             (put-text-property (1- (match-end 2)) (match-end 2)
-                               'syntax-table '(7 . ?')))))))))
+                               'syntax-table '(7 . ?')))))
+        ;; Loop 2: `(*' and `*)' block-comment delimiters.
+        ;; Uses the minimal two-alternative pattern — no 35-branch subpattern.
+        ;; These text properties also serve as jit-lock safe-point anchors,
+        ;; preventing backward scans across the whole file on each chunk.
+        (goto-char start)
+        (while (re-search-forward seed7-block-comment-delim-re end t)
+          (if (eq (char-after (match-beginning 0)) ?\()
+              (progn                    ; (* opener
+                (put-text-property (match-beginning 0) (1+ (match-beginning 0))
+                                   'syntax-table (string-to-syntax "< 1bn"))
+                (put-text-property (1+ (match-beginning 0)) (match-end 0)
+                                   'syntax-table (string-to-syntax "< 2bn")))
+            (progn                      ; *) closer
+              (put-text-property (match-beginning 0) (1+ (match-beginning 0))
+                                 'syntax-table (string-to-syntax "> 3bn"))
+              (put-text-property (1+ (match-beginning 0)) (match-end 0)
+                                 'syntax-table (string-to-syntax "> 4bn")))))))))
 
 ;; ---------------------------------------------------------------------------
 ;;* Seed7 Faces

--- a/tests/ert-tests/seed7-test-nav-final-pos-01.el
+++ b/tests/ert-tests/seed7-test-nav-final-pos-01.el
@@ -1,0 +1,251 @@
+;;; seed7-test-nav-final-pos-01.el --- ERT regression tests: long-body-final-pos separation  -*- lexical-binding: t; -*-
+
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+
+;; This file is part of the SEED7 package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Regression tests for the condition:
+;;
+;;   "Do not use mutable final-pos for nested rejection.  After the short-
+;;   function branch sets final-pos, the new forward/action guards can reject
+;;   a top-level forward/action declaration that appears before a later short
+;;   function.  Keep a separate long-body-final-pos and use that only for
+;;   nested-declaration rejection."
+;;
+;; In `seed7-end-of-defun', the 3rd (forward-declaration) and 4th
+;; (action-declaration) search paths contain a nested-candidate rejection
+;; guard of the form:
+;;
+;;   (not (and long-body-final-pos decl-pos
+;;             (< original-pos decl-pos long-body-final-pos)))
+;;
+;; The guard must use `long-body-final-pos' — the end position of the nearest
+;; long-body callable found by the first search path — NOT `final-pos', which
+;; may already be set to the end of a short function found by the second path.
+;;
+;; Failure mode (if `final-pos' were used instead of `long-body-final-pos'):
+;;
+;;   Suppose:
+;;     original-pos  = line 1  (blank, before everything)
+;;     action-decl   = line 2  (top-level, no enclosing long-body callable)
+;;     short-func end= line 5  (top-level, later in the file)
+;;
+;;   Execution order inside `seed7-end-of-defun':
+;;     1. Long-body scan: nothing found.  long-body-final-pos = nil.
+;;     2. Short-func path: final-pos ← 5.
+;;     3. Action-decl path: decl-pos = 2.
+;;        WRONG guard:   (< 1 2 5) = t  → rejected!  final-pos stays at 5.
+;;        CORRECT guard: (and nil ...)  = nil → (not nil) = t → accepted.
+;;                       (< 2 5) = t    → final-pos ← 2.
+;;
+;;   With the correct code the action declaration wins (it is nearer).
+;;   With the wrong code the short function wins — an incorrect result.
+;;
+;; The same failure mode applies to the forward-declaration path.
+;;
+;; Fixture line layout (1-based):
+;;
+;;   1   blank
+;;   2   const proc: firstAction (in integer: src) is action "ACT_FOO";
+;;   3   blank
+;;   4   const func boolean: firstShort (in integer: x) is
+;;   5     return x > 0;
+;;   6   blank
+;;   7   const func boolean: secondFwdDecl (in integer: y) is forward;
+;;   8   blank
+;;   9   const func boolean: secondShort (in integer: z) is
+;;  10     return z < 0;
+;;  11   blank
+;;
+;; All four callables are top-level (no enclosing long-body callable).
+;;
+;; To run from the command line:
+;;
+;;   emacs --batch -l seed7-mode.el \
+;;         -l tests/ert-tests/seed7-test-nav-final-pos-01.el \
+;;         -f ert-run-tests-batch-and-exit
+
+;;; --------------------------------------------------------------------------
+;;; Dependencies:
+;;
+(require 'ert)
+(require 'seed7-mode)
+
+;;; --------------------------------------------------------------------------
+;;; Fixture
+;;
+
+(defconst seed7-test--final-pos-code
+  ;; Line  1 — blank
+  "\n\
+const proc: firstAction (in integer: src) is action \"ACT_FOO\";\n\
+\n\
+const func boolean: firstShort (in integer: x) is\n\
+  return x > 0;\n\
+\n\
+const func boolean: secondFwdDecl (in integer: y) is forward;\n\
+\n\
+const func boolean: secondShort (in integer: z) is\n\
+  return z < 0;\n\
+\n"
+  ;; Line  2 — const proc: firstAction  ... is action \"ACT_FOO\";
+  ;; Line  3 — blank
+  ;; Line  4 — const func boolean: firstShort ...  is
+  ;; Line  5 —   return x > 0;
+  ;; Line  6 — blank
+  ;; Line  7 — const func boolean: secondFwdDecl ... is forward;
+  ;; Line  8 — blank
+  ;; Line  9 — const func boolean: secondShort ... is
+  ;; Line 10 —   return z < 0;
+  ;; Line 11 — blank
+  "Fixture: four top-level callables (action, short func, forward, short func)
+with no enclosing long-body callable.  Used to verify that `seed7-end-of-defun'
+uses `long-body-final-pos', not `final-pos', in the nested-rejection guards of
+the action-declaration and forward-declaration search paths.")
+
+;;; --------------------------------------------------------------------------
+;;; Helpers
+;;
+
+(defmacro seed7-test--with-final-pos-buffer (&rest body)
+  "Evaluate BODY in a `seed7-mode' temp buffer containing the final-pos fixture."
+  (declare (indent 0) (debug t))
+  `(with-temp-buffer
+     (insert seed7-test--final-pos-code)
+     (seed7-mode)
+     ,@body))
+
+(defun seed7-test--fp-goto-bol (line)
+  "Move point to the beginning of LINE (1-based) in the current buffer."
+  (goto-char (point-min))
+  (forward-line (1- line)))
+
+(defun seed7-test--fp-current-line ()
+  "Return the 1-based line number of the current point."
+  (line-number-at-pos))
+
+;;; --------------------------------------------------------------------------
+;;; Tests — core condition: long-body-final-pos must NOT be replaced by final-pos
+;;
+
+(ert-deftest seed7-nav-final-pos/action-before-short-func ()
+  "Top-level action decl (line 2) lies before top-level short func (lines 4-5).
+Starting from BOL line 1, `seed7-end-of-defun' must stop at line 2 (the
+action declaration), NOT at line 5 (the short-func end).
+
+This test fails when the action-declaration search path uses `final-pos'
+instead of `long-body-final-pos' in its nested-rejection guard:
+  short-func branch sets final-pos = 5;
+  WRONG:   (not (and 5 2 (< 1 2 5))) = (not t) = nil  -> action rejected;
+  CORRECT: (not (and nil 2 ...))     = (not nil) = t  -> action accepted;
+           (< 2 5) -> action wins, final-pos <- 2."
+  (seed7-test--with-final-pos-buffer
+    (seed7-test--fp-goto-bol 1)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 2))))
+
+(ert-deftest seed7-nav-final-pos/fwd-decl-before-short-func ()
+  "Top-level forward decl (line 7) lies before top-level short func (lines 9-10).
+Starting from BOL line 6 (between the two groups), `seed7-end-of-defun' must
+stop at line 7 (the forward declaration), NOT at line 10 (the second short-func
+end).
+
+Parallel to `seed7-nav-final-pos/action-before-short-func' but exercising the
+forward-declaration search path.  Fails when that path's guard uses `final-pos'
+instead of `long-body-final-pos':
+  short-func branch sets final-pos = 10;
+  WRONG:   (not (and 10 7 (< 6 7 10))) = (not t) = nil  -> fwd decl rejected;
+  CORRECT: (not (and nil 7 ...))        = (not nil) = t  -> fwd decl accepted;
+           (< 7 10) -> fwd decl wins, final-pos <- 7."
+  (seed7-test--with-final-pos-buffer
+    (seed7-test--fp-goto-bol 6)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 7))))
+
+;;; --------------------------------------------------------------------------
+;;; Tests — baseline: individual navigation from each callable's declaration
+;;
+
+(ert-deftest seed7-nav-final-pos/action-from-its-own-decl ()
+  "Baseline: `seed7-end-of-defun' from BOL line 2 (action decl) ends at line 2."
+  (seed7-test--with-final-pos-buffer
+    (seed7-test--fp-goto-bol 2)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 2))))
+
+(ert-deftest seed7-nav-final-pos/short-func-from-its-own-decl ()
+  "Baseline: `seed7-end-of-defun' from BOL line 4 (short func decl) ends at
+line 5 (the `return' terminator)."
+  (seed7-test--with-final-pos-buffer
+    (seed7-test--fp-goto-bol 4)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 5))))
+
+(ert-deftest seed7-nav-final-pos/fwd-decl-from-its-own-decl ()
+  "Baseline: `seed7-end-of-defun' from BOL line 7 (forward decl) ends at
+line 7 itself."
+  (seed7-test--with-final-pos-buffer
+    (seed7-test--fp-goto-bol 7)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 7))))
+
+(ert-deftest seed7-nav-final-pos/second-short-func-from-its-own-decl ()
+  "Baseline: `seed7-end-of-defun' from BOL line 9 (second short func decl) ends
+at line 10 (the `return' terminator)."
+  (seed7-test--with-final-pos-buffer
+    (seed7-test--fp-goto-bol 9)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 10))))
+
+;;; --------------------------------------------------------------------------
+;;; Tests — sequential navigation visits all callables in document order
+;;
+
+(ert-deftest seed7-nav-final-pos/sequential-all-four-callables ()
+  "Sequential `seed7-end-of-defun' calls visit all four top-level callables in
+document order: line 2 (action) → line 5 (short func) → line 7 (fwd decl) →
+line 10 (short func).
+
+This also verifies that after reaching line 2 via the first call, subsequent
+calls continue forward correctly and do not re-apply the wrong rejection."
+  (seed7-test--with-final-pos-buffer
+    ;; Step 1: action declaration at line 2.
+    (seed7-test--fp-goto-bol 1)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 2))
+    ;; Step 2: first short function ending at line 5.
+    (seed7-test--fp-goto-bol 4)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 5))
+    ;; Step 3: forward declaration at line 7.
+    (seed7-test--fp-goto-bol 7)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 7))
+    ;; Step 4: second short function ending at line 10.
+    (seed7-test--fp-goto-bol 9)
+    (seed7-end-of-defun 1 :silent)
+    (should (= (seed7-test--fp-current-line) 10))))
+
+;;; --------------------------------------------------------------------------
+(provide 'seed7-test-nav-final-pos-01)
+
+;;; seed7-test-nav-final-pos-01.el ends here

--- a/tests/ert-tests/seed7-test-syntax-propertize-01.el
+++ b/tests/ert-tests/seed7-test-syntax-propertize-01.el
@@ -1,0 +1,469 @@
+;;; seed7-test-syntax-propertize-01.el --- ERT regression tests: seed7-mode-syntax-propertize  -*- lexical-binding: t; -*-
+
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+
+;; This file is part of the SEED7 package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Regression tests for `seed7-mode-syntax-propertize'.  They serve as a
+;; safety net for the planned refactoring that replaces runtime
+;;   (string-to-syntax "< 1bn")  …  (string-to-syntax "> 4bn")
+;; calls inside the function with precomputed `defconst' values.
+;; The refactoring must not change *which* text properties are placed or
+;; *where* — only how the property values are computed internally.
+;;
+;; Every assertion compares
+;;   (get-text-property pos 'syntax-table)
+;; against
+;;   (string-to-syntax "…")
+;; so the tests document the *required* property values regardless of whether
+;; those values are produced inline or via a precomputed constant.
+;;
+;; `seed7-mode-syntax-propertize' contains two loops:
+;;
+;;   Loop 1 (`seed7-char-literal-re-no-comments'):
+;;     • `#' in a number-base literal  →  syntax `_' (symbol constituent)
+;;       on the `#' character only.
+;;     • Single-quoted char literal  →  `(7 . ?')' (string fence) on the
+;;       opening `'' and closing `'' only.
+;;
+;;   Loop 2 (`seed7-block-comment-delim-re' = `"(\\*\\|\\*)"'):
+;;     • `(*' opener: `(' gets `"< 1bn"', `*' gets `"< 2bn"'.
+;;     • `*)' closer: `*' gets `"> 3bn"', `)' gets `"> 4bn"'.
+;;     Note: Loop 2 uses plain `re-search-forward', so every `(*' and `*)'
+;;     in the buffer range gets text properties, including occurrences inside
+;;     Seed7 string literals ("…").  Correct nesting behaviour relies on
+;;     `syntax-ppss' at runtime, not on the propertize function.
+;;
+;; Sections:
+;;   A. Loop 1 — `#' number-base separator.
+;;   B. Loop 1 — single-quoted character literals.
+;;   C. Loop 2 — `(*' block-comment opener.
+;;   D. Loop 2 — `*)' block-comment closer.
+;;   E. Negative cases — characters that must NOT receive an override.
+;;   F. Multiple and nested block comments.
+;;   G. Combined Loop 1 + Loop 2 in a single buffer.
+;;
+;; To run from the command line:
+;;
+;;   emacs --batch -L . \
+;;         -l ert \
+;;         -l tests/ert-tests/seed7-test-syntax-propertize-01.el \
+;;         --eval '(setq ert-batch-print-length nil ert-batch-print-level nil)' \
+;;         -f ert-run-tests-batch-and-exit
+
+;;; --------------------------------------------------------------------------
+;;; Dependencies:
+
+(require 'ert)
+(require 'seed7-mode)
+
+;;; --------------------------------------------------------------------------
+;;; Helpers
+
+(defmacro seed7-test--with-propertized-buffer (text &rest body)
+  "Evaluate BODY in a `seed7-mode' temp buffer containing TEXT.
+`syntax-propertize' is called over the whole buffer before BODY runs,
+so all `syntax-table' text properties are in place."
+  (declare (indent 1) (debug t))
+  `(with-temp-buffer
+     (insert ,text)
+     (seed7-mode)
+     (syntax-propertize (point-max))   ; propertize entire buffer up to point-max
+     ,@body))
+
+(defun seed7-test--syntax-prop (pos)
+  "Return the `syntax-table' text property at buffer position POS (1-based)."
+  (get-text-property pos 'syntax-table))
+
+(defun seed7-test--buf-pos (offset)
+  "Return the buffer position corresponding to 0-based character OFFSET.
+In a fresh temp buffer `point-min' is 1, so `offset' 0 maps to position 1."
+  (+ (point-min) offset))
+
+;;; --------------------------------------------------------------------------
+;;; Section A: Loop 1 — `#' number-base separator
+;;; --------------------------------------------------------------------------
+
+(ert-deftest seed7-syntax-propertize/hash-sep-gets-symbol-syntax ()
+  "Loop 1: `#' in `16#FF' gets symbol-constituent `_' syntax.
+This prevents the `#' from being interpreted as a line-comment starter."
+  ;; Buffer: 1 6 # F F
+  ;; Offset: 0 1 2 3 4   (0-based)
+  (seed7-test--with-propertized-buffer "16#FF"
+    (let ((hash-pos (seed7-test--buf-pos 2)))
+      (should (eq (char-after hash-pos) ?#))
+      (should (equal (seed7-test--syntax-prop hash-pos)
+                     (string-to-syntax "_"))))))
+
+(ert-deftest seed7-syntax-propertize/hash-sep-multiple ()
+  "Loop 1: All `#' separators in a multi-expression line each get `_' syntax."
+  ;; Buffer: 16#FF + 8#77
+  ;; Offsets of `#': 2 and 8
+  (seed7-test--with-propertized-buffer "16#FF + 8#77"
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 2))
+                   (string-to-syntax "_")))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 9))
+                   (string-to-syntax "_")))))
+
+(ert-deftest seed7-syntax-propertize/hash-sep-surrounding-digits-not-marked ()
+  "Loop 1: Digits adjacent to `#' in `16#FF' receive no text property override."
+  (seed7-test--with-propertized-buffer "16#FF"
+    ;; `1' at offset 0, `6' at offset 1 — neither should have an override.
+    (should (null (seed7-test--syntax-prop (seed7-test--buf-pos 0))))
+    (should (null (seed7-test--syntax-prop (seed7-test--buf-pos 1))))))
+
+;;; --------------------------------------------------------------------------
+;;; Section B: Loop 1 — single-quoted character literals
+;;; --------------------------------------------------------------------------
+
+(ert-deftest seed7-syntax-propertize/char-literal-simple-opening-quote ()
+  "Loop 1: Opening `'' of `'a'' gets string-fence syntax `(7 . ?')'."
+  ;; Buffer: ' a '
+  ;; Offset: 0 1 2
+  (seed7-test--with-propertized-buffer "'a'"
+    (let ((open-pos (seed7-test--buf-pos 0)))
+      (should (eq (char-after open-pos) ?'))
+      (should (equal (seed7-test--syntax-prop open-pos)
+                     '(7 . ?'))))))
+
+(ert-deftest seed7-syntax-propertize/char-literal-simple-closing-quote ()
+  "Loop 1: Closing `'' of `'a'' gets string-fence syntax `(7 . ?')'."
+  (seed7-test--with-propertized-buffer "'a'"
+    (let ((close-pos (seed7-test--buf-pos 2)))
+      (should (eq (char-after close-pos) ?'))
+      (should (equal (seed7-test--syntax-prop close-pos)
+                     '(7 . ?'))))))
+
+(ert-deftest seed7-syntax-propertize/char-literal-simple-inner-char-not-marked ()
+  "Loop 1: The character `a' between the quotes in `'a'' has no property override."
+  (seed7-test--with-propertized-buffer "'a'"
+    (should (null (seed7-test--syntax-prop (seed7-test--buf-pos 1))))))
+
+(ert-deftest seed7-syntax-propertize/char-literal-backslash-opening-quote ()
+  "Loop 1: Opening `'' of `'\\n'' gets string-fence syntax `(7 . ?')'."
+  ;; Actual buffer content: '  \  n  '   (4 characters)
+  ;; Offsets:               0  1  2  3
+  (seed7-test--with-propertized-buffer "'\\n'"
+    (let ((open-pos (seed7-test--buf-pos 0)))
+      (should (eq (char-after open-pos) ?'))
+      (should (equal (seed7-test--syntax-prop open-pos)
+                     '(7 . ?'))))))
+
+(ert-deftest seed7-syntax-propertize/char-literal-backslash-closing-quote ()
+  "Loop 1: Closing `'' of `'\\n'' gets string-fence syntax `(7 . ?')'."
+  (seed7-test--with-propertized-buffer "'\\n'"
+    (let ((close-pos (seed7-test--buf-pos 3)))
+      (should (eq (char-after close-pos) ?'))
+      (should (equal (seed7-test--syntax-prop close-pos)
+                     '(7 . ?'))))))
+
+(ert-deftest seed7-syntax-propertize/char-literal-uppercase-escape-opening ()
+  "Loop 1: Opening `'' of `'\\A'' (Seed7 Ctrl-A) gets string-fence syntax."
+  ;; Actual buffer: '  \  A  '
+  (seed7-test--with-propertized-buffer "'\\A'"
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 0))
+                   '(7 . ?')))))
+
+(ert-deftest seed7-syntax-propertize/char-literal-uppercase-escape-closing ()
+  "Loop 1: Closing `'' of `'\\A'' gets string-fence syntax."
+  (seed7-test--with-propertized-buffer "'\\A'"
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 3))
+                   '(7 . ?')))))
+
+;;; --------------------------------------------------------------------------
+;;; Section C: Loop 2 — `(*' block-comment opener
+;;; --------------------------------------------------------------------------
+
+(ert-deftest seed7-syntax-propertize/bc-opener-paren-gets-comment-start-1 ()
+  "Loop 2: `(' of `(*' gets style-b comment-start-1 syntax `< 1bn'."
+  ;; Buffer: ( *   a   c o m m e n t   * )
+  ;; Offset: 0 1 2 3 4 5 6 7 8 9 10 11 12 13
+  (seed7-test--with-propertized-buffer "(* a comment *)"
+    (let ((paren-pos (seed7-test--buf-pos 0)))
+      (should (eq (char-after paren-pos) ?\())
+      (should (equal (seed7-test--syntax-prop paren-pos)
+                     (string-to-syntax "< 1bn"))))))
+
+(ert-deftest seed7-syntax-propertize/bc-opener-star-gets-comment-start-2 ()
+  "Loop 2: `*' of `(*' gets style-b comment-start-2 syntax `< 2bn'."
+  (seed7-test--with-propertized-buffer "(* a comment *)"
+    (let ((star-pos (seed7-test--buf-pos 1)))
+      (should (eq (char-after star-pos) ?*))
+      (should (equal (seed7-test--syntax-prop star-pos)
+                     (string-to-syntax "< 2bn"))))))
+
+(ert-deftest seed7-syntax-propertize/bc-opener-at-start-of-buffer ()
+  "Loop 2: `(*' at the very start of the buffer still gets both properties."
+  (seed7-test--with-propertized-buffer "(*"
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 0))
+                   (string-to-syntax "< 1bn")))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 1))
+                   (string-to-syntax "< 2bn")))))
+
+;;; --------------------------------------------------------------------------
+;;; Section D: Loop 2 — `*)' block-comment closer
+;;; --------------------------------------------------------------------------
+
+(ert-deftest seed7-syntax-propertize/bc-closer-star-gets-comment-end-3 ()
+  "Loop 2: `*' of `*)' gets style-b comment-end-3 syntax `> 3bn'."
+  ;; Buffer: ( *   a   c o m m e n t   *  )
+  ;; Offset: 0 1 2 3 4 5 6 7 8 9 10 11 12 13
+  ;; Closing `*' is at offset 12, closing `)' at offset 13.
+  (seed7-test--with-propertized-buffer "(* a comment *)"
+    (let* ((buf "(* a comment *)")
+           (star-pos (seed7-test--buf-pos (- (length buf) 2))))
+      (should (eq (char-after star-pos) ?*))
+      (should (equal (seed7-test--syntax-prop star-pos)
+                     (string-to-syntax "> 3bn"))))))
+
+(ert-deftest seed7-syntax-propertize/bc-closer-paren-gets-comment-end-4 ()
+  "Loop 2: `)' of `*)' gets style-b comment-end-4 syntax `> 4bn'."
+  (seed7-test--with-propertized-buffer "(* a comment *)"
+    (let* ((buf "(* a comment *)")
+           (paren-pos (seed7-test--buf-pos (- (length buf) 1))))
+      (should (eq (char-after paren-pos) ?\)))
+      (should (equal (seed7-test--syntax-prop paren-pos)
+                     (string-to-syntax "> 4bn"))))))
+
+(ert-deftest seed7-syntax-propertize/bc-closer-at-end-of-buffer ()
+  "Loop 2: `*)' at the very end of the buffer still gets both properties."
+  (seed7-test--with-propertized-buffer "*)"
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 0))
+                   (string-to-syntax "> 3bn")))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 1))
+                   (string-to-syntax "> 4bn")))))
+
+;;; --------------------------------------------------------------------------
+;;; Section E: Negative cases — characters that must NOT get an override
+;;; --------------------------------------------------------------------------
+
+(ert-deftest seed7-syntax-propertize/plain-paren-not-followed-by-star ()
+  "Loop 2: `(' in `foo(x)' gets no text property override.
+`seed7-block-comment-delim-re' matches `(*' as a unit; a `(' not followed
+immediately by `*' must not receive the `< 1bn' property."
+  ;; Buffer: f o o ( x )
+  ;; Offset: 0 1 2 3 4 5
+  (seed7-test--with-propertized-buffer "foo(x)"
+    (let ((paren-pos (seed7-test--buf-pos 3)))
+      (should (eq (char-after paren-pos) ?\())
+      (should (null (seed7-test--syntax-prop paren-pos))))))
+
+(ert-deftest seed7-syntax-propertize/plain-star-not-followed-by-paren ()
+  "Loop 2: `*' in `x * y' gets no text property override.
+`seed7-block-comment-delim-re' also matches `*)' as a unit; a `*' not
+followed immediately by `)' must not receive the `> 3bn' property."
+  ;; Buffer: x   *   y
+  ;; Offset: 0 1 2 3 4
+  (seed7-test--with-propertized-buffer "x * y"
+    (let ((star-pos (seed7-test--buf-pos 2)))
+      (should (eq (char-after star-pos) ?*))
+      (should (null (seed7-test--syntax-prop star-pos))))))
+
+(ert-deftest seed7-syntax-propertize/plain-star-followed-by-alnum ()
+  "Loop 2: `*' in `x*y' (multiplication) gets no text property override."
+  (seed7-test--with-propertized-buffer "x*y"
+    (let ((star-pos (seed7-test--buf-pos 1)))
+      (should (eq (char-after star-pos) ?*))
+      (should (null (seed7-test--syntax-prop star-pos))))))
+
+(ert-deftest seed7-syntax-propertize/double-star-power-operator ()
+  "Loop 2: Neither `*' in `x**y' (power operator) gets a comment property."
+  ;; Buffer: x * * y
+  ;; Offset: 0 1 2 3
+  (seed7-test--with-propertized-buffer "x**y"
+    (should (null (seed7-test--syntax-prop (seed7-test--buf-pos 1))))
+    (should (null (seed7-test--syntax-prop (seed7-test--buf-pos 2))))))
+
+(ert-deftest seed7-syntax-propertize/no-properties-on-plain-identifiers ()
+  "Neither Loop 1 nor Loop 2 places any property on plain identifier text."
+  (seed7-test--with-propertized-buffer "x := y + z;"
+    (let ((pos (point-min)))
+      (while (< pos (point-max))
+        (should (null (seed7-test--syntax-prop pos)))
+        (setq pos (1+ pos))))))
+
+;;; --------------------------------------------------------------------------
+;;; Section F: Multiple and nested block comments
+;;; --------------------------------------------------------------------------
+
+(ert-deftest seed7-syntax-propertize/two-separate-block-comments ()
+  "Loop 2: Two separate `(*..*)' pairs each get the correct four properties.
+Verifies the loop iterates beyond the first delimiter pair."
+  ;; Buffer: ( *   f i r s t   *  )     (  *     s e c o n d   *  )
+  ;; Offset: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+  ;;                                        ^--- second `(' at offset 12
+  ;; "(* first *) (* second *)" has length 24.
+  (seed7-test--with-propertized-buffer "(* first *) (* second *)"
+    ;; First opener: offsets 0 (`(') and 1 (`*').
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 0))
+                   (string-to-syntax "< 1bn")))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 1))
+                   (string-to-syntax "< 2bn")))
+    ;; First closer: offsets 9 (`*') and 10 (`)').
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 9))
+                   (string-to-syntax "> 3bn")))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 10))
+                   (string-to-syntax "> 4bn")))
+    ;; Second opener: offsets 12 (`(') and 13 (`*').
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 12))
+                   (string-to-syntax "< 1bn")))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 13))
+                   (string-to-syntax "< 2bn")))
+    ;; Second closer: offsets 22 (`*') and 23 (`)').
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 22))
+                   (string-to-syntax "> 3bn")))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 23))
+                   (string-to-syntax "> 4bn")))))
+
+(ert-deftest seed7-syntax-propertize/nested-block-comment-all-four-delimiters ()
+  "Loop 2: All four delimiter pairs in `(* outer (* inner *) end-outer *)' get
+the correct text properties.  Nesting is tracked at runtime by `syntax-ppss'
+using the `n' flag; the propertize function marks every `(*' and `*)' pair
+unconditionally."
+  ;; Buffer (offsets):
+  ;; ( * ' ' o u t e r ' ' (  *     i  n  n  e  r     *  )     e  n  d  -  o  u  t  e  r     *  )
+  ;; 0 1 2  3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
+  ;; Outer opener: 0 (`(') and 1 (`*').
+  ;; Inner opener: 9 (`(') and 10 (`*').  [" (* " starts at offset 8 (space) ... let me recount]
+  ;;
+  ;; "(* outer (* inner *) end-outer *)"
+  ;;  0123456789012345678901234567890123
+  ;;           1111111111222222222233333
+  ;;
+  ;; Char positions (0-based):
+  ;;  0: (   outer opener paren
+  ;;  1: *   outer opener star
+  ;;  9: (   inner opener paren
+  ;; 10: *   inner opener star
+  ;; 18: *   inner closer star
+  ;; 19: )   inner closer paren
+  ;; 31: *   outer closer star
+  ;; 32: )   outer closer paren
+  (seed7-test--with-propertized-buffer "(* outer (* inner *) end-outer *)"
+    ;; Outer opener.
+    (should (eq (char-after (seed7-test--buf-pos 0)) ?\())
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 0))
+                   (string-to-syntax "< 1bn")))
+    (should (eq (char-after (seed7-test--buf-pos 1)) ?*))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 1))
+                   (string-to-syntax "< 2bn")))
+    ;; Inner opener.
+    (should (eq (char-after (seed7-test--buf-pos 9)) ?\())
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 9))
+                   (string-to-syntax "< 1bn")))
+    (should (eq (char-after (seed7-test--buf-pos 10)) ?*))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 10))
+                   (string-to-syntax "< 2bn")))
+    ;; Inner closer.
+    (should (eq (char-after (seed7-test--buf-pos 18)) ?*))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 18))
+                   (string-to-syntax "> 3bn")))
+    (should (eq (char-after (seed7-test--buf-pos 19)) ?\)))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 19))
+                   (string-to-syntax "> 4bn")))
+    ;; Outer closer.
+    (should (eq (char-after (seed7-test--buf-pos 31)) ?*))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 31))
+                   (string-to-syntax "> 3bn")))
+    (should (eq (char-after (seed7-test--buf-pos 32)) ?\)))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 32))
+                   (string-to-syntax "> 4bn")))))
+
+;;; --------------------------------------------------------------------------
+;;; Section G: Combined Loop 1 + Loop 2 content in one buffer
+;;; --------------------------------------------------------------------------
+
+(ert-deftest seed7-syntax-propertize/combined-hash-and-block-comment ()
+  "Loop 1 and Loop 2 both place correct properties in a mixed buffer.
+Exercises both loops in a single `syntax-propertize' pass."
+  ;; Buffer: 16#FF (* hex value *)
+  ;;         01234567890123456789
+  ;;                   1111111111
+  ;; Offsets:
+  ;;  2: `#' → `_'
+  ;;  6: `(' → `< 1bn'
+  ;;  7: `*' → `< 2bn'
+  ;; 18: `*' → `> 3bn'
+  ;; 19: `)' → `> 4bn'
+  (seed7-test--with-propertized-buffer "16#FF (* hex value *)"
+    ;; Loop 1: `#' at offset 2.
+    (should (eq (char-after (seed7-test--buf-pos 2)) ?#))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 2))
+                   (string-to-syntax "_")))
+    ;; Loop 2: `(*' opener at offsets 6-7.
+    (should (eq (char-after (seed7-test--buf-pos 6)) ?\())
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 6))
+                   (string-to-syntax "< 1bn")))
+    (should (eq (char-after (seed7-test--buf-pos 7)) ?*))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 7))
+                   (string-to-syntax "< 2bn")))
+    ;; Loop 2: `*)' closer at offsets 19-20.
+    (let* ((buf "16#FF (* hex value *)")
+           (close-star-off  (- (length buf) 2))
+           (close-paren-off (- (length buf) 1)))
+      (should (eq (char-after (seed7-test--buf-pos close-star-off)) ?*))
+      (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos close-star-off))
+                     (string-to-syntax "> 3bn")))
+      (should (eq (char-after (seed7-test--buf-pos close-paren-off)) ?\)))
+      (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos close-paren-off))
+                     (string-to-syntax "> 4bn"))))))
+
+(ert-deftest seed7-syntax-propertize/combined-char-literal-and-block-comment ()
+  "Loop 1 char-literal quotes and Loop 2 block-comment delimiters in one buffer."
+  ;; Buffer: 'a' (* char *)
+  ;;         0123456789012
+  ;; Offsets:
+  ;;  0: `'' → `(7 . ?')'   (opening quote)
+  ;;  2: `'' → `(7 . ?')'   (closing quote)
+  ;;  4: `(' → `< 1bn'
+  ;;  5: `*' → `< 2bn'
+  ;; 11: `*' → `> 3bn'
+  ;; 12: `)' → `> 4bn'
+  (seed7-test--with-propertized-buffer "'a' (* char *)"
+    ;; Loop 1: char literal quotes.
+    (should (eq (char-after (seed7-test--buf-pos 0)) ?'))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 0))
+                   '(7 . ?')))
+    (should (eq (char-after (seed7-test--buf-pos 2)) ?'))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 2))
+                   '(7 . ?')))
+    ;; Loop 2: block comment delimiters.
+    (should (eq (char-after (seed7-test--buf-pos 4)) ?\())
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 4))
+                   (string-to-syntax "< 1bn")))
+    (should (eq (char-after (seed7-test--buf-pos 5)) ?*))
+    (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos 5))
+                   (string-to-syntax "< 2bn")))
+    (let* ((buf "'a' (* char *)")
+           (close-star-off  (- (length buf) 2))
+           (close-paren-off (- (length buf) 1)))
+      (should (eq (char-after (seed7-test--buf-pos close-star-off)) ?*))
+      (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos close-star-off))
+                     (string-to-syntax "> 3bn")))
+      (should (eq (char-after (seed7-test--buf-pos close-paren-off)) ?\)))
+      (should (equal (seed7-test--syntax-prop (seed7-test--buf-pos close-paren-off))
+                     (string-to-syntax "> 4bn"))))))
+
+;;; --------------------------------------------------------------------------
+(provide 'seed7-test-syntax-propertize-01)
+
+;;; seed7-test-syntax-propertize-01.el ends here

--- a/tools/seed7-mode-time.el
+++ b/tools/seed7-mode-time.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Wednesday, June  3 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-08 16:34:58 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-18 14:21:54 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -57,15 +57,18 @@
 ;; Using The Emacs Profiler
 ;; ========================
 ;;
-;; Start profiling
-;;    (profiler-start 'cpu)
+;; - Start profiling:
 ;;
-;; ... edit the .s7d or .s7i file for 30-60 seconds, press RET many times ...
+;;   - execute: M-:  (profiler-start 'cpu)
+;;   - or:      M-x profile-start cpu RET
 ;;
-;; Stop and display
 ;;
-;;    (profiler-stop)
-;;    (profiler-report)
+;; - ... edit the .s7d or .s7i file for 30-60 seconds, press RET many times ...
+;;
+;; - Stop and display:
+;;
+;;    - M-x profiler-stop
+;;    - M-x profiler-report
 
 ;;; --------------------------------------------------------------------------
 ;;; Dependencies:


### PR DESCRIPTION
Looking for the reason why it takes much longer now to open a long Seed7 file.  This is a regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded Emacs Profiler guidance with clearer step-by-step instructions, including explicit `profiler-start`/`profiler-stop`, tips for editing during profiling, and how to stop and review results.

* **Improvements**
  * Enhanced Seed7 syntax highlighting for `#` number-base separators and single-quoted character literals.
  * Improved handling of `(* ... *)` block comments and the `*)` closer delimiter.
  * More accurate “end of defun” navigation in nested/complex callable structures.
  * Improved callable entries in the imenu index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->