### PR TITLE
Simplified seed7--array-definition-start-regexp with a sd7-perf report

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,17 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
   customizing the user-options that control it.  The command checks for
   duplicates and errors, and warns the user of any issue found.
 
+- *seed7-list-entities*: Bound to ~C-c C-l~.
+  The command lists all defined Seed7 entities (functions, procedures,
+  enumerations, structures, arrays, sets) defined in the Seed7 file visited by
+  the current buffer showing the line, type and name of the Seed7 entity.
+  The list is shown in a special =*Seed7 Entities: FNAME=
+  buffer that provides quick 1-key commands:
+  - ~RET~:  Go to the declaration in the source buffer.
+  - ~o~: Go to the declaration in the other window.
+  - ~g~: Re-scan the source buffer and re-display.
+  - ~S~: Sort by the column at point.
+
 ** Renamed Commands
 
 - *seed7-compile* was renamed to *seed7-check-or-compile*, which

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ Seed7-mode - Emacs support for the Seed7 Programming Language
 - Cross-reference integration with xref support that uses a Seed7 code
   analyzer back-end - you must have Seed7 installed to use it.
 - Explicit outline-minor-mode support.
+- Command to list all elements of Seed7 file: seed7-list-entities.
 - Intelligent template and keyword expansion.
 - Context-aware marking with block-aware extension to `er/expand-region`_ command.
 - Deep integration with iMenu and Speedbar with nested callable lineage.
@@ -793,6 +794,14 @@ The supported alignment rules do not allow alignment of *every* code formats.
 Use the ``align-regexp`` command to perform other form of text alignment.
 
 
+List all Seed7 Elements
+-----------------------
+
+The **seed7-list-entities** command lists all Seed7 elements declared in the
+current Seed7 buffer and inside a dedicated special buffer from where you can
+sort by type, name and line number and jump to the chosen declaration.
+
+This command is bound to the ``C-c C-l`` key and is available from the menu.
 
 Code Navigation Commands
 ------------------------
@@ -865,6 +874,18 @@ all of them.  The `PEL Seed7 support`_ provides more key bindings using function
                                                  the beginning of the current
                                                  function, procedure, struct_,
                                                  enum_, array_, set_.
+
+. seed7-list-entities         ``C-c C-l``        List all defined Seed7 entities (functions, procedures,
+                                                 enumerations, structures, arrays, sets) defined in the Seed7 file visited by
+                                                 the current buffer showing the line, type and name of the Seed7 entity.
+                                                 The list is shown in a special ``*Seed7 Entities: FNAME``
+                                                 buffer that provides quick 1-key commands:
+
+                                                 - ``RET``:  Go to the declaration in the source buffer.
+                                                 - ``o``: Go to the declaration in the other window.
+                                                 - ``g``: Re-scan the source buffer and re-display.
+                                                 - ``S``: Sort by the column at point.
+
 = ============================ ================= =============================================================
 
 Note that issuing the ``seed7-end-of-defun`` or ``seed7-to-block-forward``

--- a/reports/seed7mode-nav-index-nav-01.rst
+++ b/reports/seed7mode-nav-index-nav-01.rst
@@ -1,0 +1,13157 @@
+=============================
+Seed7 Navigation Entity Index
+=============================
+
+- Running with: seed7-mode 2026-06-23T16:07:25+0000 W26-2
+- Seed7 dir: /Users/roup/my/dvo/seed7-repos/seed7/
+- Generated on: 2026-06-23T15:34:54-0400
+- Files indexed: 340
+
+.. sectnum::
+   :depth: 2
+
+.. contents:: Table of Contents
+   :depth: 2
+
+.. ---------------------------------------------------------------------------
+
+prg
+===
+
+prg/addup.sd7
+-------------
+
+:Lines:    190
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     procedure   ``human_move``
+71     procedure   ``comp_move``
+85     procedure   ``game``
+122    procedure   ``main``
+====== =========== ==================================================
+
+prg/bas7.sd7
+------------
+
+:Lines:    11459
+:Entities: 240
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+101    set         ``basic_name_char``
+102    set         ``number_suffix``
+103    set         ``numeric_var_suffix``
+105    structure   ``lineType``
+113    array       ``prg``
+154    set         ``defint_var``
+155    set         ``deflng_var``
+156    set         ``defsng_var``
+157    set         ``defdbl_var``
+158    set         ``defstr_var``
+160    structure   ``defFnType``
+202    structure   ``forLoopDescrType``
+210    array       ``forLoop``
+212    structure   ``whileLoopDescrType``
+217    array       ``whileLoop``
+219    structure   ``doLoopDescrType``
+224    array       ``doLoop``
+231    structure   ``gosubReturnDescrType``
+241    array       ``gosubReturn``
+243    structure   ``boundsType``
+260    set         ``numeric_functions``
+269    set         ``not_allowed_as_label``
+281    array       ``loresColor``
+299    array       ``hiresColor``
+310    procedure   ``sleep``
+319    procedure   ``delay``
+332    procedure   ``listProg``
+407    function    ``get_symbol``
+685    function    ``endOfStatement``
+689    function    ``ignoreRestOfLine``
+693    function    ``isStringExpr``
+700    function    ``isStringVar``
+707    function    ``isNumericExpr``
+720    function    ``isNumericVar``
+731    function    ``isIntegerVar``
+738    function    ``isLongVar``
+745    function    ``isSingleVar``
+752    function    ``isDoubleVar``
+759    procedure   ``error_marker``
+773    function    ``getNumericVar``
+788    procedure   ``setNumericVar``
+795    function    ``getStringVar``
+805    procedure   ``setStringVar``
+811    function    ``varptr``
+823    function    ``varptrStri``
+834    function    ``varname``
+844    function    ``getFileValue``
+854    procedure   ``setFileValue``
+860    procedure   ``closeAllFiles``
+871    procedure   ``addDoLoopHeader``
+887    function    ``doLoopHeaderPresent``
+902    procedure   ``line_marker``
+917    procedure   ``line_marker``
+936    procedure   ``error_marker``
+942    procedure   ``error_expect``
+950    procedure   ``error_expect2``
+958    procedure   ``error_expect3``
+967    procedure   ``expect``
+977    function    ``label_or_linenum``
+981    procedure   ``goto_label_or_linenum``
+1020   procedure   ``set_return_position``
+1034   procedure   ``set_sub_entry_position``
+1040   procedure   ``check_loop_stacks_before_return``
+1079   procedure   ``do_return``
+1089   procedure   ``goto_on_error``
+1100   procedure   ``do_resume_next``
+1116   procedure   ``do_resume_same``
+1132   function    ``color_num``
+1157   function    ``get_data_line``
+1206   procedure   ``data_statement_in_line``
+1227   function    ``get_data_field``
+1313   procedure   ``skip_space_cr_lf``
+1325   function    ``read_input_string``
+1349   function    ``read_input_number``
+1373   procedure   ``assign_input_number``
+1391   procedure   ``assign_input_string``
+1399   procedure   ``set_function``
+1412   procedure   ``define_function``
+1457   procedure   ``getBoundsFromIndexPart``
+1485   procedure   ``getBounds``
+1506   function    ``exec_lbound``
+1516   function    ``exec_ubound``
+1526   function    ``getFirstIndex``
+1561   function    ``exec_expr``
+1564   procedure   ``append_index``
+1600   function    ``get_name``
+1610   procedure   ``skip_parenthesized_stri``
+1635   function    ``is_let_statement``
+1655   function    ``exec_str_expr``
+1661   function    ``exec_str_function``
+1670   array       ``str_value_backup``
+1671   array       ``num_value_backup``
+1721   function    ``extendedKeyCode``
+1825   function    ``keyboardScanCode``
+1918   procedure   ``execLines``
+1921   function    ``exec_str_primary``
+2331   function    ``exec_str_mult``
+2356   function    ``exec_str_expr``
+2374   function    ``exec_function``
+2383   array       ``str_value_backup``
+2384   array       ``num_value_backup``
+2434   function    ``exec_primary``
+3099   function    ``exec_exponentation``
+3118   function    ``exec_negation``
+3134   function    ``exec_multdiv``
+3198   function    ``exec_addsub``
+3219   function    ``exec_comparison``
+3280   function    ``exec_cond_not``
+3296   function    ``binary_and``
+3312   function    ``exec_cond_and``
+3337   function    ``binary_or``
+3353   function    ``binary_xor``
+3369   function    ``exec_cond_or``
+3400   function    ``binary_eqv``
+3416   function    ``exec_cond_eqv``
+3433   function    ``binary_imp``
+3449   function    ``exec_expr``
+3466   function    ``getNameList``
+3483   function    ``nameInList``
+3500   function    ``removeNameFromList``
+3530   function    ``next_symbol``
+3552   function    ``find_then``
+3578   procedure   ``find_else``
+3618   function    ``find_next``
+3676   function    ``find_next``
+3702   function    ``find_wend``
+3720   function    ``find_do``
+3741   function    ``find_loop``
+3759   function    ``find_end_sub``
+3788   function    ``find_end_function``
+3817   function    ``find_end_select``
+3846   function    ``find_end_if``
+3888   function    ``find_else_elseif_or_end_if``
+3933   function    ``find_case_or_end_select``
+3965   procedure   ``exec_elseif_else_chain``
+4017   procedure   ``advance_after_statement``
+4032   procedure   ``exec_goto``
+4091   procedure   ``exec_gosub``
+4155   procedure   ``typeMismatch``
+4180   procedure   ``assignmentExpected``
+4206   procedure   ``variableExpected``
+4230   procedure   ``exec_let``
+4285   procedure   ``exec_mid_statement``
+4380   procedure   ``exec_next_decision``
+4436   procedure   ``exec_if``
+4597   procedure   ``exec_else``
+4620   procedure   ``exec_for``
+4683   procedure   ``exec_next``
+4751   procedure   ``exec_on``
+4866   procedure   ``exec_do``
+4942   procedure   ``exec_loop``
+5083   procedure   ``exec_select``
+5267   function    ``continueWithPrintStatement``
+5286   procedure   ``exec_print_using``
+5505   procedure   ``illegalFunctionCall``
+5529   procedure   ``exec_print``
+5665   procedure   ``exec_print``
+5769   procedure   ``exec_lprint``
+5777   procedure   ``exec_print_to_file``
+5815   procedure   ``exec_write_to_file``
+5867   procedure   ``exec_write``
+5904   procedure   ``exec_read``
+5974   procedure   ``exec_input_from_file``
+6047   procedure   ``read_input``
+6075   procedure   ``exec_input``
+6139   procedure   ``exec_line_input_from_file``
+6184   procedure   ``exec_line_input``
+6236   procedure   ``exec_linput_from_file``
+6281   procedure   ``exec_linput``
+6330   procedure   ``exec_accept``
+6332   set         ``accept_keywords``
+6430   procedure   ``exec_display``
+6432   set         ``display_keywords``
+6504   function    ``basicOpen``
+6508   array       ``pathElems``
+6511   array       ``directoryContent``
+6571   procedure   ``exec_open``
+6765   procedure   ``exec_close``
+6806   procedure   ``exec_file_put``
+6931   procedure   ``exec_file_get``
+7104   procedure   ``exec_seek``
+7149   procedure   ``clearProgram``
+7162   procedure   ``exec_clear``
+7174   function    ``parseType``
+7186   procedure   ``deallocateArray``
+7210   procedure   ``initArray``
+7239   procedure   ``exec_dim``
+7369   procedure   ``exec_defType_numeric``
+7420   procedure   ``exec_defstr``
+7466   procedure   ``exec_type``
+7493   function    ``readVarNameFromBloadFile``
+7522   procedure   ``exec_bload``
+7646   procedure   ``exec_bsave``
+7680   procedure   ``exec_files``
+7701   function    ``getCga2ImageFromBytes``
+7742   function    ``getCga4ImageFromBytes``
+7755   array       ``palette1``
+7783   function    ``getEgaImageFromBytes``
+7826   function    ``getVgaImageFromBytes``
+7863   function    ``getBytesFromArray``
+7904   function    ``getImageFromArray``
+7930   function    ``getImageFromArray``
+7953   procedure   ``exec_screen``
+8060   procedure   ``exec_pset``
+8092   procedure   ``exec_preset``
+8124   procedure   ``exec_line``
+8206   procedure   ``exec_circle``
+8263   procedure   ``exec_put``
+8305   procedure   ``exec_get``
+8368   function    ``getChar``
+8377   function    ``getSign``
+8390   procedure   ``exec_draw``
+8575   procedure   ``exec_plot``
+8592   procedure   ``exec_hplot``
+8628   procedure   ``setup_graphic``
+8648   procedure   ``exec_call_char``
+8653   array       ``charPicture``
+8705   procedure   ``exec_call_clear``
+8716   procedure   ``exec_call_color``
+8757   procedure   ``exec_call_hchar``
+8793   procedure   ``exec_call_key``
+8941   procedure   ``exec_call_screen``
+8955   procedure   ``exec_call_sound``
+8980   procedure   ``exec_call_vchar``
+9016   procedure   ``exec_let``
+9172   function    ``runOrChain``
+9176   function    ``execCmd``
+10878  procedure   ``execLines``
+10901  procedure   ``runProg``
+10908  procedure   ``logLine``
+10919  procedure   ``prepareLoops``
+10991  procedure   ``preprocessLine``
+11026  procedure   ``checkLabels``
+11072  function    ``loadProg``
+11075  procedure   ``loadProg``
+11283  function    ``runOrChain``
+11318  function    ``loadProg``
+11338  procedure   ``interactiveMode``
+11382  procedure   ``main``
+11384  array       ``arg_v``
+====== =========== ==================================================
+
+prg/bifurk.sd7
+--------------
+
+:Lines:    73
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     procedure   ``bifurk``
+64     procedure   ``main``
+====== =========== ==================================================
+
+prg/bigfiles.sd7
+----------------
+
+:Lines:    129
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     function    ``searchDir``
+38     array       ``dirElements``
+70     procedure   ``showResults``
+73     array       ``lengthList``
+93     procedure   ``main``
+====== =========== ==================================================
+
+prg/brainf7.sd7
+---------------
+
+:Lines:    86
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``brainF``
+31     array       ``memory``
+71     procedure   ``main``
+====== =========== ==================================================
+
+prg/calc7.sd7
+-------------
+
+:Lines:    128
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     procedure   ``main``
+====== =========== ==================================================
+
+prg/carddemo.sd7
+----------------
+
+:Lines:    190
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     structure   ``cardType``
+52     procedure   ``put``
+70     procedure   ``move``
+94     function    ``select_card``
+112    procedure   ``main``
+====== =========== ==================================================
+
+prg/castle.sd7
+--------------
+
+:Lines:    3148
+:Entities: 126
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+63     enumeration ``directionType``
+67     function    ``str``
+70     function    ``parse``
+76     enumeration ``itemType``
+88     enumeration ``monsterType``
+150    function    ``str``
+153    function    ``parse``
+159    structure   ``graphObj``
+162    array       ``picture``
+171    structure   ``itemObj``
+176    structure   ``monsterObj``
+185    structure   ``playerObj``
+193    structure   ``roomType``
+194    array       ``data``
+195    array       ``description``
+196    array       ``exits``
+199    structure   ``scoreType``
+206    array       ``item``
+207    array       ``monster``
+209    array       ``room``
+214    array       ``message``
+260    array       ``query_pic``
+271    array       ``wall_pic``
+290    array       ``colored_wall1_pic``
+309    array       ``colored_wall2_pic``
+328    array       ``vertical_pic``
+347    array       ``horizontal_pic``
+366    array       ``left_upper_pic``
+385    array       ``right_upper_pic``
+404    array       ``left_lower_pic``
+423    array       ``right_lower_pic``
+442    array       ``railing_pic``
+461    array       ``gate_pic``
+480    array       ``small_bush_pic``
+499    array       ``big_bush_pic``
+518    array       ``wood_pic``
+537    array       ``stone_pic``
+556    array       ``gray_pic``
+575    array       ``water_pic``
+594    array       ``bed_left_pic``
+613    array       ``bed_right_pic``
+632    array       ``bed_top_pic``
+651    array       ``bed_bottom_pic``
+670    array       ``bed_white_middle_pic``
+689    array       ``bed_red_middle_pic``
+708    array       ``bed_blue_middle_pic``
+727    array       ``bed_purple_middle_pic``
+746    array       ``bed_yellow_middle_pic``
+765    array       ``chain_pic``
+784    array       ``k_pic``
+795    array       ``b_pic``
+806    array       ``up_pic``
+841    array       ``down_pic``
+876    array       ``big_spider_pic``
+895    array       ``small_spider_pic``
+914    array       ``fairy_pic``
+949    array       ``large_gem_pic``
+968    array       ``floor_pic``
+979    array       ``player_pic``
+998    function    ``createPixmap``
+1005   procedure   ``initRoomData``
+1028   procedure   ``initMonster``
+1054   procedure   ``initMonsterData``
+1074   function    ``conv``
+1087   function    ``conv``
+1091   procedure   ``initItem``
+1112   procedure   ``initItemData``
+1139   procedure   ``initPlayerData``
+1155   procedure   ``loadHighScore``
+1171   procedure   ``saveHighScore``
+1185   procedure   ``initGame``
+1245   procedure   ``displayBox``
+1261   function    ``getPixmap``
+1273   procedure   ``displayRoom``
+1346   procedure   ``displayObj``
+1359   procedure   ``displayMonster``
+1371   procedure   ``objectLegend``
+1383   procedure   ``displayLegend``
+1415   function    ``sizeOfLegend``
+1443   procedure   ``collectedTreasures``
+1469   procedure   ``killedMonsters``
+1511   function    ``getInventoryStartLine``
+1522   procedure   ``displayInventoryItem``
+1538   procedure   ``displayInventoryList``
+1559   procedure   ``displayInventory``
+1572   procedure   ``displayMessage``
+1584   procedure   ``displayCommands``
+1610   procedure   ``displayAll``
+1624   procedure   ``floodTrap``
+1651   procedure   ``checkRoom``
+1695   procedure   ``hideItem``
+1708   procedure   ``showItem``
+1721   procedure   ``loadGame``
+1769   procedure   ``saveGame``
+1809   function    ``searchMonster``
+1827   function    ``hitMonster``
+1844   function    ``selectItem``
+1939   procedure   ``dropItem``
+1988   procedure   ``dropItem``
+1999   procedure   ``useItem``
+2081   procedure   ``useItem``
+2092   function    ``getMonsterMessage``
+2094   array       ``message``
+2116   function    ``getItemMessage``
+2118   array       ``message``
+2176   function    ``getScore``
+2205   procedure   ``showStatus``
+2242   procedure   ``lookItemInRoom``
+2455   procedure   ``lookItem``
+2475   procedure   ``welcomeScreen``
+2494   procedure   ``endOfGame``
+2513   function    ``getField``
+2543   procedure   ``checkField``
+2580   function    ``hitWall``
+2589   function    ``checkCollision``
+2600   function    ``hitPlayer``
+2611   procedure   ``moveMonsters``
+2709   procedure   ``enterRoom``
+2716   procedure   ``moveDelta``
+2805   procedure   ``move``
+2856   procedure   ``moveTo``
+2911   procedure   ``takeItem``
+2942   procedure   ``takeItem``
+3064   procedure   ``quitGame``
+3072   procedure   ``playGame``
+3132   procedure   ``main``
+====== =========== ==================================================
+
+prg/cat.sd7
+-----------
+
+:Lines:    82
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``cat``
+59     procedure   ``main``
+====== =========== ==================================================
+
+prg/cellauto.sd7
+----------------
+
+:Lines:    85
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     function    ``nextGeneration``
+52     procedure   ``drawGeneration``
+65     procedure   ``main``
+====== =========== ==================================================
+
+prg/celsius.sd7
+---------------
+
+:Lines:    42
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``main``
+====== =========== ==================================================
+
+prg/chk_all.sd7
+---------------
+
+:Lines:    843
+:Entities: 10
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+528    procedure   ``ignoreFileError``
+538    function    ``equalFiles``
+569    function    ``cmdOutput``
+575    array       ``parameters``
+600    function    ``checkInterpreter``
+622    function    ``checkCompiler``
+736    procedure   ``check``
+738    array       ``minimalTestOptions``
+739    array       ``options``
+770    procedure   ``main``
+====== =========== ==================================================
+
+prg/chkarr.sd7
+--------------
+
+:Lines:    8367
+:Entities: 384
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     array       ``testNumArr``
+34     array       ``testStriArr``
+36     array       ``fltArr1``
+37     array       ``fltArr2``
+38     array       ``fltArr3``
+39     array       ``fltArr4``
+41     array       ``arr1``
+43     array       ``arr2``
+45     array       ``arr3``
+47     array       ``arr4``
+50     function    ``boolExpr``
+54     function    ``intExpr``
+58     function    ``bigintExpr``
+66     function    ``floatExpr``
+70     function    ``complexExpr``
+74     function    ``charExpr``
+78     function    ``striExpr``
+82     function    ``bstriExpr``
+86     function    ``setExpr``
+90     procedure   ``DECLARE_ARR_EXPR``
+92     function    ``arrExpr``
+108    function    ``raisesIndexError``
+121    procedure   ``DECLARE_RAISES_INDEX_ERROR``
+124    function    ``raisesIndexError``
+138    function    ``raisesIndexError``
+152    function    ``raisesIndexError``
+156    array       ``exprResult``
+180    procedure   ``DECLARE_RAISES_RANGE_ERROR``
+183    function    ``raisesRangeError``
+187    array       ``exprResult``
+211    procedure   ``subprog1``
+213    array       ``arr3``
+219    procedure   ``testSpecial``
+256    function    ``striRand``
+271    procedure   ``testArrayCopy``
+278    array       ``stringArray``
+280    array       ``destArray``
+301    procedure   ``testInitialization``
+304    array       ``blnArr1Const``
+305    array       ``intArr1Const``
+306    array       ``bigArr1Const``
+307    array       ``fltArr1Const``
+308    array       ``cpxArr1Const``
+309    array       ``chrArr1Const``
+310    array       ``strArr1Const``
+311    array       ``bstArr1Const``
+312    array       ``setArr1Const``
+313    array       ``blnArr2Const``
+314    array       ``intArr2Const``
+315    array       ``bigArr2Const``
+316    array       ``fltArr2Const``
+317    array       ``cpxArr2Const``
+318    array       ``chrArr2Const``
+319    array       ``strArr2Const``
+320    array       ``bstArr2Const``
+321    array       ``setArr2Const``
+322    array       ``blnArr3Const``
+323    array       ``intArr3Const``
+324    array       ``bigArr3Const``
+325    array       ``fltArr3Const``
+326    array       ``cpxArr3Const``
+327    array       ``chrArr3Const``
+328    array       ``strArr3Const``
+329    array       ``bstArr3Const``
+330    array       ``setArr3Const``
+331    array       ``blnArr1``
+332    array       ``intArr1``
+333    array       ``bigArr1``
+334    array       ``fltArr1``
+335    array       ``cpxArr1``
+336    array       ``chrArr1``
+337    array       ``strArr1``
+338    array       ``bstArr1``
+339    array       ``setArr1``
+340    array       ``blnArr2``
+341    array       ``intArr2``
+342    array       ``bigArr2``
+343    array       ``fltArr2``
+344    array       ``cpxArr2``
+345    array       ``chrArr2``
+346    array       ``strArr2``
+347    array       ``bstArr2``
+348    array       ``setArr2``
+349    array       ``blnArr3``
+350    array       ``intArr3``
+351    array       ``bigArr3``
+352    array       ``fltArr3``
+353    array       ``cpxArr3``
+354    array       ``chrArr3``
+355    array       ``strArr3``
+356    array       ``bstArr3``
+357    array       ``setArr3``
+439    procedure   ``testCompare``
+442    array       ``blnArr``
+443    array       ``intArr``
+444    array       ``bigArr``
+445    array       ``fltArr``
+446    array       ``cpxArr``
+448    array       ``chrArr``
+449    array       ``strArr``
+450    array       ``bstArr``
+452    array       ``setArr``
+453    array       ``blnArr2``
+454    array       ``intArr2``
+455    array       ``bigArr2``
+456    array       ``fltArr2``
+457    array       ``cpxArr2``
+459    array       ``chrArr2``
+460    array       ``strArr2``
+461    array       ``bstArr2``
+463    array       ``setArr2``
+464    array       ``blnArrConst``
+465    array       ``intArrConst``
+466    array       ``bigArrConst``
+467    array       ``fltArrConst``
+468    array       ``cpxArrConst``
+470    array       ``chrArrConst``
+471    array       ``strArrConst``
+472    array       ``bstArrConst``
+474    array       ``setArrConst``
+807    procedure   ``definePeelFirstElement``
+810    function    ``peelFirstElement``
+833    procedure   ``testAssign``
+836    array       ``blnArr``
+837    array       ``intArr``
+838    array       ``bigArr``
+839    array       ``fltArr``
+840    array       ``cpxArr``
+842    array       ``chrArr``
+843    array       ``strArr``
+844    array       ``bstArr``
+846    array       ``setArr``
+847    array       ``blnArr2``
+848    array       ``intArr2``
+849    array       ``bigArr2``
+850    array       ``fltArr2``
+851    array       ``cpxArr2``
+852    array       ``chrArr2``
+853    array       ``strArr2``
+854    array       ``bstArr2``
+855    array       ``setArr2``
+856    array       ``blnArrArr``
+857    array       ``intArrArr``
+858    array       ``bigArrArr``
+859    array       ``fltArrArr``
+860    array       ``cpxArrArr``
+861    array       ``chrArrArr``
+862    array       ``strArrArr``
+863    array       ``bstArrArr``
+864    array       ``setArrArr``
+1542   procedure   ``testAppend``
+1545   array       ``blnArr``
+1546   array       ``intArr``
+1547   array       ``bigArr``
+1548   array       ``fltArr``
+1549   array       ``cpxArr``
+1551   array       ``chrArr``
+1552   array       ``strArr``
+1553   array       ``bstArr``
+1555   array       ``setArr``
+1679   procedure   ``testPush``
+1682   array       ``blnArr``
+1683   array       ``intArr``
+1684   array       ``bigArr``
+1685   array       ``fltArr``
+1686   array       ``cpxArr``
+1688   array       ``chrArr``
+1689   array       ``strArr``
+1690   array       ``bstArr``
+1692   array       ``setArr``
+1812   procedure   ``testLength``
+1815   array       ``blnArrConst``
+1816   array       ``intArrConst``
+1817   array       ``bigArrConst``
+1818   array       ``fltArrConst``
+1819   array       ``cpxArrConst``
+1821   array       ``chrArrConst``
+1822   array       ``strArrConst``
+1823   array       ``bstArrConst``
+1825   array       ``setArrConst``
+1826   array       ``blnArrConst0``
+1827   array       ``intArrConst0``
+1828   array       ``bigArrConst0``
+1829   array       ``fltArrConst0``
+1830   array       ``cpxArrConst0``
+1832   array       ``chrArrConst0``
+1833   array       ``strArrConst0``
+1834   array       ``bstArrConst0``
+1836   array       ``setArrConst0``
+1837   array       ``blnArr``
+1838   array       ``intArr``
+1839   array       ``bigArr``
+1840   array       ``fltArr``
+1841   array       ``cpxArr``
+1843   array       ``chrArr``
+1844   array       ``strArr``
+1845   array       ``bstArr``
+1847   array       ``setArr``
+1848   array       ``blnArr0``
+1849   array       ``intArr0``
+1850   array       ``bigArr0``
+1851   array       ``fltArr0``
+1852   array       ``cpxArr0``
+1854   array       ``chrArr0``
+1855   array       ``strArr0``
+1856   array       ``bstArr0``
+1858   array       ``setArr0``
+1908   function    ``testIndex1``
+1942   function    ``testIndex2``
+1987   function    ``testFixArrayIndex``
+2099   function    ``testBaseArrayIndex``
+2245   function    ``returnFileArray``
+2249   function    ``testFileArray``
+2288   function    ``testIndex1``
+2292   array       ``blnArrConst``
+2293   array       ``intArrConst``
+2294   array       ``bigArrConst``
+2295   array       ``fltArrConst``
+2296   array       ``blnArrConst0``
+2297   array       ``intArrConst0``
+2298   array       ``bigArrConst0``
+2299   array       ``fltArrConst0``
+2300   array       ``blnArr``
+2301   array       ``intArr``
+2302   array       ``bigArr``
+2303   array       ``fltArr``
+2304   array       ``emptyBlnArr``
+2305   array       ``emptyIntArr``
+2306   array       ``emptyBigArr``
+2307   array       ``emptyFltArr``
+2627   function    ``testIndex2``
+2631   array       ``cpxArrConst``
+2633   array       ``chrArrConst``
+2634   array       ``strArrConst``
+2635   array       ``bstArrConst``
+2637   array       ``setArrConst``
+2638   array       ``cpxArrConst0``
+2640   array       ``chrArrConst0``
+2641   array       ``strArrConst0``
+2642   array       ``bstArrConst0``
+2644   array       ``setArrConst0``
+2645   array       ``cpxArr``
+2647   array       ``chrArr``
+2648   array       ``strArr``
+2649   array       ``bstArr``
+2651   array       ``setArr``
+2652   array       ``emptyCpxArr``
+2653   array       ``emptyChrArr``
+2654   array       ``emptyStrArr``
+2655   array       ``emptyBstArr``
+2656   array       ``emptySetArr``
+3055   procedure   ``testIndex``
+3081   procedure   ``testTimes``
+3365   procedure   ``testHeadAndTail``
+3368   array       ``numArr``
+3369   array       ``striArr``
+3425   procedure   ``testHead``
+3428   array       ``intArr``
+3429   array       ``bigArr``
+3430   array       ``fltArr``
+3431   array       ``cpxArr``
+3433   array       ``chrArr``
+3434   array       ``strArr``
+3435   array       ``bstArr``
+3437   array       ``setArr``
+3438   array       ``intHead``
+3439   array       ``bigHead``
+3440   array       ``fltHead``
+3441   array       ``cpxHead``
+3442   array       ``chrHead``
+3443   array       ``strHead``
+3444   array       ``bstHead``
+3445   array       ``setHead``
+4094   procedure   ``testTail``
+4097   array       ``intArr``
+4098   array       ``bigArr``
+4099   array       ``fltArr``
+4100   array       ``cpxArr``
+4102   array       ``chrArr``
+4103   array       ``strArr``
+4104   array       ``bstArr``
+4106   array       ``setArr``
+4107   array       ``intTail``
+4108   array       ``bigTail``
+4109   array       ``fltTail``
+4110   array       ``cpxTail``
+4111   array       ``chrTail``
+4112   array       ``strTail``
+4113   array       ``bstTail``
+4114   array       ``setTail``
+4600   procedure   ``testRange``
+4603   array       ``intArr``
+4604   array       ``bigArr``
+4605   array       ``fltArr``
+4606   array       ``cpxArr``
+4609   array       ``chrArr``
+4610   array       ``strArr``
+4612   array       ``bstArr``
+4615   array       ``setArr``
+4616   array       ``intRange``
+4617   array       ``bigRange``
+4618   array       ``fltRange``
+4619   array       ``cpxRange``
+4620   array       ``chrRange``
+4621   array       ``strRange``
+4622   array       ``bstRange``
+4623   array       ``setRange``
+5751   procedure   ``testSubarr``
+5754   array       ``intArr``
+5755   array       ``bigArr``
+5756   array       ``fltArr``
+5757   array       ``cpxArr``
+5760   array       ``chrArr``
+5761   array       ``strArr``
+5763   array       ``bstArr``
+5766   array       ``setArr``
+5767   array       ``intSubarr``
+5768   array       ``bigSubarr``
+5769   array       ``fltSubarr``
+5770   array       ``cpxSubarr``
+5771   array       ``chrSubarr``
+5772   array       ``strSubarr``
+5773   array       ``bstSubarr``
+5774   array       ``setSubarr``
+6902   procedure   ``testInsertElement``
+6906   array       ``intArr``
+6907   array       ``bigArr``
+6908   array       ``fltArr``
+6909   array       ``cpxArr``
+6910   array       ``chrArr``
+6911   array       ``strArr``
+6912   array       ``bstArr``
+6913   array       ``setArr``
+6914   array       ``arrArr``
+7135   procedure   ``testInsertArray``
+7139   array       ``intArr``
+7140   array       ``bigArr``
+7141   array       ``fltArr``
+7142   array       ``cpxArr``
+7143   array       ``chrArr``
+7144   array       ``strArr``
+7145   array       ``bstArr``
+7146   array       ``setArr``
+7147   array       ``intArr2``
+7148   array       ``bigArr2``
+7149   array       ``fltArr2``
+7150   array       ``cpxArr2``
+7151   array       ``chrArr2``
+7152   array       ``strArr2``
+7153   array       ``bstArr2``
+7154   array       ``setArr2``
+7622   procedure   ``testRemoveElement``
+7625   array       ``intArr``
+7626   array       ``bigArr``
+7627   array       ``fltArr``
+7628   array       ``cpxArr``
+7630   array       ``chrArr``
+7631   array       ``strArr``
+7632   array       ``bstArr``
+7634   array       ``setArr``
+7882   procedure   ``testRemoveArray``
+7885   array       ``intArr``
+7886   array       ``bigArr``
+7887   array       ``fltArr``
+7888   array       ``cpxArr``
+7890   array       ``chrArr``
+7891   array       ``strArr``
+7892   array       ``bstArr``
+7894   array       ``setArr``
+7895   array       ``intRemoved``
+7896   array       ``bigRemoved``
+7897   array       ``fltRemoved``
+7898   array       ``cpxRemoved``
+7899   array       ``chrRemoved``
+7900   array       ``strRemoved``
+7901   array       ``bstRemoved``
+7902   array       ``setRemoved``
+8206   procedure   ``testArraySort``
+8208   array       ``intArr``
+8209   array       ``bigArr``
+8210   array       ``fltArr``
+8211   array       ``chrArr``
+8212   array       ``strArr``
+8343   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkbig.sd7
+--------------
+
+:Lines:    29026
+:Entities: 154
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     function    ``bigintExpr``
+44     function    ``intExpr``
+48     function    ``striExpr``
+52     function    ``boolExpr``
+56     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+59     function    ``raisesRangeError``
+80     procedure   ``DECLARE_RAISES_NUMERIC_ERROR``
+83     function    ``raisesNumericError``
+104    procedure   ``chkLiteral``
+357    function    ``chkEq``
+1163   function    ``chkNe``
+1969   function    ``chkLt``
+2775   function    ``chkLe``
+3581   function    ``chkGe``
+4387   function    ``chkGt``
+5193   procedure   ``chkComparisons``
+5222   function    ``chkParse``
+5800   procedure   ``chkStringConv``
+6476   function    ``chkRadix_1``
+6497   function    ``chkRadix_2``
+6893   function    ``chkRadix_3``
+7298   function    ``chkRadix_4``
+7464   procedure   ``chkRadix``
+7493   procedure   ``chkOrd``
+7676   procedure   ``chkBigOrdWithBigMod``
+8141   procedure   ``chkConv``
+8502   procedure   ``chkBytesBe``
+8876   procedure   ``chkBytesLe``
+9250   procedure   ``chkBytesBe2BigInt``
+9707   procedure   ``chkBytesLe2BigInt``
+10164  function    ``chkNegate``
+10175  function    ``chkNegate_1``
+10515  function    ``chkNegate_2``
+10855  procedure   ``chkNegate``
+10876  procedure   ``chkPlus``
+11223  procedure   ``chkSucc``
+11570  procedure   ``chkPred``
+11917  function    ``testIncr``
+11926  procedure   ``chkIncr``
+12273  function    ``testDecr``
+12282  procedure   ``chkDecr``
+12629  procedure   ``chkAddition``
+13058  function    ``chkAddAssignLiteral1``
+13154  function    ``chkAddAssignLiteral2``
+13291  function    ``chkAddAssignLiteral3``
+13450  function    ``chkAddAssignLiteral4``
+13546  function    ``chkAddAssignExpression1``
+13642  function    ``chkAddAssignExpression2``
+13779  function    ``chkAddAssignExpression3``
+13938  function    ``chkAddAssignExpression4``
+14034  function    ``chkAddAssignWithItself``
+14089  procedure   ``chkAddAssign``
+14108  procedure   ``chkSubtraction``
+14531  function    ``chkSubtractAssignLiteral1``
+14627  function    ``chkSubtractAssignLiteral2``
+14765  function    ``chkSubtractAssignLiteral3``
+14924  function    ``chkSubtractAssignLiteral4``
+15020  function    ``chkSubtractAssignExpression1``
+15116  function    ``chkSubtractAssignExpression2``
+15254  function    ``chkSubtractAssignExpression3``
+15413  function    ``chkSubtractAssignExpression4``
+15509  function    ``chkSubtractAssignWithItself``
+15564  procedure   ``chkSubtractAssign``
+15583  function    ``chkMultiplicationWithConst1``
+16044  function    ``chkMultiplicationWithConst2``
+16505  function    ``chkMultiplicationWithConst3``
+16901  procedure   ``chkMultiplication``
+17419  function    ``chkMultAssignLiteral1``
+17536  function    ``chkMultAssignLiteral2``
+17663  function    ``chkMultAssignLiteral3``
+17798  function    ``chkMultAssignLiteral4``
+17915  function    ``chkMultAssignExpression1``
+18032  function    ``chkMultAssignExpression2``
+18159  function    ``chkMultAssignExpression3``
+18294  function    ``chkMultAssignExpression4``
+18411  function    ``chkMultAssign1``
+18596  procedure   ``chkMultAssign``
+18705  function    ``chkDivision_1``
+19063  function    ``chkDivision_2``
+19109  function    ``chkDivision_3``
+19219  function    ``chkDivision_4``
+19401  function    ``chkDivision_5``
+19484  procedure   ``chkDivision``
+19517  function    ``chkRemainder_1``
+19875  function    ``chkRemainder_2``
+19929  function    ``chkRemainder_3``
+20039  function    ``chkRemainder_4``
+20221  function    ``chkRemainder_5``
+20283  procedure   ``chkRemainder``
+20316  function    ``chkDivRem_1``
+20410  function    ``chkDivRem_2``
+20504  function    ``chkDivRem_3``
+20598  function    ``chkDivRem_4``
+20692  function    ``chkDivRem_5``
+20746  function    ``chkDivRem_6``
+20808  procedure   ``chkDivRem``
+20845  function    ``chkModDivision_1``
+21203  function    ``chkModDivision_2``
+21285  function    ``chkModDivision_3``
+21395  function    ``chkModDivision_4``
+21577  function    ``chkModDivision_5``
+21660  procedure   ``chkModDivision``
+21693  function    ``chkModulo_1``
+22051  function    ``chkModulo_2``
+22133  function    ``chkModulo_3``
+22243  function    ``chkModulo_4``
+22425  function    ``chkModulo_5``
+22671  function    ``chkModulo_6``
+22750  procedure   ``chkModulo``
+22787  function    ``chkPower_1``
+23011  function    ``chkPower_2``
+23096  function    ``chkPower_3``
+23306  function    ``chkPower_4``
+23342  function    ``chkPower_5``
+23552  function    ``chkPower_6``
+23588  function    ``chkPower_7``
+23798  function    ``chkPower_8``
+23834  function    ``chkPower_9``
+24045  procedure   ``chkPower``
+24094  procedure   ``chkFactorial``
+24138  procedure   ``chkBinom``
+24177  function    ``chkCompare_1``
+24383  function    ``chkCompare_2``
+24589  function    ``chkCompare_3``
+24795  function    ``chkCompare_4``
+25001  procedure   ``chkCompare``
+25030  procedure   ``chkAbs``
+25711  procedure   ``chkOdd``
+25731  procedure   ``chkRand``
+25751  procedure   ``chkGcd``
+25768  procedure   ``chkLog2``
+26594  procedure   ``chkLog10``
+26830  procedure   ``chkBitLength``
+26933  procedure   ``chkLowestSetBit``
+27165  function    ``chkLShift``
+27189  function    ``chkLShift``
+27197  procedure   ``chkLShift``
+27279  procedure   ``chkLShift``
+27583  function    ``chkRShift``
+27607  function    ``chkRShift``
+27615  procedure   ``chkRShift``
+27697  procedure   ``chkRShift``
+28001  procedure   ``chkSqrt``
+28144  procedure   ``checkSci``
+28723  procedure   ``chkConstants``
+28820  procedure   ``do_assign``
+28836  function    ``peelLowestByte``
+28846  procedure   ``chkAssign``
+28851  array       ``bigNumArr``
+28875  procedure   ``checkTernary``
+28930  function    ``randDigitStri``
+28944  procedure   ``testConversion``
+28963  procedure   ``testConversion``
+28974  procedure   ``main``
+====== =========== ==================================================
+
+prg/chkbin.sd7
+--------------
+
+:Lines:    6469
+:Entities: 44
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     function    ``intExpr``
+37     function    ``bin32Expr``
+41     function    ``bin64Expr``
+45     function    ``striExpr``
+49     function    ``floatExpr``
+53     function    ``boolExpr``
+57     function    ``bigintExpr``
+65     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+68     function    ``raisesRangeError``
+91     procedure   ``checkShift``
+179    procedure   ``checkAnd``
+350    procedure   ``checkOr``
+393    procedure   ``checkXor``
+436    function    ``checkBytesBeWithLength_1``
+791    function    ``checkBytesBeWithLength_2``
+1146   function    ``checkBytesBeWithLength_3``
+1176   procedure   ``checkBytesBeWithLength``
+1201   function    ``checkBytesLeWithLength_1``
+1556   function    ``checkBytesLeWithLength_2``
+1911   function    ``checkBytesLeWithLength_3``
+1941   procedure   ``checkBytesLeWithLength``
+1966   function    ``checkBytesBe2Bin64_1``
+2321   function    ``checkBytesBe2Bin64_2``
+2676   function    ``checkBytesBe2Bin64_3``
+2734   procedure   ``checkBytesBe2Bin64``
+2759   function    ``checkBytesLe2Bin64_1``
+3114   function    ``checkBytesLe2Bin64_2``
+3469   function    ``checkBytesLe2Bin64_3``
+3527   procedure   ``checkBytesLe2Bin64``
+3552   procedure   ``checkFloat2Bin16``
+3710   procedure   ``checkBin16ToFloat``
+3774   procedure   ``checkFloat2Bin32``
+3860   procedure   ``checkBin32ToFloat``
+3996   procedure   ``checkFloat2Bin64``
+4082   procedure   ``checkBin64ToFloat``
+4172   procedure   ``checkFloat2MbfBits``
+4251   procedure   ``checkMbfBits2Float``
+4317   procedure   ``checkBinBinaryWithBigMod``
+4751   procedure   ``checkStr``
+4973   procedure   ``checkRadix``
+5919   procedure   ``checkBitLength``
+6193   procedure   ``checkLowestSetBit``
+6341   procedure   ``checkTernary``
+6442   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkbitdata.sd7
+------------------
+
+:Lines:    6624
+:Entities: 39
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     function    ``chkGetBitLsb``
+72     procedure   ``chkGetBitLsb``
+128    function    ``chkGetBitsLsb``
+170    procedure   ``chkGetBitsLsb``
+796    function    ``chkPeekBitsLsb``
+837    procedure   ``chkPeekBitsLsb``
+1474   function    ``chkEofLsb``
+1554   procedure   ``chkEofLsb``
+2172   function    ``chkGetsLsb``
+2221   procedure   ``chkGetsLsb``
+2280   function    ``chkCloseLsb``
+2312   procedure   ``chkCloseLsb``
+2371   function    ``chkGetBitMsb``
+2413   procedure   ``chkGetBitMsb``
+2451   function    ``chkGetBitsMsb``
+2493   procedure   ``chkGetBitsMsb``
+3119   function    ``chkPeekBitsMsb``
+3160   procedure   ``chkPeekBitsMsb``
+3797   function    ``chkEofMsb``
+3889   procedure   ``chkEofMsb``
+4507   function    ``chkGetsMsb``
+4560   procedure   ``chkGetsMsb``
+4619   function    ``chkCloseMsb``
+4651   procedure   ``chkCloseMsb``
+4710   procedure   ``initBitStream``
+4722   function    ``chkPutBitLsb``
+4745   procedure   ``chkPutBitLsb``
+4782   function    ``chkPutBitsLsb``
+4806   procedure   ``chkPutBitsLsb``
+5464   function    ``chkLengthTruncateLsb``
+5496   procedure   ``chkLengthTruncateLsb``
+5656   procedure   ``initBitStream``
+5668   function    ``chkPutBitMsb``
+5691   procedure   ``chkPutBitMsb``
+5728   function    ``chkPutBitsMsb``
+5752   procedure   ``chkPutBitsMsb``
+6410   function    ``chkLengthTruncateMsb``
+6442   procedure   ``chkLengthTruncateMsb``
+6602   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkbool.sd7
+---------------
+
+:Lines:    3157
+:Entities: 98
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     function    ``boolExpr``
+45     function    ``intExpr``
+49     function    ``raisesNumericError``
+64     procedure   ``check_not``
+118    procedure   ``check_and``
+261    procedure   ``check_and_assign``
+283    procedure   ``check_or``
+402    procedure   ``check_or_assign``
+424    procedure   ``check_xor_assign``
+446    procedure   ``check_eq_expr``
+468    procedure   ``check_eq_ref_param``
+490    procedure   ``check_eq_in_param``
+512    procedure   ``check_eq_local_var``
+537    procedure   ``check_eq_global_var``
+559    procedure   ``check_eq_global_const``
+581    procedure   ``check_eq_literal``
+603    procedure   ``check_eq``
+621    procedure   ``check_ne_expr``
+643    procedure   ``check_ne_ref_param``
+665    procedure   ``check_ne_in_param``
+687    procedure   ``check_ne_local_var``
+712    procedure   ``check_ne_global_var``
+734    procedure   ``check_ne_global_const``
+756    procedure   ``check_ne_literal``
+778    procedure   ``check_ne``
+796    procedure   ``check_gt_expr``
+818    procedure   ``check_gt_ref_param``
+840    procedure   ``check_gt_in_param``
+862    procedure   ``check_gt_local_var``
+887    procedure   ``check_gt_global_var``
+909    procedure   ``check_gt_global_const``
+931    procedure   ``check_gt_literal``
+953    procedure   ``check_gt``
+971    procedure   ``check_ge_expr``
+993    procedure   ``check_ge_ref_param``
+1015   procedure   ``check_ge_in_param``
+1037   procedure   ``check_ge_local_var``
+1062   procedure   ``check_ge_global_var``
+1084   procedure   ``check_ge_global_const``
+1106   procedure   ``check_ge_literal``
+1128   procedure   ``check_ge``
+1146   procedure   ``check_lt_expr``
+1168   procedure   ``check_lt_ref_param``
+1190   procedure   ``check_lt_in_param``
+1212   procedure   ``check_lt_local_var``
+1237   procedure   ``check_lt_global_var``
+1259   procedure   ``check_lt_global_const``
+1281   procedure   ``check_lt_literal``
+1303   procedure   ``check_lt``
+1321   procedure   ``check_le_expr``
+1343   procedure   ``check_le_ref_param``
+1365   procedure   ``check_le_in_param``
+1387   procedure   ``check_le_local_var``
+1412   procedure   ``check_le_global_var``
+1434   procedure   ``check_le_global_const``
+1456   procedure   ``check_le_literal``
+1478   procedure   ``check_le``
+1496   procedure   ``check_relations``
+1507   procedure   ``check_compare``
+1529   procedure   ``check_ord_expr``
+1543   procedure   ``check_ord_ref_param``
+1557   procedure   ``check_ord_in_param``
+1571   procedure   ``check_ord_local_var``
+1588   procedure   ``check_ord_global_var``
+1602   procedure   ``check_ord_global_const``
+1616   procedure   ``check_ord_literal``
+1630   procedure   ``check_ord``
+1648   procedure   ``check_conv_literal``
+1670   procedure   ``check_conv_local_const``
+1695   procedure   ``check_conv_local_var``
+1720   procedure   ``check_conv_ref_param``
+1742   procedure   ``check_conv_in_param``
+1764   procedure   ``check_conv``
+1914   procedure   ``check_str_expr``
+1928   procedure   ``check_str_ref_param``
+1942   procedure   ``check_str_in_param``
+1956   procedure   ``check_str_local_var``
+1973   procedure   ``check_str_global_var``
+1987   procedure   ``check_str_global_const``
+2001   procedure   ``check_str_literal``
+2015   procedure   ``check_str``
+2033   procedure   ``check_succ_in_param``
+2056   procedure   ``check_succ_in_var_param``
+2079   procedure   ``check_succ_val_param``
+2102   procedure   ``check_succ_ref_param``
+2125   procedure   ``check_succ_inout_param``
+2148   procedure   ``check_succ``
+2248   procedure   ``check_pred_in_param``
+2271   procedure   ``check_pred_in_var_param``
+2294   procedure   ``check_pred_val_param``
+2317   procedure   ``check_pred_ref_param``
+2340   procedure   ``check_pred_inout_param``
+2363   procedure   ``check_pred``
+2463   function    ``is_odd``
+2466   function    ``is_even``
+2470   function    ``is_odd``
+2474   procedure   ``check_ternary``
+3138   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkbst.sd7
+--------------
+
+:Lines:    722
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``&:=``
+32     function    ``bstriExpr``
+36     function    ``intExpr``
+40     function    ``boolExpr``
+44     function    ``raisesIndexError``
+59     function    ``raisesRangeError``
+74     procedure   ``check_bstring_parse``
+144    procedure   ``check_bstring_length``
+178    procedure   ``do_assign``
+194    function    ``peelFirstChar``
+204    procedure   ``check_bstring_assign``
+209    array       ``bstriArr``
+231    procedure   ``do_append``
+237    procedure   ``check_bstring_append``
+268    procedure   ``check_bstring_comparisons``
+469    procedure   ``check_bstring_index``
+629    procedure   ``check_bstring_constants``
+653    procedure   ``check_bstring_ternary``
+710    procedure   ``main``
+====== =========== ==================================================
+
+prg/chkchr.sd7
+--------------
+
+:Lines:    2809
+:Entities: 24
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     function    ``charExpr``
+34     function    ``boolExpr``
+38     function    ``intExpr``
+42     function    ``raisesRangeError``
+57     procedure   ``check_literal``
+168    procedure   ``check_conversions``
+226    procedure   ``check_functions``
+272    procedure   ``check_isLetter``
+802    function    ``check_width_1``
+1128   function    ``check_width_2``
+1457   procedure   ``check_width``
+1474   function    ``check_literal_function_1``
+1672   function    ``check_literal_function_2``
+1778   function    ``check_literal_function_3``
+1884   function    ``literalFunction``
+1888   function    ``check_literal_function_4``
+2086   function    ``check_c_literal_function_1``
+2284   function    ``check_c_literal_function_2``
+2390   function    ``check_c_literal_function_3``
+2496   function    ``cLiteralFunction``
+2500   function    ``check_c_literal_function_4``
+2698   procedure   ``check_literal_function``
+2742   procedure   ``check_ternary``
+2797   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkcmd.sd7
+--------------
+
+:Lines:    1205
+:Entities: 22
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     function    ``raisesFileError``
+45     function    ``raisesFileError``
+59     function    ``raisesFileError``
+73     function    ``raisesFileError``
+87     function    ``raisesFileError``
+101    function    ``raisesFileError``
+113    structure   ``fileProperties``
+123    function    ``=``
+132    function    ``<>``
+141    function    ``getFileProperties``
+154    procedure   ``checkRemoveFile``
+191    procedure   ``checkRemoveTree``
+233    procedure   ``checkCopyFile``
+422    procedure   ``checkCloneFile``
+661    procedure   ``checkMoveFile``
+861    function    ``checkDanglingSymlink``
+932    function    ``checkSymlinkToRegularFile``
+1062   procedure   ``checkSymlink``
+1079   function    ``randomString``
+1091   function    ``randomNameNotInEnvironment``
+1110   procedure   ``check_environment``
+1191   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkdb.sd7
+-------------
+
+:Lines:    7454
+:Entities: 117
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``connectData``
+45     function    ``connectData``
+58     structure   ``testState``
+67     function    ``testState``
+82     function    ``raisesRangeError``
+94     function    ``raisesDatabaseError``
+106    procedure   ``DECL_INSERT``
+109    procedure   ``insert``
+127    procedure   ``insert``
+148    procedure   ``insInf``
+175    procedure   ``insNaN``
+202    procedure   ``insert``
+236    procedure   ``insert``
+255    procedure   ``insert``
+276    procedure   ``insert``
+295    procedure   ``create``
+334    procedure   ``testPrepareAndExecute``
+674    function    ``changeParameter``
+691    procedure   ``testAssignDatabase``
+694    array       ``dbArr``
+723    function    ``changeParameter``
+734    procedure   ``testAssignStatement``
+737    array       ``statementArr``
+748    procedure   ``testFieldNames``
+848    procedure   ``testWithAutoCommit``
+932    procedure   ``testAutoCommit``
+1002   procedure   ``testWithoutAutoCommit``
+1116   procedure   ``testTransactions``
+1194   procedure   ``testBooleanField``
+1197   array       ``expect``
+1324   procedure   ``testInt8Field``
+1327   array       ``expect``
+1510   procedure   ``testInt16Field``
+1513   array       ``expect``
+1673   procedure   ``testInt32Field``
+1676   array       ``expect``
+1838   procedure   ``testInt64Field``
+1841   array       ``expect``
+2041   procedure   ``testBigIntField``
+2044   array       ``expect``
+2161   procedure   ``testFloatField``
+2164   array       ``expect``
+2315   procedure   ``testDoubleField``
+2318   array       ``expect``
+2469   procedure   ``testBigRatField``
+2472   array       ``expect``
+2760   procedure   ``testAnyIntegerField``
+2763   array       ``expect``
+3072   procedure   ``testDecimalIntField``
+3090   procedure   ``testNumericIntField``
+3108   procedure   ``testAnyRationalField``
+3113   array       ``expect``
+3306   procedure   ``testDecimalField``
+3329   procedure   ``testNumericField``
+3352   procedure   ``testChar1AsciiControlField``
+3355   array       ``expect``
+3513   procedure   ``testChar1AsciiField``
+3516   array       ``expect``
+3696   procedure   ``testChar1Latin1C1ControlField``
+3699   array       ``expect``
+3831   procedure   ``testChar1Latin1Field``
+3834   array       ``expect``
+4062   procedure   ``testCodePageField``
+4066   array       ``expect``
+4336   procedure   ``testChar1Field``
+4339   array       ``expect``
+4658   procedure   ``testCharField``
+4661   array       ``expect``
+4827   procedure   ``testCharField2``
+4830   array       ``expect``
+4940   procedure   ``testVarcharField``
+4943   array       ``expect``
+5111   procedure   ``testBlobField``
+5114   array       ``expect``
+5240   procedure   ``testClobField``
+5243   array       ``expect``
+5347   procedure   ``testDateField``
+5350   array       ``expect``
+5523   procedure   ``testTimeField``
+5526   array       ``expect``
+5616   procedure   ``testDateTimeField``
+5619   array       ``expect``
+5792   procedure   ``testTimeStampField``
+5795   array       ``expect``
+6018   procedure   ``testTimeStampTzField``
+6021   array       ``expect``
+6254   procedure   ``testPositiveYearMonthDurationField``
+6257   array       ``expect``
+6320   procedure   ``testNegativeYearMonthDurationField``
+6323   array       ``expect``
+6384   procedure   ``testPositiveDurationField``
+6387   array       ``expect``
+6459   procedure   ``testNegativeDurationField``
+6462   array       ``expect``
+6530   procedure   ``testPositiveFractionDurationField``
+6533   array       ``expect``
+6623   procedure   ``testNegativeFractionDurationField``
+6626   array       ``expect``
+6716   procedure   ``testCombinedDurationField``
+6719   array       ``expect``
+6797   procedure   ``testAdvancedDurationField``
+6800   array       ``expect``
+6878   procedure   ``testFloatField2``
+6913   procedure   ``testBigRatField2``
+6947   procedure   ``testBlobField2``
+7006   procedure   ``testTimeField2``
+7009   array       ``expect``
+7063   procedure   ``testDurationField2``
+7066   array       ``expect``
+7120   procedure   ``testNumericField2``
+7177   procedure   ``testVarcharField2``
+7180   array       ``expect``
+7257   procedure   ``testDb``
+7316   function    ``failed``
+7333   procedure   ``testDatabase``
+7360   procedure   ``main``
+7362   array       ``dbConnectDataList``
+====== =========== ==================================================
+
+prg/chkdecl.sd7
+---------------
+
+:Lines:    448
+:Entities: 9
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+59     procedure   ``XX``
+74     procedure   ``YY``
+88     procedure   ``WW``
+94     procedure   ``UU``
+98     procedure   ``ZZ``
+282    procedure   ``AA``
+286    procedure   ``BB``
+373    procedure   ``recursive``
+398    procedure   ``main``
+====== =========== ==================================================
+
+prg/chkenum.sd7
+---------------
+
+:Lines:    1230
+:Entities: 21
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+28     enumeration ``directionType``
+33     function    ``enumExpr``
+37     function    ``boolExpr``
+41     function    ``intExpr``
+45     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+48     function    ``raisesRangeError``
+69     function    ``checkEq``
+191    function    ``checkNe``
+313    function    ``checkLt``
+435    function    ``checkLe``
+557    function    ``checkGe``
+679    function    ``checkGt``
+801    procedure   ``checkComparisons``
+830    procedure   ``checkCompare``
+956    procedure   ``checkOrd``
+984    procedure   ``checkConv``
+1041   procedure   ``checkSuccAndPred``
+1095   procedure   ``checkIncrAndDecr``
+1137   procedure   ``checkLiteralFunction``
+1165   procedure   ``checkTernary``
+1218   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkerr.sd7
+--------------
+
+:Lines:    4663
+:Entities: 92
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``show``
+41     function    ``checkError``
+77     function    ``checkError1``
+84     function    ``checkError2``
+91     function    ``checkError``
+125    function    ``checkError1``
+132    function    ``checkError2``
+139    function    ``checkEofEncountered``
+174    function    ``checkCharIllegal``
+312    function    ``checkCommentOpen``
+337    function    ``checkScannerErrors``
+352    function    ``checkFileNotFound``
+399    function    ``checkWrongPathDelimiter``
+423    function    ``checkEssentialIncludeFailed``
+438    function    ``checkIllegalPragma``
+461    function    ``checkIncludeAndPragmaErrors``
+477    function    ``checkWrongAction``
+493    function    ``checkWrongSystem``
+508    function    ``checkDollarValueWrong``
+554    function    ``checkDollarTypeWrong``
+600    function    ``checkSystemMainMissing``
+615    function    ``checkBasicDeclarationErrors``
+632    function    ``checkCardDecimalTooBig``
+691    function    ``checkNegativeExponent``
+726    function    ``checkDigitExpected``
+781    function    ``checkCardWithExponentTooBig``
+824    function    ``checkBase2To36Allowed``
+859    function    ``checkExtDigitExpected``
+1010   function    ``checkIllegalBaseDigit``
+1293   function    ``checkCardBasedTooBig``
+1584   function    ``checkNumericLiteralErrors``
+1604   function    ``checkApostrophExpected``
+1627   function    ``checkCharExceeds``
+1654   function    ``checkWrongQuotationRepresentation``
+1669   function    ``checkStringEscape``
+1868   function    ``checkWrongNumericalEscape``
+1911   function    ``checkNumericalEscapeTooBig``
+1942   function    ``checkBackslashExpected``
+2005   function    ``checkStringExceeds``
+2048   function    ``checkStringAndCharLiteralErrors``
+2068   function    ``checkNameExpected``
+2103   function    ``checkCardExpected``
+2214   function    ``checkStriExpected``
+2250   function    ``checkIdentExpected``
+2308   function    ``checkTypeExpected``
+2375   function    ``checkProcExpected``
+2624   function    ``checkParamSpecifierExpected``
+2640   function    ``checkParamDeclOrSymbolExpected``
+2664   function    ``checkExceptionExpected``
+2720   function    ``checkExprExpected``
+2744   function    ``checkExpectedSymbol``
+2842   function    ``checkExpectedErrors``
+2865   function    ``checkParamDeclFailed``
+2898   function    ``checkDeclFailed``
+2968   function    ``checkObjTwiceDeclared``
+3002   function    ``checkPreviousDeclaration``
+3036   function    ``checkExceptionRaised``
+3110   function    ``checkDeclarationErrors``
+3127   function    ``checkIllegalAssociativity``
+3183   function    ``checkIllegalPriority``
+3210   function    ``checkTwoParameterSyntax``
+3241   function    ``checkSyntaxDeclaredTwice``
+3264   function    ``checkDotExprExpected``
+3280   function    ``checkRedeclaredInfixPriority``
+3303   function    ``checkRedeclaredPrefixPriority``
+3332   function    ``checkWrongExprParamPriority``
+3361   function    ``checkWrongPrefixPriority``
+3378   function    ``checkDotExprIllegal``
+3395   function    ``checkSyntaxDeclarationErrors``
+3417   function    ``checkNoMatch``
+3582   function    ``checkWrongAccessRight``
+3699   function    ``checkLiteralTypeUndefined``
+3730   function    ``checkKindOfParamUndefined``
+3753   function    ``checkSemanticErrors``
+3769   function    ``checkOverlongUtf8Encoding``
+3900   function    ``checkUtf16SurrogateChar``
+3959   function    ``checkCharNotUnicode``
+4042   function    ``checkUTF8ContinuationByte1``
+4085   function    ``checkUTF8ContinuationByte2``
+4160   function    ``checkUTF8ContinuationByte3``
+4203   function    ``checkUTF8ContinuationByte4``
+4230   function    ``checkUTF8ContinuationByte5``
+4305   function    ``checkUTF8ContinuationByte6``
+4348   function    ``checkUTF8ContinuationByte7``
+4375   function    ``checkUTF8ContinuationByte8``
+4402   function    ``checkUTF8ContinuationByte9``
+4477   function    ``checkUTF8ContinuationByte10``
+4520   function    ``checkUnexpectedUtf8ContinuationByte``
+4547   function    ``checkSolitaryUtf8StartByte``
+4598   function    ``checkUtf16ByteOrderMarkFound``
+4617   function    ``checkUnicodeErrors``
+4645   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkexc.sd7
+--------------
+
+:Lines:    2627
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     procedure   ``f1``
+42     procedure   ``f2``
+48     procedure   ``f3``
+54     procedure   ``f4``
+60     function    ``test_func``
+64     function    ``intExpr``
+68     procedure   ``check_ord_and_conv``
+118    procedure   ``check_integer_exponentiation``
+439    procedure   ``check_integer``
+840    function    ``bigIntExpr``
+844    procedure   ``check_bigInteger_exponentiation``
+1165   procedure   ``check_bigInteger``
+1309   procedure   ``check_float``
+1523   procedure   ``check_string``
+1759   procedure   ``check_array``
+1765   array       ``arr``
+1766   array       ``constantArray``
+2074   procedure   ``check_file``
+2445   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkfil.sd7
+--------------
+
+:Lines:    1615
+:Entities: 37
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+56     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+59     function    ``raisesRangeError``
+81     procedure   ``DECLARE_RAISES_FILE_ERROR``
+84     function    ``raisesFileError``
+109    procedure   ``check_clib_file``
+113    array       ``fileArr``
+150    function    ``genTempClibFile``
+180    function    ``changeParameter``
+191    procedure   ``check_clib_file_assign``
+198    array       ``fileArr``
+234    function    ``genTempFile``
+264    function    ``changeParameter``
+275    procedure   ``check_file_assign``
+282    array       ``fileArr``
+318    procedure   ``check_file_open``
+368    function    ``check_file_io_1``
+483    function    ``check_file_io_2``
+598    function    ``check_file_io_3``
+717    procedure   ``check_file_io``
+751    procedure   ``check_file_seek``
+885    procedure   ``check_file_append``
+934    procedure   ``check_automatic_close``
+983    function    ``check_use_after_close1``
+1030   function    ``check_use_after_close2``
+1101   procedure   ``check_use_after_close``
+1142   procedure   ``check_utf8_file_open``
+1192   procedure   ``check_utf8_io``
+1273   procedure   ``check_utf8_seek``
+1376   procedure   ``check_automatic_close_utf8``
+1427   procedure   ``check_use_after_close_utf8``
+1468   structure   ``myFile``
+1473   function    ``openMyFile``
+1483   procedure   ``write``
+1489   procedure   ``check_my_file``
+1498   procedure   ``check_null_file``
+1576   procedure   ``check_keybd_and_console``
+1593   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkflt.sd7
+--------------
+
+:Lines:    20620
+:Entities: 91
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     function    ``striExpr``
+40     function    ``floatExpr``
+44     function    ``intExpr``
+48     function    ``boolExpr``
+52     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+55     function    ``raisesRangeError``
+77     procedure   ``check_literal``
+360    function    ``check_equal_and_not_equal``
+910    function    ``check_less_than_and_greater_than``
+1460   function    ``check_less_equal_and_greater_equal``
+2010   procedure   ``check_comparison``
+2100   procedure   ``check_compare``
+2452   function    ``check_parse_operator``
+2993   function    ``check_parse_function``
+3534   procedure   ``check_parse``
+3553   function    ``check_str_1``
+4204   function    ``check_str_scientific``
+4794   function    ``check_digits``
+4908   function    ``check_sci``
+5144   procedure   ``check_str``
+5172   procedure   ``check_conversion``
+5636   procedure   ``check_trunc``
+5830   function    ``check_round_1``
+5995   function    ``check_round_2``
+6160   procedure   ``check_round``
+6190   function    ``changeParameter``
+6199   procedure   ``check_assign``
+6204   array       ``intArr``
+6222   procedure   ``check_add``
+6277   function    ``check_mult_with_ipower_base_minus_infinity``
+6575   function    ``check_mult_with_ipower_base_minus_0``
+6885   function    ``check_mult_with_ipower_base_0``
+7195   function    ``check_mult_with_ipower_base_1``
+7451   function    ``check_mult_with_ipower_base_2``
+7716   function    ``check_mult_with_ipower_base_4``
+7981   function    ``check_mult_with_ipower_base_infinity``
+8291   function    ``check_mult_minus_infinity_with_ipower_base_2``
+8479   function    ``check_mult_minus_zero_with_ipower_base_2``
+8667   function    ``check_mult_zero_with_ipower_base_2``
+8855   function    ``check_mult_infinity_with_ipower_base_2``
+9043   function    ``check_mult_nan_with_ipower_base_2``
+9231   function    ``check_mult_minus_infinity_with_ipower_base_4``
+9419   function    ``check_mult_minus_zero_with_ipower_base_4``
+9607   function    ``check_mult_zero_with_ipower_base_4``
+9795   function    ``check_mult_infinity_with_ipower_base_4``
+9983   function    ``check_mult_nan_with_ipower_base_4``
+10171  procedure   ``check_mult``
+10374  procedure   ``check_division``
+10399  procedure   ``check_remainder``
+10823  procedure   ``check_modulo``
+11247  function    ``check_power_base_minus_0``
+11617  function    ``check_power_base_0``
+11987  function    ``check_power_base_1``
+12085  function    ``check_power_base_2``
+12247  procedure   ``check_power``
+12796  function    ``check_ipower_base_minus_infinity``
+12878  function    ``check_ipower_base_minus_2``
+13114  function    ``check_ipower_base_minus_1``
+13196  function    ``check_ipower_base_minus_0``
+13608  function    ``check_ipower_base_0``
+14020  function    ``check_ipower_base_1``
+14102  function    ``check_ipower_base_2``
+14322  function    ``check_ipower_base_4``
+14534  function    ``check_ipower_base_infinity``
+14616  function    ``check_ipower_base_nan``
+14958  procedure   ``check_ipower``
+15121  function    ``check_lshift_minus_infinity``
+15327  function    ``check_lshift_minus_0``
+15533  function    ``check_lshift_0``
+15739  function    ``check_lshift_infinity``
+15945  function    ``check_lshift_nan``
+16151  procedure   ``check_lshift``
+16545  function    ``check_rshift_minus_infinity``
+16751  function    ``check_rshift_minus_0``
+16957  function    ``check_rshift_0``
+17163  function    ``check_rshift_infinity``
+17369  function    ``check_rshift_nan``
+17575  procedure   ``check_rshift``
+17969  procedure   ``check_functions``
+18050  procedure   ``check_negative_zero``
+18075  function    ``check_inf_1``
+18162  function    ``check_inf_2``
+18216  function    ``check_inf_3``
+18260  function    ``check_inf_4``
+18509  function    ``check_inf_5``
+18900  procedure   ``check_inf``
+18932  procedure   ``check_nan``
+20245  procedure   ``check_rand``
+20416  procedure   ``check_decompose``
+20461  procedure   ``check_ternary``
+20590  procedure   ``main``
+====== =========== ==================================================
+
+prg/chkhent.sd7
+---------------
+
+:Lines:    54
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``main``
+33     array       ``fileNames``
+====== =========== ==================================================
+
+prg/chkhsh.sd7
+--------------
+
+:Lines:    4548
+:Entities: 27
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     enumeration ``enumerationType``
+249    procedure   ``DECLARE_RAISES_INDEX_ERROR``
+252    function    ``raisesIndexError``
+286    procedure   ``DECLARE_RAISES_RANGE_ERROR``
+289    function    ``raisesRangeError``
+309    procedure   ``chkBooleanHash``
+613    procedure   ``chkIntegerHash``
+918    procedure   ``chkBigIntegerHash``
+1223   procedure   ``chkRationalHash``
+1528   procedure   ``chkBigRationalHash``
+1833   procedure   ``chkFloatHash``
+2138   procedure   ``chkComplexHash``
+2443   procedure   ``chkCharHash``
+2748   procedure   ``chkStringHash``
+3053   procedure   ``chkBstringHash``
+3358   procedure   ``chkBitsetHash``
+3663   procedure   ``chkTimeHash``
+3968   procedure   ``chkEnumerationTypeHash``
+4273   procedure   ``chkKeysFunction``
+4277   array       ``hashKeys``
+4303   procedure   ``chkValuesFunction``
+4307   array       ``hashValues``
+4333   procedure   ``chkForLoop``
+4379   procedure   ``chkAssignmentToItself``
+4397   procedure   ``chkHashLiteral``
+4508   procedure   ``chkInlineHashKeys``
+4525   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkidx.sd7
+--------------
+
+:Lines:    19567
+:Entities: 56
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     function    ``striExpr``
+34     function    ``intExpr``
+38     function    ``charExpr``
+42     procedure   ``DECLARE_RAISES_INDEX_ERROR``
+45     function    ``raisesIndexError``
+68     procedure   ``check_string_index``
+312    function    ``headOfEmptyString``
+316    function    ``headOfString1``
+320    function    ``headFunction``
+324    function    ``headFunction``
+328    procedure   ``check_string_head``
+652    function    ``tailOfEmptyString``
+656    function    ``tailOfString1``
+660    function    ``tailFunction``
+664    function    ``tailFunction``
+668    procedure   ``check_string_tail``
+1010   function    ``check_string_range_expr_1``
+1880   function    ``check_string_range_expr_2``
+2750   function    ``check_string_range_expr_3``
+2913   function    ``check_string_range_assign_1``
+3785   function    ``check_string_range_assign_2``
+4657   function    ``check_string_range_assign_3``
+4822   function    ``rangeFunction``
+4826   function    ``check_string_range_func_1``
+5696   function    ``check_string_range_func_2``
+6566   procedure   ``check_string_range``
+6868   function    ``check_string_substr_expr_1``
+7706   function    ``check_string_substr_expr_2``
+8544   function    ``check_string_substr_assign_1``
+9356   function    ``check_string_substr_assign_2``
+10168  function    ``substrFunction``
+10172  function    ``substrFunction``
+10176  function    ``check_string_substr_func_1``
+11048  function    ``check_string_substr_func_2``
+11455  function    ``check_string_substr_func_3``
+11862  procedure   ``check_string_substr``
+11968  function    ``check_string_substr_fixLen_empty_1``
+12278  function    ``check_string_substr_fixLen_empty_2``
+12588  function    ``check_string_substr_fixLen_empty_3``
+12900  function    ``check_string_substr_fixLen_empty_4``
+13212  function    ``check_string_substr_fixLen_expr_1``
+13986  function    ``check_string_substr_fixLen_expr_2``
+14760  function    ``check_string_substr_fixLen_assign_1``
+15536  function    ``check_string_substr_fixLen_assign_2``
+16312  function    ``substrFixLen``
+16316  function    ``substrFixLen``
+16320  function    ``check_string_substr_fixLen_func_1``
+17500  function    ``check_string_substr_fixLen_func_2``
+18576  procedure   ``check_string_substr_fixLen``
+18642  function    ``check_string_eq_of_substr_fixlen_1``
+18736  function    ``check_string_eq_of_substr_fixlen_2``
+18829  function    ``check_string_eq_of_substr_fixlen_3``
+18942  function    ``check_string_eq_of_substr_fixlen_4``
+19036  procedure   ``check_string_eq_of_substr_fixlen``
+19058  procedure   ``check_string_assign_at``
+19552  procedure   ``main``
+====== =========== ==================================================
+
+prg/chkint.sd7
+--------------
+
+:Lines:    38129
+:Entities: 193
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     function    ``intExpr``
+42     function    ``striExpr``
+46     function    ``charExpr``
+50     function    ``boolExpr``
+54     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+57     function    ``raisesRangeError``
+78     procedure   ``DECLARE_RAISES_NUMERIC_ERROR``
+81     function    ``raisesNumericError``
+102    function    ``raisesIndexError``
+117    procedure   ``check_exponent_integer_literal``
+178    procedure   ``check_based_integer_literal``
+359    procedure   ``check_compare``
+712    procedure   ``check_bytesBe``
+1241   procedure   ``check_bytesLe``
+1770   function    ``check_bytesSignedBeWithLength``
+2214   function    ``check_bytesUnsignedBeWithLength_1``
+2597   function    ``check_bytesUnsignedBeWithLength_2``
+3078   procedure   ``check_bytesBeWithLength``
+3101   function    ``check_bytesSignedLeWithLength``
+3545   function    ``check_bytesUnsignedLeWithLength_1``
+3928   function    ``check_bytesUnsignedLeWithLength_2``
+4409   procedure   ``check_bytesLeWithLength``
+4432   function    ``check_bytes2IntSignedBe_len_optimization``
+4792   function    ``check_bytes2IntSignedBe_fixLen_optimization``
+5152   function    ``check_bytes2IntSignedBe``
+5393   function    ``check_bytes2IntUnsignedBe_len_optimization``
+5717   function    ``check_bytes2IntUnsignedBe_fixLen_optimization``
+6041   function    ``check_bytes2IntUnsignedBe``
+6254   procedure   ``check_bytes2IntBe``
+6275   function    ``check_bytes2IntSignedLe_len_optimization``
+6675   function    ``check_bytes2IntSignedLe_fixLen_optimization``
+7075   function    ``check_bytes2IntSignedLe``
+7317   function    ``check_bytes2IntUnsignedLe_len_optimization``
+7641   function    ``check_bytes2IntUnsignedLe_fixLen_optimization``
+7965   function    ``check_bytes2IntUnsignedLe``
+8179   procedure   ``check_bytes2IntLe``
+8200   procedure   ``check_leb128``
+8608   function    ``changeParameter``
+8617   procedure   ``check_assign``
+8622   array       ``intArr``
+8640   procedure   ``check_negation``
+8677   function    ``check_reduced_overflow_checking_for_sums_1``
+9083   function    ``check_reduced_overflow_checking_for_sums_2``
+9334   function    ``check_reduced_overflow_checking_for_sums_3``
+9559   procedure   ``check_add``
+10272  function    ``check_add_assign_minimum_result``
+10278  array       ``arr``
+10481  function    ``check_add_assign_maximum_result``
+10487  array       ``arr``
+10690  procedure   ``check_add_assign``
+10695  array       ``arr``
+10805  procedure   ``check_subtract``
+11414  function    ``check_subtract_assign_minimum_result``
+11420  array       ``arr``
+11619  function    ``check_subtract_assign_maximum_result``
+11625  array       ``arr``
+11828  procedure   ``check_subtract_assign``
+11833  array       ``arr``
+11950  procedure   ``check_succ``
+12016  procedure   ``check_pred``
+12082  procedure   ``check_incr``
+12085  array       ``arr``
+12147  procedure   ``check_decr``
+12150  array       ``arr``
+12212  function    ``check_mult_positive_product``
+12418  function    ``check_mult_negative_product``
+12608  function    ``check_mult_minimum_product``
+12846  function    ``check_mult_minimum_plus_1_product``
+13076  function    ``check_mult_maximum_product``
+13310  function    ``check_reduced_overflow_checking_for_mult``
+13452  function    ``check_mult_with_power_base_0``
+13908  function    ``check_mult_with_power_base_1``
+14344  function    ``check_mult_with_power_base_2``
+14970  procedure   ``check_mult``
+15086  function    ``check_mult_assign_positive_product``
+15092  array       ``arr``
+15311  function    ``check_mult_assign_negative_product``
+15317  array       ``arr``
+15520  function    ``check_mult_assign_minimum_product_1``
+15652  function    ``check_mult_assign_minimum_product_2``
+15657  array       ``arr``
+15784  function    ``check_mult_assign_minimum_plus_1_product_1``
+15912  function    ``check_mult_assign_minimum_plus_1_product_2``
+15917  array       ``arr``
+16040  function    ``check_mult_assign_maximum_product_1``
+16168  function    ``check_mult_assign_maximum_product_2``
+16173  array       ``arr``
+16296  procedure   ``check_mult_assign``
+16301  array       ``arr``
+16452  procedure   ``check_division``
+16535  function    ``check_div_with_small_numbers_1``
+16755  function    ``check_div_with_small_numbers_2``
+16975  function    ``check_div_with_small_numbers_3``
+17195  function    ``check_div_with_small_numbers_4``
+17415  function    ``check_div_min_max``
+17585  function    ``check_div_by_zero``
+17652  function    ``check_div_optimization_1``
+17992  function    ``check_div_optimization_2``
+18184  function    ``check_div_optimization_3``
+18227  function    ``check_div_optimization_4``
+18513  function    ``check_div_division_check_optimization``
+19070  function    ``check_div_of_product_optimization``
+19291  function    ``check_mdiv_of_product_optimization``
+19512  procedure   ``check_div``
+19576  function    ``check_rem_with_small_numbers_1``
+19796  function    ``check_rem_with_small_numbers_2``
+20016  function    ``check_rem_with_small_numbers_3``
+20236  function    ``check_rem_with_small_numbers_4``
+20456  function    ``check_rem_min_max``
+20626  function    ``check_rem_by_zero``
+20701  function    ``check_rem_optimization_1``
+21041  function    ``check_rem_optimization_2``
+21233  function    ``check_rem_optimization_3``
+21382  function    ``check_rem_optimization_4``
+21518  function    ``check_rem_division_check_optimization``
+21680  procedure   ``check_rem``
+21736  function    ``check_mdiv_with_small_numbers_1``
+21956  function    ``check_mdiv_with_small_numbers_2``
+22176  function    ``check_mdiv_with_small_numbers_3``
+22396  function    ``check_mdiv_with_small_numbers_4``
+22616  function    ``check_mdiv_min_max``
+22786  function    ``check_mdiv_powers_of_two``
+23068  function    ``check_mdiv_by_zero``
+23135  function    ``check_mdiv_optimization_1``
+23475  function    ``check_mdiv_optimization_2``
+23667  function    ``check_mdiv_optimization_3``
+23946  function    ``check_mdiv_optimization_4``
+24232  function    ``check_mdiv_division_check_optimization``
+24789  procedure   ``check_mdiv``
+24849  function    ``check_mod_with_small_numbers_1``
+25069  function    ``check_mod_with_small_numbers_2``
+25289  function    ``check_mod_with_small_numbers_3``
+25509  function    ``check_mod_with_small_numbers_4``
+25729  function    ``check_mod_min_max``
+26147  function    ``check_mod_by_power_of_two_optimization``
+26546  function    ``check_mod_by_computed_power_of_two_optimization``
+26992  function    ``check_mod_optimization_1``
+27332  function    ``check_mod_optimization_2``
+27524  function    ``check_mod_optimization_3``
+27803  function    ``check_mod_by_zero``
+27870  function    ``check_mod_division_check_optimization``
+28427  procedure   ``check_mod``
+28487  procedure   ``check_odd``
+28507  procedure   ``check_fact``
+28550  procedure   ``check_binom``
+30308  function    ``check_power_1``
+31642  function    ``check_power_with_constant_base``
+31980  function    ``check_power_with_constant_exponent``
+32096  function    ``check_power_optimization_with_ranges``
+32194  procedure   ``check_power``
+32283  procedure   ``check_abs``
+32326  procedure   ``check_rand``
+32413  procedure   ``check_sqrt``
+32710  procedure   ``check_log2``
+32980  procedure   ``check_log10``
+33074  function    ``check_reduced_overflow_checking_for_lshift``
+33208  function    ``check_lshift_by_sum``
+33254  function    ``chkLShift``
+33270  function    ``chkLShift``
+33289  procedure   ``chkLShift``
+33361  function    ``check_lShift_assign_1``
+33459  function    ``check_lShift_assign_2``
+33464  array       ``arr``
+33512  function    ``check_lShift_assign_3``
+33517  array       ``arr``
+33565  function    ``check_lShift_assign_4``
+33665  function    ``check_lShift_assign_5``
+33670  array       ``arr``
+33719  function    ``check_lShift_assign_6``
+33724  array       ``arr``
+33773  procedure   ``check_lShift``
+34171  function    ``chkRShift``
+34187  function    ``chkRShift``
+34201  procedure   ``chkRShift``
+34253  function    ``check_rShift_assign_1``
+34315  function    ``check_rShift_assign_2``
+34320  array       ``arr``
+34377  procedure   ``check_rShift``
+34405  function    ``check_radix``
+34800  function    ``strFunction``
+34804  procedure   ``check_str``
+35177  function    ``check_sci_negative``
+35457  function    ``check_sci_positive``
+35746  procedure   ``check_sci``
+35776  procedure   ``check_parse``
+36639  procedure   ``check_lpad0``
+37195  function    ``check_bitLength_1``
+37457  function    ``check_bitLength_2``
+37719  procedure   ``check_bitLength``
+37737  procedure   ``check_lowestSetBit``
+37828  function    ``decrementAndCheck``
+37837  procedure   ``check_ternary``
+38079  procedure   ``main``
+====== =========== ==================================================
+
+prg/chkjson.sd7
+---------------
+
+:Lines:    1764
+:Entities: 27
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     enumeration ``directionType``
+82     structure   ``stringIntegerStruct2``
+87     function    ``mapJsonElementName``
+91     function    ``mapStructElementName``
+98     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+101    function    ``raisesRangeError``
+127    procedure   ``DECLARE_RAISES_ILLEGAL_ACTION``
+130    function    ``raisesIllegalAction``
+154    function    ``initScan``
+163    function    ``getJsonStringOkay``
+217    function    ``getJsonStringRaisesRangeError``
+240    function    ``checkGetJsonString1``
+396    procedure   ``checkGetJsonString``
+410    function    ``getJsonNumberOkay``
+464    function    ``getJsonNumberRaisesRangeError``
+487    function    ``checkGetJsonNumber1``
+848    procedure   ``checkGetJsonNumber``
+862    procedure   ``checkGetJsonSymbol``
+904    procedure   ``checkJsonDom``
+1148   procedure   ``checkStructElementFunctions``
+1193   procedure   ``DECLARE_CHECK_PARSE_JSON``
+1196   function    ``checkParseJson``
+1233   function    ``parseJsonRaisesRangeError``
+1279   procedure   ``checkParseJson``
+1335   procedure   ``checkFromJson``
+1548   procedure   ``checkToJson``
+1752   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkovf.sd7
+--------------
+
+:Lines:    8216
+:Entities: 66
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     function    ``intExpr``
+40     function    ``striExpr``
+44     function    ``charExpr``
+48     function    ``boolExpr``
+52     function    ``raisesOverflowError``
+67     function    ``raisesOverflowError``
+82     function    ``raisesOverflowError``
+95     function    ``exceptionName``
+110    function    ``exceptionName``
+123    procedure   ``check_negation``
+147    function    ``check_reduced_overflow_checking_for_sums``
+503    procedure   ``check_add``
+975    function    ``check_add_assign_underflow``
+981    array       ``arr``
+1176   function    ``check_add_assign_overflow``
+1182   array       ``arr``
+1377   procedure   ``check_add_assign``
+1382   array       ``arr``
+1469   procedure   ``check_subtract``
+1889   function    ``check_subtract_assign_underflow``
+1895   array       ``arr``
+2086   function    ``check_subtract_assign_overflow``
+2092   array       ``arr``
+2291   procedure   ``check_subtract_assign``
+2296   array       ``arr``
+2357   procedure   ``check_succ``
+2375   procedure   ``check_pred``
+2393   procedure   ``check_incr``
+2396   array       ``arr``
+2410   procedure   ``check_decr``
+2413   array       ``arr``
+2431   function    ``check_reduced_overflow_checking_for_mult``
+2600   function    ``check_mult_with_power_base_2``
+3135   procedure   ``check_mult``
+3846   function    ``check_mult_assign_underflow_1``
+4042   function    ``check_mult_assign_underflow_2``
+4047   array       ``arr``
+4238   function    ``check_mult_assign_overflow_1``
+4436   function    ``check_mult_assign_overflow_2``
+4441   array       ``arr``
+4634   procedure   ``check_mult_assign``
+4639   array       ``arr``
+4689   procedure   ``check_div``
+4735   procedure   ``check_rem``
+4768   procedure   ``check_mdiv``
+4814   procedure   ``check_mod``
+4976   function    ``check_reduced_overflow_checking_for_lshift``
+5050   function    ``check_lshift_by_sum``
+5120   procedure   ``check_lShift``
+5872   function    ``check_lShift_assign_1``
+6082   function    ``check_lShift_assign_2``
+6087   array       ``arr``
+6292   procedure   ``check_lShift_assign``
+6312   procedure   ``check_rShift``
+6440   procedure   ``check_rShift_assign``
+6445   array       ``arr``
+6540   procedure   ``check_ulShift``
+6668   procedure   ``check_ulShift_assign``
+6673   array       ``arr``
+6768   procedure   ``check_urShift``
+6896   procedure   ``check_urShift_assign``
+6901   array       ``arr``
+6996   procedure   ``check_power``
+7340   procedure   ``check_binom``
+8164   procedure   ``check_abs``
+8185   procedure   ``main``
+====== =========== ==================================================
+
+prg/chkprc.sd7
+--------------
+
+:Lines:    10111
+:Entities: 40
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     enumeration ``enumerationType``
+50     function    ``boolExpr``
+58     function    ``enumExpr``
+62     function    ``striExpr``
+66     function    ``bstriExpr``
+70     function    ``intExpr``
+74     function    ``charExpr``
+78     function    ``bigintExpr``
+86     function    ``floatExpr``
+90     function    ``rationalExpr``
+94     function    ``setExpr``
+98     function    ``typeExpr``
+102    procedure   ``check_if``
+946    procedure   ``check_while``
+950    array       ``array_loop_control``
+1164   procedure   ``check_repeat``
+1168   array       ``array_loop_control``
+1351   procedure   ``check_for_int_to``
+1581   procedure   ``check_for_int_downto``
+1811   procedure   ``check_for_int_to_until``
+2060   procedure   ``check_for_int_downto_until``
+2313   procedure   ``check_for_char_to``
+2477   procedure   ``check_for_char_downto``
+2640   procedure   ``check_for_char_to_until``
+2889   procedure   ``check_for_char_downto_until``
+3142   procedure   ``check_for_bool_to``
+3205   procedure   ``check_for_bool_downto``
+3268   procedure   ``check_for_big_to``
+3313   procedure   ``check_case_boolean``
+3601   procedure   ``check_case_int``
+4267   procedure   ``check_case_enum``
+4851   procedure   ``check_case_char``
+5503   procedure   ``check_case_string``
+6155   procedure   ``check_case_bstring``
+6807   procedure   ``check_case_bigint``
+7459   procedure   ``check_case_float``
+8111   procedure   ``check_case_rational``
+8777   procedure   ``check_case_bitset``
+9429   procedure   ``check_case_type``
+10081  procedure   ``main``
+====== =========== ==================================================
+
+prg/chkscan.sd7
+---------------
+
+:Lines:    714
+:Entities: 20
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     function    ``initScan``
+40     procedure   ``checkGetDigits``
+72     procedure   ``checkGetHexDigits``
+104    procedure   ``checkGetInteger``
+138    procedure   ``checkGetNumber``
+178    procedure   ``checkGetNonDigits``
+210    procedure   ``checkGetQuotedText``
+246    procedure   ``checkGetCommandLineWord``
+302    procedure   ``checkGetSimpleStringLiteral``
+348    procedure   ``checkGetLetters``
+380    procedure   ``checkGetName``
+412    procedure   ``checkSkipSpace``
+442    procedure   ``checkSkipSpaceOrTab``
+472    procedure   ``checkSkipWhiteSpace``
+502    procedure   ``checkGetWhiteSpace``
+532    procedure   ``checkGetWord``
+584    procedure   ``checkSkipLine``
+612    procedure   ``checkGetLine``
+640    procedure   ``checkGetXmlTagHeadOrContent``
+692    procedure   ``main``
+====== =========== ==================================================
+
+prg/chkset.sd7
+--------------
+
+:Lines:    11974
+:Entities: 157
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     set         ``uc_letter_char``
+32     set         ``lc_letter_char``
+33     set         ``letter_char``
+34     set         ``digit_char``
+35     set         ``alphanum_char``
+36     set         ``special_char``
+40     set         ``name_start_char``
+41     set         ``name_char``
+48     function    ``intExpr``
+52     function    ``charExpr``
+56     function    ``striExpr``
+60     function    ``boolExpr``
+64     function    ``genSet``
+74     set         ``aSet``
+80     function    ``genSet``
+88     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+91     function    ``raisesRangeError``
+113    procedure   ``check_literal``
+185    procedure   ``check_conv``
+337    procedure   ``check_card``
+345    set         ``test_set2``
+346    set         ``constStriSet1``
+347    set         ``constStriSet2``
+689    procedure   ``check_rand``
+697    set         ``test_set2``
+698    set         ``constStriSet1``
+699    set         ``constStriSet2``
+814    procedure   ``check_incl``
+821    array       ``compare_set``
+861    procedure   ``check_excl``
+896    function    ``compareTest``
+902    procedure   ``check_compare``
+1782   function    ``relationTest``
+1794   function    ``relationTests1``
+2077   function    ``relationTests2``
+2480   function    ``relationTests3``
+2883   function    ``relationTests4``
+3286   procedure   ``check_relations``
+3445   function    ``check_union_1``
+3650   function    ``check_union_2``
+3968   function    ``check_union_3``
+4201   function    ``check_union_4``
+4238   function    ``check_union_5``
+4304   procedure   ``check_union``
+4337   function    ``check_union_assign_1``
+4460   function    ``check_union_assign_2``
+4555   function    ``check_union_assign_3``
+4706   function    ``check_union_assign_4``
+4886   function    ``check_union_assign_5``
+5009   function    ``check_union_assign_6``
+5160   function    ``check_union_assign_7``
+5228   procedure   ``check_union_assign``
+5269   function    ``check_symdiff_1``
+5474   function    ``check_symdiff_2``
+5791   function    ``check_symdiff_3``
+6024   function    ``check_symdiff_4``
+6061   procedure   ``check_symdiff``
+6090   function    ``check_intersection_1``
+6295   function    ``check_intersection_2``
+6612   function    ``check_intersection_3``
+6845   function    ``check_intersection_4``
+6882   function    ``check_intersection_5``
+6948   procedure   ``check_intersection``
+6981   function    ``check_intersection_assign_1``
+7104   function    ``check_intersection_assign_2``
+7199   function    ``check_intersection_assign_3``
+7350   function    ``check_intersection_assign_4``
+7529   function    ``check_intersection_assign_5``
+7652   function    ``check_intersection_assign_6``
+7803   function    ``check_intersection_assign_7``
+7871   procedure   ``check_intersection_assign``
+7912   function    ``check_difference_1``
+8117   function    ``check_difference_2``
+8434   function    ``check_difference_3``
+8667   function    ``check_difference_4``
+8704   function    ``check_difference_5``
+8770   function    ``check_difference_6``
+8790   procedure   ``check_difference``
+8827   function    ``check_difference_assign_1``
+8950   function    ``check_difference_assign_2``
+9045   function    ``check_difference_assign_3``
+9196   function    ``check_difference_assign_4``
+9375   function    ``check_difference_assign_5``
+9498   function    ``check_difference_assign_6``
+9649   function    ``check_difference_assign_7``
+9717   procedure   ``check_difference_assign``
+9758   function    ``check_elem1``
+10012  function    ``check_elem2``
+10238  function    ``check_elem3``
+10291  function    ``check_elem_with_range_0_1``
+10386  function    ``check_elem_with_range_0_63``
+10581  procedure   ``check_elem``
+10793  procedure   ``check_elem_char``
+10797  set         ``set_a``
+10798  set         ``set_b``
+10799  set         ``set_a_b``
+10800  set         ``set_b_c``
+10801  set         ``set_a_b_c``
+10802  set         ``set_b_c_d``
+10803  set         ``set_a_e_g``
+10804  set         ``set_b_e_g``
+10805  set         ``set_a_b_c_d``
+10806  set         ``set_b_c_d_e``
+10807  set         ``set_a_c_e_g``
+10808  set         ``set_b_c_e_g``
+10809  set         ``set_a_b_c_d_e``
+10810  set         ``set_b_c_d_e_f``
+10811  set         ``set_a_c_e_g_k``
+10812  set         ``set_b_c_e_g_k``
+10813  set         ``set_a_unicode``
+10814  set         ``set_b_unicode``
+10815  set         ``set_1_3_5``
+10816  set         ``set_2_3_5``
+10817  set         ``set_1_3_5_7``
+10818  set         ``set_2_3_5_7``
+10819  set         ``set_1_3_5_7_9``
+10820  set         ``set_2_3_5_7_9``
+10821  set         ``set_1_unicode``
+10822  set         ``set_2_unicode``
+11096  procedure   ``check_elem_string``
+11100  set         ``set_a``
+11101  set         ``set_b``
+11102  set         ``set_a_b``
+11103  set         ``set_b_c``
+11104  set         ``set_a_b_c``
+11105  set         ``set_b_c_d``
+11106  set         ``set_a_e_g``
+11107  set         ``set_b_e_g``
+11108  set         ``set_a_b_c_d``
+11109  set         ``set_b_c_d_e``
+11110  set         ``set_a_c_e_g``
+11111  set         ``set_b_c_e_g``
+11112  set         ``set_a_b_c_d_e``
+11113  set         ``set_b_c_d_e_f``
+11114  set         ``set_a_c_e_g_k``
+11115  set         ``set_b_c_e_g_k``
+11116  set         ``set_a_unicode``
+11117  set         ``set_b_unicode``
+11118  set         ``set_1_3_5``
+11119  set         ``set_2_3_5``
+11120  set         ``set_1_3_5_7``
+11121  set         ``set_2_3_5_7``
+11122  set         ``set_1_3_5_7_9``
+11123  set         ``set_2_3_5_7_9``
+11124  set         ``set_1_unicode``
+11125  set         ``set_2_unicode``
+11398  procedure   ``check_to_array``
+11424  procedure   ``check_min``
+11475  procedure   ``check_max``
+11526  procedure   ``check_next``
+11594  procedure   ``check_str``
+11645  function    ``peelMinimum``
+11658  procedure   ``check_assign``
+11662  array       ``arr_1``
+11709  procedure   ``check_charset``
+11711  array       ``special_char_list``
+11944  procedure   ``main``
+====== =========== ==================================================
+
+prg/chkstr.sd7
+--------------
+
+:Lines:    26952
+:Entities: 156
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     function    ``striExpr``
+37     function    ``intExpr``
+41     function    ``charExpr``
+45     function    ``boolExpr``
+49     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+52     function    ``raisesRangeError``
+74     procedure   ``check_string_literal``
+326    function    ``check_string_eq``
+500    function    ``check_string_ne``
+674    function    ``check_string_gt``
+1088   function    ``check_string_ge``
+1502   function    ``check_string_lt``
+1916   function    ``check_string_le``
+2330   function    ``check_string_comparisons_1``
+2357   function    ``check_string_compare``
+2361   array       ``arr1``
+2362   array       ``arr2``
+2487   function    ``check_eq_of_substr_fixlen``
+2639   procedure   ``check_string_comparisons``
+2685   procedure   ``check_string_length``
+3139   procedure   ``check_string_index``
+3314   function    ``check_string_head_assign``
+3499   function    ``headOfEmptyString``
+3503   function    ``headOfString1``
+3507   function    ``headFunction``
+3511   function    ``headFunction1``
+3515   function    ``headFunction2``
+3519   function    ``headFunction``
+3523   function    ``check_string_head_func``
+3739   procedure   ``check_string_head``
+4009   function    ``check_string_tail_assign``
+4182   function    ``tailOfEmptyString``
+4186   function    ``tailOfString1``
+4190   function    ``tailFunction``
+4194   function    ``tailFunction``
+4198   function    ``tailFunction``
+4202   function    ``check_string_tail_func``
+4390   procedure   ``check_string_tail``
+4637   function    ``check_string_range_expr_1``
+4939   function    ``check_string_range_expr_2``
+5241   function    ``check_string_range_expr_3``
+5617   function    ``check_string_range_assign_1``
+5929   function    ``check_string_range_assign_2``
+6241   function    ``check_string_range_assign_3``
+6550   function    ``check_string_range_assign_4``
+6634   function    ``rangeFunction``
+6638   function    ``check_string_range_func_1``
+6940   function    ``check_string_range_func_2``
+7242   procedure   ``check_string_range``
+7288   function    ``check_string_substr_expr_1``
+7734   function    ``check_string_substr_expr_2``
+8180   function    ``check_string_substr_expr_3``
+8466   function    ``check_string_substr_expr_4``
+8612   function    ``check_string_substr_assign_1``
+8844   function    ``check_string_substr_assign_2``
+9076   function    ``check_string_substr_assign_3``
+9308   function    ``check_string_substr_assign_4``
+9540   function    ``check_string_substr_assign_5``
+9692   function    ``check_string_substr_assign_6``
+9844   function    ``check_string_substr_assign_7``
+9996   function    ``substrFunction``
+10000  function    ``substrFunction``
+10004  function    ``check_string_substr_func_1``
+10090  function    ``check_string_substr_func_2``
+10316  function    ``check_string_substr_func_3``
+10542  function    ``check_string_substr_func_4``
+10768  function    ``check_string_substr_func_5``
+10994  procedure   ``check_string_substr``
+11068  function    ``check_string_substr_fixLen_expr_1``
+11206  function    ``check_string_substr_fixLen_expr_2``
+11344  function    ``check_string_substr_fixLen_assign_1``
+11492  function    ``check_string_substr_fixLen_assign_2``
+11640  function    ``substrFixLen``
+11644  function    ``substrFixLen``
+11648  function    ``check_string_substr_fixLen_func_1``
+11826  function    ``check_string_substr_fixLen_func_2``
+11964  procedure   ``check_string_substr_fixLen``
+12022  function    ``check_string_concat_1``
+12396  function    ``check_string_concat_2``
+12770  procedure   ``check_string_concat``
+12920  function    ``check_string_mult_1``
+13401  function    ``check_string_mult_2``
+13882  function    ``check_string_mult_3``
+14363  function    ``check_string_mult_4``
+14844  function    ``check_string_mult_5``
+15086  function    ``check_string_mult_6``
+15163  procedure   ``check_string_mult``
+15197  function    ``check_string_lpad``
+15369  function    ``check_string_lpad0``
+15729  function    ``check_string_rpad``
+15901  procedure   ``check_string_ops``
+15923  function    ``check_string_pos_1``
+16274  function    ``check_string_pos_2``
+16625  function    ``check_string_pos_3``
+16976  function    ``check_string_pos_4``
+17327  function    ``check_string_pos_5``
+17811  procedure   ``check_string_pos``
+17841  function    ``check_string_char_pos_1``
+17951  function    ``check_string_char_pos_2``
+18061  function    ``check_string_char_pos_3``
+18171  function    ``check_string_char_pos_4``
+18281  function    ``check_string_char_pos_5``
+18446  procedure   ``check_string_char_pos``
+18476  procedure   ``check_string_pos_idx``
+19412  function    ``check_string_rpos_1``
+19580  function    ``check_string_rpos_2``
+19748  function    ``check_string_rpos_3``
+19916  function    ``check_string_rpos_4``
+20084  procedure   ``check_string_rpos``
+20175  procedure   ``check_string_char_rpos``
+20558  procedure   ``check_string_rpos_idx``
+21609  procedure   ``check_string_replace``
+21875  function    ``check_utf8_conversions``
+22388  procedure   ``check_string_unicode_conversons``
+22512  procedure   ``check_string_case_conversions``
+23027  function    ``check_string_trim``
+23239  function    ``check_string_ltrim``
+23453  function    ``check_string_rtrim``
+23667  function    ``check_string_str``
+23679  procedure   ``check_string_funcs``
+23705  procedure   ``check_string_split``
+24324  procedure   ``check_string_join``
+24596  procedure   ``do_assign``
+24602  function    ``stringFromChar``
+24616  function    ``peelFirstChar``
+24626  procedure   ``check_string_assign``
+24632  array       ``striArr``
+24737  procedure   ``do_append``
+24743  function    ``check_string_append_self_ref1``
+24758  procedure   ``test1``
+24789  procedure   ``do_append``
+24795  function    ``check_string_append_self_ref2_short``
+24850  function    ``check_string_append_self_ref2_long``
+24905  function    ``check_string_append_to_empty``
+24950  function    ``check_string_append_mult``
+25002  function    ``check_string_append_1``
+25196  function    ``check_string_append_2``
+25412  function    ``returnStringWithCapacity``
+25421  function    ``check_string_append_3``
+25427  array       ``arr``
+25487  procedure   ``check_string_append``
+25529  function    ``check_string_assign_at_with_char``
+25535  array       ``arr``
+25688  function    ``check_string_assign_at_with_string_1``
+25860  function    ``check_string_assign_at_with_string_2``
+25951  function    ``check_string_assign_at_with_string_3``
+26084  function    ``check_string_assign_at_with_string_4``
+26089  array       ``arr``
+26174  function    ``check_string_assign_at_with_string_5``
+26179  array       ``arr``
+26264  function    ``check_string_assign_at_with_string_mult_1``
+26436  function    ``check_string_assign_at_with_string_mult_2``
+26608  procedure   ``check_string_assign_at``
+26650  procedure   ``check_string_for``
+26840  procedure   ``check_string_ternary``
+26916  procedure   ``main``
+====== =========== ==================================================
+
+prg/chktime.sd7
+---------------
+
+:Lines:    2025
+:Entities: 16
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+32     function    ``raisesRangeError``
+53     procedure   ``checkISO8601ToTimeConversion``
+461    function    ``checkTimeToStringConversion_1``
+612    function    ``checkTimeToStringConversion_2``
+763    function    ``checkTimeToStringConversion_3``
+1070   procedure   ``checkTimeToStringConversion``
+1092   procedure   ``checkLeapYearFunctions``
+1212   procedure   ``checkTimestamp1970``
+1282   procedure   ``checkTimestamp1601``
+1350   procedure   ``checkJulianDayNumber``
+1408   procedure   ``checkTrunc``
+1448   procedure   ``checkWeekDate``
+1482   procedure   ``checkAwait``
+1623   procedure   ``checkSetLocalTZ``
+2011   procedure   ``main``
+====== =========== ==================================================
+
+prg/chktoml.sd7
+---------------
+
+:Lines:    1656
+:Entities: 17
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``DECLARE_RAISES_RANGE_ERROR``
+33     function    ``raisesRangeError``
+53     function    ``initScan``
+62     function    ``getTomlSymbolOkay``
+116    function    ``getTomlSymbolRaisesRangeError``
+139    function    ``checkGetTomlBasicString``
+368    function    ``checkGetTomlMultiLineBasicString``
+629    function    ``checkGetTomlLiteralString``
+841    function    ``checkGetTomlMultiLineLiteralString``
+954    procedure   ``checkGetTomlString``
+1036   procedure   ``checkGetTomlInteger``
+1231   procedure   ``checkGetTomlFloat``
+1378   procedure   ``checkGetTomlDate``
+1479   procedure   ``checkGetTomlSymbol``
+1505   function    ``getTomlKeyOkay``
+1559   procedure   ``checkGetTomlKey``
+1646   procedure   ``main``
+====== =========== ==================================================
+
+prg/clock.sd7
+-------------
+
+:Lines:    47
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``main``
+====== =========== ==================================================
+
+prg/clock2.sd7
+--------------
+
+:Lines:    43
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     procedure   ``main``
+====== =========== ==================================================
+
+prg/clock3.sd7
+--------------
+
+:Lines:    95
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     procedure   ``main``
+====== =========== ==================================================
+
+prg/cmpfil.sd7
+--------------
+
+:Lines:    84
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+28     procedure   ``main``
+====== =========== ==================================================
+
+prg/comanche.sd7
+----------------
+
+:Lines:    180
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     procedure   ``main``
+45     array       ``args``
+====== =========== ==================================================
+
+prg/confval.sd7
+---------------
+
+:Lines:    175
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     function    ``noEmptyArray``
+33     array       ``resultArray``
+41     procedure   ``main``
+====== =========== ==================================================
+
+prg/db7.sd7
+-----------
+
+:Lines:    417
+:Entities: 11
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+43     function    ``failed``
+63     function    ``fetchLines``
+98     procedure   ``displayMessage``
+119    procedure   ``displayMessage``
+138    procedure   ``displayResult``
+188    procedure   ``doExecute``
+219    procedure   ``doCatalog``
+221    array       ``tableNames``
+293    procedure   ``doStatements``
+343    function    ``doLogin``
+401    procedure   ``main``
+====== =========== ==================================================
+
+prg/diff7.sd7
+-------------
+
+:Lines:    263
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``showLines``
+41     procedure   ``changeMessage``
+56     procedure   ``diffContent``
+58     array       ``lines1``
+59     array       ``lines2``
+161    procedure   ``diff``
+228    procedure   ``main``
+====== =========== ==================================================
+
+prg/dirtst.sd7
+--------------
+
+:Lines:    42
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``main``
+====== =========== ==================================================
+
+prg/dirx.sd7
+------------
+
+:Lines:    152
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     function    ``wildcard_match``
+71     procedure   ``main``
+75     array       ``names``
+====== =========== ==================================================
+
+prg/dnafight.sd7
+----------------
+
+:Lines:    1381
+:Entities: 67
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+82     structure   ``lifeForm``
+89     structure   ``bacterium``
+98     function    ``.``
+99     function    ``.``
+100    function    ``.``
+101    function    ``.``
+102    function    ``.``
+103    function    ``.``
+104    function    ``.``
+105    function    ``.``
+107    structure   ``position``
+113    array       ``area``
+114    array       ``animates``
+115    array       ``children``
+120    enumeration ``killReason``
+147    function    ``str``
+151    structure   ``statRecord``
+159    array       ``statValues``
+162    array       ``killarray``
+165    array       ``REASON``
+195    function    ``display_color``
+197    function    ``upper_char``
+204    function    ``lower_char``
+215    array       ``fieldWin``
+218    array       ``diffx``
+220    array       ``diffy``
+227    procedure   ``resetStat``
+236    procedure   ``incrKillStat``
+243    function    ``continue``
+263    procedure   ``setclass``
+289    procedure   ``writeParameters``
+300    procedure   ``initScreen``
+372    procedure   ``readLimits``
+376    array       ``intValue``
+428    function    ``charCol``
+455    procedure   ``initDisplay``
+468    function    ``ranDir``
+479    function    ``shrinkSize``
+490    function    ``nextSize``
+506    function    ``newBacterium``
+523    procedure   ``create``
+534    procedure   ``setBact``
+543    procedure   ``die``
+557    procedure   ``move``
+585    procedure   ``digest``
+611    procedure   ``eatat``
+623    function    ``strength``
+639    function    ``view``
+648    function    ``food``
+657    function    ``hunger``
+666    procedure   ``doWait``
+679    procedure   ``eat``
+702    procedure   ``kill``
+738    procedure   ``split``
+779    procedure   ``setAllBacterials``
+803    procedure   ``writeInfo``
+829    function    ``readCommand``
+848    procedure   ``InitAnimates``
+980    procedure   ``initArea``
+1010   procedure   ``statistics``
+1124   procedure   ``finalStatistics``
+1133   array       ``colField``
+1134   array       ``valueField``
+1201   procedure   ``initStatistics``
+1238   procedure   ``execute``
+1272   procedure   ``generation``
+1293   procedure   ``main``
+====== =========== ==================================================
+
+prg/dragon.sd7
+--------------
+
+:Lines:    73
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     procedure   ``turn``
+40     procedure   ``forward``
+52     procedure   ``dragon``
+65     procedure   ``main``
+====== =========== ==================================================
+
+prg/echo.sd7
+------------
+
+:Lines:    39
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``main``
+====== =========== ==================================================
+
+prg/eliza.sd7
+-------------
+
+:Lines:    302
+:Entities: 6
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     array       ``keyword_table``
+38     array       ``replace_words``
+48     array       ``example_sentence``
+191    array       ``keyword_assignment``
+198    array       ``current_sentence``
+201    procedure   ``main``
+====== =========== ==================================================
+
+prg/err.sd7
+-----------
+
+:Lines:    96
+:Entities: 0
+
+(none)
+
+
+prg/fannkuch.sd7
+----------------
+
+:Lines:    131
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``fannkuch``
+44     array       ``p``
+45     array       ``q``
+46     array       ``s``
+118    procedure   ``main``
+====== =========== ==================================================
+
+prg/fib.sd7
+-----------
+
+:Lines:    47
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+28     function    ``fib``
+39     procedure   ``main``
+====== =========== ==================================================
+
+prg/find7.sd7
+-------------
+
+:Lines:    133
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``writeMatchingLines``
+55     procedure   ``searchDir``
+58     array       ``dirElements``
+97     procedure   ``main``
+====== =========== ==================================================
+
+prg/findchar.sd7
+----------------
+
+:Lines:    149
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     procedure   ``doFind``
+71     procedure   ``doFindRecursive``
+75     array       ``dir``
+92     procedure   ``main``
+94     array       ``arg_v``
+====== =========== ==================================================
+
+prg/fractree.sd7
+----------------
+
+:Lines:    55
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     procedure   ``drawTree``
+47     procedure   ``main``
+====== =========== ==================================================
+
+prg/ftp7.sd7
+------------
+
+:Lines:    296
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     procedure   ``writeHelp``
+44     procedure   ``longFileListing``
+46     array       ``dir``
+55     array       ``monthName``
+99     procedure   ``fileListing``
+101    array       ``dir``
+122    procedure   ``directoryListing``
+124    array       ``dir``
+145    procedure   ``copyFtpFile``
+171    procedure   ``execute``
+173    array       ``dir``
+241    procedure   ``main``
+====== =========== ==================================================
+
+prg/ftpserv.sd7
+---------------
+
+:Lines:    74
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``main``
+====== =========== ==================================================
+
+prg/gcd.sd7
+-----------
+
+:Lines:    109
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     function    ``gcd``
+44     function    ``binaryGcd``
+91     procedure   ``main``
+====== =========== ==================================================
+
+prg/gkbd.sd7
+------------
+
+:Lines:    358
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+47     array       ``buttonColor``
+51     set         ``mouseKeys``
+58     procedure   ``displayKey``
+174    procedure   ``checkKey``
+186    procedure   ``main``
+====== =========== ==================================================
+
+prg/gtksvtst.sd7
+----------------
+
+:Lines:    94
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``show_message``
+40     procedure   ``main_window``
+81     procedure   ``main``
+====== =========== ==================================================
+
+prg/hal.sd7
+-----------
+
+:Lines:    250
+:Entities: 14
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+42     procedure   ``write_camera``
+58     procedure   ``focus_0``
+68     procedure   ``focus_1``
+78     procedure   ``focus_2``
+88     procedure   ``focus_3``
+98     procedure   ``focus_4``
+108    procedure   ``write_sys_0``
+122    procedure   ``write_sys_1``
+134    procedure   ``write_shp``
+149    procedure   ``write_antenna``
+164    procedure   ``write_com``
+178    procedure   ``write_lrn_0``
+192    procedure   ``write_lrn_1``
+203    procedure   ``main``
+====== =========== ==================================================
+
+prg/hamu.sd7
+------------
+
+:Lines:    573
+:Entities: 17
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+42     procedure   ``read_number``
+74     procedure   ``title``
+94     procedure   ``think_it_over``
+103    procedure   ``init_game``
+120    procedure   ``state_of_the_nation``
+154    procedure   ``buy_soil``
+185    procedure   ``sell_soil``
+214    procedure   ``support_population``
+242    procedure   ``cultivate_soil``
+288    procedure   ``budget``
+344    procedure   ``work_on_soil``
+367    procedure   ``population_growth``
+425    procedure   ``statistics``
+441    procedure   ``evaluation``
+504    procedure   ``final_report``
+530    procedure   ``game``
+554    procedure   ``main``
+====== =========== ==================================================
+
+prg/hanoi.sd7
+-------------
+
+:Lines:    55
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``hanoi``
+39     procedure   ``hanoi``
+48     procedure   ``main``
+====== =========== ==================================================
+
+prg/hd.sd7
+----------
+
+:Lines:    79
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``main``
+====== =========== ==================================================
+
+prg/hello.sd7
+-------------
+
+:Lines:    32
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+28     procedure   ``main``
+====== =========== ==================================================
+
+prg/hilbert.sd7
+---------------
+
+:Lines:    108
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``drawDown``
+32     procedure   ``drawUp``
+34     procedure   ``drawRight``
+50     procedure   ``drawLeft``
+66     procedure   ``drawDown``
+82     procedure   ``drawUp``
+98     procedure   ``main``
+====== =========== ==================================================
+
+prg/ide7.sd7
+------------
+
+:Lines:    196
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+83     procedure   ``loadFile``
+89     array       ``dirContent``
+118    procedure   ``saveFileAs``
+144    procedure   ``main``
+====== =========== ==================================================
+
+prg/kbd.sd7
+-----------
+
+:Lines:    49
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``main``
+====== =========== ==================================================
+
+prg/klondike.sd7
+----------------
+
+:Lines:    883
+:Entities: 56
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+50     function    ``suit``
+51     function    ``rank``
+52     function    ``visible``
+53     procedure   ``setVisible``
+54     procedure   ``putCard``
+60     structure   ``cardType``
+73     function    ``suit``
+77     function    ``rank``
+81     function    ``visible``
+85     procedure   ``setVisible``
+96     procedure   ``putCard``
+110    structure   ``cardDeck``
+111    array       ``cards``
+116    function    ``cardsInDeck``
+120    function    ``genCardImage``
+135    function    ``createCardDeck``
+151    procedure   ``shuffle``
+153    array       ``shuffled``
+163    function    ``dealCard``
+172    function    ``selectCard``
+186    function    ``cardBelow``
+226    structure   ``stateType``
+235    function    ``dealCard``
+245    procedure   ``dealCards``
+269    procedure   ``recycleWaste``
+282    function    ``cardIndex``
+301    function    ``searchCard``
+321    function    ``getSubPile``
+336    procedure   ``toTop``
+346    function    ``isAtPlace``
+365    function    ``isAtDestPlace``
+369    function    ``atDestPlace``
+384    function    ``cardFitsToDest``
+390    procedure   ``removeFromDest``
+399    procedure   ``appendToDest``
+410    function    ``isFinished``
+427    function    ``isAtPilePlace``
+433    function    ``atFreePilePlace``
+449    function    ``cardFitsToPile``
+456    procedure   ``removeFromPile``
+463    procedure   ``appendToPile``
+479    procedure   ``removeFromOldPlace``
+505    procedure   ``move``
+530    procedure   ``move``
+561    procedure   ``move``
+585    procedure   ``move``
+613    function    ``selectCard``
+624    procedure   ``processMouseClick``
+710    function    ``findCard``
+726    procedure   ``createSolution``
+728    array       ``wholeSuit``
+748    function    ``jumpingCard``
+751    function    ``jumpingCard``
+794    procedure   ``victoryAnimation``
+815    function    ``playGame``
+871    procedure   ``main``
+====== =========== ==================================================
+
+prg/lander.sd7
+--------------
+
+:Lines:    1551
+:Entities: 57
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+53     structure   ``rocket_type``
+74     structure   ``point``
+79     array       ``landscape``
+80     array       ``advanced_landscape``
+82     array       ``explosion_data``
+96     array       ``COS_ANG``
+97     array       ``SIN_ANG``
+110    structure   ``lineCoordinates``
+117    array       ``ship``
+118    array       ``flames``
+120    structure   ``tonetype``
+132    function    ``frequency``
+145    function    ``tone``
+155    array       ``BLUE``
+309    array       ``STAR``
+394    procedure   ``sound``
+400    procedure   ``nosound``
+406    procedure   ``delay``
+412    procedure   ``doBeep``
+418    procedure   ``welcome``
+479    procedure   ``turn_sound_on``
+485    procedure   ``play_soundstep``
+512    procedure   ``pause_game``
+547    procedure   ``check_keyboard``
+594    procedure   ``readHiScore``
+609    procedure   ``writeHiScore``
+622    function    ``genLine``
+634    procedure   ``addNoiseToLandscape``
+652    procedure   ``load``
+786    procedure   ``calculate_height``
+800    procedure   ``init_display``
+847    procedure   ``drawLandscape``
+850    array       ``pointxy``
+877    procedure   ``setup``
+930    procedure   ``drawLine``
+944    procedure   ``ship_picture``
+966    procedure   ``display_gauges``
+1034   procedure   ``display_ship``
+1059   procedure   ``drawLogo``
+1062   array       ``logo``
+1081   procedure   ``setupAdvancedLander``
+1139   procedure   ``prepare_message``
+1148   procedure   ``too_high``
+1160   procedure   ``outside_operating_area``
+1172   procedure   ``revise_control``
+1228   procedure   ``anounceAdvancedLander``
+1274   procedure   ``end_of_flight``
+1309   procedure   ``play_stars_and_stripes``
+1328   procedure   ``crash_sound``
+1347   procedure   ``explosion``
+1366   procedure   ``crash_landing``
+1386   procedure   ``good_landing``
+1440   procedure   ``fast_landing``
+1462   procedure   ``tilt_landing``
+1477   procedure   ``ground_contact``
+1498   procedure   ``crash_test``
+1521   procedure   ``main``
+====== =========== ==================================================
+
+prg/lst80bas.sd7
+----------------
+
+:Lines:    344
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     array       ``tokenTable``
+158    procedure   ``appendToken``
+175    function    ``decodeTokenizedLine``
+296    procedure   ``writeLines``
+317    procedure   ``main``
+====== =========== ==================================================
+
+prg/lst99bas.sd7
+----------------
+
+:Lines:    401
+:Entities: 8
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     array       ``tokenTable``
+163    procedure   ``appendToken``
+180    function    ``decodeTokenizedLine``
+248    function    ``convertIntVar254``
+278    function    ``searchStartOfBasicFile``
+305    procedure   ``writeLines``
+356    procedure   ``writeLines``
+374    procedure   ``main``
+====== =========== ==================================================
+
+prg/lstgwbas.sd7
+----------------
+
+:Lines:    577
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     array       ``tokenTable1``
+151    array       ``tokenTable2``
+164    array       ``tokenTable3``
+206    array       ``tokenTable4``
+246    procedure   ``appendToken``
+256    function    ``floatLiteral``
+302    function    ``decodeTokenizedLine``
+492    procedure   ``unprotect``
+494    array       ``patterns1``
+498    array       ``patterns2``
+526    procedure   ``writeLines``
+550    procedure   ``main``
+====== =========== ==================================================
+
+prg/mahjong.sd7
+---------------
+
+:Lines:    1943
+:Entities: 82
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+75     function    ``colorScale``
+78     array       ``colorScale``
+97     array       ``leftFrameColor``
+98     array       ``rightFrameColor``
+99     array       ``nearFrameColor``
+100    array       ``farFrameColor``
+102    array       ``nearLeftEdgeColor``
+107    array       ``digit_pixmap``
+109    structure   ``tileType``
+110    array       ``pattern``
+116    structure   ``fieldType``
+124    structure   ``positionType``
+130    structure   ``moveType``
+137    array       ``field``
+138    array       ``demoMoves``
+139    array       ``playerMoves``
+297    array       ``zero``
+316    array       ``one``
+335    array       ``two``
+354    array       ``three``
+373    array       ``four``
+391    array       ``five``
+410    array       ``six``
+429    array       ``seven``
+448    array       ``eight``
+467    array       ``nine``
+486    procedure   ``writeButtons``
+508    function    ``getCommand``
+540    function    ``genTile``
+548    array       ``tiles``
+599    procedure   ``draw``
+615    procedure   ``putFrame``
+659    procedure   ``drawLeftSide``
+682    procedure   ``drawNearSide``
+710    procedure   ``drawTile``
+748    procedure   ``drawBoardWithFlush``
+775    procedure   ``drawBoard``
+800    function    ``getMaximumLevelLeftward``
+821    function    ``getMaximumLevelDownward``
+842    procedure   ``markFrame``
+890    procedure   ``unmarkFrame``
+903    procedure   ``mark``
+913    procedure   ``unmark``
+923    procedure   ``unmarkAll``
+943    procedure   ``refresh``
+979    procedure   ``remove``
+991    procedure   ``insert``
+1000   procedure   ``draw_number``
+1022   function    ``covered``
+1046   function    ``getFirstAccessibleTileColumn``
+1075   function    ``getLastAccessibleTileColumn``
+1104   function    ``getAccessibleTilePositions``
+1106   array       ``accessibleTilePositions``
+1127   function    ``countPossibleMoves``
+1131   array       ``accessibleTilePositions``
+1154   array       ``accessibleTilePositions``
+1180   procedure   ``showPossibleMatches``
+1182   array       ``accessibleTilePositions``
+1203   procedure   ``updateNumbers``
+1210   procedure   ``showDemo``
+1212   array       ``backupField``
+1255   procedure   ``locateTile``
+1289   function    ``legalMove``
+1320   procedure   ``playerMove``
+1384   procedure   ``playerTurn``
+1450   procedure   ``initLayout``
+1469   function    ``getFirstFreeColumn``
+1505   function    ``getLastFreeColumn``
+1543   function    ``lineIsFree``
+1563   function    ``getAnyFreeColumn``
+1596   function    ``getFreeColumn``
+1625   function    ``getFreePlaceColumn``
+1665   procedure   ``getFreePlace``
+1678   procedure   ``dealOneTile``
+1689   procedure   ``removeOneTile``
+1712   procedure   ``dealTilePair``
+1757   procedure   ``initTiles``
+1783   procedure   ``dealTiles``
+1820   procedure   ``dealTiles2``
+1842   procedure   ``startNewGame``
+1863   procedure   ``writeCentered``
+1870   procedure   ``main``
+====== =========== ==================================================
+
+prg/make7.sd7
+-------------
+
+:Lines:    121
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``main``
+39     array       ``targets``
+====== =========== ==================================================
+
+prg/mandelbr.sd7
+----------------
+
+:Lines:    237
+:Entities: 6
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+47     array       ``colorTable``
+52     function    ``iterate``
+68     procedure   ``displayMandelbrotSet``
+83     procedure   ``showHelp``
+137    procedure   ``doCommand``
+170    procedure   ``main``
+====== =========== ==================================================
+
+prg/mind.sd7
+------------
+
+:Lines:    443
+:Entities: 11
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     structure   ``guess``
+41     array       ``guesses``
+44     procedure   ``read_number``
+75     function    ``question``
+96     procedure   ``compare``
+176    function    ``legal``
+279    procedure   ``search_try``
+296    procedure   ``verify``
+327    procedure   ``round_computer_guesses``
+372    procedure   ``round_human_guesses``
+408    procedure   ``main``
+====== =========== ==================================================
+
+prg/mirror.sd7
+--------------
+
+:Lines:    131
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     structure   ``rectangularArea``
+40     function    ``selectArea``
+97     procedure   ``main``
+====== =========== ==================================================
+
+prg/ms.sd7
+----------
+
+:Lines:    641
+:Entities: 34
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+53     structure   ``field_place``
+64     array       ``area``
+67     procedure   ``init_area``
+75     procedure   ``display_place``
+95     procedure   ``show_place``
+104    procedure   ``incr_place``
+113    procedure   ``init_mines``
+153    function    ``place_is_free``
+171    procedure   ``display_nonfree_place``
+200    procedure   ``show_free_NW``
+201    procedure   ``show_free_NE``
+202    procedure   ``show_free_SW``
+203    procedure   ``show_free_SE``
+206    procedure   ``show_free_N``
+218    procedure   ``show_free_S``
+230    procedure   ``show_free_W``
+242    procedure   ``show_free_E``
+254    procedure   ``show_free_NW``
+268    procedure   ``show_free_NE``
+282    procedure   ``show_free_SE``
+296    procedure   ``show_free_SW``
+310    procedure   ``show_free_area``
+327    procedure   ``show_explosion``
+340    procedure   ``show_wrong_mark``
+347    procedure   ``show_area_around``
+393    procedure   ``show_solution``
+410    procedure   ``read_command``
+424    procedure   ``congratulation``
+450    procedure   ``select_round``
+494    procedure   ``init_round``
+518    procedure   ``shut_round``
+527    procedure   ``init``
+539    procedure   ``play_round``
+625    procedure   ``main``
+====== =========== ==================================================
+
+prg/nicoma.sd7
+--------------
+
+:Lines:    135
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     procedure   ``verify``
+69     function    ``read_remainder``
+90     procedure   ``guess_number``
+120    procedure   ``main``
+====== =========== ==================================================
+
+prg/pac.sd7
+-----------
+
+:Lines:    726
+:Entities: 39
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     enumeration ``placeType``
+42     function    ``str``
+47     enumeration ``directType``
+51     structure   ``pacmanType``
+62     structure   ``ghostType``
+75     array       ``ghostList``
+84     array       ``labyrinthMap``
+85     array       ``map``
+89     array       ``field``
+120    procedure   ``showLifes``
+137    procedure   ``left``
+150    procedure   ``right``
+163    procedure   ``up``
+176    procedure   ``down``
+189    procedure   ``sendHome``
+203    procedure   ``readCommand``
+231    procedure   ``writeMapPosition``
+239    procedure   ``pacmanCought``
+267    procedure   ``ghostCought``
+283    procedure   ``someoneCought``
+294    procedure   ``eat``
+300    procedure   ``eat``
+312    procedure   ``eat``
+332    procedure   ``checkGhost``
+341    procedure   ``checkAllGhosts``
+352    procedure   ``movePacman``
+382    function    ``selectDirection``
+390    array       ``possible``
+417    procedure   ``turn``
+420    procedure   ``turn``
+428    procedure   ``turn``
+436    procedure   ``turn``
+444    procedure   ``turn``
+452    procedure   ``move``
+574    procedure   ``moveGhosts``
+586    procedure   ``readMap``
+611    procedure   ``showMap``
+631    procedure   ``mainControl``
+658    procedure   ``main``
+====== =========== ==================================================
+
+prg/pairs.sd7
+-------------
+
+:Lines:    2025
+:Entities: 78
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+55     array       ``digit_pixmap``
+58     structure   ``cardType``
+59     array       ``picture``
+64     enumeration ``visibleType``
+68     structure   ``fieldType``
+74     structure   ``gameObj``
+86     array       ``size_2_5``
+121    array       ``size_3_4``
+156    array       ``size_4_4``
+191    array       ``size_4_5``
+226    array       ``size_4_6``
+261    array       ``size_5_6``
+296    array       ``size_6_6``
+331    array       ``size_6_7``
+366    array       ``size_6_8``
+401    array       ``size_6_10``
+436    array       ``size_6_12``
+471    array       ``size_6_14``
+506    array       ``panic_monster1_pic``
+525    array       ``panic_monster2_pic``
+544    array       ``panic_monster3_pic``
+563    array       ``dig_right_pic``
+582    array       ``big_bush_pic``
+617    array       ``chain_pic``
+636    array       ``large_gem_pic``
+671    array       ``fairy_pic``
+738    array       ``computer_pic``
+805    array       ``sea_pic``
+872    array       ``woman_pic``
+939    array       ``zero``
+958    array       ``one``
+977    array       ``two``
+996    array       ``three``
+1015   array       ``four``
+1033   array       ``five``
+1052   array       ``six``
+1071   array       ``seven``
+1090   array       ``eight``
+1109   array       ``nine``
+1128   function    ``genCard``
+1138   array       ``cards``
+1183   array       ``size_descr``
+1198   array       ``size_list``
+1214   array       ``field``
+1217   procedure   ``draw``
+1230   procedure   ``put``
+1237   procedure   ``prepare``
+1268   procedure   ``show``
+1278   procedure   ``hide``
+1292   procedure   ``remove``
+1302   procedure   ``hideAll``
+1315   procedure   ``draw_number``
+1337   procedure   ``showHit``
+1354   function    ``countCardBacks``
+1371   procedure   ``randomField``
+1396   procedure   ``randomNotVisited``
+1431   procedure   ``firstOfPair``
+1472   procedure   ``secondOfPair``
+1494   procedure   ``computerLevel0``
+1508   procedure   ``computerLevel1``
+1529   procedure   ``computerLevel2``
+1550   procedure   ``computerLevel3``
+1571   procedure   ``computerLevel4``
+1592   procedure   ``computerLevel5``
+1611   procedure   ``computerLevel6``
+1636   procedure   ``computerLevel7``
+1661   procedure   ``computerLevel8``
+1686   procedure   ``computerLevel9``
+1709   procedure   ``computerTurn``
+1746   procedure   ``checkHit``
+1763   procedure   ``mouseCommand``
+1782   procedure   ``playerMove``
+1841   procedure   ``playerTurn``
+1851   procedure   ``dealCards``
+1875   procedure   ``initializeGame``
+1887   procedure   ``selectSize``
+1929   function    ``createButton``
+1939   procedure   ``main``
+====== =========== ==================================================
+
+prg/panic.sd7
+-------------
+
+:Lines:    2634
+:Entities: 123
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+58     enumeration ``holeType``
+64     function    ``str``
+69     array       ``round_description``
+121    array       ``layout_description``
+132    array       ``monster_pixmap``
+133    array       ``player_left_pixmap``
+134    array       ``player_right_pixmap``
+135    array       ``player_up_pixmap``
+136    array       ``player_down_pixmap``
+137    array       ``player_falling_pixmap``
+138    array       ``player_dig_left_pixmap``
+139    array       ``player_dig_right_pixmap``
+140    array       ``digit_pixmap``
+148    structure   ``screenObj``
+164    structure   ``playerObj``
+172    structure   ``monsterObj``
+182    structure   ``gameObj``
+195    array       ``monster``
+199    array       ``level_line``
+203    array       ``field``
+204    array       ``hole_status``
+209    array       ``player_right_1``
+228    array       ``player_right_2``
+247    array       ``player_left_1``
+266    array       ``player_left_2``
+285    array       ``player_falling``
+304    array       ``player_dig_right_1``
+323    array       ``player_dig_right_2``
+342    array       ``player_dig_left_1``
+361    array       ``player_dig_left_2``
+379    array       ``player_up_down_1``
+398    array       ``player_up_down_2``
+417    array       ``monster1_1``
+430    array       ``monster1_2``
+443    array       ``monster1_3``
+456    array       ``monster1_4``
+469    array       ``monster1_5``
+482    array       ``monster2_1``
+495    array       ``monster2_2``
+508    array       ``monster3_1``
+521    array       ``monster3_2``
+534    array       ``player_reserve``
+545    array       ``score_text``
+555    array       ``bonus_text``
+565    array       ``hiscore_text``
+575    array       ``zero``
+585    array       ``one``
+595    array       ``two``
+605    array       ``three``
+615    array       ``four``
+625    array       ``five``
+635    array       ``six``
+645    array       ``seven``
+655    array       ``eight``
+665    array       ``nine``
+675    function    ``createPixmap``
+679    procedure   ``init_pictures``
+802    procedure   ``visible``
+810    procedure   ``invisible``
+816    procedure   ``allObjectsInvisible``
+831    procedure   ``pause_game``
+865    procedure   ``game_command``
+883    procedure   ``draw_number``
+905    function    ``number_pixmap``
+928    procedure   ``draw_level``
+968    procedure   ``draw_base_level``
+978    procedure   ``mark_level``
+988    procedure   ``draw_level_piece``
+1037   procedure   ``draw_hole``
+1111   procedure   ``draw_ladder``
+1140   procedure   ``mark_ladder``
+1151   procedure   ``set_ladder``
+1159   procedure   ``init_ladders``
+1171   procedure   ``change_direction``
+1223   function    ``collision``
+1236   function    ``collision2``
+1253   procedure   ``avoid_monster_collision``
+1302   procedure   ``move``
+1322   procedure   ``place``
+1336   procedure   ``die``
+1348   procedure   ``mark_hole``
+1386   procedure   ``fall_at_monsters``
+1414   procedure   ``check_falling``
+1480   procedure   ``set_direction``
+1509   procedure   ``player_collision``
+1556   procedure   ``check_hole``
+1620   procedure   ``check_direction``
+1664   procedure   ``place_monster``
+1684   procedure   ``draw_reserve``
+1706   procedure   ``init_round``
+1801   procedure   ``dig_hole``
+1820   procedure   ``shut_hole``
+1845   procedure   ``do_dig``
+1865   function    ``hole_position_ok``
+1891   function    ``ladder_up_direction``
+1912   function    ``ladder_down_direction``
+1933   function    ``level_direction``
+1954   function    ``hole_direction``
+1975   procedure   ``stop``
+1984   procedure   ``left``
+2002   procedure   ``right``
+2020   procedure   ``up``
+2038   procedure   ``down``
+2056   procedure   ``dig_left``
+2074   procedure   ``dig_right``
+2092   procedure   ``shut_left``
+2110   procedure   ``shut_right``
+2128   procedure   ``go_horizontally``
+2138   procedure   ``go_vertically``
+2148   procedure   ``player_falling``
+2185   procedure   ``process_command``
+2242   procedure   ``stop_at_hole``
+2273   procedure   ``process``
+2302   function    ``getLevel``
+2321   function    ``getLevel``
+2334   function    ``clickedAtLadder``
+2362   function    ``clickedAboveHole``
+2376   function    ``clickedAtMonsterInHole``
+2390   procedure   ``get_command``
+2482   procedure   ``game_round``
+2547   procedure   ``play_game``
+2568   procedure   ``writeCentered``
+2575   procedure   ``main``
+====== =========== ==================================================
+
+prg/percolation.sd7
+-------------------
+
+:Lines:    330
+:Entities: 21
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+47     function    ``open``
+49     function    ``dimensions``
+51     function    ``percolates``
+53     function    ``isOpen``
+55     function    ``isFull``
+57     structure   ``virtualGrid``
+62     array       ``status``
+69     procedure   ``initVirtualGrid``
+93     procedure   ``connect``
+99     function    ``coordsTo1D``
+109    function    ``open``
+150    function    ``dimensions``
+157    function    ``percolates``
+164    function    ``isOpen``
+174    function    ``isFull``
+192    procedure   ``delay``
+204    procedure   ``draw_update``
+241    procedure   ``open_random``
+258    function    ``build_stats``
+275    procedure   ``main``
+281    array       ``all_simulations``
+====== =========== ==================================================
+
+prg/planets.sd7
+---------------
+
+:Lines:    1486
+:Entities: 61
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+61     structure   ``orbitType``
+78     array       ``orbitDescr``
+83     structure   ``heliocentricPlanetType``
+97     structure   ``eclipticalCoordinateType``
+102    structure   ``equatorialCoordinateType``
+107    structure   ``horizontalCoordinateType``
+112    structure   ``earthCoordinateType``
+117    structure   ``geocentricPlanetType``
+131    function    ``toDegrees``
+135    function    ``toRadians``
+139    function    ``sinD``
+143    function    ``cosD``
+147    function    ``tanD``
+151    function    ``asinD``
+155    function    ``acosD``
+159    function    ``atanD``
+163    function    ``atan2D``
+167    function    ``frac``
+174    function    ``julianDay``
+179    function    ``minutes``
+183    function    ``seconds``
+187    function    ``angleAsDegrees``
+210    function    ``angleAsHours``
+233    function    ``anomaly``
+250    function    ``anomaly2``
+268    function    ``eclipticalCoordinatesToRightAscension``
+281    function    ``eclipticalCoordinatesToDeclination``
+285    procedure   ``degreesToRange``
+296    procedure   ``hoursToRange``
+307    function    ``localSiderealToCivilTime``
+334    procedure   ``showLocalTime``
+371    function    ``calculateGreenwichMeanSiderealTime``
+390    procedure   ``showTime``
+426    function    ``locatePositionOfPlanetInItsOrbitalPlane``
+452    procedure   ``plotPlanet``
+454    function    ``computeRadiusVector``
+490    procedure   ``showMenu``
+534    procedure   ``setup``
+564    procedure   ``plotInnerPlanets``
+589    procedure   ``plotOuterPlanets``
+613    procedure   ``changeDateTime``
+644    procedure   ``changeLongLat``
+657    function    ``computeProjectedHeliocentricLongitude``
+674    procedure   ``ProjectPlanetOntoEclipticalPlane``
+683    function    ``calculateEclipticalCoordinates``
+710    function    ``calculateEquatorialCoordinates``
+724    function    ``calculateHourAngle``
+736    function    ``calculateHorizontalCoordinates``
+754    function    ``genGeocentricPos``
+768    function    ``panoramaXPos``
+772    function    ``panoramaYPos``
+776    procedure   ``drawAllPlanets``
+796    procedure   ``drawSun``
+809    procedure   ``drawHorizont``
+813    array       ``name``
+839    procedure   ``writePoint``
+903    procedure   ``drawStars``
+933    procedure   ``locatePlanet``
+1150   procedure   ``showName``
+1268   procedure   ``initOrbitDescr``
+1407   procedure   ``main``
+====== =========== ==================================================
+
+prg/portfwd7.sd7
+----------------
+
+:Lines:    139
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     procedure   ``connectPort``
+84     procedure   ``main``
+====== =========== ==================================================
+
+prg/prime.sd7
+-------------
+
+:Lines:    74
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``isPrime``
+54     procedure   ``main``
+====== =========== ==================================================
+
+prg/printpi1.sd7
+----------------
+
+:Lines:    56
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     function    ``compute_pi_machin``
+52     procedure   ``main``
+====== =========== ==================================================
+
+prg/printpi2.sd7
+----------------
+
+:Lines:    54
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     function    ``compute_pi_bailey_borwein_plouffe``
+50     procedure   ``main``
+====== =========== ==================================================
+
+prg/printpi3.sd7
+----------------
+
+:Lines:    60
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     procedure   ``main``
+45     array       ``arr``
+====== =========== ==================================================
+
+prg/pv7.sd7
+-----------
+
+:Lines:    337
+:Entities: 13
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     procedure   ``writeMessage``
+54     procedure   ``nextImageFile``
+64     procedure   ``previousImageFile``
+74     procedure   ``findFileWithName``
+86     function    ``isGraphicFile``
+90     set         ``imageMagic``
+108    structure   ``sectionData``
+116    procedure   ``displayImage``
+150    procedure   ``move``
+179    procedure   ``zoomIn``
+205    procedure   ``zoomOut``
+231    procedure   ``main``
+236    array       ``fileList``
+====== =========== ==================================================
+
+prg/queen.sd7
+-------------
+
+:Lines:    149
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     procedure   ``initialize``
+50     procedure   ``display``
+80     function    ``canPlace``
+121    procedure   ``place``
+138    procedure   ``main``
+====== =========== ==================================================
+
+prg/rand.sd7
+------------
+
+:Lines:    121
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``rand_test_1``
+49     procedure   ``rand_test_2``
+68     procedure   ``rand_test_3``
+87     procedure   ``main``
+====== =========== ==================================================
+
+prg/raytrace.sd7
+----------------
+
+:Lines:    538
+:Entities: 43
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     function    ``*``
+38     function    ``str``
+43     procedure   ``add``
+60     structure   ``ray``
+65     function    ``ray``
+74     structure   ``view``
+87     function    ``calcDirection``
+91     structure   ``light``
+97     function    ``light``
+106    function    ``pos``
+109    function    ``colour``
+112    function    ``castsShadows``
+116    structure   ``surface``
+126    function    ``surface``
+146    function    ``dull``
+158    function    ``shiny``
+174    structure   ``baseRayTraceObject``
+180    function    ``rayTraceObject``
+187    function    ``surfaceAt``
+191    structure   ``intersect``
+197    function    ``intersect``
+204    procedure   ``setValue``
+212    function    ``intersect``
+213    function    ``surfaceAt``
+216    structure   ``sphere``
+223    function    ``sphere``
+232    function    ``intersect``
+268    function    ``surfaceAt``
+277    structure   ``infinitePlane``
+284    function    ``infinitePlane``
+293    function    ``intersect``
+318    function    ``surfaceAt``
+327    structure   ``canvas``
+333    structure   ``rayTraceCanvas``
+334    array       ``scene``
+341    function    ``intersect``
+354    function    ``shadow``
+369    function    ``trace``
+371    function    ``shade``
+451    function    ``trace``
+465    procedure   ``trace``
+501    procedure   ``main``
+503    array       ``scene``
+====== =========== ==================================================
+
+prg/rever.sd7
+-------------
+
+:Lines:    816
+:Entities: 28
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     enumeration ``direction_type``
+46     array       ``ALL_DIRECTIONS``
+55     structure   ``moveType``
+67     array       ``TVAL``
+68     array       ``field_counter``
+78     function    ``line_delta``
+88     function    ``column_delta``
+91     procedure   ``rules``
+122    procedure   ``count_fields``
+141    procedure   ``write_move``
+148    procedure   ``show_board``
+180    procedure   ``show_board``
+218    procedure   ``turn``
+263    procedure   ``turn_evaluation``
+300    procedure   ``move_value``
+348    procedure   ``calculate_move``
+358    array       ``best_move``
+512    procedure   ``computer_move``
+532    procedure   ``read_column``
+557    procedure   ``read_line``
+593    procedure   ``read_move``
+618    procedure   ``human_move``
+640    procedure   ``first_move``
+669    procedure   ``final_result``
+689    procedure   ``set_tvals``
+718    procedure   ``generate_start_board``
+746    procedure   ``start``
+797    procedure   ``main``
+====== =========== ==================================================
+
+prg/roman.sd7
+-------------
+
+:Lines:    38
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``main``
+====== =========== ==================================================
+
+prg/s7c.sd7
+-----------
+
+:Lines:    9060
+:Entities: 227
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+67     array       ``libraryDirs``
+97     array       ``elementNameTable``
+106    function    ``isFuncParamData``
+110    procedure   ``count_declarations``
+123    procedure   ``process_value_hashCode_declaration``
+143    procedure   ``process_value_cpy_declaration``
+164    procedure   ``process_value_create_declaration``
+189    procedure   ``process_value_destr_declaration``
+208    procedure   ``process_value_cmp_declaration``
+231    procedure   ``process_big_create_call``
+245    procedure   ``process_str_create_call``
+286    procedure   ``getAnyParamToTempAssigns``
+302    procedure   ``getAnyParamToTempAssigns``
+353    function    ``enum_value``
+382    procedure   ``ref_list_value``
+408    function    ``getExprValue``
+425    function    ``isPointerParam``
+430    function    ``isCopyParam``
+435    function    ``isInOutParam``
+439    function    ``canTakeAddress``
+470    procedure   ``process_constenumobject``
+479    function    ``param_list_okay``
+498    function    ``containsFunctionCall``
+529    function    ``recursiveFunctionCall``
+548    function    ``identical_values``
+605    function    ``canUseArrTimes``
+639    procedure   ``assignArrayValue``
+757    procedure   ``process_local_declaration``
+1073   procedure   ``process_local_var_declaration``
+1087   procedure   ``determineDataForActualFuncParam``
+1110   function    ``determineDataForActualFuncParam``
+1119   procedure   ``defineFunctype``
+1189   procedure   ``defineActualFuncParam``
+1249   procedure   ``defineFuncValue``
+1288   procedure   ``callActualFuncParam``
+1305   procedure   ``processFuncValue``
+1338   procedure   ``processFuncParam``
+1349   procedure   ``checkParameterAliasing``
+1385   procedure   ``call_params``
+1482   procedure   ``process_prototype_declaration``
+1486   procedure   ``process_const_func_call``
+1561   procedure   ``process_func_call``
+1595   procedure   ``process_call``
+1598   procedure   ``process_indirect_func_call``
+1621   procedure   ``process_call``
+1731   procedure   ``process_match``
+1781   procedure   ``optimize_constant_expressions``
+1822   procedure   ``process_expr``
+2139   procedure   ``process_call_by_name_expr``
+2188   procedure   ``declare_types_of_params``
+2203   procedure   ``process_param_declaration``
+2263   procedure   ``process_param_list_declaration``
+2295   procedure   ``process_result_declaration``
+2324   procedure   ``process_return``
+2336   procedure   ``process_return_value``
+2369   procedure   ``process_local_consts``
+2373   procedure   ``process_const_func_declaration``
+2617   procedure   ``process_library_initialisation``
+2637   procedure   ``declare_exception_name``
+2662   procedure   ``process_main_declaration``
+2880   procedure   ``process_var_func_declaration``
+2904   procedure   ``process_func_declaration``
+2916   procedure   ``process_prototype_declaration``
+2953   procedure   ``process_forward_declaration``
+2968   procedure   ``addImplementationToInterface``
+2984   procedure   ``process_type_declaration``
+3028   procedure   ``process_int_declaration``
+3059   procedure   ``process_bigint_declaration``
+3077   procedure   ``process_char_declaration``
+3092   procedure   ``process_stri_declaration``
+3110   procedure   ``process_bstri_declaration``
+3129   procedure   ``process_float_declaration``
+3144   procedure   ``action_address``
+3302   procedure   ``block_address``
+3359   procedure   ``object_address``
+3392   procedure   ``process_reference_declaration``
+3420   procedure   ``process_ref_list_declaration``
+3463   procedure   ``process_file_declaration``
+3476   procedure   ``process_socket_declaration``
+3487   procedure   ``process_poll_declaration``
+3502   procedure   ``process_array_declaration``
+3535   procedure   ``process_hash_declaration``
+3570   procedure   ``process_set_declaration``
+3590   procedure   ``process_struct_declaration``
+3631   procedure   ``process_interface_declaration``
+3654   procedure   ``process_win_declaration``
+3673   procedure   ``process_plist_declaration``
+3692   procedure   ``process_process_declaration``
+3705   procedure   ``process_prog_declaration``
+3718   procedure   ``process_database_declaration``
+3729   procedure   ``process_sql_stmt_declaration``
+3740   procedure   ``process_enum_declaration``
+3766   procedure   ``process_enum_literal_declaration``
+3796   procedure   ``print_parameter_list``
+3871   procedure   ``process_dynamic_parameter_list``
+3923   procedure   ``process_dynamic_function_call``
+3970   procedure   ``process_dynamic_action_call``
+4004   function    ``process_dynamic_call``
+4064   function    ``process_dynamic_condition``
+4069   function    ``process_dynamic_param_implements``
+4157   function    ``process_dynamic_param_enumeration``
+4246   function    ``process_dynamic_param_struct_elem``
+4368   function    ``process_dynamic_condition``
+4447   procedure   ``process_dynamic_decision``
+4503   procedure   ``process_dynamic_decisions``
+4514   procedure   ``process_dynamic_declaration``
+4546   procedure   ``declare_literal_function_of_enum``
+4585   procedure   ``declare_literal_function_of_enums``
+4597   procedure   ``process_hashcode``
+4612   function    ``keyCreateObj``
+4627   function    ``keyCompareObj``
+4642   function    ``dataCreateObj``
+4657   function    ``dataCopyObj``
+4672   procedure   ``process_arr_cpy_declaration``
+4697   procedure   ``process_arr_create_declaration``
+4722   procedure   ``process_arr_destr_declaration``
+4747   procedure   ``process_arr_gen_declaration``
+4774   procedure   ``process_arr_idx_declaration``
+4801   procedure   ``process_arr_times_declaration``
+4862   procedure   ``defineParam1TypeCategory``
+4877   procedure   ``process_itf_next_file_declaration``
+4889   procedure   ``process_hsh_cpy_declaration``
+4904   procedure   ``process_hsh_create_declaration``
+4919   procedure   ``process_hsh_destr_declaration``
+4934   procedure   ``addStructElem``
+4956   procedure   ``process_sct_cpy_declaration``
+4983   procedure   ``process_sct_create_declaration``
+4996   procedure   ``process_sct_destr_declaration``
+5009   procedure   ``process_sct_select_declaration``
+5037   procedure   ``process_var_action_declaration``
+5059   procedure   ``process_action_declaration``
+5197   procedure   ``process_object_declaration``
+5281   procedure   ``replaceLocalsFromOutside``
+5320   procedure   ``changeCallsOfLocalFunction``
+5349   procedure   ``changeCallsFromSubFunctions``
+5368   procedure   ``adjustParamsToAdd``
+5403   function    ``fixLocalFunction``
+5433   procedure   ``processLocalFunctions``
+5455   procedure   ``addTypeCategoryForLocalVars``
+5477   procedure   ``process_local_consts``
+5500   procedure   ``process_object``
+5524   procedure   ``declare_failed_inline_functions``
+5538   procedure   ``write_file_head``
+6042   procedure   ``declareExtern``
+6053   procedure   ``write_prototypes``
+6142   procedure   ``initPollOperations``
+6155   function    ``determine_multiple_array_elements``
+6192   procedure   ``walk_const_list``
+6287   procedure   ``prepare_func_literal``
+6303   procedure   ``process_func_literal``
+6315   procedure   ``process_pollData_literal``
+6323   procedure   ``init_const_value``
+6431   function    ``int32AsFourBytes``
+6443   function    ``int64AsEightBytes``
+6455   function    ``int64AsTwoInt32``
+6474   procedure   ``init_bigint_constants``
+6492   procedure   ``assign_bigint_constants``
+6528   function    ``pixelEncodingIdentical``
+6537   function    ``pixelEncodingWithoutAlphaChannel``
+6544   function    ``pixelEncodingWithRedAndBlueSwapped``
+6553   function    ``pixelEncodingWithRedAndBlueSwappedWithoutAlphaChannel``
+6560   function    ``swapRedAndBlue``
+6586   array       ``pixelArray``
+6586   function    ``fixPixels``
+6620   procedure   ``init_win_constants``
+6677   procedure   ``assign_win_constants``
+6716   function    ``pointListEncodingIdentical``
+6725   function    ``toPointListAbsolute``
+6730   array       ``xyArray``
+6762   function    ``toPointListRelative16``
+6767   array       ``xyArray``
+6798   function    ``toPointListRelative32``
+6803   array       ``xyArray``
+6834   function    ``toTargetPointListBstring``
+6855   procedure   ``init_plist_constants``
+6875   procedure   ``assign_plist_constants``
+6905   procedure   ``write_striChars``
+6928   procedure   ``write_str_table``
+6973   procedure   ``handleOverlappingStrings``
+7027   procedure   ``init_string_constants_with_slices``
+7034   array       ``lengthList``
+7037   array       ``stringPosition``
+7084   procedure   ``init_string_constants_no_slices``
+7136   procedure   ``init_string_constants``
+7150   procedure   ``write_bstriChars``
+7187   procedure   ``write_bst_table``
+7225   procedure   ``init_bstri_constants_with_slices``
+7232   array       ``lengthList``
+7235   array       ``stringPosition``
+7282   procedure   ``init_bstri_constants_no_slices``
+7349   procedure   ``init_bstri_constants``
+7363   procedure   ``init_set_constants``
+7425   procedure   ``init_type_constants``
+7468   procedure   ``enter_ref_constant_types``
+7481   procedure   ``init_ref_constants``
+7544   procedure   ``init_array_constants``
+7603   procedure   ``malloc_struct``
+7623   procedure   ``init_struct_constants``
+7661   procedure   ``init_hash_constants``
+7726   procedure   ``init_interface_constants``
+7753   procedure   ``init_nan_constants``
+7776   procedure   ``initCaseLabelsOfWhen``
+7824   procedure   ``initCaseLabelsOfCase``
+7840   procedure   ``initCaseLabels``
+7860   procedure   ``initElementNameLabelsOfCase``
+7887   procedure   ``initElementNameLabels``
+7907   procedure   ``walk_const_list``
+7942   procedure   ``init_values``
+8052   procedure   ``declare_rtlRaiseError``
+8106   procedure   ``declare_raise_error2``
+8148   procedure   ``init_globals``
+8160   procedure   ``process_global_declarations``
+8229   procedure   ``init_systypes``
+8283   function    ``temp_name``
+8296   procedure   ``pass_1``
+8432   procedure   ``pass_2``
+8538   procedure   ``importEnvironment``
+8556   procedure   ``appendLibrary``
+8572   procedure   ``appendLibrary``
+8582   procedure   ``logProgram``
+8600   procedure   ``execProgramScript``
+8622   procedure   ``execProgram``
+8652   procedure   ``pass_3``
+8674   array       ``compileParams``
+8676   array       ``linkParams``
+8937   procedure   ``writeHelp``
+8983   procedure   ``main``
+====== =========== ==================================================
+
+prg/s7check.sd7
+---------------
+
+:Lines:    68
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     procedure   ``main``
+====== =========== ==================================================
+
+prg/savehd7.sd7
+---------------
+
+:Lines:    1110
+:Entities: 31
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     enumeration ``phaseType``
+44     function    ``str``
+47     function    ``parse``
+60     structure   ``stateType``
+83     procedure   ``showProgress``
+118    function    ``loadState``
+158    procedure   ``saveState``
+189    procedure   ``checkSumOfBadBytes``
+204    function    ``countBadBytesInAreasForward``
+220    procedure   ``listBadAreas``
+232    function    ``confirmSave``
+399    procedure   ``nextPhase``
+434    function    ``bigLength``
+438    function    ``afterMaximumBadArea``
+453    function    ``searchPossibleAreaCombine``
+471    procedure   ``combineBadAreas``
+503    procedure   ``addBadArea``
+529    function    ``searchPossibleAreaShrink``
+546    procedure   ``shrinkBadAreas``
+588    procedure   ``removeBadArea``
+603    procedure   ``copyFile``
+680    function    ``repairBlock``
+710    procedure   ``repairChunk``
+739    procedure   ``rereadFile``
+789    procedure   ``determineBadAreaToProcess``
+813    procedure   ``processAreaBackward``
+853    procedure   ``fixOrImproveFile``
+910    procedure   ``processAreaForward``
+951    procedure   ``examineFile``
+1028   procedure   ``writeHelp``
+1065   procedure   ``main``
+====== =========== ==================================================
+
+prg/self.sd7
+------------
+
+:Lines:    49
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+26     array       ``prog``
+39     procedure   ``main``
+====== =========== ==================================================
+
+prg/shisen.sd7
+--------------
+
+:Lines:    1423
+:Entities: 53
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+57     array       ``digit_pixmap``
+59     structure   ``cardType``
+60     array       ``picture``
+65     enumeration ``visibleType``
+69     structure   ``fieldType``
+79     array       ``big_bush_pic``
+114    array       ``large_gem_pic``
+149    array       ``fairy_pic``
+216    array       ``computer_pic``
+283    array       ``sea_pic``
+350    array       ``zero``
+369    array       ``one``
+388    array       ``two``
+407    array       ``three``
+426    array       ``four``
+444    array       ``five``
+463    array       ``six``
+482    array       ``seven``
+501    array       ``eight``
+520    array       ``nine``
+539    function    ``genCard``
+547    array       ``cards``
+574    array       ``field``
+577    procedure   ``draw``
+590    procedure   ``put``
+597    procedure   ``show``
+604    procedure   ``mark``
+625    procedure   ``unmark``
+646    procedure   ``remove``
+656    procedure   ``unmarkAll``
+669    function    ``countCards``
+686    procedure   ``showHit``
+699    procedure   ``horizontal``
+711    procedure   ``vertical``
+723    function    ``line_free``
+739    function    ``column_free``
+755    procedure   ``upper_way``
+782    procedure   ``lower_way``
+809    procedure   ``left_way``
+836    procedure   ``right_way``
+863    procedure   ``way_down_right``
+885    procedure   ``way_right_down``
+907    procedure   ``way_down_left``
+929    procedure   ``way_left_down``
+951    function    ``find_way``
+1085   procedure   ``readHelpCommand``
+1102   procedure   ``help``
+1178   procedure   ``playerMove``
+1238   procedure   ``playerTurn``
+1276   function    ``solvable``
+1333   procedure   ``dealCards``
+1365   procedure   ``writeCentered``
+1372   procedure   ``main``
+====== =========== ==================================================
+
+prg/sl.sd7
+----------
+
+:Lines:    1029
+:Entities: 28
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+57     structure   ``coord``
+68     structure   ``workplace``
+75     array       ``workspace``
+76     array       ``listlength``
+92     procedure   ``info1``
+119    procedure   ``info2``
+150    procedure   ``nextDecimal``
+162    procedure   ``writeHeader``
+178    procedure   ``editInfo``
+206    procedure   ``clearScreen``
+219    procedure   ``writeScreen``
+232    procedure   ``writeMap``
+239    array       ``mapfield``
+304    procedure   ``redraw``
+317    procedure   ``shiftField``
+351    procedure   ``mark``
+365    procedure   ``erase``
+402    procedure   ``clearField``
+423    procedure   ``readFilename``
+463    procedure   ``load``
+520    procedure   ``save``
+576    procedure   ``pressakey``
+592    procedure   ``editmode``
+771    procedure   ``runinfo``
+789    procedure   ``init``
+802    procedure   ``markcell``
+814    procedure   ``nextgeneration``
+960    procedure   ``main``
+====== =========== ==================================================
+
+prg/snake.sd7
+-------------
+
+:Lines:    615
+:Entities: 25
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     enumeration ``direction_type``
+46     array       ``FIELD``
+48     structure   ``screen_object``
+54     structure   ``apple_object``
+60     structure   ``snake_object``
+67     array       ``position``
+75     procedure   ``move``
+83     procedure   ``beep``
+91     procedure   ``set_position``
+111    procedure   ``show_status``
+119    procedure   ``turn``
+131    procedure   ``turn``
+143    procedure   ``turn``
+155    procedure   ``turn``
+167    procedure   ``move``
+178    procedure   ``move``
+189    procedure   ``move``
+200    procedure   ``move``
+211    procedure   ``move``
+218    procedure   ``move``
+228    procedure   ``enlarge``
+244    procedure   ``show``
+282    function    ``play``
+356    procedure   ``init_level``
+578    procedure   ``main``
+====== =========== ==================================================
+
+prg/sokoban.sd7
+---------------
+
+:Lines:    891
+:Entities: 33
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+54     enumeration ``categoryType``
+58     structure   ``fieldType``
+64     array       ``levelMap``
+85     enumeration ``moveMode``
+89     enumeration ``moveDirection``
+93     structure   ``moveType``
+98     array       ``playerMoves``
+102    array       ``player_pic``
+137    array       ``goal_pic``
+172    array       ``wall_pic``
+207    array       ``packet_pic``
+242    array       ``player_at_goal_pic``
+277    array       ``packet_at_goal_pic``
+312    procedure   ``introduction``
+339    function    ``createButton``
+356    procedure   ``loadPixmaps``
+373    procedure   ``readLevel``
+411    procedure   ``recognizeFieldsOutside``
+431    procedure   ``recognizeFieldsOutside``
+451    procedure   ``generateLevelMap``
+500    procedure   ``readLevelMap``
+506    procedure   ``writeStatus``
+517    procedure   ``drawMap``
+565    procedure   ``assignDxDy``
+583    procedure   ``moveDxDy``
+595    procedure   ``pushDxDy``
+620    procedure   ``pullDxDy``
+645    procedure   ``undoMove``
+670    procedure   ``redoMove``
+695    function    ``doMove``
+732    procedure   ``doMove``
+775    procedure   ``playLevel``
+875    procedure   ``main``
+====== =========== ==================================================
+
+prg/spigotpi.sd7
+----------------
+
+:Lines:    64
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+28     procedure   ``main``
+====== =========== ==================================================
+
+prg/sql7.sd7
+------------
+
+:Lines:    278
+:Entities: 6
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     procedure   ``writeHelp``
+60     function    ``failed``
+77     procedure   ``displayResult``
+105    procedure   ``doExecute``
+142    function    ``getSqlStatement``
+196    procedure   ``main``
+====== =========== ==================================================
+
+prg/startrek.sd7
+----------------
+
+:Lines:    979
+:Entities: 43
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+42     array       ``description``
+47     array       ``klingonRow``
+48     array       ``klingonColumn``
+49     array       ``klingonEnergy``
+51     array       ``quad``
+58     array       ``sect``
+68     array       ``damage``
+73     procedure   ``title``
+81     procedure   ``help_course``
+91     procedure   ``help_sector``
+100    procedure   ``help_quadrant``
+110    procedure   ``help_warp_engines``
+132    procedure   ``help_short_range_sensors``
+143    procedure   ``help_long_range_sensors``
+153    procedure   ``help_phasers``
+165    procedure   ``help_photon_torpedoes``
+176    procedure   ``help_galactic_records``
+186    procedure   ``help_commands``
+198    procedure   ``help_game``
+214    procedure   ``help_quit``
+221    procedure   ``help``
+250    procedure   ``fix_damage``
+260    procedure   ``find_free_sector``
+269    procedure   ``init``
+320    procedure   ``enter_quadrant``
+367    function    ``get_condition``
+398    procedure   ``write_phaser_hit``
+407    function    ``klingon_distance``
+416    procedure   ``hits_from_klingons``
+439    procedure   ``time_for_repair``
+446    procedure   ``show_damage``
+453    procedure   ``move_ship``
+528    procedure   ``short_range_sensors``
+557    procedure   ``warp_engines``
+664    function    ``quadrant_description``
+673    procedure   ``long_range_sensors``
+699    procedure   ``phasers``
+754    procedure   ``torpedo_track``
+818    procedure   ``photon_torpedoes``
+862    procedure   ``galactic_records``
+891    procedure   ``write_stardate``
+898    procedure   ``game``
+958    procedure   ``main``
+====== =========== ==================================================
+
+prg/sudoku7.sd7
+---------------
+
+:Lines:    2657
+:Entities: 139
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+64     array       ``blue_digits``
+65     array       ``red_digits``
+66     array       ``small_digits``
+73     array       ``field``
+74     array       ``candidates``
+75     array       ``user_input``
+94     array       ``blue_zero``
+113    array       ``blue_one``
+132    array       ``blue_two``
+151    array       ``blue_three``
+170    array       ``blue_four``
+188    array       ``blue_five``
+207    array       ``blue_six``
+226    array       ``blue_seven``
+245    array       ``blue_eight``
+264    array       ``blue_nine``
+283    array       ``red_zero``
+302    array       ``red_one``
+321    array       ``red_two``
+340    array       ``red_three``
+359    array       ``red_four``
+377    array       ``red_five``
+396    array       ``red_six``
+415    array       ``red_seven``
+434    array       ``red_eight``
+453    array       ``red_nine``
+472    array       ``blue_single``
+490    array       ``blue_double``
+509    array       ``blue_triple``
+527    array       ``candidates_pic``
+545    procedure   ``initCandidates``
+566    procedure   ``initGrid``
+592    procedure   ``clearField``
+600    procedure   ``markField``
+608    procedure   ``clearDigit``
+619    procedure   ``setRedDigit``
+632    procedure   ``setBlueDigit``
+645    procedure   ``writeSmallDigit``
+656    procedure   ``excludeInRow``
+668    procedure   ``excludeInColumn``
+680    procedure   ``excludeInBox``
+695    procedure   ``excludeDigit``
+703    procedure   ``excludeFields``
+718    procedure   ``showAllCandidates``
+747    procedure   ``checkSingles``
+769    procedure   ``checkHiddenSinglesInRow``
+795    procedure   ``checkHiddenSinglesInColumn``
+821    procedure   ``checkHiddenSinglesInBox``
+852    procedure   ``checkHiddenSingles``
+871    procedure   ``checkLockedCandidatesInRow``
+906    procedure   ``checkLockedCandidatesInColumn``
+941    procedure   ``checkLockedCandidatesInBox``
+993    procedure   ``checkLockedCandidates``
+1012   procedure   ``checkNakedPairsInRow``
+1018   set         ``pairSet``
+1039   procedure   ``checkNakedPairsInColumn``
+1045   set         ``pairSet``
+1066   procedure   ``checkNakedPairsInBox``
+1075   set         ``pairSet``
+1104   procedure   ``checkNakedPairs``
+1123   procedure   ``checkNakedTriplesInRow``
+1130   set         ``tripleSet``
+1159   procedure   ``checkNakedTriplesInColumn``
+1166   set         ``tripleSet``
+1195   procedure   ``checkNakedTriplesInBox``
+1206   set         ``tripleSet``
+1248   procedure   ``checkNakedTriples``
+1267   procedure   ``checkNakedQuadsInRow``
+1275   set         ``quadSet``
+1310   procedure   ``checkNakedQuadsInColumn``
+1318   set         ``quadSet``
+1353   procedure   ``checkNakedQuadsInBox``
+1366   set         ``quadSet``
+1420   procedure   ``checkNakedQuads``
+1439   procedure   ``checkHiddenPairsInRow``
+1445   array       ``columnsWithDigit``
+1446   set         ``pairColumns``
+1447   set         ``pairSet``
+1473   procedure   ``checkHiddenPairsInColumn``
+1479   array       ``rowsWithDigit``
+1480   set         ``pairRows``
+1481   set         ``pairSet``
+1507   procedure   ``checkHiddenPairsInBox``
+1514   array       ``cellsWithDigit``
+1515   set         ``pairCells``
+1516   set         ``pairSet``
+1548   procedure   ``checkHiddenPairs``
+1567   procedure   ``checkHiddenTriplesInRow``
+1574   array       ``columnsWithDigit``
+1575   set         ``tripleColumns``
+1576   set         ``tripleSet``
+1611   procedure   ``checkHiddenTriplesInColumn``
+1618   array       ``rowsWithDigit``
+1619   set         ``tripleRows``
+1620   set         ``tripleSet``
+1655   procedure   ``checkHiddenTriplesInBox``
+1663   array       ``cellsWithDigit``
+1664   set         ``tripleCells``
+1665   set         ``tripleSet``
+1706   procedure   ``checkHiddenTriples``
+1725   procedure   ``checkHiddenQuadsInRow``
+1733   array       ``columnsWithDigit``
+1734   set         ``quadColumns``
+1735   set         ``quadSet``
+1776   procedure   ``checkHiddenQuadsInColumn``
+1784   array       ``rowsWithDigit``
+1785   set         ``quadRows``
+1786   set         ``quadSet``
+1827   procedure   ``checkHiddenQuadsInBox``
+1836   array       ``cellsWithDigit``
+1837   set         ``quadCells``
+1838   set         ``quadSet``
+1885   procedure   ``checkHiddenQuads``
+1904   procedure   ``checkXWingForDigit``
+1913   array       ``rowsInColumn``
+1914   array       ``columnsInRow``
+1915   set         ``xWingColumns``
+1916   set         ``xWingRows``
+1971   procedure   ``checkXWing``
+1981   procedure   ``checkSwordfishForDigit``
+1992   array       ``rowsInColumn``
+1993   array       ``columnsInRow``
+1994   set         ``swordfishColumns``
+1995   set         ``swordfishRows``
+2066   procedure   ``checkSwordfish``
+2076   procedure   ``solve``
+2120   procedure   ``blueChanges``
+2130   function    ``readCommand``
+2142   procedure   ``showSolved``
+2160   procedure   ``showNumberOfCandidates``
+2180   procedure   ``showCandidatesDigit``
+2200   procedure   ``showCandidates``
+2222   procedure   ``showStrategyCheckboxes``
+2277   procedure   ``hideStrategyCheckboxes``
+2283   procedure   ``showButtons``
+2318   procedure   ``loadField``
+2336   procedure   ``processCommand``
+2591   procedure   ``writeCentered``
+2598   procedure   ``main``
+====== =========== ==================================================
+
+prg/sydir7.sd7
+--------------
+
+:Lines:    384
+:Entities: 9
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     structure   ``syncFlags``
+43     procedure   ``syncFile``
+47     procedure   ``syncDir``
+50     array       ``sourceContent``
+51     array       ``destContent``
+111    function    ``equalFileContent``
+140    procedure   ``syncFile``
+147    array       ``dirContent``
+288    procedure   ``main``
+====== =========== ==================================================
+
+prg/syntaxhl.sd7
+----------------
+
+:Lines:    177
+:Entities: 6
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+105    array       ``emptyArray``
+110    enumeration ``myEnum``
+113    structure   ``myStruct``
+116    function    ``test``
+117    function    ``test``
+120    procedure   ``main``
+====== =========== ==================================================
+
+prg/tak.sd7
+-----------
+
+:Lines:    59
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     function    ``tak``
+49     procedure   ``main``
+====== =========== ==================================================
+
+prg/tar7.sd7
+------------
+
+:Lines:    121
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     procedure   ``main``
+40     array       ``arg_list``
+41     array       ``fileList``
+====== =========== ==================================================
+
+prg/tch.sd7
+-----------
+
+:Lines:    55
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``main``
+====== =========== ==================================================
+
+prg/testfont.sd7
+----------------
+
+:Lines:    95
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+45     array       ``fontList``
+50     procedure   ``main``
+====== =========== ==================================================
+
+prg/tet.sd7
+-----------
+
+:Lines:    479
+:Entities: 22
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+47     array       ``occupied``
+49     enumeration ``rot_position``
+53     enumeration ``tetromino_type``
+57     function    ``score``
+67     array       ``tetromino_list``
+72     function    ``PATTERN``
+185    structure   ``piece``
+194    procedure   ``next``
+204    procedure   ``prev``
+214    procedure   ``show``
+232    procedure   ``hide``
+250    function    ``is_occupied``
+269    procedure   ``do_occupie``
+285    procedure   ``left``
+296    procedure   ``right``
+307    procedure   ``rotate``
+318    procedure   ``down``
+331    procedure   ``position``
+341    procedure   ``drop``
+355    procedure   ``set_piece``
+405    procedure   ``remove_full_lines``
+428    procedure   ``main``
+====== =========== ==================================================
+
+prg/tetg.sd7
+------------
+
+:Lines:    501
+:Entities: 23
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+53     array       ``occupied``
+55     enumeration ``rot_position``
+59     enumeration ``tetromino_type``
+63     function    ``score``
+73     function    ``color``
+83     array       ``tetromino_list``
+88     function    ``PATTERN``
+201    structure   ``piece``
+210    procedure   ``next``
+220    procedure   ``prev``
+230    procedure   ``show``
+247    procedure   ``hide``
+264    function    ``is_occupied``
+283    procedure   ``do_occupie``
+299    procedure   ``left``
+310    procedure   ``right``
+321    procedure   ``rotate``
+332    procedure   ``down``
+345    procedure   ``position``
+355    procedure   ``drop``
+369    procedure   ``set_piece``
+421    procedure   ``remove_full_lines``
+447    procedure   ``main``
+====== =========== ==================================================
+
+prg/toutf8.sd7
+--------------
+
+:Lines:    240
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     procedure   ``main``
+====== =========== ==================================================
+
+prg/tst_cli.sd7
+---------------
+
+:Lines:    40
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``main``
+====== =========== ==================================================
+
+prg/tst_srv.sd7
+---------------
+
+:Lines:    47
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+30     procedure   ``main``
+====== =========== ==================================================
+
+prg/wator.sd7
+-------------
+
+:Lines:    651
+:Entities: 16
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+61     structure   ``cellType``
+73     array       ``sumContent``
+79     procedure   ``introduction``
+122    procedure   ``display``
+153    procedure   ``writeInfo``
+203    procedure   ``initInfo``
+223    procedure   ``readNumber``
+253    procedure   ``initialize``
+306    procedure   ``moveFish``
+322    procedure   ``moveAllFish``
+333    array       ``moveopts``
+413    procedure   ``killFish``
+430    procedure   ``moveShark``
+447    procedure   ``moveAllSharks``
+457    array       ``moveopts``
+563    procedure   ``main``
+====== =========== ==================================================
+
+prg/which.sd7
+-------------
+
+:Lines:    65
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     procedure   ``main``
+====== =========== ==================================================
+
+prg/wiz.sd7
+-----------
+
+:Lines:    2833
+:Entities: 132
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+43     enumeration ``speciesType``
+47     function    ``str``
+53     enumeration ``directType``
+57     function    ``str``
+65     enumeration ``objectType``
+70     function    ``str``
+83     enumeration ``animateType``
+88     function    ``str``
+94     enumeration ``armorType``
+98     function    ``str``
+104    enumeration ``weaponType``
+108    function    ``str``
+114    enumeration ``commandType``
+120    enumeration ``contentType``
+125    enumeration ``transferType``
+129    enumeration ``occurType``
+134    structure   ``playerType``
+159    structure   ``fightStateType``
+170    structure   ``roomType``
+187    procedure   ``writePos``
+188    procedure   ``enterRoom``
+190    procedure   ``incident``
+192    procedure   ``teleportTo``
+194    procedure   ``writeFightState``
+196    procedure   ``executeCommand``
+198    procedure   ``removeFromRoom``
+212    function    ``rangeLaby``
+216    function    ``rangeLevel``
+220    function    ``range18``
+224    function    ``rand``
+228    function    ``rand``
+232    procedure   ``startText``
+261    procedure   ``writeHelp``
+288    procedure   ``randomRoom``
+297    procedure   ``findUninhabitedRoom``
+308    procedure   ``findEmptyRoom``
+322    procedure   ``initRoom``
+332    procedure   ``initEntrance``
+340    procedure   ``initRoomConnections``
+342    array       ``restrictedConnections``
+392    procedure   ``initRoomProperties``
+442    procedure   ``initRoomTransfers``
+470    function    ``aOrAn``
+484    procedure   ``DECLARE_A_OR_AN``
+486    function    ``aOrAn``
+495    function    ``anyFood``
+500    function    ``anyAdjective``
+506    function    ``numberName``
+510    function    ``sexName``
+514    function    ``titleName``
+518    function    ``countOwnedObjects``
+522    function    ``countOwnedTreasures``
+526    function    ``ownedTreasure``
+530    function    ``treasureNumber``
+534    procedure   ``removeFromRoom``
+541    procedure   ``writePos``
+547    procedure   ``findGoldPieces``
+558    procedure   ``findFlares``
+569    function    ``roomAdjective``
+575    function    ``roomIdInLevel``
+579    function    ``roomId``
+583    procedure   ``writeRoomDescription``
+656    procedure   ``writeConnections``
+724    procedure   ``writeThings``
+737    procedure   ``writeAnimates``
+745    procedure   ``writeObjects``
+772    procedure   ``writeRoomDetails``
+781    procedure   ``look``
+794    function    ``readChar``
+807    function    ``readChoice``
+817    procedure   ``readNumber``
+841    procedure   ``readSpecies``
+866    procedure   ``readSex``
+889    procedure   ``riseAttribute``
+922    procedure   ``readAttributes``
+961    procedure   ``buyAttribute``
+999    procedure   ``buyArmor``
+1053   procedure   ``buyWeapon``
+1113   procedure   ``buyLamp``
+1144   procedure   ``buyFlares``
+1178   procedure   ``buyTreasures``
+1216   procedure   ``buy``
+1257   procedure   ``sellTreasures``
+1294   procedure   ``sell``
+1309   procedure   ``checkArmor``
+1334   procedure   ``vendorDies``
+1362   procedure   ``monsterDies``
+1396   procedure   ``monsterAttacks``
+1420   procedure   ``attackMonster``
+1453   procedure   ``castSpell``
+1498   procedure   ``bribeMonster``
+1538   procedure   ``meetMonster``
+1571   procedure   ``retreatFromMonster``
+1599   procedure   ``attack``
+1616   procedure   ``cast``
+1636   procedure   ``bribe``
+1656   procedure   ``meetVendor``
+1667   procedure   ``enterRoom``
+1721   procedure   ``readCoordinate``
+1747   procedure   ``teleportTo``
+1769   procedure   ``teleport``
+1797   procedure   ``go``
+1800   array       ``delta_x``
+1801   array       ``delta_y``
+1802   array       ``delta_z``
+1830   procedure   ``status``
+1848   procedure   ``listInventory``
+1881   procedure   ``inventory``
+1889   procedure   ``contentInfo``
+1936   procedure   ``map``
+1960   procedure   ``flare``
+1992   procedure   ``shineIntoRoom``
+2004   procedure   ``lamp``
+2038   procedure   ``drink``
+2093   procedure   ``read``
+2139   procedure   ``viewRoomWithOrb``
+2151   procedure   ``gazeIntoOrb``
+2238   procedure   ``gaze``
+2276   procedure   ``openChest``
+2342   procedure   ``open``
+2354   procedure   ``quit``
+2367   procedure   ``wait``
+2374   procedure   ``illegal``
+2381   function    ``readCommand``
+2451   procedure   ``executeCommand``
+2485   procedure   ``writeFightState``
+2507   procedure   ``incident``
+2603   procedure   ``curesAndDissolves``
+2633   procedure   ``writeRemark``
+2724   procedure   ``die``
+2746   procedure   ``exitCastle``
+2773   procedure   ``main``
+====== =========== ==================================================
+
+prg/wordcnt.sd7
+---------------
+
+:Lines:    54
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     procedure   ``main``
+====== =========== ==================================================
+
+prg/wrinum.sd7
+--------------
+
+:Lines:    43
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     procedure   ``main``
+====== =========== ==================================================
+
+prg/wumpus.sd7
+--------------
+
+:Lines:    372
+:Entities: 15
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     array       ``loc``
+39     array       ``save``
+41     enumeration ``status_type``
+47     array       ``cave``
+70     procedure   ``print_instructions``
+117    procedure   ``check_hazards``
+146    function    ``shoot_or_move``
+166    procedure   ``check_shot``
+178    procedure   ``move_wumpus``
+193    procedure   ``shoot_arrow``
+199    array       ``path``
+246    function    ``readmove``
+277    procedure   ``move_player``
+302    procedure   ``init_setup``
+323    procedure   ``main``
+====== =========== ==================================================
+
+lib
+===
+
+lib/aes.s7i
+-----------
+
+:Lines:    1144
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     structure   ``aesState``
+40     array       ``encryptionSubKey``
+41     array       ``decryptionSubKey``
+56     array       ``Te``
+384    array       ``Td``
+712    array       ``rcon``
+720    procedure   ``expandAesKey128``
+742    procedure   ``expandAesKey192``
+768    procedure   ``expandAesKey256``
+801    function    ``setAesKey``
+803    array       ``encryptKey``
+826    function    ``genAesDecryptKey``
+828    array       ``decryptKey``
+873    function    ``setAesKey``
+890    function    ``setCipherKey``
+895    function    ``encodeAesBlock``
+995    function    ``decodeAesBlock``
+1099   function    ``encode``
+1125   function    ``decode``
+====== =========== ==================================================
+
+lib/aes_gcm.s7i
+---------------
+
+:Lines:    392
+:Entities: 17
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``factorHType``
+42     function    ``computeFactorH``
+78     array       ``last4``
+89     function    ``gcmMult``
+134    structure   ``aesGcmState``
+166    function    ``setAesGcmKey``
+189    function    ``setCipherKey``
+200    procedure   ``initAead``
+213    function    ``getComputedMac``
+222    function    ``getMac``
+229    procedure   ``incrementGcmNonceCounter``
+243    function    ``aesGcmEncode``
+281    function    ``aesGcmDecode``
+319    procedure   ``initializeComputedMac``
+331    procedure   ``finalizeComputedMac``
+356    function    ``encode``
+376    function    ``decode``
+====== =========== ==================================================
+
+lib/ar.s7i
+----------
+
+:Lines:    1532
+:Entities: 49
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+47     structure   ``arHeader``
+64     procedure   ``showHeader``
+79     procedure   ``assignFilePath``
+113    function    ``arHeader``
+129    procedure   ``readHead``
+145    procedure   ``readMinimumOfHead``
+161    function    ``str``
+188    procedure   ``writeHead``
+194    function    ``getLongName``
+221    function    ``addLongName``
+272    structure   ``arArchive``
+286    function    ``openAr``
+345    function    ``openAr``
+359    procedure   ``close``
+365    function    ``addToCatalog``
+377    function    ``addImplicitDir``
+389    function    ``followSymlink``
+431    function    ``followSymlink``
+445    procedure   ``fixRegisterAndCatalog``
+464    procedure   ``setHeaderFileName``
+522    function    ``readDir``
+533    function    ``readDir``
+548    function    ``fileType``
+609    function    ``fileTypeSL``
+655    function    ``getFileMode``
+674    procedure   ``setFileMode``
+705    function    ``fileSize``
+727    function    ``getMTime``
+751    procedure   ``setMTime``
+784    function    ``getOwner``
+806    procedure   ``setOwner``
+842    function    ``getGroup``
+864    procedure   ``setGroup``
+901    function    ``getFileMode``
+939    function    ``getMTime``
+978    procedure   ``setMTime``
+1020   function    ``getOwner``
+1059   procedure   ``setOwner``
+1104   function    ``getGroup``
+1143   procedure   ``setGroup``
+1186   function    ``readLink``
+1228   procedure   ``makeLink``
+1278   function    ``getFile``
+1305   procedure   ``putFile``
+1384   procedure   ``makeDir``
+1442   procedure   ``removeFile``
+1488   procedure   ``for``
+1498   function    ``openFileInAr``
+1529   function    ``open``
+====== =========== ==================================================
+
+lib/arc4.s7i
+------------
+
+:Lines:    144
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     structure   ``arc4State``
+39     array       ``s``
+59     function    ``setArc4Key``
+90     function    ``setCipherKey``
+95     function    ``getArc4PseudoRandomByte``
+114    function    ``encode``
+132    function    ``decode``
+====== =========== ==================================================
+
+lib/archive.s7i
+---------------
+
+:Lines:    143
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+48     function    ``openArchive``
+102    function    ``openArchive``
+118    function    ``openArchiveByExtension``
+====== =========== ==================================================
+
+lib/archive_base.s7i
+--------------------
+
+:Lines:    135
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+52     function    ``readDir``
+54     array       ``fileNames``
+58     set         ``fileNameSet``
+105    function    ``implicitDir``
+123    function    ``isEmptyDir``
+====== =========== ==================================================
+
+lib/array.s7i
+-------------
+
+:Lines:    610
+:Entities: 49
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     structure   ``ARRAY_IDX_RANGE``
+34     function    ``..``
+43     function    ``len``
+56     function    ``array``
+74     procedure   ``:=``
+81     procedure   ``&:=``
+88     procedure   ``&:=``
+99     function    ``&``
+117    function    ``..``
+134    function    ``..``
+144    function    ``len``
+159    procedure   ``insert``
+170    procedure   ``insert``
+186    function    ``remove``
+197    function    ``remove``
+207    function    ``length``
+216    function    ``minIdx``
+225    function    ``maxIdx``
+236    function    ``times``
+238    function    ``.``
+241    function    ``conv``
+258    function    ``times``
+266    procedure   ``for``
+281    procedure   ``for``
+295    procedure   ``for``
+310    procedure   ``for``
+333    procedure   ``for``
+361    procedure   ``for``
+372    procedure   ``for``
+390    procedure   ``for``
+413    procedure   ``for``
+442    function    ``rand``
+448    function    ``=``
+464    function    ``<>``
+485    procedure   ``insert``
+504    function    ``compare``
+524    function    ``<``
+527    function    ``>``
+530    function    ``<=``
+533    function    ``>=``
+538    function    ``SORT``
+540    function    ``SORT_REVERSE``
+555    function    ``sort``
+558    function    ``sort``
+574    function    ``sort``
+577    function    ``sort``
+601    procedure   ``ENABLE_SORT``
+605    function    ``SORT``
+607    function    ``sort``
+====== =========== ==================================================
+
+lib/asn1.s7i
+------------
+
+:Lines:    544
+:Entities: 26
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     array       ``classTagName``
+71     enumeration ``asn1TagType``
+106    enumeration ``asn1TagClass``
+114    structure   ``asn1DataElement``
+125    function    ``.``
+127    function    ``.``
+131    function    ``encodeObjectIdentifier``
+161    function    ``decodeObjectIdentifier``
+163    array       ``oid``
+184    function    ``objectIdentifier``
+218    function    ``getAsn1DataElement``
+264    function    ``getData``
+279    procedure   ``skipData``
+285    function    ``genAsn1Length``
+303    function    ``asn1TagTypeOfString``
+307    set         ``visibleChar``
+308    set         ``printableChar``
+337    function    ``genAsn1Element``
+353    function    ``genAsn1Integer``
+372    function    ``genAsn1String``
+392    function    ``genAsn1Sequence``
+408    function    ``genAsn1Set``
+423    function    ``genExplicitAsn1Tag``
+434    procedure   ``printAsn1``
+522    procedure   ``printAsn1``
+532    procedure   ``searchLengthByte``
+====== =========== ==================================================
+
+lib/asn1oid.s7i
+---------------
+
+:Lines:    157
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+102    structure   ``algorithmIdentifierType``
+109    function    ``getAlgorithmIdentifier``
+143    function    ``genAlgorithmIdentifier``
+====== =========== ==================================================
+
+lib/basearray.s7i
+-----------------
+
+:Lines:    450
+:Entities: 35
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+42     function    ``array``
+58     procedure   ``:=``
+65     procedure   ``&:=``
+72     procedure   ``&:=``
+78     function    ``&``
+96     function    ``..``
+113    function    ``..``
+123    function    ``len``
+134    procedure   ``insert``
+145    procedure   ``insert``
+157    function    ``remove``
+168    function    ``remove``
+175    function    ``length``
+195    function    ``maxIdx``
+197    function    ``SET_MIN_IDX``
+199    function    ``SET_MIN_IDX``
+201    function    ``SET_MIN_IDX``
+203    function    ``TIMES``
+211    function    ``;``
+218    procedure   ``:=``
+220    function    ``ord``
+222    function    ``conv``
+227    function    ``times``
+234    procedure   ``for``
+249    procedure   ``for``
+263    procedure   ``for``
+278    procedure   ``for``
+301    procedure   ``for``
+329    procedure   ``for``
+340    procedure   ``for``
+358    procedure   ``for``
+381    procedure   ``for``
+410    function    ``rand``
+416    function    ``=``
+431    function    ``<>``
+====== =========== ==================================================
+
+lib/bigfile.s7i
+---------------
+
+:Lines:    136
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     function    ``bigLength``
+36     procedure   ``seek``
+37     function    ``bigTell``
+42     function    ``bigLength``
+43     procedure   ``seek``
+44     function    ``bigTell``
+58     function    ``bigLength``
+73     procedure   ``seek``
+87     function    ``bigTell``
+106    function    ``bigLength``
+119    procedure   ``seek``
+134    function    ``bigTell``
+====== =========== ==================================================
+
+lib/bigint.s7i
+--------------
+
+:Lines:    824
+:Entities: 60
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+51     procedure   ``:=``
+64     function    ``+``
+71     function    ``-``
+78     function    ``+``
+85     function    ``-``
+92     function    ``*``
+107    function    ``div``
+119    function    ``rem``
+135    function    ``mdiv``
+147    function    ``mod``
+159    function    ``**``
+172    function    ``<<``
+182    function    ``>>``
+188    procedure   ``+:=``
+194    procedure   ``-:=``
+200    procedure   ``*:=``
+207    procedure   ``<<:=``
+214    procedure   ``>>:=``
+222    function    ``=``
+230    function    ``<>``
+238    function    ``<``
+246    function    ``>``
+254    function    ``<=``
+262    function    ``>=``
+271    function    ``compare``
+278    function    ``hashCode``
+281    structure   ``quotRem``
+287    function    ``quotRem``
+296    function    ``=``
+301    function    ``<>``
+312    function    ``divRem``
+320    function    ``succ``
+328    function    ``pred``
+335    function    ``abs``
+349    function    ``log10``
+363    function    ``log2``
+371    function    ``odd``
+379    function    ``ord``
+387    function    ``integer``
+395    function    ``gcd``
+403    function    ``bigInteger``
+411    function    ``conv``
+421    function    ``str``
+429    function    ``literal``
+445    function    ``radix``
+460    function    ``RADIX``
+483    function    ``bigInteger``
+506    function    ``parse``
+530    function    ``bigInteger``
+540    function    ``rand``
+556    function    ``bitLength``
+571    function    ``lowestSetBit``
+580    procedure   ``incr``
+589    procedure   ``decr``
+621    function    ``sci``
+666    function    ``!``
+692    function    ``!``
+725    function    ``sqrt``
+749    function    ``modInverse``
+799    function    ``modPow``
+====== =========== ==================================================
+
+lib/bigrat.s7i
+--------------
+
+:Lines:    784
+:Entities: 42
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     structure   ``bigRational``
+47     procedure   ``normalize``
+56     procedure   ``reduce``
+72     function    ``/``
+87     function    ``+``
+95     function    ``-``
+108    function    ``+``
+126    function    ``-``
+144    function    ``*``
+163    function    ``/``
+181    procedure   ``+:=``
+196    procedure   ``-:=``
+211    procedure   ``*:=``
+222    procedure   ``/:=``
+235    function    ``**``
+255    function    ``=``
+265    function    ``<>``
+275    function    ``<``
+285    function    ``>``
+295    function    ``<=``
+305    function    ``>=``
+316    function    ``compare``
+325    function    ``hashCode``
+332    function    ``rat``
+344    function    ``bigRational``
+356    function    ``conv``
+368    function    ``bigRational``
+380    function    ``conv``
+393    function    ``abs``
+405    function    ``floor``
+412    function    ``ceil``
+419    function    ``trunc``
+428    function    ``round``
+445    function    ``round10``
+479    function    ``str``
+524    function    ``literal``
+533    function    ``fraction``
+560    function    ``digits``
+594    function    ``decimalExponent``
+631    function    ``sci``
+700    function    ``bigRational``
+773    function    ``parse``
+====== =========== ==================================================
+
+lib/bin16.s7i
+-------------
+
+:Lines:    592
+:Entities: 39
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     procedure   ``:=``
+51     function    ``bin16``
+65     function    ``bin16``
+81     function    ``conv``
+88     function    ``conv``
+95     function    ``ord``
+102    function    ``integer``
+109    function    ``char``
+117    function    ``bin64``
+124    function    ``bin16``
+133    function    ``compare``
+140    function    ``hashCode``
+148    function    ``rand``
+160    function    ``bitLength``
+172    function    ``lowestSetBit``
+181    function    ``str``
+194    function    ``radix``
+207    function    ``RADIX``
+225    function    ``bytes``
+243    function    ``bytes``
+251    function    ``=``
+259    function    ``<>``
+267    function    ``&``
+275    function    ``|``
+283    function    ``><``
+291    function    ``~``
+303    function    ``<<``
+314    function    ``>>``
+322    procedure   ``<<:=``
+331    procedure   ``>>:=``
+337    procedure   ``&:=``
+343    procedure   ``|:=``
+349    procedure   ``><:=``
+361    function    ``rotLeft``
+374    function    ``rotRight``
+406    function    ``float``
+472    function    ``bin16``
+570    function    ``bin16``
+579    function    ``bin16``
+====== =========== ==================================================
+
+lib/bin32.s7i
+-------------
+
+:Lines:    490
+:Entities: 39
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+43     procedure   ``:=``
+50     function    ``bin32``
+63     function    ``bin32``
+76     function    ``bin32``
+83     function    ``conv``
+90     function    ``conv``
+97     function    ``ord``
+104    function    ``integer``
+111    function    ``char``
+124    function    ``float``
+133    function    ``compare``
+140    function    ``hashCode``
+148    function    ``rand``
+160    function    ``bitLength``
+172    function    ``lowestSetBit``
+181    function    ``str``
+194    function    ``radix``
+207    function    ``RADIX``
+225    function    ``bytes``
+243    function    ``bytes``
+251    function    ``=``
+259    function    ``<>``
+267    function    ``&``
+275    function    ``|``
+283    function    ``><``
+291    function    ``~``
+303    function    ``<<``
+314    function    ``>>``
+322    procedure   ``<<:=``
+331    procedure   ``>>:=``
+337    procedure   ``&:=``
+343    procedure   ``|:=``
+349    procedure   ``><:=``
+361    function    ``rotLeft``
+374    function    ``rotRight``
+392    function    ``float2MbfBits``
+437    function    ``mbfBits2Float``
+464    function    ``bin32``
+475    function    ``bin32``
+====== =========== ==================================================
+
+lib/bin64.s7i
+-------------
+
+:Lines:    539
+:Entities: 43
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     procedure   ``:=``
+56     function    ``bin64``
+77     function    ``bin64``
+84     function    ``bin64``
+97     function    ``bin64``
+104    function    ``conv``
+111    function    ``conv``
+118    function    ``ord``
+125    function    ``integer``
+133    function    ``big``
+141    function    ``bigInteger``
+148    function    ``char``
+161    function    ``float``
+170    function    ``compare``
+177    function    ``hashCode``
+185    function    ``rand``
+197    function    ``bitLength``
+209    function    ``lowestSetBit``
+219    function    ``str``
+232    function    ``radix``
+245    function    ``RADIX``
+263    function    ``bytes``
+281    function    ``bytes``
+289    function    ``=``
+297    function    ``<>``
+305    function    ``&``
+313    function    ``|``
+321    function    ``><``
+329    function    ``~``
+342    function    ``<<``
+353    function    ``>>``
+362    procedure   ``<<:=``
+371    procedure   ``>>:=``
+377    procedure   ``&:=``
+383    procedure   ``|:=``
+389    procedure   ``><:=``
+401    function    ``rotLeft``
+414    function    ``rotRight``
+422    function    ``getBinary``
+440    function    ``float2MbfBits``
+482    function    ``mbfBits2Float``
+515    function    ``bin64``
+528    function    ``bin64``
+====== =========== ==================================================
+
+lib/bitdata.s7i
+---------------
+
+:Lines:    1330
+:Entities: 52
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     array       ``reverseBits``
+109    function    ``reverseBits``
+123    function    ``reverseByteBits``
+146    structure   ``lsbInBitStream``
+161    procedure   ``show``
+176    procedure   ``fillStriBuffer``
+195    procedure   ``fillBuffer``
+209    function    ``openLsbInBitStream``
+224    function    ``openLsbInBitStream``
+245    procedure   ``close``
+282    function    ``getBit``
+327    function    ``getBits``
+378    function    ``peekBits``
+399    procedure   ``skipBits``
+430    function    ``eof``
+463    function    ``gets``
+500    structure   ``msbInBitStream``
+515    procedure   ``show``
+530    procedure   ``fillStriBuffer``
+549    procedure   ``fillBuffer``
+563    function    ``openMsbInBitStream``
+578    function    ``openMsbInBitStream``
+599    procedure   ``close``
+638    function    ``getBit``
+683    function    ``getBits``
+726    function    ``peekBits``
+747    procedure   ``skipBits``
+775    function    ``eof``
+808    function    ``gets``
+850    structure   ``lsbOutBitStream``
+878    procedure   ``putBit``
+908    procedure   ``putBits``
+924    procedure   ``&:=``
+941    function    ``length``
+954    procedure   ``truncate``
+988    procedure   ``flush``
+1007   function    ``getBytes``
+1022   procedure   ``write``
+1040   structure   ``msbOutBitStream``
+1068   procedure   ``putBit``
+1099   procedure   ``putBits``
+1122   procedure   ``&:=``
+1139   function    ``length``
+1152   procedure   ``truncate``
+1188   procedure   ``flush``
+1207   function    ``getBytes``
+1222   procedure   ``write``
+1234   structure   ``reverseBitStream``
+1243   function    ``reverseBitStream``
+1257   function    ``bitsStillInStream``
+1266   function    ``bitsRead``
+1277   function    ``getBits``
+====== =========== ==================================================
+
+lib/bitmapfont.s7i
+------------------
+
+:Lines:    215
+:Entities: 8
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+45     structure   ``bitmapFont``
+57     function    ``width``
+84     function    ``numOfCharsInWidth``
+117    function    ``genPixmap``
+149    function    ``genPixmapFont``
+176    function    ``getFontCharPixmap``
+191    procedure   ``setFont``
+203    function    ``columnWidth``
+====== =========== ==================================================
+
+lib/bitset.s7i
+--------------
+
+:Lines:    593
+:Entities: 39
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     procedure   ``:=``
+46     function    ``_GENERATE_EMPTY_SET``
+64     function    ``|``
+73     function    ``&``
+82     function    ``><``
+91     function    ``-``
+98     procedure   ``|:=``
+105    procedure   ``&:=``
+112    procedure   ``-:=``
+128    function    ``=``
+144    function    ``<>``
+164    function    ``<``
+184    function    ``>``
+204    function    ``<=``
+224    function    ``>=``
+249    function    ``compare``
+256    function    ``hashCode``
+267    function    ``in``
+278    function    ``not``
+286    procedure   ``incl``
+293    procedure   ``excl``
+302    procedure   ``@:=``
+319    function    ``card``
+329    function    ``rand``
+342    function    ``min``
+355    function    ``max``
+368    function    ``next``
+400    function    ``integer``
+410    function    ``conv``
+420    function    ``bitset``
+430    function    ``conv``
+436    procedure   ``for``
+457    procedure   ``for``
+480    procedure   ``for``
+494    function    ``toArray``
+496    array       ``values``
+526    function    ``str``
+550    function    ``bitset``
+580    function    ``parse``
+====== =========== ==================================================
+
+lib/bitsetof.s7i
+----------------
+
+:Lines:    431
+:Entities: 37
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     function    ``bitset``
+52     procedure   ``:=``
+56     function    ``bitset``
+57     function    ``conv``
+58     function    ``varConv``
+59     function    ``conv``
+73     function    ``|``
+81     function    ``&``
+89     function    ``><``
+97     function    ``-``
+103    procedure   ``|:=``
+109    procedure   ``&:=``
+115    procedure   ``-:=``
+122    function    ``=``
+129    function    ``<>``
+139    function    ``<``
+149    function    ``>``
+159    function    ``<=``
+169    function    ``>=``
+183    function    ``compare``
+189    function    ``hashCode``
+199    function    ``in``
+210    function    ``not``
+218    procedure   ``incl``
+227    procedure   ``excl``
+238    procedure   ``@:=``
+253    function    ``card``
+261    function    ``rand``
+273    function    ``min``
+285    function    ``max``
+297    function    ``next``
+323    procedure   ``for``
+344    procedure   ``for``
+367    procedure   ``for``
+381    function    ``toArray``
+383    array       ``values``
+412    function    ``str``
+====== =========== ==================================================
+
+lib/blowfish.s7i
+----------------
+
+:Lines:    383
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     structure   ``blowfishState``
+39     array       ``pBox``
+40     array       ``sBox``
+53     array       ``pBoxInit``
+60     array       ``sBoxInit``
+235    function    ``f``
+242    procedure   ``encrypt``
+264    procedure   ``decrypt``
+291    function    ``setBlowfishKey``
+336    function    ``setCipherKey``
+345    function    ``encode``
+367    function    ``decode``
+====== =========== ==================================================
+
+lib/bmp.s7i
+-----------
+
+:Lines:    924
+:Entities: 37
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+64     structure   ``bmpColorBitfield``
+70     structure   ``bmpHeader``
+90     array       ``colorSpaceEndpoints``
+99     function    ``bmpColorBitfield``
+110    function    ``str``
+116    function    ``toColor``
+120    procedure   ``readBitMasks``
+144    procedure   ``showHeader``
+169    procedure   ``readDibHeader``
+236    procedure   ``readHeader``
+255    procedure   ``computeNumberOfPaletteColors``
+267    procedure   ``readPaletteData``
+293    procedure   ``readPalette``
+314    procedure   ``readBmpImageLine1Bit``
+344    procedure   ``readBmpImage1Bit``
+363    procedure   ``readBmpImageLine2Bit``
+389    procedure   ``readBmpImage2Bit``
+408    procedure   ``readBmpImageLine4Bit``
+427    procedure   ``readBmpImage4Bit``
+446    procedure   ``readBmpImageLine8Bit``
+463    procedure   ``readBmpImage8Bit``
+482    procedure   ``readBmpBitfieldImageLine16Bit``
+501    procedure   ``readBmpNoBitfieldImageLine16Bit``
+520    procedure   ``readBmpImage16Bit``
+541    procedure   ``readBmpImageLine24Bit``
+558    procedure   ``readBmpImage24Bit``
+571    procedure   ``readBmpBitfieldImageLine32Bit``
+590    procedure   ``readBmpNoBitfieldImageLine32Bit``
+607    procedure   ``readBmpImage32Bit``
+628    procedure   ``processHuffman1d``
+646    procedure   ``readBmpImageRle4``
+706    procedure   ``readBmpImageRle8``
+757    function    ``readBmp``
+827    function    ``readBmp``
+851    function    ``readBmp``
+870    function    ``str``
+914    procedure   ``writeBmp``
+====== =========== ==================================================
+
+lib/boolean.s7i
+---------------
+
+:Lines:    403
+:Entities: 39
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     procedure   ``:=``
+83     function    ``not``
+94     function    ``and``
+95     function    ``and``
+96     function    ``and``
+107    function    ``or``
+108    function    ``or``
+109    function    ``or``
+117    procedure   ``&:=``
+125    procedure   ``|:=``
+133    procedure   ``><:=``
+141    function    ``=``
+150    function    ``<>``
+158    function    ``<``
+166    function    ``>``
+174    function    ``<=``
+182    function    ``>=``
+191    function    ``compare``
+198    function    ``hashCode``
+206    function    ``ord``
+214    function    ``integer``
+222    function    ``conv``
+231    function    ``boolean``
+240    function    ``conv``
+243    function    ``varConv``
+257    function    ``succ``
+267    function    ``pred``
+273    procedure   ``incr``
+282    procedure   ``decr``
+295    function    ``str``
+305    function    ``literal``
+314    function    ``parse``
+323    function    ``boolean``
+334    function    ``rand``
+337    procedure   ``DECLARE_TERNARY``
+345    function    ``?``
+347    function    ``?``
+349    function    ``?``
+351    function    ``?``
+====== =========== ==================================================
+
+lib/browser.s7i
+---------------
+
+:Lines:    280
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     structure   ``browserConnection``
+47     function    ``processHttpRequest``
+146    function    ``openBrowser``
+192    procedure   ``close``
+203    procedure   ``acceptNewSock``
+219    procedure   ``sendClientError``
+245    procedure   ``display``
+====== =========== ==================================================
+
+lib/bstring.s7i
+---------------
+
+:Lines:    227
+:Entities: 17
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+43     procedure   ``:=``
+45     function    ``_GENERATE_EMPTY_BSTRING``
+59     function    ``str``
+67     function    ``literal``
+76     function    ``string``
+85     function    ``bstring``
+94     function    ``parse``
+112    function    ``length``
+120    function    ``=``
+128    function    ``<>``
+137    function    ``compare``
+144    function    ``hashCode``
+150    procedure   ``for``
+173    function    ``bStriBe2BigInt``
+187    function    ``bStriLe2BigInt``
+204    function    ``bStriBe``
+221    function    ``bStriLe``
+====== =========== ==================================================
+
+lib/bytedata.s7i
+----------------
+
+:Lines:    482
+:Entities: 41
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     enumeration ``signedness``
+53     enumeration ``endianness``
+64     function    ``fromAsciiz``
+90     function    ``getAsciiz``
+113    function    ``getAsciiz``
+134    function    ``hex``
+159    function    ``hex2Bytes``
+176    function    ``bytes``
+178    function    ``bytes``
+180    function    ``bytes``
+182    function    ``bytes``
+203    function    ``bytes``
+207    function    ``bytes``
+209    function    ``bytes``
+211    function    ``bytes``
+213    function    ``bytes``
+250    function    ``bytes``
+254    function    ``bytes``
+257    function    ``bytes``
+260    function    ``bytes``
+263    function    ``bytes``
+290    function    ``bytes``
+294    function    ``bytes``
+307    function    ``bytes``
+320    function    ``bytes``
+337    function    ``bytes``
+381    function    ``bytes``
+385    function    ``bytes2Int``
+387    function    ``bytes2Int``
+389    function    ``bytes2Int``
+391    function    ``bytes2Int``
+413    function    ``bytes2Int``
+417    function    ``bytes2BigInt``
+420    function    ``bytes2BigInt``
+423    function    ``bytes2BigInt``
+426    function    ``bytes2BigInt``
+452    function    ``bytes2BigInt``
+459    function    ``getUInt16Le``
+466    function    ``getUInt32Le``
+473    function    ``getUInt16Be``
+480    function    ``getUInt32Be``
+====== =========== ==================================================
+
+lib/bzip2.s7i
+-------------
+
+:Lines:    887
+:Entities: 35
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+97     structure   ``bzip2Header``
+103    procedure   ``showHeader``
+110    function    ``readBzip2Header``
+123    function    ``readBzip2Header``
+139    structure   ``bzip2BlockHeader``
+149    procedure   ``showHeader``
+159    procedure   ``readMappingTable``
+188    procedure   ``readHuffmanGroups``
+199    structure   ``bzip2HuffmanDecoder``
+205    structure   ``bzip2DecoderState``
+212    function    ``getHuffmanSymbol``
+227    procedure   ``readSelectors``
+234    array       ``mtfSelector``
+268    procedure   ``readHuffmanDecoders``
+273    array       ``codeLengths``
+313    procedure   ``initMoveToFront``
+339    procedure   ``moveMtfDataToTheEnd``
+384    function    ``decodeMoveToFront``
+447    procedure   ``processInputData``
+494    function    ``computeFrequenciesSum``
+510    function    ``inverseBurrowsWheelerTransform``
+538    function    ``getBwtByte``
+555    function    ``runLengthDecoding``
+612    function    ``decompressBzip2Block``
+638    function    ``bzip2Decompress``
+670    function    ``bzip2Decompress``
+699    structure   ``bzip2File``
+716    function    ``openBzip2File``
+744    function    ``getc``
+770    function    ``gets``
+804    function    ``eof``
+814    function    ``hasNext``
+837    function    ``length``
+869    procedure   ``seek``
+885    function    ``tell``
+====== =========== ==================================================
+
+lib/cards.s7i
+-------------
+
+:Lines:    1342
+:Entities: 59
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     array       ``black_A_sign``
+46     array       ``black_K_sign``
+61     array       ``black_Q_sign``
+78     array       ``black_J_sign``
+93     array       ``black_10_sign``
+108    array       ``black_9_sign``
+123    array       ``black_8_sign``
+138    array       ``black_7_sign``
+153    array       ``black_6_sign``
+168    array       ``black_5_sign``
+183    array       ``black_4_sign``
+198    array       ``black_3_sign``
+213    array       ``black_2_sign``
+228    array       ``red_A_sign``
+242    array       ``red_K_sign``
+257    array       ``red_Q_sign``
+274    array       ``red_J_sign``
+289    array       ``red_10_sign``
+304    array       ``red_9_sign``
+319    array       ``red_8_sign``
+334    array       ``red_7_sign``
+349    array       ``red_6_sign``
+364    array       ``red_5_sign``
+379    array       ``red_4_sign``
+394    array       ``red_3_sign``
+409    array       ``red_2_sign``
+424    array       ``small_spades_sign``
+436    array       ``small_hearts_sign``
+449    array       ``small_diamonds_sign``
+462    array       ``small_clubs_sign``
+475    array       ``big_spades_sign``
+495    array       ``big_hearts_sign``
+515    array       ``big_diamonds_sign``
+535    array       ``big_clubs_sign``
+555    array       ``king_of_spades_pic``
+594    array       ``queen_of_spades_pic``
+633    array       ``jack_of_spades_pic``
+672    array       ``king_of_hearts_pic``
+711    array       ``queen_of_hearts_pic``
+750    array       ``jack_of_hearts_pic``
+789    array       ``king_of_diamonds_pic``
+828    array       ``queen_of_diamonds_pic``
+867    array       ``jack_of_diamonds_pic``
+906    array       ``king_of_clubs_pic``
+945    array       ``queen_of_clubs_pic``
+984    array       ``jack_of_clubs_pic``
+1023   array       ``backside_pic``
+1072   procedure   ``drawPic``
+1094   procedure   ``drawPic2``
+1123   function    ``genPixmap``
+1159   function    ``genPixmap``
+1202   enumeration ``cardSuit``
+1206   function    ``str``
+1209   set         ``blackCardSuit``
+1210   set         ``redCardSuit``
+1216   enumeration ``cardRank``
+1220   function    ``str``
+1228   function    ``cardPixmap``
+1316   function    ``cardBackside``
+====== =========== ==================================================
+
+lib/category.s7i
+----------------
+
+:Lines:    209
+:Entities: 13
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     procedure   ``:=``
+49     function    ``category``
+62     function    ``=``
+69     function    ``<>``
+78     function    ``compare``
+85     function    ``hashCode``
+92     function    ``ord``
+99     function    ``conv``
+106    function    ``category``
+115    function    ``str``
+124    function    ``parse``
+188    procedure   ``for``
+202    procedure   ``for``
+====== =========== ==================================================
+
+lib/cc_conf.s7i
+---------------
+
+:Lines:    1314
+:Entities: 20
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     structure   ``ccConfigType``
+699    array       ``CC_OPT_DEBUG_INFO``
+715    array       ``CC_OPT_OPTIMIZE_1``
+720    array       ``CC_OPT_OPTIMIZE_2``
+725    array       ``CC_OPT_OPTIMIZE_3``
+749    array       ``CC_FLAGS``
+818    array       ``LINKER_FLAGS``
+834    array       ``SYSTEM_LIBS``
+841    array       ``SYSTEM_BIGINT_LIBS``
+848    array       ``SYSTEM_CONSOLE_LIBS``
+855    array       ``SYSTEM_DATABASE_LIBS``
+862    array       ``SYSTEM_DRAW_LIBS``
+869    array       ``SYSTEM_MATH_LIBS``
+954    function    ``configValue``
+961    function    ``getBuiltInConfig``
+1128   procedure   ``assignConfigValue``
+1267   function    ``readConfig``
+1282   function    ``determineCCVersion``
+1286   array       ``redirection``
+1312   function    ``ccVersionIsOkay``
+====== =========== ==================================================
+
+lib/ccittfax.s7i
+----------------
+
+:Lines:    1022
+:Entities: 35
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     function    ``createMsbHuffmanDecoder``
+46     procedure   ``addCode``
+65     function    ``createLsbHuffmanDecoder``
+76     procedure   ``addCode``
+93     structure   ``huffmanSymbolBits``
+99     function    ``huffmanSymbolBits``
+108    array       ``whiteHuffmanSymbolBits``
+216    array       ``blackHuffmanSymbolBits``
+324    procedure   ``addHuffmanSymbols``
+335    procedure   ``addHuffmanSymbols``
+346    function    ``genWhiteMsbHuffmanDecoder``
+355    function    ``genBlackMsbHuffmanDecoder``
+364    function    ``genWhiteLsbHuffmanDecoder``
+373    function    ``genBlackLsbHuffmanDecoder``
+400    array       ``t4HuffmanSymbolBits``
+414    function    ``genT4MsbHuffmanDecoder``
+423    function    ``genT4LsbHuffmanDecoder``
+436    procedure   ``DECLARE_CcittModifiedGroup3Fax_FUNCTIONS``
+441    function    ``getWhiteBits``
+463    function    ``getBlackBits``
+485    procedure   ``skipToStart``
+502    procedure   ``skipEol``
+512    procedure   ``processCcittFaxRow``
+568    procedure   ``processCcittModifiedGroup3FaxMsb``
+602    procedure   ``processCcittModifiedGroup3FaxLsb``
+623    procedure   ``DECLARE_CcittT6Fax_FUNCTIONS``
+628    procedure   ``processCcittT4Fax2dRow``
+784    procedure   ``processCcittT6FaxMsb``
+815    procedure   ``processCcittT6FaxLsb``
+847    procedure   ``processCcittT4Fax1dMsb``
+880    procedure   ``processCcittT4Fax1dLsb``
+898    procedure   ``DECLARE_CcittT4Fax2d_FUNCTIONS``
+903    procedure   ``processCcittT4Fax1dRow``
+960    procedure   ``processCcittT4Fax2dMsb``
+999    procedure   ``processCcittT4Fax2dLsb``
+====== =========== ==================================================
+
+lib/cgi.s7i
+-----------
+
+:Lines:    109
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+53     array       ``paramArray``
+====== =========== ==================================================
+
+lib/cgidialog.s7i
+-----------------
+
+:Lines:    1118
+:Entities: 102
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+47     structure   ``emptyDialog``
+56     function    ``genDialogElementName``
+64     structure   ``webPage``
+70     procedure   ``assignName``
+71     procedure   ``update``
+72     function    ``toHtml``
+75     function    ``webPage``
+83     function    ``webForm``
+92     procedure   ``update``
+103    procedure   ``send``
+138    structure   ``header``
+149    function    ``header``
+160    function    ``toHtml``
+170    structure   ``label``
+180    function    ``label``
+190    function    ``toHtml``
+199    structure   ``image``
+212    function    ``image``
+226    procedure   ``assignName``
+234    function    ``toHtml``
+243    structure   ``space``
+253    function    ``space``
+263    function    ``toHtml``
+278    structure   ``vspace``
+288    function    ``vspace``
+298    function    ``toHtml``
+309    structure   ``script``
+315    function    ``script``
+325    function    ``toHtml``
+336    structure   ``textField``
+348    function    ``textField``
+357    procedure   ``assignName``
+363    procedure   ``update``
+370    function    ``toHtml``
+384    structure   ``passwordField``
+396    function    ``passwordField``
+405    procedure   ``assignName``
+411    procedure   ``update``
+418    function    ``toHtml``
+432    structure   ``textArea``
+445    function    ``textArea``
+454    procedure   ``assignName``
+460    procedure   ``update``
+467    function    ``toHtml``
+479    structure   ``checkbox``
+490    function    ``checkbox``
+499    procedure   ``update``
+504    function    ``toHtml``
+517    structure   ``radioButton``
+519    array       ``labelList``
+529    function    ``radioButton``
+537    procedure   ``assignName``
+543    procedure   ``update``
+554    function    ``toHtml``
+571    structure   ``resetButton``
+584    function    ``resetButton``
+596    function    ``resetButton``
+608    function    ``resetButton``
+616    procedure   ``assignName``
+624    function    ``toHtml``
+647    structure   ``submitButton``
+661    function    ``submitButton``
+673    function    ``submitButton``
+685    function    ``submitButton``
+693    procedure   ``assignName``
+699    procedure   ``update``
+704    function    ``toHtml``
+727    structure   ``closeButton``
+739    function    ``closeButton``
+747    procedure   ``assignName``
+753    procedure   ``update``
+758    function    ``toHtml``
+767    structure   ``selection``
+770    array       ``labelList``
+780    function    ``selection``
+789    procedure   ``assignName``
+795    procedure   ``update``
+806    function    ``toHtml``
+827    structure   ``dialogSequenceBase``
+828    array       ``elementList``
+837    function    ``&``
+848    function    ``&``
+857    procedure   ``&:=``
+862    procedure   ``assignName``
+871    procedure   ``update``
+881    structure   ``dialogSequence``
+890    function    ``dialogSequence``
+904    function    ``dialogSequence``
+914    function    ``toHtml``
+927    structure   ``dialogColumn``
+936    function    ``dialogColumn``
+946    function    ``toHtml``
+965    structure   ``dialogRow``
+974    function    ``dialogRow``
+984    function    ``toHtml``
+1005   structure   ``dialogTable``
+1007   array       ``elementTable``
+1018   function    ``dialogTable``
+1045   function    ``dialogTable``
+1067   procedure   ``assignName``
+1079   procedure   ``update``
+1091   function    ``toHtml``
+====== =========== ==================================================
+
+lib/char.s7i
+------------
+
+:Lines:    356
+:Entities: 30
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     procedure   ``:=``
+67     function    ``=``
+75     function    ``<>``
+83     function    ``<``
+91     function    ``>``
+99     function    ``<=``
+107    function    ``>=``
+116    function    ``compare``
+123    function    ``hashCode``
+133    function    ``ord``
+143    function    ``integer``
+154    function    ``chr``
+165    function    ``char``
+176    function    ``conv``
+179    function    ``varConv``
+186    function    ``succ``
+193    function    ``pred``
+200    function    ``str``
+213    function    ``upper``
+226    function    ``lower``
+249    function    ``isLetter``
+263    function    ``width``
+271    procedure   ``incr``
+279    procedure   ``decr``
+282    function    ``c_literal``
+292    function    ``rand``
+313    function    ``parse``
+326    function    ``char``
+342    function    ``trimValue``
+352    function    ``literal``
+====== =========== ==================================================
+
+lib/charsets.s7i
+----------------
+
+:Lines:    2024
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+1917   procedure   ``conv2unicode``
+1940   procedure   ``conv2unicodeByName``
+====== =========== ==================================================
+
+lib/chartype.s7i
+----------------
+
+:Lines:    121
+:Entities: 37
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     set         ``letter_char``
+30     set         ``digit_char``
+31     set         ``hexdigit_char``
+32     set         ``octdigit_char``
+33     set         ``alphanum_char``
+34     set         ``control_char``
+35     set         ``ascii_control_char``
+36     set         ``special_char``
+40     set         ``extended_special_char``
+41     set         ``left_angle_bracket``
+42     set         ``right_angle_bracket``
+43     set         ``special_html_char``
+44     set         ``single_quotation_char``
+45     set         ``double_quotation_char``
+46     set         ``sharp_char``
+47     set         ``hyphen_char``
+48     set         ``slash_char``
+49     set         ``special_sql_char``
+50     set         ``paren_char``
+51     set         ``left_paren_char``
+52     set         ``other_paren_char``
+53     set         ``name_start_char``
+54     set         ``name_char``
+55     set         ``space_or_tab``
+56     set         ``line_end_char``
+57     set         ``white_space_char``
+58     set         ``white_space_or_end_tag``
+59     set         ``white_space_or_printable``
+60     set         ``equals_or_end_tag``
+61     set         ``special_comment_char``
+62     set         ``html_name_start_char``
+63     set         ``html_name_char``
+64     set         ``http_separators``
+67     set         ``http_token_char``
+69     set         ``no_escape_char``
+83     array       ``esc_tab``
+108    function    ``pos``
+====== =========== ==================================================
+
+lib/cipher.s7i
+--------------
+
+:Lines:    146
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     enumeration ``cipherAlgorithm``
+53     function    ``blockSize``
+61     function    ``setCipherKey``
+69     procedure   ``initAead``
+79     function    ``getComputedMac``
+88     function    ``getMac``
+95     function    ``encode``
+102    function    ``decode``
+112    structure   ``noCipherState``
+125    function    ``setCipherKey``
+140    function    ``encode``
+144    function    ``decode``
+====== =========== ==================================================
+
+lib/cli_cmds.s7i
+----------------
+
+:Lines:    1360
+:Entities: 45
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     set         ``parameter_char``
+38     set         ``dos_parameter_char``
+50     procedure   ``doRemoveCmd``
+92     array       ``fileList``
+92     procedure   ``doCopyCmd``
+181    array       ``fileList``
+181    procedure   ``doMoveCmd``
+254    procedure   ``doMkdirCmd``
+287    function    ``getCommandParameter``
+394    function    ``getUnixCommandParameter``
+467    function    ``getDosCommandParameter``
+562    function    ``getDosEchoParameter``
+608    function    ``doOneCommand``
+613    function    ``execCommand``
+623    function    ``execBacktickCommands``
+647    procedure   ``addToFileList``
+670    procedure   ``doRm``
+677    array       ``fileList``
+710    procedure   ``doDel``
+714    array       ``fileList``
+739    procedure   ``doCp``
+747    array       ``fileList``
+782    procedure   ``doCopy``
+786    array       ``fileList``
+811    procedure   ``doXCopy``
+817    array       ``fileList``
+846    procedure   ``doMv``
+852    array       ``fileList``
+884    procedure   ``doMove``
+888    array       ``fileList``
+913    procedure   ``doMkdir``
+919    array       ``fileList``
+950    procedure   ``doMd``
+953    array       ``fileList``
+976    function    ``doPwd``
+997    function    ``doEcho``
+1032   procedure   ``doCd``
+1052   procedure   ``appendToFile``
+1066   function    ``oneExternalCommand``
+1072   array       ``parameterArray``
+1160   function    ``oneExternalCommand``
+1166   array       ``parameterArray``
+1216   procedure   ``doMake``
+1219   function    ``doOneCommand``
+1312   function    ``processCommand``
+====== =========== ==================================================
+
+lib/clib_file.s7i
+-----------------
+
+:Lines:    301
+:Entities: 27
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     procedure   ``:=``
+52     function    ``=``
+60     function    ``<>``
+63     function    ``_GENERATE_EMPTY_CLIB_FILE``
+76     function    ``CLIB_INPUT``
+77     function    ``CLIB_OUTPUT``
+78     function    ``CLIB_ERROR``
+113    function    ``openClibFile``
+116    function    ``openNullDeviceClibFile``
+117    procedure   ``pipe``
+124    procedure   ``close``
+133    function    ``eof``
+141    function    ``hasNext``
+151    function    ``inputReady``
+158    procedure   ``flush``
+165    function    ``getc``
+175    function    ``gets``
+195    function    ``terminated_read``
+212    function    ``word_read``
+226    function    ``line_read``
+236    procedure   ``write``
+248    function    ``length``
+263    procedure   ``truncate``
+272    function    ``seekable``
+284    procedure   ``seek``
+297    function    ``tell``
+300    function    ``literal``
+====== =========== ==================================================
+
+lib/color.s7i
+-------------
+
+:Lines:    185
+:Entities: 8
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     structure   ``color``
+44     function    ``=``
+54     function    ``<>``
+64     function    ``+``
+79     function    ``color``
+94     function    ``gray``
+110    function    ``compare``
+134    function    ``hashCode``
+====== =========== ==================================================
+
+lib/complex.s7i
+---------------
+
+:Lines:    464
+:Entities: 31
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     structure   ``complex``
+49     function    ``complex``
+62     function    ``complex``
+75     function    ``polar``
+88     function    ``complex``
+101    function    ``conv``
+114    function    ``conv``
+127    function    ``=``
+135    function    ``<>``
+143    function    ``+``
+151    function    ``-``
+164    function    ``conj``
+177    function    ``+``
+190    function    ``-``
+203    function    ``*``
+216    function    ``/``
+231    procedure   ``+:=``
+241    procedure   ``-:=``
+251    procedure   ``*:=``
+264    procedure   ``/:=``
+280    function    ``abs``
+296    function    ``sqrAbs``
+305    function    ``arg``
+313    function    ``**``
+333    function    ``compare``
+348    function    ``hashCode``
+360    function    ``str``
+380    function    ``complex``
+408    function    ``parse``
+424    function    ``digits``
+449    function    ``sci``
+====== =========== ==================================================
+
+lib/compress.s7i
+----------------
+
+:Lines:    150
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     function    ``toPackBits``
+90     function    ``fromPackBits``
+120    function    ``toPackBitsPdf``
+129    function    ``fromPackBitsPdf``
+====== =========== ==================================================
+
+lib/console.s7i
+---------------
+
+:Lines:    188
+:Entities: 18
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     structure   ``console_file``
+60     procedure   ``CON_OPEN``
+68     function    ``open``
+81     procedure   ``flush``
+88     function    ``height``
+95     function    ``width``
+101    procedure   ``setPos``
+109    function    ``column``
+116    function    ``line``
+119    procedure   ``cursor``
+120    procedure   ``clearArea``
+129    procedure   ``clear``
+140    procedure   ``clear``
+146    procedure   ``v_scroll``
+149    procedure   ``h_scroll``
+167    procedure   ``write``
+170    procedure   ``moveLeft``
+176    procedure   ``erase``
+====== =========== ==================================================
+
+lib/cpio.s7i
+------------
+
+:Lines:    1708
+:Entities: 46
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+51     structure   ``cpioHeader``
+73     function    ``computeCheck``
+85     procedure   ``showHeader``
+108    procedure   ``readHead``
+235    procedure   ``readMinimumOfHead``
+321    function    ``str``
+393    procedure   ``writeHead``
+399    procedure   ``writeTrailer``
+431    structure   ``cpioArchive``
+449    function    ``openCpio``
+498    function    ``openCpio``
+512    procedure   ``close``
+518    function    ``addToCatalog``
+532    function    ``addImplicitDir``
+544    function    ``followSymlink``
+590    function    ``followSymlink``
+604    procedure   ``fixRegisterAndCatalog``
+634    function    ``readDir``
+645    function    ``readDir``
+660    function    ``fileType``
+721    function    ``fileTypeSL``
+767    function    ``getFileMode``
+787    procedure   ``setFileMode``
+819    function    ``fileSize``
+840    function    ``getMTime``
+863    procedure   ``setMTime``
+896    function    ``getOwner``
+918    procedure   ``setOwner``
+954    function    ``getGroup``
+976    procedure   ``setGroup``
+1013   function    ``getFileMode``
+1051   function    ``getMTime``
+1090   procedure   ``setMTime``
+1132   function    ``getOwner``
+1171   procedure   ``setOwner``
+1216   function    ``getGroup``
+1255   procedure   ``setGroup``
+1298   function    ``readLink``
+1340   procedure   ``makeLink``
+1415   function    ``getFile``
+1443   procedure   ``putFile``
+1545   procedure   ``makeDir``
+1622   procedure   ``removeFile``
+1669   procedure   ``for``
+1679   function    ``openFileInCpio``
+1705   function    ``open``
+====== =========== ==================================================
+
+lib/crc32.s7i
+-------------
+
+:Lines:    193
+:Entities: 6
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     function    ``createCrc32Table``
+63     function    ``crc32``
+79     function    ``crc32``
+93     array       ``bzip2Crc32Table``
+163    function    ``bzip2Crc32``
+180    function    ``bzip2Crc32``
+====== =========== ==================================================
+
+lib/cronos16.s7i
+----------------
+
+:Lines:    1173
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genCronos16``
+====== =========== ==================================================
+
+lib/cronos27.s7i
+----------------
+
+:Lines:    1464
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genCronos27``
+====== =========== ==================================================
+
+lib/csv.s7i
+-----------
+
+:Lines:    201
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     function    ``toCsvLine``
+81     function    ``fromCsvLine``
+83     array       ``data``
+153    function    ``readCsvLine``
+155    array       ``data``
+====== =========== ==================================================
+
+lib/db_prop.s7i
+---------------
+
+:Lines:    991
+:Entities: 47
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     set         ``forbidden``
+48     function    ``allowedInFieldName``
+52     function    ``ddlStatementsNeedCommit``
+68     function    ``transactionLocks``
+89     function    ``int8Type``
+110    function    ``maxInt8Value``
+130    function    ``int64Type``
+146    function    ``withRangeCheck``
+162    function    ``bigIntType``
+178    function    ``sqlIntLiteralBits``
+194    function    ``bigIntTypeBits``
+214    function    ``floatType``
+230    function    ``compareFloatAsDecimalString``
+250    function    ``doubleType``
+266    function    ``compareDoubleAsDecimalString``
+282    function    ``bigRatType``
+302    function    ``decimalIntType``
+322    function    ``maxDecimalPrecision``
+338    function    ``maxDecimalLiteralPrecision``
+358    function    ``numericIntType``
+378    function    ``maxNumericPrecision``
+394    function    ``maxNumericLiteralPrecision``
+414    function    ``decimalType``
+434    function    ``minDecimalScale``
+456    function    ``maxDecimalScale``
+476    function    ``numericType``
+496    function    ``minNumericScale``
+518    function    ``maxNumericScale``
+534    function    ``maxChar1FieldCharacter``
+550    function    ``charFieldPreservesTrailingSpaces``
+566    function    ``nullAllowedInStringLiteral``
+582    function    ``nullAllowedInString``
+602    function    ``varcharType``
+622    function    ``blobType``
+642    function    ``clobType``
+658    function    ``minDate``
+674    function    ``toDate``
+725    function    ``timeType``
+741    function    ``toTime``
+765    function    ``dateTimeType``
+781    function    ``toDateTime``
+840    function    ``timeStampType``
+856    function    ``minTimeStamp``
+872    function    ``toTimeStamp``
+944    function    ``timeStampTzType``
+960    function    ``durationType``
+976    function    ``supportsFloatingDecimals``
+====== =========== ==================================================
+
+lib/deflate.s7i
+---------------
+
+:Lines:    740
+:Entities: 30
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     procedure   ``putLiteralOrLength``
+51     procedure   ``putLength``
+79     procedure   ``putDistance``
+133    structure   ``deflateData``
+137    array       ``literalOrLengthSymbolCount``
+138    array       ``distanceSymbolCount``
+142    procedure   ``deflateFixed``
+214    function    ``encodeLz77Length``
+258    procedure   ``addLz77Length``
+273    function    ``encodeLz77Distance``
+356    procedure   ``addLz77Distance``
+371    function    ``compressWithLz77``
+449    procedure   ``huffmanEncodeLz77``
+474    procedure   ``checkMaximumCodeLength``
+489    function    ``processCombinedData``
+554    procedure   ``huffmanEncodeCombinedData``
+582    function    ``mapCombinedDataCodeLengths``
+584    array       ``mappedCodeLengths``
+586    array       ``mapFromOrderedLengths``
+601    procedure   ``deflateDynamic``
+605    array       ``literalOrLengthCodeLengths``
+607    array       ``distanceCodeLengths``
+609    array       ``combinedData``
+611    array       ``combinedDataSymbolCount``
+612    array       ``combinedDataCodeLengths``
+614    array       ``mappedCodeLengths``
+644    procedure   ``uncompressedBlock``
+669    procedure   ``deflateBlock``
+707    procedure   ``deflate``
+730    function    ``deflate``
+====== =========== ==================================================
+
+lib/des.s7i
+-----------
+
+:Lines:    444
+:Entities: 18
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     structure   ``desState``
+60     function    ``setDesKey``
+64     array       ``pc1``
+69     array       ``pc2``
+74     array       ``bytebit``
+77     array       ``totrot``
+79     array       ``pc1m``
+80     array       ``pcr``
+81     array       ``ks``
+126    function    ``reverseKeyScheduleOrder``
+145    function    ``setDesKey``
+161    function    ``setCipherKey``
+166    array       ``spBox``
+297    procedure   ``initialPermutation``
+325    procedure   ``finalPermutation``
+353    function    ``processDesBlock``
+399    function    ``encode``
+425    function    ``decode``
+====== =========== ==================================================
+
+lib/dialog.s7i
+--------------
+
+:Lines:    311
+:Entities: 11
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     function    ``clickedWindow``
+38     function    ``buttonWindow``
+41     function    ``clickedWindow``
+45     function    ``buttonWindow``
+48     procedure   ``writeButton``
+60     procedure   ``writeButton``
+71     function    ``isOkay``
+181    function    ``isOkay``
+189    procedure   ``messageWindow``
+270    procedure   ``messageWindow``
+276    procedure   ``bossMode``
+====== =========== ==================================================
+
+lib/dir.s7i
+-----------
+
+:Lines:    163
+:Entities: 9
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``dirFile``
+38     array       ``dirArray``
+54     function    ``openDir``
+73     function    ``openDirPath``
+102    function    ``getln``
+124    function    ``getwd``
+140    function    ``gets``
+152    function    ``eof``
+161    function    ``hasNext``
+====== =========== ==================================================
+
+lib/draw.s7i
+------------
+
+:Lines:    854
+:Entities: 60
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     function    ``colorPixel``
+51     function    ``pixelToColor``
+62     procedure   ``screen``
+80     procedure   ``point``
+91     procedure   ``point``
+102    procedure   ``line``
+115    procedure   ``line``
+128    procedure   ``lineTo``
+142    procedure   ``lineTo``
+154    procedure   ``lineToAngle``
+169    procedure   ``lineToAngle``
+178    procedure   ``hline``
+186    procedure   ``hline``
+193    procedure   ``vline``
+201    procedure   ``vline``
+213    procedure   ``rect``
+226    procedure   ``rect``
+233    procedure   ``rect``
+255    procedure   ``rectTo``
+280    procedure   ``rectTo``
+304    procedure   ``box``
+323    procedure   ``box``
+341    procedure   ``boxTo``
+360    procedure   ``boxTo``
+377    procedure   ``circle``
+388    procedure   ``circle``
+398    procedure   ``fcircle``
+409    procedure   ``fcircle``
+420    procedure   ``arc``
+433    procedure   ``arc``
+445    procedure   ``arc``
+459    procedure   ``arc``
+467    procedure   ``chord``
+479    procedure   ``pieslice``
+486    procedure   ``fellipse``
+494    procedure   ``fellipse``
+504    procedure   ``clear``
+513    procedure   ``clear``
+522    procedure   ``clear``
+532    procedure   ``polyLine``
+543    procedure   ``polyLine``
+554    procedure   ``fpolyLine``
+566    procedure   ``fpolyLine``
+572    procedure   ``paint``
+586    procedure   ``put``
+597    procedure   ``put``
+614    procedure   ``put``
+624    function    ``newPixmap``
+636    function    ``getPixmap``
+648    function    ``getPixmap``
+658    function    ``getPixmap``
+670    function    ``getPixmap``
+728    function    ``getPixmap``
+779    function    ``getPixmap``
+804    procedure   ``setTransparentColor``
+814    function    ``getPixelColor``
+826    function    ``getPixelColor``
+838    procedure   ``palette``
+844    procedure   ``palette``
+850    procedure   ``sound``
+====== =========== ==================================================
+
+lib/duration.s7i
+----------------
+
+:Lines:    1038
+:Entities: 50
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     structure   ``duration``
+57     function    ``getYears``
+66     function    ``getMonths``
+77     function    ``getDays``
+85     function    ``getHours``
+93     function    ``getMinutes``
+101    function    ``getSeconds``
+109    function    ``getMicroSeconds``
+120    function    ``str``
+174    function    ``literal``
+184    function    ``duration``
+312    function    ``parse``
+323    function    ``=``
+338    function    ``<>``
+354    function    ``<=``
+395    function    ``>=``
+436    function    ``<``
+445    function    ``>``
+454    function    ``compare``
+496    function    ``hashCode``
+508    function    ``toYears``
+517    function    ``toMonths``
+529    function    ``toDays``
+543    function    ``toHours``
+551    function    ``toMinutes``
+561    function    ``toSeconds``
+572    function    ``toMicroSeconds``
+580    procedure   ``NORMALIZE_DUR_TIME``
+593    procedure   ``NORMALIZE``
+603    function    ``.``
+612    function    ``.``
+621    function    ``.``
+630    function    ``.``
+639    function    ``.``
+648    function    ``.``
+657    function    ``.``
+670    function    ``+``
+692    function    ``-``
+714    function    ``+``
+737    function    ``-``
+760    function    ``*``
+783    function    ``*``
+805    procedure   ``+:=``
+825    procedure   ``-:=``
+845    procedure   ``+:=``
+861    procedure   ``-:=``
+878    function    ``+``
+899    function    ``-``
+920    function    ``-``
+1031   procedure   ``wait``
+====== =========== ==================================================
+
+lib/echo.s7i
+------------
+
+:Lines:    132
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     structure   ``echoFile``
+45     function    ``openEcho``
+67     function    ``getc``
+113    function    ``gets``
+====== =========== ==================================================
+
+lib/editline.s7i
+----------------
+
+:Lines:    398
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     structure   ``editLineFile``
+43     array       ``history``
+61     function    ``openEditLine``
+88     function    ``openEditLineLatin1``
+115    function    ``getln``
+122    array       ``history``
+257    function    ``getc``
+281    function    ``gets``
+314    function    ``eof``
+324    function    ``hasNext``
+328    function    ``readPassword``
+331    function    ``readPassword``
+====== =========== ==================================================
+
+lib/elf.s7i
+-----------
+
+:Lines:    1560
+:Entities: 86
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+258    structure   ``elfHeader``
+281    procedure   ``show``
+305    procedure   ``readHeader32Le``
+323    procedure   ``readHeader32Be``
+341    procedure   ``readHeader64Le``
+359    procedure   ``readHeader64Be``
+377    procedure   ``readHeader``
+433    structure   ``elfProgramHeader``
+447    procedure   ``show``
+462    procedure   ``readProgramHeader32Le``
+476    procedure   ``readProgramHeader32Be``
+490    procedure   ``readProgramHeader64Le``
+504    procedure   ``readProgramHeader64Be``
+518    procedure   ``readProgramHeader``
+554    structure   ``elfSectionHeader``
+571    function    ``sectionTypeName``
+609    procedure   ``show``
+627    procedure   ``readSectionHeader32Le``
+643    procedure   ``readSectionHeader32Be``
+659    procedure   ``readSectionHeader64Le``
+675    procedure   ``readSectionHeader64Be``
+691    procedure   ``readSectionHeader``
+729    structure   ``elfData``
+732    array       ``programHeaders``
+733    array       ``sectionHeaders``
+742    function    ``openElf``
+790    function    ``readSectionNames``
+799    function    ``getSection``
+812    function    ``getSectionData``
+826    structure   ``elfGnuHashHeader``
+831    array       ``bloom_filter``
+832    array       ``buckets``
+833    array       ``values``
+837    procedure   ``show``
+846    procedure   ``readGnuHashHeaderLe``
+862    procedure   ``readGnuHashHeaderBe``
+878    function    ``readGnuHashHeader``
+896    structure   ``elfNoteHeader``
+905    procedure   ``show``
+915    procedure   ``readNoteHeaderLe``
+923    procedure   ``readNoteHeaderBe``
+931    function    ``readNoteHeader``
+970    function    ``getNote``
+997    function    ``getBuildId``
+1004   function    ``getNotes``
+1028   structure   ``elfSym``
+1038   procedure   ``show``
+1049   procedure   ``readSym32Le``
+1060   procedure   ``readSym32Be``
+1071   procedure   ``readSym64Le``
+1082   procedure   ``readSym64Be``
+1093   function    ``readSym``
+1135   function    ``getDynsymNames``
+1138   array       ``dynsymNames``
+1167   function    ``getDynsymNames``
+1176   function    ``getDynsymNames``
+1180   structure   ``elfDyn``
+1186   procedure   ``show``
+1193   procedure   ``readDyn32Le``
+1200   procedure   ``readDyn32Be``
+1207   procedure   ``readDyn64Le``
+1214   procedure   ``readDyn64Be``
+1221   function    ``readDyn``
+1263   function    ``getDynamicNeeds``
+1266   array       ``dynNames``
+1298   function    ``getDynamicNeeds``
+1307   function    ``getDynamicNeeds``
+1311   structure   ``elfVerDAux``
+1317   procedure   ``show``
+1324   procedure   ``readVerDAuxLe``
+1331   procedure   ``readVerDAuxBe``
+1338   function    ``readVerDAux``
+1366   structure   ``elfVerNAux``
+1376   procedure   ``show``
+1387   procedure   ``readVerNAuxLe``
+1397   procedure   ``readVerNAuxBe``
+1407   function    ``readVerNAux``
+1425   structure   ``elfVerNeed``
+1435   procedure   ``show``
+1446   procedure   ``readVerNeedLe``
+1456   procedure   ``readVerNeedBe``
+1466   function    ``readVerNeed``
+1492   function    ``getVerNeeds``
+1495   array       ``verNeedNames``
+1549   function    ``getVerNeeds``
+1558   function    ``getVerNeeds``
+====== =========== ==================================================
+
+lib/elliptic.s7i
+----------------
+
+:Lines:    649
+:Entities: 33
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     structure   ``ecPoint``
+47     function    ``ecPoint``
+56     function    ``literal``
+64     function    ``getNeutralEcPoint``
+83     function    ``=``
+93     function    ``<>``
+103    structure   ``ellipticCurve``
+125    function    ``ellipticCurve``
+231    function    ``getSizeInBytes``
+238    function    ``element``
+247    function    ``double``
+271    function    ``add``
+301    function    ``mult``
+321    structure   ``jacobianPoint``
+334    function    ``toJacobian``
+353    function    ``fromJacobian``
+370    function    ``double``
+397    function    ``add``
+442    function    ``mult``
+462    function    ``multFast``
+470    function    ``multAddFast``
+479    function    ``ecPointCompress``
+486    function    ``ecPointEncode``
+494    function    ``ecPointDecode``
+522    structure   ``eccKeyPair``
+529    function    ``eccKeyPair``
+550    function    ``genPrivateKey``
+557    function    ``genEccKeyPair``
+570    function    ``verifyKeyPair``
+577    function    ``truncate``
+592    structure   ``ecdsaSignatureType``
+602    function    ``sign``
+628    function    ``verify``
+====== =========== ==================================================
+
+lib/enable_io.s7i
+-----------------
+
+:Lines:    312
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+53     procedure   ``enable_input``
+66     procedure   ``read``
+82     procedure   ``read``
+104    procedure   ``readln``
+119    procedure   ``readln``
+142    procedure   ``read``
+158    procedure   ``read``
+172    procedure   ``readln``
+187    procedure   ``readln``
+212    procedure   ``enable_output``
+218    procedure   ``write``
+226    procedure   ``writeln``
+234    procedure   ``write``
+242    procedure   ``writeln``
+252    function    ``lpad``
+260    function    ``rpad``
+268    function    ``<&``
+276    function    ``<&``
+298    procedure   ``enable_io``
+====== =========== ==================================================
+
+lib/encoding.s7i
+----------------
+
+:Lines:    931
+:Entities: 28
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     function    ``toBase64``
+102    function    ``fromBase64``
+106    array       ``decode``
+168    function    ``toBase64Url``
+220    function    ``fromBase64Url``
+224    array       ``decode``
+289    function    ``toQuotedPrintable``
+344    function    ``fromQuotedPrintable``
+389    function    ``toUuencoded``
+445    function    ``fromUuencoded``
+500    function    ``toPercentEncoded``
+504    set         ``unreservedChars``
+530    function    ``fromPercentEncoded``
+564    function    ``toUrlEncoded``
+568    set         ``unreservedChars``
+599    function    ``fromUrlEncoded``
+639    function    ``toAscii85``
+692    function    ``fromAscii85``
+696    set         ``whiteSpace``
+735    function    ``toAsciiHex``
+763    function    ``fromAsciiHex``
+768    set         ``whiteSpace``
+798    function    ``toBase``
+824    function    ``fromBaseToBigInt``
+856    function    ``toBase``
+885    function    ``fromBase``
+916    function    ``toBase58``
+929    function    ``fromBase58``
+====== =========== ==================================================
+
+lib/enumeration.s7i
+-------------------
+
+:Lines:    236
+:Entities: 24
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     function    ``expr_to_list``
+45     function    ``new``
+62     procedure   ``:=``
+69     function    ``literal``
+71     function    ``getValue``
+73     function    ``ICONV2``
+76     function    ``ORD2``
+113    function    ``=``
+120    function    ``<>``
+128    function    ``conv``
+136    function    ``ord``
+144    function    ``integer``
+151    function    ``hashCode``
+160    function    ``compare``
+168    function    ``conv``
+177    function    ``succ``
+186    function    ``pred``
+193    procedure   ``incr``
+202    procedure   ``decr``
+214    function    ``rand``
+217    function    ``<``
+220    function    ``<=``
+223    function    ``>``
+226    function    ``>=``
+====== =========== ==================================================
+
+lib/environment.s7i
+-------------------
+
+:Lines:    175
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     function    ``argv``
+46     function    ``name``
+56     function    ``path``
+65     function    ``dir``
+86     function    ``file``
+100    function    ``sourceLine``
+110    procedure   ``exit``
+120    procedure   ``exit``
+139    function    ``getenv``
+154    procedure   ``setenv``
+166    procedure   ``unsetenv``
+174    function    ``environment``
+====== =========== ==================================================
+
+lib/exif.s7i
+------------
+
+:Lines:    152
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+73     structure   ``exifDataType``
+81     procedure   ``readExifData``
+133    procedure   ``changeOrientation``
+====== =========== ==================================================
+
+lib/external_file.s7i
+---------------------
+
+:Lines:    340
+:Entities: 22
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     structure   ``external_file``
+82     function    ``open``
+98     function    ``openNullDevice``
+117    procedure   ``close``
+128    procedure   ``flush``
+140    procedure   ``write``
+146    procedure   ``moveLeft``
+152    procedure   ``erase``
+162    function    ``getc``
+173    function    ``gets``
+192    function    ``getTerminatedString``
+209    function    ``getwd``
+224    function    ``getln``
+234    function    ``eof``
+243    function    ``hasNext``
+254    function    ``inputReady``
+267    function    ``length``
+283    procedure   ``truncate``
+295    function    ``seekable``
+308    procedure   ``seek``
+324    function    ``tell``
+328    function    ``fileOpenSucceeds``
+====== =========== ==================================================
+
+lib/field.s7i
+-------------
+
+:Lines:    268
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``fieldFile``
+61     function    ``openField``
+88     function    ``getwd``
+162    function    ``getln``
+229    function    ``getc``
+241    function    ``gets``
+257    procedure   ``write``
+====== =========== ==================================================
+
+lib/file.s7i
+------------
+
+:Lines:    372
+:Entities: 35
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+45     procedure   ``write``
+54     procedure   ``writeln``
+66     procedure   ``writeln``
+69     procedure   ``moveLeft``
+70     procedure   ``erase``
+73     procedure   ``backSpace``
+81     procedure   ``cursorOn``
+82     procedure   ``cursorOff``
+88     procedure   ``close``
+96     procedure   ``flush``
+103    function    ``getc``
+111    function    ``gets``
+127    function    ``getTerminatedString``
+140    function    ``getwd``
+151    function    ``getln``
+154    function    ``getk``
+155    function    ``eoln``
+164    function    ``eof``
+173    function    ``hasNext``
+183    function    ``inputReady``
+196    function    ``length``
+211    procedure   ``truncate``
+220    function    ``seekable``
+233    procedure   ``seek``
+247    function    ``tell``
+263    function    ``compare``
+270    function    ``hashCode``
+273    function    ``.``
+274    function    ``.``
+285    procedure   ``read``
+300    procedure   ``read``
+317    procedure   ``readln``
+331    procedure   ``readln``
+347    procedure   ``readln``
+361    procedure   ``skip``
+====== =========== ==================================================
+
+lib/filebits.s7i
+----------------
+
+:Lines:    46
+:Entities: 0
+
+(none)
+
+
+lib/filesys.s7i
+---------------
+
+:Lines:    601
+:Entities: 51
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+60     enumeration ``filePermission``
+80     function    ``integer``
+83     function    ``conv``
+86     function    ``fileMode``
+89     function    ``conv``
+92     function    ``str``
+119    function    ``removeDotFiles``
+177    function    ``symlinkDestination``
+214    procedure   ``close``
+225    function    ``readDir``
+235    function    ``readDir``
+243    function    ``readDir``
+251    function    ``readDir``
+262    function    ``fileType``
+273    function    ``fileTypeSL``
+282    function    ``fileSize``
+291    function    ``bigFileSize``
+299    function    ``getFileMode``
+303    function    ``fileMode``
+312    procedure   ``setFileMode``
+321    function    ``getMTime``
+328    procedure   ``setMTime``
+337    function    ``getOwner``
+344    procedure   ``setOwner``
+353    function    ``getGroup``
+360    procedure   ``setGroup``
+370    function    ``getFileMode``
+379    function    ``getMTime``
+387    procedure   ``setMTime``
+397    function    ``getOwner``
+405    procedure   ``setOwner``
+415    function    ``getGroup``
+423    procedure   ``setGroup``
+430    function    ``open``
+438    function    ``getFile``
+446    procedure   ``putFile``
+454    function    ``readLink``
+466    procedure   ``makeLink``
+477    procedure   ``removeFile``
+484    procedure   ``removeTree``
+491    procedure   ``moveFile``
+501    procedure   ``makeDir``
+505    procedure   ``mkdir``
+515    procedure   ``rmdir``
+523    function    ``getcwd``
+530    procedure   ``chdir``
+536    structure   ``emptyFileSys``
+559    function    ``readDir``
+562    array       ``filePaths``
+564    array       ``pathsInDir``
+599    function    ``bigFileSize``
+====== =========== ==================================================
+
+lib/fileutil.s7i
+----------------
+
+:Lines:    144
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     procedure   ``copyFile``
+52     function    ``copyFile``
+73     procedure   ``insertArea``
+114    procedure   ``deleteArea``
+====== =========== ==================================================
+
+lib/fixarray.s7i
+----------------
+
+:Lines:    307
+:Entities: 15
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+43     function    ``array``
+53     procedure   ``:=``
+55     function    ``SET_MIN_IDX``
+57     function    ``TIMES``
+69     function    ``times``
+128    procedure   ``for``
+143    procedure   ``for``
+157    procedure   ``for``
+172    procedure   ``for``
+193    procedure   ``for``
+219    procedure   ``for``
+230    procedure   ``for``
+248    procedure   ``for``
+268    procedure   ``for``
+305    function    ``array``
+====== =========== ==================================================
+
+lib/float.s7i
+-------------
+
+:Lines:    757
+:Entities: 50
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+53     procedure   ``:=``
+60     function    ``+``
+67     function    ``-``
+74     function    ``+``
+81     function    ``-``
+88     function    ``*``
+98     function    ``/``
+115    function    ``rem``
+134    function    ``mod``
+149    function    ``**``
+167    function    ``**``
+180    function    ``<<``
+193    function    ``>>``
+199    procedure   ``+:=``
+205    procedure   ``-:=``
+211    procedure   ``*:=``
+217    procedure   ``/:=``
+227    function    ``=``
+237    function    ``<>``
+249    function    ``<``
+261    function    ``>``
+273    function    ``<=``
+285    function    ``>=``
+320    function    ``compare``
+327    function    ``hashCode``
+347    function    ``str``
+367    function    ``string``
+392    function    ``str``
+408    function    ``literal``
+438    function    ``float``
+457    function    ``parse``
+484    function    ``digits``
+512    function    ``sci``
+534    function    ``exp``
+559    function    ``flt``
+566    function    ``float``
+573    function    ``conv``
+580    function    ``abs``
+589    function    ``floor``
+598    function    ``ceil``
+615    function    ``round``
+634    function    ``round10``
+679    function    ``trunc``
+688    function    ``isNaN``
+701    function    ``isNegativeZero``
+709    function    ``isPositiveZero``
+719    function    ``rand``
+722    procedure   ``decompose``
+726    structure   ``floatElements``
+742    function    ``decompose``
+====== =========== ==================================================
+
+lib/font.s7i
+------------
+
+:Lines:    196
+:Entities: 22
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+42     function    ``xHeight``
+50     function    ``capHeight``
+59     function    ``lineHeight``
+68     function    ``ascent``
+77     function    ``descent``
+80     function    ``baseLineDelta``
+89     function    ``columnWidth``
+97     function    ``characterSpacing``
+104    function    ``width``
+116    function    ``numOfCharsInWidth``
+133    function    ``compare``
+140    function    ``hashCode``
+146    structure   ``emptyFont``
+158    structure   ``fontProperties``
+173    function    ``xHeight``
+176    function    ``capHeight``
+179    function    ``lineHeight``
+182    function    ``ascent``
+185    function    ``descent``
+188    function    ``baseLineDelta``
+191    function    ``columnWidth``
+194    function    ``characterSpacing``
+====== =========== ==================================================
+
+lib/font8x8.s7i
+---------------
+
+:Lines:    998
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genFont8x8``
+====== =========== ==================================================
+
+lib/forloop.s7i
+---------------
+
+:Lines:    449
+:Entities: 27
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     procedure   ``for``
+52     procedure   ``for``
+66     procedure   ``for``
+81     procedure   ``for``
+94     procedure   ``FOR_STEP_DECLS``
+98     procedure   ``for``
+112    procedure   ``for``
+136    procedure   ``FOR_UNTIL_DECLS``
+138    procedure   ``for``
+158    procedure   ``for``
+178    procedure   ``for``
+198    procedure   ``for``
+228    procedure   ``FOR_DECLS``
+231    procedure   ``for``
+248    procedure   ``for``
+275    procedure   ``FOR_ENUM_DECLS``
+278    procedure   ``for``
+295    procedure   ``for``
+310    procedure   ``for``
+318    procedure   ``for``
+326    procedure   ``for``
+336    procedure   ``for``
+357    procedure   ``for``
+383    procedure   ``for``
+395    procedure   ``for``
+412    procedure   ``for``
+431    procedure   ``for``
+====== =========== ==================================================
+
+lib/ftp.s7i
+-----------
+
+:Lines:    969
+:Entities: 50
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+54     function    ``listDir``
+55     function    ``getActiveMode``
+56     procedure   ``setActiveMode``
+57     function    ``getAsciiTransfer``
+58     procedure   ``setAsciiTransfer``
+59     procedure   ``closeFtpData``
+60     procedure   ``ftpResponse``
+67     structure   ``ftpConnection``
+83     procedure   ``ftpCommand``
+90     procedure   ``ftpResponse``
+111    function    ``allowUtf8``
+141    function    ``openFtp``
+189    function    ``openFtp``
+216    function    ``openFtp``
+268    function    ``openFtp``
+275    procedure   ``close``
+286    procedure   ``openActiveFtpData``
+301    procedure   ``openPassiveFtpData``
+305    array       ``addrAndPort``
+326    procedure   ``openFtpData``
+336    procedure   ``prepareFtpDataCommunication``
+346    procedure   ``closeFtpData``
+361    function    ``readDir``
+363    array       ``fileNames``
+423    function    ``listDir``
+425    array       ``directoryListing``
+463    procedure   ``chdir``
+482    function    ``getcwd``
+512    function    ``fileType``
+561    function    ``fileTypeSL``
+570    function    ``fileSize``
+587    function    ``bigFileSize``
+605    function    ``getMTime``
+638    function    ``getActiveMode``
+646    procedure   ``setActiveMode``
+657    function    ``getAsciiTransfer``
+665    procedure   ``setAsciiTransfer``
+687    structure   ``ftpDataFile``
+692    function    ``ftpDataFile``
+703    procedure   ``close``
+729    function    ``open``
+781    function    ``getFile``
+822    procedure   ``putFile``
+851    procedure   ``removeFile``
+865    procedure   ``moveFile``
+885    procedure   ``makeDir``
+899    procedure   ``rmdir``
+909    procedure   ``splitFtpLocation``
+934    function    ``getFtp``
+958    function    ``getFtp``
+====== =========== ==================================================
+
+lib/ftpserv.s7i
+---------------
+
+:Lines:    631
+:Entities: 24
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     structure   ``ftpServer``
+48     structure   ``ftpServerConnection``
+63     procedure   ``ftpResponse``
+70     function    ``openActiveData``
+74     array       ``addrAndPort``
+87     function    ``openPassiveData``
+116    function    ``getPathArgument``
+132    function    ``toQuotedUtf8``
+136    procedure   ``listOneFile``
+143    array       ``monthName``
+175    procedure   ``listFiles``
+179    array       ``dirContent``
+220    procedure   ``nameListFiles``
+223    array       ``dirContent``
+251    procedure   ``mlsdFileList``
+253    array       ``dirContent``
+292    procedure   ``retrieveFile``
+310    procedure   ``storeFile``
+328    procedure   ``openFtpSession``
+341    procedure   ``closeFtpSession``
+348    procedure   ``processFtpRequest``
+581    procedure   ``processFtpRequest``
+595    procedure   ``processFtpRequest``
+613    procedure   ``runServer``
+====== =========== ==================================================
+
+lib/getf.s7i
+------------
+
+:Lines:    115
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     function    ``getf``
+55     procedure   ``putf``
+76     function    ``readf``
+78     array       ``data``
+100    procedure   ``writef``
+====== =========== ==================================================
+
+lib/gethttp.s7i
+---------------
+
+:Lines:    41
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     function    ``getHttp``
+====== =========== ==================================================
+
+lib/gethttps.s7i
+----------------
+
+:Lines:    41
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     function    ``getHttps``
+====== =========== ==================================================
+
+lib/gif.s7i
+-----------
+
+:Lines:    561
+:Entities: 25
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+50     structure   ``gifHeader``
+60     structure   ``gifImageHeader``
+72     structure   ``gifGraphicControlExtension``
+80     structure   ``gifApplicationExtension``
+86     procedure   ``readGifColorMap``
+106    procedure   ``showHeader``
+117    procedure   ``readHeader``
+139    procedure   ``showImageHeader``
+152    procedure   ``readImageHeader``
+176    function    ``readSubBlockSeries``
+190    procedure   ``showExtension``
+200    procedure   ``readGraphicControlExtension``
+226    procedure   ``showExtension``
+233    procedure   ``readApplicationExtension``
+252    procedure   ``fillGifImageLine8Bit``
+267    procedure   ``fillGifImage8Bit``
+287    procedure   ``fillGifImageLine8Bit``
+305    procedure   ``fillGifImage8Bit``
+326    procedure   ``fillGifImage8BitInterlaced``
+368    procedure   ``fillGifImage8BitInterlaced``
+412    procedure   ``readImage``
+462    structure   ``gifData``
+473    procedure   ``getImage``
+521    function    ``readGif``
+549    function    ``readGif``
+====== =========== ==================================================
+
+lib/graph.s7i
+-------------
+
+:Lines:    415
+:Entities: 71
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     procedure   ``:=``
+42     function    ``=``
+43     function    ``<>``
+44     function    ``_GENERATE_EMPTY_WINDOW``
+53     procedure   ``:=``
+54     function    ``=``
+55     function    ``<>``
+56     function    ``conv``
+57     function    ``pixel``
+58     function    ``conv``
+59     function    ``ord``
+60     function    ``compare``
+61     function    ``hashCode``
+66     procedure   ``DRAW_PPOINT``
+69     procedure   ``DRAW_PLINE``
+73     procedure   ``DRAW_PRECT``
+77     procedure   ``DRAW_CIRCLE``
+80     procedure   ``DRAW_CLEAR``
+82     procedure   ``FILL_CIRCLE``
+85     procedure   ``DRAW_ARC``
+89     procedure   ``DRAW_ARC``
+93     procedure   ``FILL_ARCCHORD``
+97     procedure   ``FILL_ARCPIESLICE``
+101    procedure   ``FILL_ELLIPSE``
+105    function    ``PRIMITIVE_GRAPHIC_OPEN``
+116    procedure   ``flushGraphic``
+136    function    ``openSubWindow``
+146    procedure   ``setWindowName``
+155    procedure   ``setCursorVisible``
+170    function    ``capturePixmap``
+176    function    ``getPixelData``
+178    function    ``getPixelData``
+180    function    ``getPixel``
+183    function    ``getPixel``
+201    procedure   ``copyArea``
+207    procedure   ``SET_TRANSPARENTCOLOR``
+209    function    ``hashCode``
+210    function    ``compare``
+212    procedure   ``setContent``
+220    function    ``rgbPixel``
+224    procedure   ``DRAW_PIXEL_TO_RGB``
+227    procedure   ``DRAW_TEXT``
+234    function    ``screenHeight``
+239    function    ``screenWidth``
+246    function    ``height``
+253    function    ``width``
+264    function    ``xPos``
+275    function    ``yPos``
+285    procedure   ``setPos``
+291    procedure   ``setSize``
+297    procedure   ``toBottom``
+302    procedure   ``toTop``
+310    function    ``getBorder``
+319    function    ``pointerXPos``
+328    function    ``pointerYPos``
+337    procedure   ``setPointerPos``
+356    procedure   ``selectInput``
+366    procedure   ``:=``
+368    function    ``_GENERATE_EMPTY_POINT_LIST``
+371    function    ``bstring``
+372    function    ``pointList``
+374    function    ``=``
+375    function    ``<>``
+377    function    ``hashCode``
+378    function    ``compare``
+387    function    ``genPointList``
+393    function    ``xyArray``
+395    function    ``scale``
+399    array       ``coordinates``
+409    procedure   ``DRAW_POLYLINE``
+412    procedure   ``FILL_POLYLINE``
+====== =========== ==================================================
+
+lib/graph_file.s7i
+------------------
+
+:Lines:    399
+:Entities: 27
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     structure   ``graph_file``
+64     function    ``open``
+88     function    ``open``
+113    function    ``open``
+133    function    ``open``
+155    procedure   ``close``
+165    procedure   ``flush``
+174    procedure   ``color``
+183    procedure   ``color``
+194    function    ``height``
+202    function    ``width``
+210    function    ``line``
+218    function    ``column``
+227    procedure   ``clear``
+247    procedure   ``clear``
+256    procedure   ``v_scroll``
+286    procedure   ``h_scroll``
+297    procedure   ``setPos``
+311    procedure   ``setPosXY``
+324    procedure   ``setLine``
+334    procedure   ``setColumn``
+344    procedure   ``write``
+357    procedure   ``writeln``
+367    procedure   ``moveLeft``
+374    procedure   ``erase``
+383    procedure   ``cursorOn``
+390    procedure   ``cursorOff``
+====== =========== ==================================================
+
+lib/gtkserver.s7i
+-----------------
+
+:Lines:    161
+:Entities: 6
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+48     procedure   ``set_gtk_logging``
+54     procedure   ``gtk_log``
+88     procedure   ``gtk_start``
+104    procedure   ``gtk_stop``
+129    function    ``gtk``
+155    procedure   ``gtk_exec``
+====== =========== ==================================================
+
+lib/gzip.s7i
+------------
+
+:Lines:    573
+:Entities: 23
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     structure   ``gzipHeader``
+59     procedure   ``showHeader``
+78     function    ``readGzipHeader``
+130    function    ``readGzipHeader``
+191    function    ``gzuncompress``
+220    function    ``gzcompress``
+242    function    ``gunzip``
+273    structure   ``gzipFile``
+293    function    ``openGzipFile``
+318    function    ``getc``
+341    function    ``gets``
+372    function    ``eof``
+381    function    ``hasNext``
+399    function    ``length``
+426    procedure   ``seek``
+442    function    ``tell``
+453    function    ``gzip``
+477    structure   ``gzipWriteFile``
+498    function    ``openGzipFile``
+519    procedure   ``close``
+536    procedure   ``write``
+561    function    ``length``
+571    function    ``tell``
+====== =========== ==================================================
+
+lib/hash.s7i
+------------
+
+:Lines:    421
+:Entities: 37
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     function    ``hash``
+64     procedure   ``CREATE``
+67     procedure   ``DESTROY``
+69     procedure   ``COPY``
+72     procedure   ``FOR_DATA``
+74     procedure   ``FOR_KEY``
+76     procedure   ``FOR_DATA_KEY``
+79     function    ``KEYS``
+81     function    ``VALUES``
+95     procedure   ``:=``
+105    function    ``length``
+107    function    ``INDEX``
+110    function    ``INDEX``
+114    function    ``INDEX2``
+119    procedure   ``INCL``
+123    procedure   ``EXCL``
+126    function    ``UPDATE``
+130    function    ``CONTAINS``
+133    function    ``GEN_HASH``
+142    function    ``.``
+153    function    ``;``
+164    function    ``default``
+174    function    ``in``
+183    function    ``not``
+193    procedure   ``incl``
+202    procedure   ``excl``
+215    procedure   ``@:=``
+233    function    ``update``
+246    function    ``:``
+248    function    ``,``
+282    procedure   ``for``
+298    procedure   ``for``
+318    procedure   ``for``
+337    function    ``keys``
+352    function    ``values``
+357    function    ``=``
+375    function    ``<>``
+====== =========== ==================================================
+
+lib/hashsetof.s7i
+-----------------
+
+:Lines:    499
+:Entities: 34
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     function    ``hashset``
+59     procedure   ``CREATE``
+62     procedure   ``DESTROY``
+64     procedure   ``COPY``
+67     procedure   ``FOR_KEY``
+69     function    ``KEYS``
+83     procedure   ``:=``
+91     function    ``.``
+104    function    ``card``
+112    function    ``rand``
+114    procedure   ``INCL``
+118    procedure   ``EXCL``
+121    function    ``CONTAINS``
+133    function    ``in``
+144    function    ``not``
+152    procedure   ``incl``
+162    procedure   ``excl``
+174    procedure   ``@:=``
+188    procedure   ``for``
+199    function    ``toArray``
+208    function    ``|``
+226    function    ``&``
+245    function    ``><``
+269    function    ``-``
+285    procedure   ``|:=``
+298    procedure   ``&:=``
+315    procedure   ``-:=``
+329    function    ``=``
+352    function    ``<>``
+363    function    ``<``
+391    function    ``>``
+419    function    ``<=``
+440    function    ``>=``
+480    function    ``str``
+====== =========== ==================================================
+
+lib/hmac.s7i
+------------
+
+:Lines:    152
+:Entities: 6
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+42     function    ``><``
+65     function    ``hmac``
+93     function    ``p_hash``
+110    function    ``pseudoRandomFunction``
+123    function    ``keyBlockFunction``
+140    function    ``mgf1Sha1``
+====== =========== ==================================================
+
+lib/html.s7i
+------------
+
+:Lines:    83
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     set         ``voidHtmlElements``
+40     function    ``getValueOfHtmlAttribute``
+58     function    ``getHtmlLinks``
+60     array       ``htmlLinks``
+====== =========== ==================================================
+
+lib/html_ent.s7i
+----------------
+
+:Lines:    476
+:Entities: 9
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     structure   ``htmlEntityType``
+34     function    ``genHtmlEntity``
+42     array       ``htmlEntityList``
+312    function    ``genHtmlEntityHash``
+327    function    ``genHtmlCharNameHash``
+346    function    ``decodeHtmlEntities``
+399    function    ``encodeHtmlEntities``
+425    function    ``encodeHtmlContent``
+457    function    ``quoteHtmlAttrValue``
+====== =========== ==================================================
+
+lib/htmldom.s7i
+---------------
+
+:Lines:    286
+:Entities: 14
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     structure   ``htmlDocument``
+39     array       ``doctypeArguments``
+47     function    ``getHtmlRoot``
+54     function    ``getDoctypeName``
+61     function    ``getDoctypeParameter``
+65     structure   ``htmlDomParserState``
+72     function    ``readHtmlNode``
+76     function    ``readHtmlContainerSubNodes``
+82     set         ``alternateEndTags``
+141    function    ``readHtmlNode``
+199    function    ``readHtml``
+252    function    ``readHtml``
+266    procedure   ``writeHtml``
+282    procedure   ``writeHtml``
+====== =========== ==================================================
+
+lib/http_request.s7i
+--------------------
+
+:Lines:    696
+:Entities: 35
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+51     structure   ``httpLocation``
+58     array       ``cookies``
+62     procedure   ``show``
+73     structure   ``httpBody``
+79     structure   ``httpCreds``
+86     function    ``basicAuth``
+96     function    ``bearerAuth``
+107    structure   ``httpRequest``
+115    function    ``httpGetRequest``
+126    structure   ``httpResponse``
+136    procedure   ``setProxy``
+143    function    ``getHttpLocation``
+202    function    ``toHttpAscii``
+228    procedure   ``sendHttp``
+279    function    ``openHttp``
+292    function    ``openHttp``
+303    function    ``getHttpStatusCode``
+329    structure   ``httpHeader``
+336    array       ``cookies``
+340    function    ``getHttpHeader``
+392    function    ``getHttpBody``
+465    function    ``getHttp``
+476    function    ``getHttpLocation``
+515    function    ``sendHttp``
+564    function    ``sendHttp``
+575    function    ``http``
+594    function    ``http``
+609    function    ``http``
+622    function    ``http``
+629    function    ``http``
+643    function    ``http``
+650    function    ``http``
+665    function    ``http``
+672    function    ``http``
+694    function    ``http``
+====== =========== ==================================================
+
+lib/http_srv_resp.s7i
+---------------------
+
+:Lines:    380
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+42     structure   ``httpResponseData``
+58     function    ``httpResponseData``
+70     procedure   ``sendHttpResponse``
+139    procedure   ``failExpectation``
+152    procedure   ``failExpectation``
+163    procedure   ``sendHttpContinue``
+173    procedure   ``sendClientError``
+199    function    ``callCgi``
+288    procedure   ``processGet``
+293    array       ``cgiHeader``
+354    procedure   ``processPost``
+358    array       ``cgiHeader``
+====== =========== ==================================================
+
+lib/https_request.s7i
+---------------------
+
+:Lines:    211
+:Entities: 14
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     function    ``openHttps``
+48     function    ``openHttps``
+59     function    ``sendHttps``
+108    function    ``sendHttps``
+112    function    ``https``
+131    function    ``https``
+135    function    ``https``
+148    function    ``https``
+152    function    ``https``
+165    function    ``https``
+169    function    ``https``
+183    function    ``https``
+187    function    ``https``
+209    function    ``https``
+====== =========== ==================================================
+
+lib/httpserv.s7i
+----------------
+
+:Lines:    345
+:Entities: 12
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+48     structure   ``httpServerRequest``
+63     structure   ``httpServerConnection``
+80     structure   ``httpServer``
+97     function    ``expecting``
+108    procedure   ``resetRequest``
+118    function    ``getHttpRequest``
+221    procedure   ``openHttpSession``
+250    procedure   ``closeHttpSession``
+258    function    ``getHttpRequest``
+281    procedure   ``cleanSessions``
+303    function    ``openHttpServer``
+322    function    ``getHttpRequest``
+====== =========== ==================================================
+
+lib/huffman.s7i
+---------------
+
+:Lines:    644
+:Entities: 29
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     function    ``computeSymbolsWithCodeLength``
+51     array       ``numberOfCodesWithLength``
+52     array       ``valueIndex``
+90     structure   ``msbHuffmanDecoder``
+109    function    ``createMsbHuffmanDecoder``
+148    function    ``createHuffmanTableMsb``
+153    function    ``createMsbHuffmanDecoder``
+224    function    ``createMsbHuffmanDecoder``
+244    function    ``getHuffmanSymbol``
+261    structure   ``lsbHuffmanDecoder``
+264    array       ``codeLengths``
+268    function    ``createLsbHuffmanDecoder``
+333    function    ``createLsbHuffmanDecoder``
+346    function    ``createHuffmanTableLsb``
+359    function    ``getHuffmanSymbol``
+375    structure   ``huffmanEncoding``
+396    procedure   ``putHuffmanSymbol``
+409    procedure   ``putHuffmanSymbol``
+415    structure   ``huffmanSymbolNode``
+421    function    ``compare``
+427    structure   ``huffmanTreeNode``
+437    function    ``getHuffmanSymbolNodes``
+455    procedure   ``getLengthsFromTree``
+474    procedure   ``getLengthsFromTree``
+494    function    ``getHuffmanCodeLengths``
+496    array       ``codeLengths``
+542    procedure   ``reduceMaximumHuffmanCodeLength``
+604    function    ``createHuffmanEncoder``
+634    function    ``createHuffmanEncoder``
+====== =========== ==================================================
+
+lib/ico.s7i
+-----------
+
+:Lines:    221
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     structure   ``icoDirEntry``
+50     procedure   ``showDirEntry``
+62     procedure   ``readDirEntry``
+90     function    ``readIco``
+129    function    ``readIco``
+149    function    ``str``
+211    procedure   ``writeIco``
+====== =========== ==================================================
+
+lib/idxarray.s7i
+----------------
+
+:Lines:    232
+:Entities: 25
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``array``
+51     procedure   ``:=``
+58     procedure   ``&:=``
+65     procedure   ``&:=``
+71     function    ``&``
+78     function    ``length``
+85     function    ``minIntIdx``
+92     function    ``maxIntIdx``
+94     function    ``conv``
+95     function    ``conv``
+96     function    ``conv``
+97     function    ``conv``
+98     function    ``.``
+102    function    ``;``
+108    function    ``;``
+130    function    ``..``
+139    function    ``;``
+154    function    ``len``
+162    function    ``minIdx``
+170    function    ``maxIdx``
+176    procedure   ``for``
+191    procedure   ``for``
+203    procedure   ``for``
+216    function    ``times``
+230    function    ``array``
+====== =========== ==================================================
+
+lib/image.s7i
+-------------
+
+:Lines:    156
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     function    ``width``
+51     function    ``height``
+58     function    ``xPos``
+65     function    ``yPos``
+73     function    ``window``
+79     procedure   ``setPos``
+85     procedure   ``toTop``
+91     procedure   ``toBottom``
+98     function    ``str``
+104    structure   ``baseImage``
+116    function    ``width``
+120    function    ``height``
+124    function    ``xPos``
+128    function    ``yPos``
+132    function    ``window``
+136    procedure   ``setPos``
+142    procedure   ``toTop``
+148    procedure   ``toBottom``
+154    function    ``str``
+====== =========== ==================================================
+
+lib/imagefile.s7i
+-----------------
+
+:Lines:    171
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+50     function    ``hasImageExtension``
+83     function    ``readImage``
+159    function    ``readImage``
+====== =========== ==================================================
+
+lib/inflate.s7i
+---------------
+
+:Lines:    411
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     procedure   ``getNonCompressedBlock``
+56     function    ``getLiteralOrLength``
+79     function    ``getDistance``
+83     function    ``decodeLength``
+124    function    ``decodeDistance``
+165    procedure   ``decodeFixedHuffmanCodes``
+197    procedure   ``decodeDynamicHuffmanCodes``
+231    procedure   ``decodeDynamicHuffmanCodes``
+234    array       ``mapToOrderedLengths``
+239    array       ``combinedDataCodeLengths``
+241    array       ``combinedData``
+242    array       ``literalOrLengthCodeLengths``
+244    array       ``distanceCodeLengths``
+287    procedure   ``processCompressedBlock``
+314    function    ``inflate``
+336    function    ``inflate``
+350    procedure   ``processCompressedBlock64``
+377    function    ``inflate64``
+399    function    ``inflate64``
+====== =========== ==================================================
+
+lib/inifile.s7i
+---------------
+
+:Lines:    129
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     function    ``getParamValue``
+53     procedure   ``getKeyValuePair``
+69     function    ``getIniSection``
+87     function    ``readIniFile``
+117    function    ``readIniFile``
+====== =========== ==================================================
+
+lib/integer.s7i
+---------------
+
+:Lines:    663
+:Entities: 55
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     procedure   ``:=``
+58     function    ``+``
+66     function    ``-``
+75     function    ``!``
+83     function    ``+``
+91     function    ``-``
+102    function    ``*``
+118    function    ``div``
+131    function    ``rem``
+148    function    ``mdiv``
+161    function    ``mod``
+174    function    ``**``
+185    function    ``<<``
+195    function    ``>>``
+202    procedure   ``+:=``
+209    procedure   ``-:=``
+216    procedure   ``*:=``
+225    procedure   ``<<:=``
+233    procedure   ``>>:=``
+248    function    ``!``
+256    function    ``=``
+264    function    ``<>``
+272    function    ``<``
+280    function    ``>``
+288    function    ``<=``
+296    function    ``>=``
+305    function    ``compare``
+312    function    ``hashCode``
+320    function    ``succ``
+328    function    ``pred``
+336    function    ``abs``
+346    function    ``sqrt``
+360    function    ``log10``
+374    function    ``log2``
+382    function    ``odd``
+389    function    ``ord``
+396    function    ``conv``
+407    function    ``str``
+418    function    ``string``
+429    function    ``literal``
+446    function    ``radix``
+463    function    ``RADIX``
+482    function    ``lpad0``
+492    procedure   ``incr``
+502    procedure   ``decr``
+512    function    ``rand``
+527    function    ``bitLength``
+542    function    ``lowestSetBit``
+565    function    ``integer``
+588    function    ``parse``
+612    function    ``integer``
+638    function    ``sci``
+641    procedure   ``DECLARE_MIN_MAX``
+648    function    ``min``
+655    function    ``max``
+====== =========== ==================================================
+
+lib/iobuffer.s7i
+----------------
+
+:Lines:    289
+:Entities: 17
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     enumeration ``bufferModeType``
+34     procedure   ``setbuf``
+42     structure   ``bufferFile``
+58     function    ``openBufferFile``
+74     procedure   ``close``
+84     procedure   ``flush``
+94     procedure   ``setbuf``
+104    procedure   ``write``
+128    procedure   ``moveLeft``
+145    function    ``getc``
+167    function    ``gets``
+215    function    ``eof``
+226    function    ``hasNext``
+236    function    ``length``
+246    function    ``seekable``
+258    procedure   ``seek``
+278    function    ``tell``
+====== =========== ==================================================
+
+lib/jpeg.s7i
+------------
+
+:Lines:    1761
+:Entities: 51
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+66     structure   ``jpegComponent``
+70     structure   ``jpegScan``
+83     structure   ``jpegHeader``
+114    structure   ``jpegMinimumCodedUnit``
+123    procedure   ``showHeader``
+163    procedure   ``readStartOfFrame``
+217    procedure   ``readDefineHuffmanTable``
+222    array       ``numberOfCodesWithLength``
+275    procedure   ``readStartOfScan``
+338    procedure   ``readDefineQuantizationTable``
+384    procedure   ``readDefineRestartInterval``
+403    procedure   ``readApplicationSegment``
+430    procedure   ``readComment``
+453    function    ``getSymbol``
+474    procedure   ``readBlock``
+506    function    ``unzigzag``
+510    array       ``zigzag``
+534    procedure   ``fastIdct8``
+616    procedure   ``idct8x8``
+651    procedure   ``processBlock``
+669    function    ``clampColor``
+680    function    ``setPixel``
+686    procedure   ``colorMinimumCodedUnit11``
+713    procedure   ``colorMinimumCodedUnit12``
+751    procedure   ``colorMinimumCodedUnit21``
+784    procedure   ``colorMinimumCodedUnit22``
+837    procedure   ``setupQuantization``
+861    function    ``readEntropyCodedSegment``
+877    procedure   ``loadMonochromeImage``
+930    procedure   ``loadColorImage``
+945    array       ``luma``
+999    procedure   ``loadImage``
+1037   function    ``loadSequential``
+1055   procedure   ``readDcValue``
+1073   procedure   ``readLumaDcOfAllBlocks``
+1109   procedure   ``readDcValuesOfAllBlocks``
+1163   procedure   ``refineDcValuesOfAllBlocks``
+1214   procedure   ``readBlockAc``
+1256   procedure   ``readLumaAcOfAllBlocks``
+1296   procedure   ``readChromaAcOfAllBlocks``
+1335   procedure   ``refineNonZeroes``
+1369   procedure   ``refineBlockAc``
+1423   procedure   ``refineLumaAcOfAllBlocks``
+1460   procedure   ``refineChromaAcOfAllBlocks``
+1495   procedure   ``loadProgressive``
+1568   procedure   ``processBlock``
+1580   procedure   ``colorMinimumCodedUnit``
+1627   function    ``colorAllMinimumCodedUnits``
+1664   function    ``readJpeg``
+1673   array       ``mcuImage``
+1749   function    ``readJpeg``
+====== =========== ==================================================
+
+lib/json.s7i
+------------
+
+:Lines:    891
+:Entities: 80
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     enumeration ``jsonCategory``
+49     function    ``str``
+73     function    ``readJson``
+90     function    ``category``
+107    function    ``type``
+123    function    ``void``
+139    function    ``boolean``
+154    function    ``integer``
+169    function    ``bigInteger``
+182    function    ``float``
+202    function    ``string``
+227    function    ``length``
+238    function    ``minIdx``
+249    function    ``maxIdx``
+273    function    ``in``
+283    function    ``not``
+294    function    ``keys``
+305    function    ``values``
+313    function    ``str``
+325    procedure   ``for``
+344    procedure   ``for``
+364    procedure   ``for``
+375    structure   ``jsonBase``
+390    structure   ``jsonNull``
+409    function    ``jsonValue``
+419    function    ``readJsonNull``
+428    function    ``category``
+429    function    ``type``
+430    function    ``void``
+431    function    ``str``
+442    structure   ``jsonBoolean``
+455    function    ``jsonValue``
+466    function    ``readJsonBoolean``
+481    function    ``category``
+482    function    ``type``
+483    function    ``boolean``
+484    function    ``str``
+495    structure   ``jsonNumber``
+506    function    ``jsonNumber``
+522    function    ``jsonValue``
+530    function    ``jsonValue``
+538    function    ``jsonValue``
+541    function    ``readJsonNumber``
+550    function    ``category``
+553    function    ``type``
+569    function    ``integer``
+570    function    ``bigInteger``
+571    function    ``float``
+572    function    ``str``
+583    structure   ``jsonString``
+596    function    ``jsonValue``
+607    function    ``readJsonString``
+616    function    ``category``
+617    function    ``type``
+618    function    ``string``
+619    function    ``str``
+630    structure   ``jsonArray``
+643    function    ``jsonValue``
+654    function    ``readJsonArray``
+677    function    ``category``
+678    function    ``type``
+680    function    ``length``
+681    function    ``minIdx``
+682    function    ``maxIdx``
+683    function    ``values``
+686    function    ``str``
+713    structure   ``jsonObject``
+714    array       ``elementNames``
+726    procedure   ``@:=``
+740    function    ``jsonValue``
+748    function    ``readJsonObject``
+796    function    ``category``
+797    function    ``type``
+799    function    ``in``
+800    function    ``not``
+801    function    ``keys``
+804    function    ``str``
+825    function    ``readJson``
+863    function    ``readJson``
+882    function    ``readJson``
+====== =========== ==================================================
+
+lib/json_serde.s7i
+------------------
+
+:Lines:    783
+:Entities: 60
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     function    ``key_type``
+35     function    ``base_type``
+41     function    ``toJson``
+70     function    ``toJson``
+77     function    ``toJson``
+81     procedure   ``DECLARE_TO_JSON_ARRAY``
+82     procedure   ``DECLARE_TO_JSON_HASH``
+83     procedure   ``DECLARE_TO_JSON_SET``
+84     procedure   ``DECLARE_TO_JSON_ENUM``
+85     procedure   ``DECLARE_TO_JSON_STRUCT``
+92     procedure   ``declare_to_json``
+106    function    ``toJson``
+117    procedure   ``DECLARE_TO_JSON_ARRAY``
+124    function    ``toJson``
+145    procedure   ``DECLARE_TO_JSON_HASH``
+153    function    ``toJson``
+176    procedure   ``DECLARE_TO_JSON_SET``
+183    function    ``toJson``
+204    procedure   ``DECLARE_TO_JSON_ENUM``
+209    function    ``toJson``
+215    procedure   ``DECLARE_STRUCT_TO_JSON``
+221    function    ``toJson``
+227    procedure   ``DECLARE_TO_JSON_STRUCT``
+231    function    ``toJson``
+238    function    ``mapStructElementName``
+245    function    ``toJson``
+268    procedure   ``DECLARE_PARSE_JSON_ARRAY``
+269    procedure   ``DECLARE_PARSE_JSON_HASH``
+270    procedure   ``DECLARE_PARSE_JSON_SET``
+271    procedure   ``DECLARE_PARSE_JSON_ENUM``
+272    procedure   ``DECLARE_PARSE_JSON_STRUCT``
+275    procedure   ``DECLARE_PARSE_JSON_BOOLEAN``
+284    function    ``parseJson``
+300    procedure   ``DECLARE_PARSE_JSON_OTHER``
+309    function    ``parseJson``
+331    procedure   ``declare_parse_json``
+364    procedure   ``DECLARE_PARSE_JSON_ARRAY``
+374    function    ``parseJson``
+408    procedure   ``DECLARE_PARSE_JSON_HASH``
+420    function    ``parseJson``
+464    procedure   ``DECLARE_PARSE_JSON_SET``
+475    function    ``parseJson``
+509    procedure   ``DECLARE_PARSE_JSON_ENUM``
+519    function    ``parseJson``
+536    function    ``parseJson``
+554    procedure   ``DECLARE_PARSE_STRUCT_ELEMENT_JSON``
+562    procedure   ``parseStructElementJson``
+570    procedure   ``DECLARE_PARSE_JSON_STRUCT``
+574    procedure   ``parseStructElementJson``
+582    function    ``mapStructElementName``
+587    function    ``genMapJsonElementName``
+609    function    ``parseJson``
+665    function    ``fromJson``
+683    function    ``fromJson``
+702    function    ``fromJson``
+717    procedure   ``DECLARE_FROM_JSON_OTHER``
+723    function    ``fromJson``
+745    procedure   ``declare_from_json``
+756    function    ``fromJson``
+778    procedure   ``declare_json_serde``
+====== =========== ==================================================
+
+lib/keybd.s7i
+-------------
+
+:Lines:    639
+:Entities: 27
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+74     function    ``buttonPressed``
+84     function    ``clickedXPos``
+94     function    ``clickedYPos``
+97     structure   ``console_keybd_file``
+116    function    ``getc``
+124    function    ``gets``
+127    function    ``raw_getc``
+128    function    ``line_read``
+130    function    ``word_read``
+140    function    ``inputReady``
+154    function    ``getk``
+175    function    ``getwd``
+192    function    ``getln``
+200    structure   ``graph_keybd_file``
+220    function    ``getc``
+228    function    ``gets``
+261    function    ``buttonPressed``
+271    function    ``clickedXPos``
+281    function    ``clickedYPos``
+284    function    ``raw_getc``
+285    function    ``line_read``
+287    function    ``word_read``
+297    function    ``inputReady``
+311    function    ``getk``
+332    function    ``getwd``
+349    function    ``getln``
+637    function    ``getc``
+====== =========== ==================================================
+
+lib/keydescr.s7i
+----------------
+
+:Lines:    192
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     function    ``genKeyDescription``
+====== =========== ==================================================
+
+lib/leb128.s7i
+--------------
+
+:Lines:    218
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     function    ``getLeb128``
+66     function    ``leb128ToInt``
+104    function    ``leb128ToInt``
+126    function    ``uLeb128ToInt``
+157    function    ``uLeb128ToInt``
+172    function    ``leb128``
+199    function    ``uLeb128``
+====== =========== ==================================================
+
+lib/line.s7i
+------------
+
+:Lines:    164
+:Entities: 8
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     structure   ``lineFile``
+44     function    ``openLine``
+58     procedure   ``write``
+67     procedure   ``writeln``
+75     procedure   ``flush``
+91     function    ``getln``
+127    function    ``getc``
+148    function    ``gets``
+====== =========== ==================================================
+
+lib/listener.s7i
+----------------
+
+:Lines:    247
+:Entities: 11
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     structure   ``inetListener``
+68     function    ``openInetListener``
+96     procedure   ``close``
+117    procedure   ``signOn``
+127    procedure   ``signOff``
+139    procedure   ``listen``
+158    function    ``accept``
+176    procedure   ``waitForRequest``
+203    function    ``getExistingConnection``
+207    function    ``getNewConnection``
+240    procedure   ``waitForRequest``
+====== =========== ==================================================
+
+lib/logfile.s7i
+---------------
+
+:Lines:    73
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+46     procedure   ``write``
+64     procedure   ``writeln``
+====== =========== ==================================================
+
+lib/lower.s7i
+-------------
+
+:Lines:    142
+:Entities: 10
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``lowerFile``
+66     function    ``openLower``
+81     procedure   ``write``
+90     procedure   ``writeln``
+100    procedure   ``writeln``
+106    procedure   ``moveLeft``
+112    procedure   ``erase``
+118    procedure   ``cursorOn``
+124    procedure   ``cursorOff``
+136    function    ``gets``
+====== =========== ==================================================
+
+lib/lzma.s7i
+------------
+
+:Lines:    934
+:Entities: 43
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     structure   ``lzmaRangeDecoderState``
+42     function    ``getc``
+61     function    ``gets``
+79     procedure   ``resetRangeDecoder``
+99     function    ``isFinishedOK``
+103    procedure   ``normalize``
+111    function    ``getBit``
+134    function    ``getDirectBit``
+152    function    ``getDirectBits``
+177    function    ``lzmaBitTreeDecoder``
+190    procedure   ``init``
+195    function    ``decode``
+207    function    ``reverseDecode``
+238    structure   ``lzmaLenDecoder``
+247    procedure   ``init``
+263    function    ``decodeLen``
+277    function    ``updateState_Literal``
+291    function    ``updateState_Match``
+303    function    ``updateState_Rep``
+315    function    ``updateState_ShortRep``
+344    structure   ``lzmaDecoder``
+353    array       ``litProbs``
+372    procedure   ``showLzmaDecoder``
+402    function    ``decodeProperties``
+428    procedure   ``resetDictionary``
+435    procedure   ``decodeLiteral``
+466    procedure   ``initDist``
+478    function    ``bitTreeReverseDecode``
+497    function    ``decodeDistance``
+525    procedure   ``resetPropabilities``
+543    procedure   ``resetState``
+561    procedure   ``copyMatch``
+586    function    ``decodePacket``
+683    function    ``lzmaDecompress``
+726    structure   ``lzmaFile``
+746    function    ``openLzmaFile``
+781    function    ``getc``
+811    function    ``gets``
+850    function    ``eof``
+861    function    ``hasNext``
+886    function    ``length``
+916    procedure   ``seek``
+932    function    ``tell``
+====== =========== ==================================================
+
+lib/lzw.s7i
+-----------
+
+:Lines:    861
+:Entities: 13
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+50     function    ``lzwCompressLsb``
+128    function    ``lzwDecompress``
+216    function    ``lzwDecompressLsb``
+241    function    ``lzwCompressMsb``
+320    function    ``lzwDecompress``
+409    function    ``lzwDecompressMsb``
+435    function    ``lzwCompressMsbEarlyChange``
+515    function    ``lzwDecompressEarlyChange``
+605    function    ``lzwDecompressMsbEarlyChange``
+632    function    ``lzwDecompressEarlyChange``
+723    function    ``lzwDecompressMsbEarlyChange``
+745    function    ``unshrinkPartialClear``
+782    function    ``lzwDecompressShrink``
+====== =========== ==================================================
+
+lib/magic.s7i
+-------------
+
+:Lines:    403
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+93     function    ``getMagic``
+210    function    ``getMagic``
+343    function    ``magicDescription``
+====== =========== ==================================================
+
+lib/mahjng32.s7i
+----------------
+
+:Lines:    1500
+:Entities: 42
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     array       ``dot1_pic``
+67     array       ``dot2_pic``
+102    array       ``dot3_pic``
+137    array       ``dot4_pic``
+172    array       ``dot5_pic``
+207    array       ``dot6_pic``
+242    array       ``dot7_pic``
+277    array       ``dot8_pic``
+312    array       ``dot9_pic``
+347    array       ``bamboo1_pic``
+382    array       ``bamboo2_pic``
+417    array       ``bamboo3_pic``
+452    array       ``bamboo4_pic``
+487    array       ``bamboo5_pic``
+522    array       ``bamboo6_pic``
+557    array       ``bamboo7_pic``
+592    array       ``bamboo8_pic``
+627    array       ``bamboo9_pic``
+662    array       ``character1_pic``
+697    array       ``character2_pic``
+732    array       ``character3_pic``
+767    array       ``character4_pic``
+802    array       ``character5_pic``
+837    array       ``character6_pic``
+872    array       ``character7_pic``
+907    array       ``character8_pic``
+942    array       ``character9_pic``
+977    array       ``north_pic``
+1012   array       ``south_pic``
+1047   array       ``east_pic``
+1082   array       ``west_pic``
+1117   array       ``middle_pic``
+1152   array       ``green_pic``
+1187   array       ``white_pic``
+1222   array       ``plum_pic``
+1257   array       ``orchid_pic``
+1292   array       ``chrysanthemum_pic``
+1327   array       ``bamboo_pic``
+1362   array       ``spring_pic``
+1397   array       ``summer_pic``
+1432   array       ``autumn_pic``
+1467   array       ``winter_pic``
+====== =========== ==================================================
+
+lib/make.s7i
+------------
+
+:Lines:    544
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     enumeration ``makeFlag``
+43     procedure   ``make``
+46     procedure   ``doMake``
+50     array       ``targets``
+91     function    ``expandInternalMacro``
+119    function    ``applyInternalMacros``
+123    set         ``iternalMacroDesignator``
+127    set         ``dependencySet``
+128    array       ``strictDependencies``
+189    procedure   ``processCommands``
+230    function    ``pattern_match``
+251    procedure   ``processRule``
+254    procedure   ``processRule``
+299    procedure   ``processPatternRule``
+381    procedure   ``processRule``
+412    procedure   ``make``
+505    procedure   ``make``
+521    procedure   ``make``
+540    procedure   ``make``
+====== =========== ==================================================
+
+lib/makedata.s7i
+----------------
+
+:Lines:    1428
+:Entities: 55
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     set         ``target_name_char``
+37     set         ``macro_name_char``
+42     structure   ``ruleType``
+44     array       ``dependencies``
+45     array       ``commands``
+57     structure   ``makeDataType``
+69     function    ``patternMatches``
+86     function    ``patternMatches``
+98     function    ``patternSubstitute``
+127    function    ``replaceSuffixes``
+151    function    ``getMacroName``
+165    function    ``getMacroParameter``
+189    function    ``applyMacros``
+193    function    ``replaceSuffixes``
+214    function    ``strip``
+230    function    ``subst``
+256    function    ``patsubst``
+282    function    ``dir``
+313    function    ``notdir``
+344    function    ``suffix``
+376    function    ``basename``
+412    function    ``addprefix``
+444    function    ``addsuffix``
+476    function    ``filter``
+486    array       ``patternList``
+514    function    ``filterOut``
+524    array       ``patternList``
+552    function    ``foreach``
+592    function    ``call``
+620    function    ``sort``
+628    array       ``wordArray``
+653    function    ``shell``
+667    function    ``wildcard``
+673    array       ``matches``
+700    function    ``applyMacros``
+824    function    ``getMacroParameter``
+859    function    ``getMakeLine``
+909    function    ``getMakeTarget``
+922    procedure   ``find_endif_directive``
+943    procedure   ``find_endif_or_else_directive``
+964    procedure   ``execIf``
+988    procedure   ``find_endif``
+1003   procedure   ``find_endif_or_else``
+1018   procedure   ``execIfeq``
+1049   procedure   ``execIfdef``
+1071   function    ``getMakeDependency``
+1130   function    ``readRule``
+1181   function    ``patternRulePresent``
+1206   procedure   ``addPatternRule``
+1221   procedure   ``addRule``
+1243   procedure   ``includeMakefile``
+1246   procedure   ``readMakefile``
+1250   array       ``alternateTargets``
+1379   procedure   ``includeMakefile``
+1410   procedure   ``readMakefile``
+====== =========== ==================================================
+
+lib/math.s7i
+------------
+
+:Lines:    201
+:Entities: 17
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+50     function    ``sin``
+57     function    ``cos``
+64     function    ``tan``
+72     function    ``asin``
+80     function    ``acos``
+88     function    ``atan``
+99     function    ``atan2``
+107    function    ``sinh``
+115    function    ``cosh``
+123    function    ``tanh``
+130    function    ``exp``
+139    function    ``expm1``
+151    function    ``log``
+165    function    ``log1p``
+177    function    ``log10``
+189    function    ``log2``
+200    function    ``sqrt``
+====== =========== ==================================================
+
+lib/mixarith.s7i
+----------------
+
+:Lines:    249
+:Entities: 25
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     function    ``+``
+45     function    ``+``
+53     function    ``-``
+61     function    ``-``
+69     function    ``*``
+77     function    ``*``
+88     function    ``/``
+99     function    ``/``
+107    function    ``+``
+115    function    ``+``
+123    function    ``-``
+131    function    ``-``
+139    function    ``*``
+147    function    ``*``
+158    function    ``/``
+169    function    ``/``
+177    function    ``float``
+185    function    ``+``
+193    function    ``+``
+201    function    ``-``
+209    function    ``-``
+217    function    ``*``
+225    function    ``*``
+236    function    ``/``
+247    function    ``/``
+====== =========== ==================================================
+
+lib/modern27.s7i
+----------------
+
+:Lines:    1099
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genModern27``
+====== =========== ==================================================
+
+lib/more.s7i
+------------
+
+:Lines:    130
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     structure   ``moreFile``
+58     function    ``openMore``
+83     procedure   ``writeln``
+112    procedure   ``write``
+====== =========== ==================================================
+
+lib/msgdigest.s7i
+-----------------
+
+:Lines:    1222
+:Entities: 47
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+50     function    ``md4``
+55     array       ``shiftAmount``
+59     array       ``idx``
+133    function    ``createMd5Table``
+135    array       ``k``
+152    function    ``md5``
+157    array       ``shiftAmount``
+162    array       ``k``
+244    function    ``ripemd160``
+248    array       ``k1``
+249    array       ``k2``
+250    array       ``r1``
+256    array       ``r2``
+262    array       ``s1``
+268    array       ``s2``
+277    array       ``x``
+379    function    ``sha1``
+476    function    ``sha224``
+482    array       ``k``
+601    function    ``sha256``
+607    array       ``k``
+727    function    ``sha384``
+734    array       ``k``
+873    function    ``sha512``
+880    array       ``k``
+1020   procedure   ``keccakf``
+1023   array       ``roundConstant``
+1036   array       ``permute``
+1040   array       ``rotationCount``
+1089   function    ``keccak1600``
+1131   function    ``sha3_224``
+1140   function    ``sha3_256``
+1149   function    ``sha3_384``
+1158   function    ``sha3_512``
+1166   enumeration ``digestAlgorithm``
+1177   function    ``msgDigest``
+1179   function    ``msgDigest``
+1180   function    ``msgDigest``
+1181   function    ``msgDigest``
+1182   function    ``msgDigest``
+1183   function    ``msgDigest``
+1184   function    ``msgDigest``
+1185   function    ``msgDigest``
+1186   function    ``msgDigest``
+1187   function    ``msgDigest``
+1194   function    ``blockSize``
+1211   function    ``digestSize``
+====== =========== ==================================================
+
+lib/multiscr.s7i
+----------------
+
+:Lines:    68
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+46     procedure   ``INIT_MULTI``
+====== =========== ==================================================
+
+lib/null_file.s7i
+-----------------
+
+:Lines:    345
+:Entities: 14
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+48     structure   ``null_file``
+89     procedure   ``writeln``
+101    procedure   ``writeln``
+114    function    ``gets``
+131    function    ``getc``
+163    function    ``getTerminatedString``
+194    function    ``getwd``
+227    function    ``getln``
+263    function    ``eoln``
+275    function    ``length``
+299    procedure   ``seek``
+313    function    ``tell``
+321    procedure   ``moveLeft``
+327    procedure   ``erase``
+====== =========== ==================================================
+
+lib/osfiles.s7i
+---------------
+
+:Lines:    1085
+:Entities: 84
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     procedure   ``GET_ATIME``
+41     procedure   ``GET_CTIME``
+46     procedure   ``GET_MTIME``
+51     procedure   ``SET_ATIME``
+55     procedure   ``SET_MTIME``
+59     procedure   ``GET_ATIME_OF_SYMLINK``
+64     procedure   ``GET_MTIME_OF_SYMLINK``
+69     procedure   ``SET_MTIME_OF_SYMLINK``
+91     function    ``readDir``
+111    function    ``fileType``
+128    function    ``fileTypeSL``
+144    function    ``fileSize``
+159    function    ``bigFileSize``
+174    function    ``getFileMode``
+178    function    ``fileMode``
+193    procedure   ``setFileMode``
+208    function    ``getATime``
+232    procedure   ``setATime``
+252    function    ``getCTime``
+275    function    ``getMTime``
+300    procedure   ``setMTime``
+320    function    ``getOwner``
+334    procedure   ``setOwner``
+349    function    ``getGroup``
+363    procedure   ``setGroup``
+380    function    ``getFileMode``
+397    function    ``getATime``
+423    function    ``getMTime``
+450    procedure   ``setMTime``
+470    function    ``getOwner``
+486    procedure   ``setOwner``
+501    function    ``getGroup``
+517    procedure   ``setGroup``
+540    function    ``readLink``
+564    function    ``readLink``
+584    function    ``finalPath``
+600    procedure   ``makeLink``
+605    procedure   ``symlink``
+624    procedure   ``removeFile``
+637    procedure   ``removeTree``
+659    procedure   ``copyFile``
+676    procedure   ``cloneFile``
+697    procedure   ``moveFile``
+711    procedure   ``makeDir``
+715    procedure   ``mkdir``
+728    function    ``getcwd``
+740    procedure   ``chdir``
+754    function    ``homeDir``
+772    function    ``toAbsPath``
+798    function    ``getParentDir``
+821    function    ``getFileName``
+846    procedure   ``makeParentDirs``
+886    function    ``convDosPath``
+910    function    ``toStdPath``
+927    structure   ``osFileSys``
+934    function    ``openOsFileSys``
+952    function    ``readDir``
+955    function    ``fileType``
+958    function    ``fileTypeSL``
+961    function    ``fileSize``
+964    function    ``bigFileSize``
+967    function    ``getFileMode``
+970    procedure   ``setFileMode``
+976    function    ``getMTime``
+979    procedure   ``setMTime``
+985    function    ``getOwner``
+988    procedure   ``setOwner``
+994    function    ``getGroup``
+997    procedure   ``setGroup``
+1003   function    ``getFileMode``
+1006   function    ``getMTime``
+1009   procedure   ``setMTime``
+1015   function    ``getOwner``
+1018   procedure   ``setOwner``
+1024   function    ``getGroup``
+1027   procedure   ``setGroup``
+1033   function    ``open``
+1036   function    ``getFile``
+1051   procedure   ``putFile``
+1064   function    ``readLink``
+1067   procedure   ``makeLink``
+1073   procedure   ``makeDir``
+1078   function    ``getcwd``
+1081   procedure   ``chdir``
+====== =========== ==================================================
+
+lib/pbm.s7i
+-----------
+
+:Lines:    230
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     procedure   ``readPbmAsciiImage``
+63     procedure   ``readPbmBinaryImageLine``
+92     procedure   ``readPbmBinaryImage``
+111    function    ``readPbm``
+157    function    ``readPbm``
+176    function    ``str``
+220    procedure   ``writePbm``
+====== =========== ==================================================
+
+lib/pcx.s7i
+-----------
+
+:Lines:    638
+:Entities: 27
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+58     structure   ``pcxHeader``
+81     procedure   ``showHeader``
+104    procedure   ``readHeader``
+143    function    ``isPcxMagic``
+154    function    ``fromPcxRunLengthEncoding``
+191    procedure   ``readPcxEgaPalette``
+208    procedure   ``readPcxVgaPalette``
+225    procedure   ``readPcxImageLineVga``
+238    procedure   ``readPcxImageVga``
+252    procedure   ``readPcxGrayscaleImageLineVga``
+267    procedure   ``readPcxGrayscaleImageVga``
+280    procedure   ``readPcxTrueColorImageLine``
+295    procedure   ``readPcxTrueColorImage``
+310    procedure   ``readPcxImageLine16Colors``
+324    procedure   ``readPcxImage16Colors``
+338    procedure   ``readPcxImageLineCga4``
+354    procedure   ``readPcxImageCga4``
+368    procedure   ``readPcxImageLineCga2``
+388    procedure   ``readPcxImageCga2``
+402    procedure   ``readPcxImageLine2Planes``
+425    procedure   ``readPcxImage2Planes``
+439    procedure   ``readPcxImageLine3Planes``
+462    procedure   ``readPcxImage3Planes``
+476    procedure   ``readPcxImageLineEga``
+498    procedure   ``readPcxImageEga``
+522    function    ``readPcx``
+626    function    ``readPcx``
+====== =========== ==================================================
+
+lib/pem.s7i
+-----------
+
+:Lines:    185
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+42     structure   ``pemObject``
+55     function    ``pemObject``
+74     function    ``str``
+90     function    ``pemObject``
+139    function    ``readPemObject``
+====== =========== ==================================================
+
+lib/pgm.s7i
+-----------
+
+:Lines:    238
+:Entities: 8
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     procedure   ``readPgmAsciiImage``
+60     procedure   ``readPgmBinaryImageLine8``
+77     procedure   ``readPgmBinaryImageLine16``
+95     procedure   ``readPgmBinaryImage``
+123    function    ``readPgm``
+179    function    ``readPgm``
+198    function    ``str``
+228    procedure   ``writePgm``
+====== =========== ==================================================
+
+lib/pic16.s7i
+-------------
+
+:Lines:    1037
+:Entities: 53
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     array       ``bat_pic``
+51     array       ``book_pic``
+70     array       ``cancel_pic``
+89     array       ``card_back_pic``
+108    array       ``checkmark_pic``
+127    array       ``clear_pic``
+146    array       ``crown_pic``
+165    array       ``crystal_ball_pic``
+184    array       ``demon_pic``
+203    array       ``diamond_pic``
+222    array       ``drop_pic``
+241    array       ``execute_pic``
+260    array       ``exit_pic``
+279    array       ``eye_pic``
+298    array       ``flask_pic``
+317    array       ``folder_pic``
+336    array       ``fountain_pic``
+355    array       ``glasses_pic``
+374    array       ``goblet_pic``
+393    array       ``goldbar_pic``
+412    array       ``grating_pic``
+431    array       ``hand_pic``
+450    array       ``harp_pic``
+469    array       ``helmet_pic``
+488    array       ``holy_cross_pic``
+507    array       ``hourglass_pic``
+526    array       ``hut_pic``
+545    array       ``jade_figurine_pic``
+564    array       ``key_pic``
+583    array       ``lamp_pic``
+602    array       ``load_pic``
+621    array       ``magic_wand_pic``
+640    array       ``magnifier_pic``
+659    array       ``necklace_pic``
+678    array       ``ogre_pic``
+697    array       ``on_off_pic``
+716    array       ``reset_pic``
+735    array       ``return_pic``
+754    array       ``right_arrow_pic``
+773    array       ``ruby_pic``
+792    array       ``save_pic``
+811    array       ``save_as_pic``
+830    array       ``scepter_pic``
+849    array       ``seed7_include_pic``
+868    array       ``seed7_source_pic``
+887    array       ``silver_bars_pic``
+906    array       ``snake_pic``
+925    array       ``statue_pic``
+944    array       ``sword_pic``
+963    array       ``take_pic``
+982    array       ``terminate_pic``
+1001   array       ``tree_pic``
+1020   array       ``vampire_pic``
+====== =========== ==================================================
+
+lib/pic32.s7i
+-------------
+
+:Lines:    2060
+:Entities: 58
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     array       ``bat_pic``
+67     array       ``book_pic``
+102    array       ``cancel_pic``
+137    array       ``card_back_pic``
+172    array       ``checkmark_pic``
+207    array       ``clear_pic``
+242    array       ``crown_pic``
+277    array       ``crystal_ball_pic``
+312    array       ``demon_pic``
+347    array       ``diamond_pic``
+382    array       ``drop_pic``
+417    array       ``execute_pic``
+452    array       ``exit_pic``
+487    array       ``eye_pic``
+522    array       ``flask_pic``
+557    array       ``folder_pic``
+592    array       ``fountain_pic``
+627    array       ``glasses_pic``
+662    array       ``goblet_pic``
+697    array       ``goldbar_pic``
+732    array       ``grating_pic``
+767    array       ``hand_pic``
+802    array       ``harp_pic``
+837    array       ``helmet_pic``
+872    array       ``holy_cross_pic``
+907    array       ``hourglass_pic``
+942    array       ``hut_pic``
+977    array       ``jade_figurine_pic``
+1012   array       ``key_pic``
+1047   array       ``lamp_pic``
+1082   array       ``left_arrow_pic``
+1117   array       ``load_pic``
+1152   array       ``magic_wand_pic``
+1187   array       ``magnifier_pic``
+1222   array       ``necklace_pic``
+1257   array       ``next_pic``
+1292   array       ``ogre_pic``
+1327   array       ``on_off_pic``
+1362   array       ``previous_pic``
+1397   array       ``reset_pic``
+1432   array       ``redo_pic``
+1467   array       ``return_pic``
+1502   array       ``right_arrow_pic``
+1537   array       ``ruby_pic``
+1572   array       ``save_pic``
+1607   array       ``save_as_pic``
+1642   array       ``scepter_pic``
+1677   array       ``seed7_include_pic``
+1712   array       ``seed7_source_pic``
+1747   array       ``silver_bars_pic``
+1782   array       ``snake_pic``
+1817   array       ``statue_pic``
+1852   array       ``sword_pic``
+1887   array       ``take_pic``
+1922   array       ``terminate_pic``
+1957   array       ``tree_pic``
+1992   array       ``undo_pic``
+2027   array       ``vampire_pic``
+====== =========== ==================================================
+
+lib/pic_util.s7i
+----------------
+
+:Lines:    144
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     function    ``charColor``
+79     function    ``createPixmap``
+109    procedure   ``drawPattern``
+====== =========== ==================================================
+
+lib/pixelimage.s7i
+------------------
+
+:Lines:    320
+:Entities: 13
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     procedure   ``setPixels``
+61     function    ``getPixmap``
+80     function    ``getPixelImage``
+86     function    ``getRotated90``
+115    procedure   ``rotate90``
+124    function    ``getRotated180``
+154    procedure   ``rotate180``
+183    function    ``getRotated270``
+210    procedure   ``rotate270``
+219    procedure   ``mirrorHorizontally``
+245    procedure   ``mirrorVertically``
+270    function    ``getRotated90AndMirroredHorizontally``
+301    function    ``getRotated270AndMirroredHorizontally``
+====== =========== ==================================================
+
+lib/pixmap_file.s7i
+-------------------
+
+:Lines:    459
+:Entities: 28
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     structure   ``pixmapFontFile``
+66     function    ``openPixmapFontFile``
+83     function    ``openPixmapFontFile``
+105    procedure   ``flush``
+114    procedure   ``setFont``
+120    function    ``getFont``
+123    function    ``getFont``
+134    function    ``height``
+142    function    ``width``
+150    function    ``line``
+158    function    ``column``
+167    procedure   ``clear``
+186    procedure   ``clear``
+201    procedure   ``v_scroll``
+234    procedure   ``setPos``
+252    procedure   ``setPosXY``
+270    procedure   ``setLine``
+281    procedure   ``setColumn``
+292    procedure   ``color``
+302    procedure   ``color``
+309    procedure   ``scale``
+312    procedure   ``scale``
+322    procedure   ``write``
+355    procedure   ``writeln``
+369    procedure   ``moveLeft``
+388    procedure   ``erase``
+420    procedure   ``cursorOn``
+442    procedure   ``cursorOff``
+====== =========== ==================================================
+
+lib/pixmapfont.s7i
+------------------
+
+:Lines:    184
+:Entities: 29
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     function    ``.``
+38     function    ``.``
+39     function    ``.``
+40     function    ``.``
+41     function    ``fontSize``
+42     function    ``scale``
+43     function    ``foreground``
+44     function    ``background``
+45     function    ``baseLineDelta``
+46     function    ``line_delta``
+47     function    ``column_delta``
+48     function    ``characterSpacing``
+55     structure   ``pixmapFontType``
+73     function    ``genPixmapFont``
+76     function    ``getFontCharPixmap``
+80     function    ``fontSize``
+81     function    ``scale``
+82     function    ``foreground``
+83     function    ``background``
+84     function    ``baseLineDelta``
+85     function    ``line_delta``
+86     function    ``column_delta``
+87     function    ``characterSpacing``
+98     structure   ``fontKeyType``
+106    function    ``hashCode``
+110    function    ``compare``
+137    function    ``genPixmapFont``
+159    function    ``getFont``
+181    function    ``getFontCharPixmap``
+====== =========== ==================================================
+
+lib/pkcs1.s7i
+-------------
+
+:Lines:    543
+:Entities: 26
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     structure   ``rsaKey``
+48     structure   ``rsaKeyPair``
+57     function    ``rsaKey``
+69     function    ``literal``
+77     function    ``rsaKeyPair``
+89     function    ``rsaKeyPair``
+103    function    ``literal``
+114    function    ``isProbablyPrime``
+129    function    ``getProbablyPrime``
+149    function    ``genRsaKeyPair``
+174    function    ``int2Octets``
+183    function    ``octets2int``
+191    function    ``emeOaepEncoding``
+224    function    ``emeOaepDecoding``
+264    function    ``emePkcs1V15Encoding``
+284    function    ``emePkcs1V15Decoding``
+308    function    ``emsaPkcs1V15Encoding``
+325    function    ``emsaPkcs1V15Decoding``
+351    function    ``rsaEncrypt``
+369    function    ``rsaDecrypt``
+391    function    ``rsaesOaepEncrypt``
+416    function    ``rsaesOaepDecrypt``
+444    function    ``rsaesPkcs1V15Encrypt``
+470    function    ``rsaesPkcs1V15Decrypt``
+498    function    ``rsassaPkcs1V15Encrypt``
+525    function    ``rsassaPkcs1V15Decrypt``
+====== =========== ==================================================
+
+lib/png.s7i
+-----------
+
+:Lines:    1064
+:Entities: 43
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+48     structure   ``pngHeader``
+62     procedure   ``showHeader``
+76     function    ``pngHeader``
+95     function    ``str``
+105    function    ``isOkay``
+117    procedure   ``computeBytesPerPixel``
+133    procedure   ``computeBytesPerScanline``
+147    function    ``readPngChunk``
+175    function    ``paethPredictor``
+197    procedure   ``filterPngData``
+269    procedure   ``fillPngImageLine1Bit``
+301    procedure   ``fillPngImage1Bit``
+313    procedure   ``fillPngImageLine2Bit``
+341    procedure   ``fillPngImage2Bit``
+353    procedure   ``fillPngImageLine4Bit``
+373    procedure   ``fillPngImage4Bit``
+385    procedure   ``fillPngImageLine8Bit``
+398    procedure   ``fillPngImage8Bit``
+410    procedure   ``fillPngImageLine8Bit``
+425    procedure   ``fillPngImage8Bit``
+437    procedure   ``fillPngImageLine16Bit``
+452    procedure   ``fillPngImage16Bit``
+464    procedure   ``fillPngImageLine24Bit``
+479    procedure   ``fillPngImage24Bit``
+491    procedure   ``fillPngImageLine48Bit``
+506    procedure   ``fillPngImage48Bit``
+518    function    ``pixelDataToImage``
+586    function    ``interlaceToImage``
+678    function    ``readPng``
+748    function    ``readPng``
+762    function    ``imageToPixelData``
+782    procedure   ``doFilter0``
+799    procedure   ``doFilter1``
+818    procedure   ``doFilter2``
+837    procedure   ``doFilter3``
+856    procedure   ``doFilter3``
+886    procedure   ``doFilter4``
+906    procedure   ``doFilter4``
+939    procedure   ``setPngFilter``
+1007   procedure   ``setPngFilter``
+1017   function    ``genPngChunk``
+1028   function    ``str``
+1054   procedure   ``writePng``
+====== =========== ==================================================
+
+lib/poll.s7i
+------------
+
+:Lines:    313
+:Entities: 22
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+57     procedure   ``:=``
+59     function    ``_GENERATE_EMPTY_POLL_DATA``
+73     procedure   ``clear``
+92     procedure   ``addCheck``
+96     procedure   ``addCheck``
+117    procedure   ``addCheck``
+133    procedure   ``removeCheck``
+137    procedure   ``removeCheck``
+156    procedure   ``removeCheck``
+172    function    ``getCheck``
+176    function    ``getCheck``
+192    function    ``getCheck``
+206    procedure   ``poll``
+222    function    ``getFinding``
+226    function    ``getFinding``
+243    function    ``getFinding``
+257    procedure   ``iterChecks``
+271    procedure   ``iterFindings``
+279    function    ``hasNext``
+282    function    ``nextFile``
+294    function    ``nextFile``
+304    procedure   ``for``
+====== =========== ==================================================
+
+lib/ppm.s7i
+-----------
+
+:Lines:    240
+:Entities: 8
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     procedure   ``readPpmAsciiImage``
+66     procedure   ``readPpmBinaryImageLine8``
+83     procedure   ``readPpmBinaryImageLine16``
+101    procedure   ``readPpmBinaryImage``
+129    function    ``readPpm``
+185    function    ``readPpm``
+204    function    ``str``
+230    procedure   ``writePpm``
+====== =========== ==================================================
+
+lib/process.s7i
+---------------
+
+:Lines:    541
+:Entities: 33
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+44     procedure   ``:=``
+45     function    ``_GENERATE_EMPTY_PROCESS``
+61     function    ``=``
+70     function    ``<>``
+84     function    ``compare``
+91     function    ``hashCode``
+100    function    ``str``
+108    function    ``isAlive``
+111    function    ``startProcess``
+137    function    ``startProcess``
+179    function    ``startProcess``
+199    function    ``startProcess``
+205    array       ``parameters``
+235    function    ``startPipe``
+255    function    ``startPipe``
+261    array       ``parameters``
+273    function    ``childStdInClibFile``
+274    function    ``childStdOutClibFile``
+275    function    ``childStdErrClibFile``
+285    function    ``childStdIn``
+307    function    ``childStdOut``
+329    function    ``childStdErr``
+348    procedure   ``kill``
+356    procedure   ``waitFor``
+365    function    ``exitValue``
+373    function    ``getSearchPath``
+385    procedure   ``setSearchPath``
+393    function    ``commandPath``
+440    function    ``commandDir``
+477    procedure   ``pipe2``
+498    procedure   ``pipe2``
+518    procedure   ``pty``
+523    procedure   ``pty``
+====== =========== ==================================================
+
+lib/progs.s7i
+-------------
+
+:Lines:    789
+:Entities: 100
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+50     procedure   ``:=``
+52     function    ``_GENERATE_EMPTY_PROG``
+66     function    ``=``
+73     function    ``<>``
+82     function    ``compare``
+89     function    ``hashCode``
+100    function    ``name``
+108    function    ``path``
+111    enumeration ``singleParseOption``
+128    function    ``parseFile``
+133    function    ``parseFile``
+139    function    ``parseFile``
+158    function    ``parseFile``
+175    function    ``parseFile``
+191    function    ``parseFile``
+205    function    ``parseFile``
+209    function    ``parseStri``
+214    function    ``parseStri``
+220    function    ``parseStri``
+235    function    ``parseStri``
+248    function    ``parseStri``
+260    function    ``parseStri``
+270    function    ``parseStri``
+274    function    ``parseStri``
+279    function    ``parseStri``
+285    function    ``parseStri``
+300    function    ``parseStri``
+313    function    ``parseStri``
+325    function    ``parseStri``
+335    function    ``parseStri``
+343    function    ``evaluate``
+352    function    ``evaluate``
+360    procedure   ``execute``
+368    procedure   ``execute``
+378    procedure   ``execute``
+387    procedure   ``execute``
+398    function    ``sysVar``
+405    function    ``errorCount``
+411    enumeration ``errorType``
+481    function    ``str``
+492    structure   ``parseError``
+502    procedure   ``DO_GET_ERROR``
+514    function    ``getError``
+534    function    ``globalObjects``
+537    function    ``structSymbols``
+546    function    ``syobject``
+553    function    ``match``
+556    function    ``matchExpr``
+565    function    ``isTemp``
+573    function    ``isVar``
+580    procedure   ``setVar``
+588    function    ``category``
+607    procedure   ``setCategory``
+618    function    ``formalParams``
+626    procedure   ``setFormalParams``
+635    procedure   ``appendFormalParams``
+644    function    ``resultVar``
+653    function    ``resultInitValue``
+663    function    ``localConsts``
+673    function    ``localVars``
+682    function    ``body``
+691    function    ``arrayMinIdx``
+700    function    ``arrayMaxIdx``
+709    function    ``arrayLength``
+713    function    ``arrayToList``
+714    function    ``structToList``
+715    function    ``hashDataToList``
+716    function    ``hashKeysToList``
+717    function    ``hashLength``
+718    function    ``interfaceToStruct``
+727    function    ``file``
+736    function    ``path``
+744    function    ``line``
+753    function    ``objNumber``
+756    function    ``allocList``
+757    function    ``alloc``
+759    function    ``alloc``
+760    function    ``alloc``
+762    function    ``getValue``
+763    function    ``getValue``
+764    function    ``getValue``
+765    function    ``getValue``
+766    function    ``getValue``
+767    function    ``getValue``
+768    function    ``getValue``
+769    function    ``getValue``
+770    function    ``getValue``
+771    function    ``getValue``
+772    function    ``getValue``
+774    function    ``getValue``
+775    function    ``getValue``
+776    function    ``getValue``
+777    function    ``getValue``
+778    function    ``getValue``
+780    function    ``getValue``
+781    function    ``getValue``
+784    procedure   ``setValue``
+786    function    ``typeNumber``
+787    function    ``typeObject``
+788    function    ``interfaces``
+====== =========== ==================================================
+
+lib/propertyfile.s7i
+--------------------
+
+:Lines:    155
+:Entities: 7
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     set         ``propertyWhiteSpace``
+41     function    ``readPropertyNameOrValue``
+84     function    ``readPropertyFile``
+88     set         ``keyTerminator``
+89     set         ``valueTerminator``
+126    function    ``readPropertyFile``
+143    function    ``readPropertyFile8``
+====== =========== ==================================================
+
+lib/rational.s7i
+----------------
+
+:Lines:    792
+:Entities: 41
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     structure   ``rational``
+43     procedure   ``normalize``
+52     procedure   ``reduce``
+72     function    ``gcd1``
+87     function    ``gcd2``
+112    function    ``/``
+127    function    ``+``
+135    function    ``-``
+148    function    ``+``
+166    function    ``-``
+184    function    ``*``
+203    function    ``/``
+221    procedure   ``+:=``
+236    procedure   ``-:=``
+251    procedure   ``*:=``
+262    procedure   ``/:=``
+275    function    ``**``
+295    function    ``=``
+305    function    ``<>``
+315    function    ``<``
+325    function    ``>``
+335    function    ``<=``
+345    function    ``>=``
+356    function    ``compare``
+365    function    ``hashCode``
+372    function    ``rat``
+384    function    ``rational``
+396    function    ``conv``
+409    function    ``abs``
+421    function    ``floor``
+428    function    ``ceil``
+435    function    ``trunc``
+444    function    ``round``
+461    function    ``round10``
+495    function    ``str``
+541    function    ``fraction``
+568    function    ``digits``
+602    function    ``decimalExponent``
+639    function    ``sci``
+708    function    ``rational``
+781    function    ``parse``
+====== =========== ==================================================
+
+lib/ref_list.s7i
+----------------
+
+:Lines:    252
+:Entities: 24
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     procedure   ``:=``
+41     function    ``_GENERATE_EMPTY_REFLIST``
+56     procedure   ``&:=``
+68     procedure   ``@:=``
+77     function    ``make_list``
+85     function    ``=``
+93     function    ``<>``
+111    function    ``..``
+129    function    ``..``
+138    function    ``&``
+147    function    ``in``
+156    function    ``not``
+165    function    ``pos``
+184    function    ``pos``
+188    procedure   ``incl``
+189    procedure   ``excl``
+196    function    ``length``
+199    procedure   ``TRACE_LIST``
+205    procedure   ``for``
+213    procedure   ``for``
+231    procedure   ``for``
+241    procedure   ``for``
+246    procedure   ``for``
+249    procedure   ``for``
+====== =========== ==================================================
+
+lib/reference.s7i
+-----------------
+
+:Lines:    126
+:Entities: 16
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     procedure   ``:=``
+41     function    ``_GENERATE_NIL``
+61     function    ``=``
+69     function    ``<>``
+78     function    ``compare``
+85     function    ``hashCode``
+93     function    ``str``
+100    function    ``getType``
+107    procedure   ``setType``
+110    function    ``is_symb``
+111    function    ``symb``
+112    function    ``getValue``
+113    function    ``getfunc``
+114    function    ``getobj``
+116    procedure   ``TRACE_REF``
+118    function    ``get_type``
+====== =========== ==================================================
+
+lib/reverse.s7i
+---------------
+
+:Lines:    94
+:Entities: 6
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     structure   ``reverse_file``
+35     function    ``openReverse``
+55     procedure   ``write``
+72     procedure   ``writeln``
+79     procedure   ``moveLeft``
+89     procedure   ``erase``
+====== =========== ==================================================
+
+lib/rpm.s7i
+-----------
+
+:Lines:    3487
+:Entities: 114
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+54     enumeration ``rpmPackageType``
+58     structure   ``rpmLead``
+69     structure   ``rpmHeader``
+78     structure   ``rpmIndexEntry``
+84     array       ``arrayValue``
+460    function    ``sigtagName``
+495    function    ``rpmtagName``
+794    function    ``rpmDependencyFlagsString``
+837    procedure   ``show``
+852    procedure   ``show``
+866    procedure   ``show``
+877    function    ``getUtf8z``
+893    function    ``getStriValue``
+931    function    ``getArrayValue``
+934    array       ``arrayValue``
+949    function    ``getIntValue``
+967    procedure   ``initLead``
+980    procedure   ``readLead``
+1005   function    ``str``
+1018   procedure   ``writeLead``
+1024   procedure   ``readHeader``
+1039   function    ``str``
+1047   function    ``str``
+1054   structure   ``rpmDependency``
+1061   function    ``=``
+1067   function    ``<>``
+1073   function    ``compare``
+1087   function    ``findDependency``
+1101   procedure   ``addDependency``
+1115   structure   ``rpmCatalogEntry``
+1140   array       ``dependencies``
+1145   procedure   ``write``
+1177   structure   ``rpmSection``
+1200   structure   ``rpmArchive``
+1211   array       ``dirNames``
+1212   array       ``classDict``
+1213   array       ``provided``
+1214   array       ``required``
+1215   array       ``dependsDict``
+1222   function    ``getStringArray``
+1224   array       ``stringArray``
+1242   procedure   ``createMinimumOfCatalog``
+1300   function    ``getInt``
+1335   procedure   ``readCatalogEntry``
+1367   procedure   ``updateIndexEntry``
+1395   procedure   ``updateIndexEntry``
+1424   procedure   ``updateIndexEntry``
+1444   procedure   ``updateIndexEntry``
+1482   procedure   ``updateIndexEntry``
+1509   procedure   ``updateProvisions``
+1513   array       ``provideName``
+1514   array       ``provideVersion``
+1528   procedure   ``updateRequirements``
+1532   array       ``requireName``
+1533   array       ``requireVersion``
+1547   procedure   ``updateDependencies``
+1577   procedure   ``updateHeader``
+1629   procedure   ``updateHeader``
+1650   procedure   ``update``
+1669   function    ``isDirty``
+1687   procedure   ``fillTagMap``
+1702   procedure   ``readSection``
+1716   function    ``sectionStri``
+1748   procedure   ``assignIndexValues``
+1770   procedure   ``updateStore``
+1818   function    ``checkHeaderDigest``
+1846   procedure   ``doSettings``
+1873   procedure   ``readDependencies``
+1920   function    ``getDigest``
+1939   procedure   ``checkPayloadDigest``
+1979   procedure   ``checkUncompressedDigest``
+2003   procedure   ``getArchive``
+2046   function    ``archiveFilePath``
+2065   function    ``openRpm``
+2108   function    ``openRpm``
+2122   procedure   ``close``
+2215   function    ``addImplicitDir``
+2227   function    ``followSymlink``
+2265   function    ``followSymlink``
+2279   procedure   ``fixRegisterAndCatalog``
+2298   function    ``findNameIndex``
+2312   function    ``getNameIndex``
+2325   function    ``fileClass``
+2344   procedure   ``setDependencies``
+2370   procedure   ``setDirIndexAndBaseName``
+2399   function    ``readDir``
+2410   function    ``readDir``
+2425   function    ``fileType``
+2484   function    ``fileTypeSL``
+2531   function    ``getFileMode``
+2551   procedure   ``setFileMode``
+2587   function    ``fileSize``
+2608   function    ``getMTime``
+2631   procedure   ``setMTime``
+2667   function    ``getOwner``
+2694   procedure   ``setOwner``
+2736   function    ``getGroup``
+2763   procedure   ``setGroup``
+2806   function    ``getFileMode``
+2845   function    ``getMTime``
+2885   procedure   ``setMTime``
+2933   function    ``getOwner``
+2975   procedure   ``setOwner``
+3030   function    ``getGroup``
+3072   procedure   ``setGroup``
+3125   function    ``readLink``
+3160   procedure   ``makeLink``
+3216   function    ``getFile``
+3252   procedure   ``putFile``
+3346   procedure   ``makeDir``
+3412   procedure   ``removeFile``
+3453   procedure   ``for``
+3463   function    ``openFileInRpm``
+3484   function    ``open``
+====== =========== ==================================================
+
+lib/rpmext.s7i
+--------------
+
+:Lines:    318
+:Entities: 30
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``getName``
+34     procedure   ``setName``
+36     function    ``getPackageType``
+38     procedure   ``setPackageType``
+40     procedure   ``addProvision``
+43     procedure   ``addRequirement``
+46     function    ``getTagValue``
+48     function    ``getTagValue``
+50     procedure   ``setTagValue``
+53     procedure   ``setTagValue``
+56     procedure   ``setTagValue``
+59     procedure   ``getFileFlags``
+61     procedure   ``getFileFlags``
+63     procedure   ``setFileFlags``
+66     procedure   ``setFileFlags``
+73     function    ``getName``
+80     procedure   ``setName``
+89     function    ``getPackageType``
+96     procedure   ``setPackageType``
+105    procedure   ``addProvision``
+120    procedure   ``addRequirement``
+135    function    ``getTagValue``
+148    function    ``getTagValue``
+161    procedure   ``setTagValue``
+171    procedure   ``setTagValue``
+181    procedure   ``setTagValue``
+201    function    ``getFileFlags``
+221    procedure   ``setFileFlags``
+251    function    ``getFileFlags``
+290    procedure   ``setFileFlags``
+====== =========== ==================================================
+
+lib/scanfile.s7i
+----------------
+
+:Lines:    1779
+:Entities: 42
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     procedure   ``skipComment``
+80     function    ``getComment``
+125    procedure   ``skipClassicComment``
+148    procedure   ``skipLineComment``
+170    function    ``getLineComment``
+198    function    ``getDigits``
+228    function    ``getHexDigits``
+262    function    ``getInteger``
+296    function    ``getNumber``
+375    function    ``getNonDigits``
+409    function    ``getQuotedText``
+452    function    ``getSimpleStringLiteral``
+488    procedure   ``getEscapeSequence``
+527    function    ``getCharLiteral``
+575    function    ``getStringLiteral``
+625    function    ``getLetters``
+657    function    ``getName``
+684    procedure   ``skipSpace``
+706    procedure   ``skipSpaceOrTab``
+724    procedure   ``skipWhiteSpace``
+739    procedure   ``skipWhiteSpace``
+759    function    ``getWhiteSpace``
+783    function    ``getWord``
+817    function    ``getWord``
+845    procedure   ``skipLine``
+868    function    ``getLine``
+903    function    ``getSymbolOrComment``
+965    function    ``getSymbol``
+1030   function    ``getSymbolWithHtmlEntities``
+1109   function    ``getHtmlTagSymbolOrComment``
+1187   procedure   ``skipXmlComment``
+1226   function    ``getXmlTagOrContent``
+1253   function    ``getXmlCharacterReference``
+1312   function    ``getXmlCdataContent``
+1389   function    ``getXmlTagHeadOrContent``
+1480   function    ``getSymbolInXmlTag``
+1529   procedure   ``skipXmlTag``
+1545   procedure   ``skipXmlTag``
+1589   procedure   ``getNextXmlAttribute``
+1640   function    ``getHtmlAttributeValue``
+1703   procedure   ``getNextHtmlAttribute``
+1740   function    ``getSimpleSymbol``
+====== =========== ==================================================
+
+lib/scanjson.s7i
+----------------
+
+:Lines:    413
+:Entities: 8
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+49     function    ``getJsonString``
+53     set         ``special_stri_char``
+114    function    ``getJsonString``
+118    set         ``special_stri_char``
+178    function    ``getJsonNumber``
+247    function    ``getJsonNumber``
+326    function    ``getJsonSymbol``
+385    function    ``getJsonSymbol``
+====== =========== ==================================================
+
+lib/scanstri.s7i
+----------------
+
+:Lines:    1814
+:Entities: 41
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     procedure   ``skipComment``
+78     function    ``getComment``
+119    procedure   ``skipClassicComment``
+144    procedure   ``skipLineComment``
+168    function    ``getLineComment``
+197    function    ``getDigits``
+226    function    ``getHexDigits``
+259    function    ``getInteger``
+294    function    ``getNumber``
+358    function    ``getNonDigits``
+390    function    ``getQuotedText``
+433    function    ``getCommandLineWord``
+495    function    ``getSimpleStringLiteral``
+533    procedure   ``getEscapeSequence``
+583    function    ``getCharLiteral``
+631    function    ``getStringLiteral``
+678    function    ``getCStringLiteralText``
+791    function    ``getLetters``
+821    function    ``getName``
+850    procedure   ``skipSpace``
+875    procedure   ``skipSpaceOrTab``
+900    procedure   ``skipWhiteSpace``
+927    function    ``getWhiteSpace``
+958    function    ``getWord``
+997    function    ``getWord``
+1031   procedure   ``skipLine``
+1056   function    ``getLine``
+1087   function    ``getSymbolOrComment``
+1160   function    ``getSymbol``
+1230   procedure   ``skipXmlComment``
+1270   function    ``getXmlTagOrContent``
+1309   function    ``getXmlCdataContent``
+1382   function    ``getXmlTagHeadOrContent``
+1471   function    ``getSymbolInXmlTag``
+1525   procedure   ``skipXmlTag``
+1541   procedure   ``skipXmlTag``
+1585   procedure   ``getNextXmlAttribute``
+1636   function    ``getHtmlAttributeValue``
+1709   procedure   ``getNextHtmlAttribute``
+1747   function    ``getHttpSymbol``
+1798   function    ``getValueOfHeaderAttribute``
+====== =========== ==================================================
+
+lib/scantoml.s7i
+----------------
+
+:Lines:    1603
+:Entities: 59
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     set         ``tomlBareKeyChar``
+36     function    ``getTomlUnicode4``
+48     function    ``getTomlUnicode8``
+64     function    ``getTomlBasicString``
+68     set         ``illegalControlChar``
+70     set         ``specialStriChar``
+124    function    ``getTomlMultiLineBasicString``
+128    set         ``illegalControlChar``
+130    set         ``specialStriChar``
+245    function    ``getTomlLiteralString``
+249    set         ``illegalControlChar``
+251    set         ``specialStriChar``
+269    function    ``getTomlMultiLineLiteralString``
+273    set         ``illegalControlChar``
+275    set         ``specialStriChar``
+310    function    ``getTomlString``
+328    function    ``getTomlHexInteger``
+358    function    ``getTomlOctInteger``
+388    function    ``getTomlBinInteger``
+418    function    ``getTomlDecInteger``
+465    function    ``getTomlInteger``
+497    function    ``getTomlFloat``
+557    function    ``getTomlName``
+578    function    ``getTomlMonth``
+597    function    ``getTomlTwoDigits``
+620    function    ``getTomlDate``
+700    function    ``getTomlTime``
+743    function    ``getTomlNumberOrDate``
+771    function    ``getTomlSymbol``
+797    procedure   ``skipTomlSpaceTabNlAndComments``
+824    function    ``getTomlKey``
+848    function    ``getTomlBasicString``
+852    set         ``illegalControlChar``
+854    set         ``specialStriChar``
+905    function    ``getTomlMultiLineBasicString``
+909    set         ``illegalControlChar``
+911    set         ``specialStriChar``
+1031   function    ``getTomlLiteralString``
+1035   set         ``illegalControlChar``
+1037   set         ``specialStriChar``
+1055   function    ``getTomlMultiLineLiteralString``
+1059   set         ``illegalControlChar``
+1061   set         ``specialStriChar``
+1105   function    ``getTomlString``
+1123   function    ``getTomlHexInteger``
+1148   function    ``getTomlOctInteger``
+1173   function    ``getTomlBinInteger``
+1198   function    ``getTomlDecInteger``
+1240   function    ``getTomlInteger``
+1267   function    ``getTomlFloat``
+1325   function    ``getTomlName``
+1340   function    ``getTomlMonth``
+1361   function    ``getTomlTwoDigits``
+1383   function    ``getTomlDate``
+1475   function    ``getTomlTime``
+1513   function    ``getTomlNumberOrDate``
+1541   function    ``getTomlSymbol``
+1561   procedure   ``skipTomlSpaceTabNlAndComments``
+1588   function    ``getTomlKey``
+====== =========== ==================================================
+
+lib/seed7_05.s7i
+----------------
+
+:Lines:    1072
+:Entities: 164
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+57     procedure   ``const``
+58     procedure   ``var``
+59     procedure   ``var``
+60     procedure   ``syntax``
+62     function    ``ref``
+63     function    ``val``
+64     function    ``val``
+65     function    ``in``
+66     function    ``in``
+67     function    ``in``
+68     function    ``in``
+69     function    ``inout``
+70     function    ``inout``
+71     function    ``attr``
+72     function    ``attr``
+73     procedure   ``global``
+80     procedure   ``:=``
+83     function    ``func``
+84     function    ``func``
+85     function    ``func``
+87     function    ``return``
+88     function    ``return``
+93     procedure   ``:=``
+94     procedure   ``noop``
+95     procedure   ``:=``
+96     procedure   ``;``
+99     procedure   ``PRINT``
+101    procedure   ``IN_PARAM_IS_VALUE``
+102    procedure   ``IN_PARAM_IS_REFERENCE``
+114    procedure   ``BASIC_TYPE_DECLS``
+118    procedure   ``TRACE``
+126    procedure   ``:=``
+127    procedure   ``:=``
+138    function    ``func``
+147    function    ``func``
+156    function    ``func``
+163    function    ``func``
+170    function    ``return``
+171    function    ``return``
+172    function    ``return``
+173    function    ``return``
+175    function    ``return``
+176    function    ``return``
+177    function    ``return``
+178    function    ``return``
+204    procedure   ``var``
+211    function    ``str``
+212    function    ``gentype``
+213    function    ``gensub``
+215    function    ``newtype``
+226    function    ``subtype``
+236    function    ``func``
+245    function    ``func``
+254    function    ``func``
+261    function    ``func``
+268    function    ``return``
+269    function    ``return``
+270    function    ``return``
+271    function    ``return``
+309    procedure   ``:=``
+315    procedure   ``:=``
+344    procedure   ``raise``
+345    function    ``str``
+346    function    ``conv``
+347    function    ``ord``
+352    procedure   ``TRACE_OPTIONS``
+353    procedure   ``TRACE_OBJ``
+354    procedure   ``TRACE_PROC``
+372    function    ``ord``
+373    function    ``ACTION``
+374    function    ``conv``
+375    function    ``str``
+376    function    ``=``
+377    function    ``<>``
+378    function    ``compare``
+379    function    ``hashCode``
+387    function    ``=``
+388    function    ``<>``
+389    function    ``compare``
+390    function    ``hashCode``
+391    function    ``isFunc``
+392    function    ``isVarfunc``
+393    function    ``resultType``
+394    function    ``isDerived``
+395    function    ``meta``
+396    procedure   ``addInterface``
+401    function    ``=``
+402    function    ``<>``
+419    procedure   ``if``
+423    procedure   ``if``
+428    procedure   ``if``
+459    procedure   ``while``
+460    procedure   ``while``
+461    procedure   ``while``
+463    procedure   ``while``
+464    procedure   ``while``
+465    procedure   ``while``
+467    procedure   ``repeat``
+468    procedure   ``repeat``
+469    procedure   ``repeat``
+471    procedure   ``repeat``
+472    procedure   ``repeat``
+473    procedure   ``repeat``
+480    function    ``conv``
+483    function    ``rand``
+486    function    ``compare``
+503    function    ``parse``
+514    function    ``trimValue``
+524    function    ``parse``
+539    function    ``literal``
+567    function    ``width``
+579    function    ``reverse``
+599    function    ``noCtrlChars``
+619    function    ``tuple``
+631    function    ``,``
+632    function    ``,``
+677    function    ``split``
+678    function    ``split``
+680    function    ``join``
+693    function    ``join``
+706    function    ``noEmptyStrings``
+708    array       ``noEmptyStrings``
+719    function    ``isDigitString``
+733    function    ``isDigitString``
+779    function    ``integer``
+783    array       ``digitval``
+823    function    ``sci``
+865    function    ``new``
+874    procedure   ``:=``
+875    function    ``=``
+876    function    ``<>``
+880    function    ``sub``
+889    procedure   ``:=``
+890    function    ``=``
+891    function    ``<>``
+896    procedure   ``type_implements_interface``
+899    procedure   ``:=``
+900    function    ``conv``
+901    function    ``toInterface``
+903    function    ``conv``
+904    function    ``conv``
+909    function    ``create``
+918    function    ``create``
+929    procedure   ``CASE_DECLS``
+940    procedure   ``case``
+948    procedure   ``case``
+951    procedure   ``case``
+956    procedure   ``case``
+959    procedure   ``case``
+977    procedure   ``TRACE``
+985    procedure   ``BLOCK_DECLS``
+994    procedure   ``block``
+997    procedure   ``block``
+1001   procedure   ``block``
+1012   function    ``succeeds``
+1023   function    ``=``
+1024   function    ``<>``
+1030   structure   ``runError``
+1036   procedure   ``GET_RUN_ERROR``
+1043   function    ``getRunError``
+1058   procedure   ``heapstat``
+1059   function    ``heapsize``
+1061   procedure   ``include``
+1067   procedure   ``main``
+====== =========== ==================================================
+
+lib/set.s7i
+-----------
+
+:Lines:    57
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     function    ``set``
+====== =========== ==================================================
+
+lib/shell.s7i
+-------------
+
+:Lines:    615
+:Entities: 25
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+55     function    ``shell``
+78     function    ``shell``
+109    function    ``shell``
+118    array       ``parameterArray``
+150    function    ``shell``
+175    function    ``shell``
+208    procedure   ``shellCmd``
+236    procedure   ``shellCmd``
+256    function    ``shellEscape``
+275    function    ``toOsPath``
+292    function    ``toShellPath``
+296    function    ``shellParameters``
+311    function    ``popenClibFile``
+318    structure   ``popenFile``
+347    function    ``popen``
+391    function    ``popen``
+397    array       ``parameterArray``
+442    function    ``popen``
+460    procedure   ``close``
+469    structure   ``popen8File``
+498    function    ``popen8``
+542    function    ``popen8``
+548    array       ``parameterArray``
+593    function    ``popen8``
+611    procedure   ``close``
+====== =========== ==================================================
+
+lib/showtls.s7i
+---------------
+
+:Lines:    678
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     procedure   ``showChangeCipherSpec``
+39     procedure   ``showAlert``
+83     procedure   ``showExtensions``
+205    procedure   ``showClientHello``
+249    procedure   ``showServerHello``
+286    procedure   ``showX509Cert``
+339    procedure   ``showCertificate``
+346    array       ``certList``
+382    procedure   ``showServerKeyExchange``
+436    procedure   ``showCertificateRequest``
+481    procedure   ``showServerHelloDone``
+495    procedure   ``showCertificateVerify``
+511    procedure   ``showClientKeyExchange``
+527    procedure   ``showFinished``
+547    procedure   ``showHandshakeMsg``
+578    procedure   ``showHandshake``
+600    procedure   ``showApplicationData``
+614    procedure   ``showTlsMsg``
+640    procedure   ``showTlsMsgType``
+====== =========== ==================================================
+
+lib/signature.s7i
+-----------------
+
+:Lines:    131
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+34     structure   ``rsaSignatureType``
+40     function    ``genRsaSignature``
+58     function    ``getRsaSignature``
+92     function    ``genSignature``
+116    function    ``verifySignature``
+====== =========== ==================================================
+
+lib/smtp.s7i
+------------
+
+:Lines:    261
+:Entities: 13
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     structure   ``smtpConnection``
+47     structure   ``smtpMessage``
+49     array       ``toAddrs``
+50     array       ``ccAddrs``
+51     array       ``bccAddrs``
+57     function    ``str``
+79     procedure   ``smtpCommand``
+86     procedure   ``smtpResponse``
+111    procedure   ``close``
+137    function    ``openSmtp``
+186    procedure   ``login``
+213    procedure   ``send``
+256    procedure   ``send``
+====== =========== ==================================================
+
+lib/sockbase.s7i
+----------------
+
+:Lines:    217
+:Entities: 38
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     procedure   ``:=``
+41     function    ``_GENERATE_EMPTY_SOCKET_ADDRESS``
+44     function    ``=``
+45     function    ``<>``
+47     function    ``addrFamily``
+56     function    ``compare``
+63     function    ``hashCode``
+74     function    ``numericAddress``
+77     function    ``service``
+95     function    ``inetSocketAddress``
+106    function    ``inetSocketAddress``
+116    function    ``inetListenerAddress``
+124    function    ``getHostname``
+133    procedure   ``:=``
+135    function    ``=``
+136    function    ``<>``
+138    function    ``_GENERATE_EMPTY_PRIMITIVE_SOCKET``
+142    procedure   ``close``
+143    function    ``localAddress``
+144    function    ``peerAddress``
+145    function    ``ord``
+146    function    ``getc``
+148    function    ``gets``
+150    function    ``hasNext``
+151    function    ``word_read``
+153    function    ``line_read``
+155    procedure   ``write``
+156    function    ``recv``
+158    function    ``recvfrom``
+161    function    ``send``
+163    function    ``sendto``
+165    procedure   ``setSockOpt``
+169    function    ``PRIMITIVE_SOCKET``
+178    procedure   ``connect``
+192    function    ``accept``
+201    procedure   ``bind``
+211    procedure   ``listen``
+215    function    ``inputReady``
+====== =========== ==================================================
+
+lib/socket.s7i
+--------------
+
+:Lines:    326
+:Entities: 38
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+46     procedure   ``close``
+47     procedure   ``listen``
+48     function    ``accept``
+49     procedure   ``signOn``
+50     procedure   ``signOff``
+51     procedure   ``waitForRequest``
+52     function    ``getExistingConnection``
+53     function    ``getNewConnection``
+56     structure   ``baseListener``
+74     structure   ``socket``
+84     function    ``localAddress``
+85     function    ``peerAddress``
+94     function    ``localAddress``
+104    function    ``peerAddress``
+108    function    ``service``
+109    function    ``service``
+112    function    ``port``
+113    function    ``port``
+116    function    ``ord``
+117    function    ``ord``
+121    function    ``inputReady``
+122    function    ``inputReady``
+133    function    ``openSocket``
+166    function    ``openInetSocket``
+182    function    ``openInetSocket``
+193    procedure   ``close``
+203    procedure   ``release``
+206    procedure   ``release``
+216    procedure   ``flush``
+229    procedure   ``write``
+243    procedure   ``writeln``
+253    function    ``getc``
+263    function    ``gets``
+278    function    ``getwd``
+291    function    ``getln``
+303    function    ``eof``
+314    function    ``hasNext``
+324    function    ``inputReady``
+====== =========== ==================================================
+
+lib/sokoban1.s7i
+----------------
+
+:Lines:    1519
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+29     array       ``levels``
+====== =========== ==================================================
+
+lib/sql_base.s7i
+----------------
+
+:Lines:    1000
+:Entities: 75
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+51     enumeration ``dbCategory``
+57     function    ``str``
+61     function    ``dbCategory``
+100    function    ``parse``
+117    procedure   ``:=``
+119    function    ``_GENERATE_EMPTY_DATABASE``
+133    function    ``=``
+141    function    ``<>``
+144    function    ``DRIVER_NUM``
+147    function    ``DB_CATEGORY_NUM``
+160    procedure   ``:=``
+162    function    ``_GENERATE_EMPTY_STATEMENT``
+176    function    ``=``
+184    function    ``<>``
+187    procedure   ``BIND_BIG_RAT``
+190    procedure   ``BIND_TIME``
+195    procedure   ``BIND_DURATION``
+200    procedure   ``COLUMN_BIG_RAT``
+203    procedure   ``COLUMN_TIME``
+209    procedure   ``COLUMN_DURATION``
+215    function    ``openDatabase``
+219    function    ``openDatabase``
+223    function    ``openDatabase``
+227    function    ``openDatabase``
+231    function    ``openDatabase``
+235    function    ``openDatabase``
+239    function    ``openDatabase``
+243    function    ``openDatabase``
+263    function    ``openDatabase``
+282    function    ``openDatabase``
+304    function    ``openDatabase``
+310    function    ``openDatabase``
+367    function    ``openDatabase``
+462    function    ``openDatabase``
+497    procedure   ``close``
+508    function    ``prepare``
+521    procedure   ``bind``
+534    procedure   ``bind``
+551    procedure   ``bind``
+564    procedure   ``bind``
+577    procedure   ``bind``
+590    procedure   ``bind``
+601    procedure   ``bind``
+614    procedure   ``bind``
+627    procedure   ``bind``
+646    procedure   ``bind``
+662    procedure   ``execute``
+676    function    ``fetch``
+693    function    ``column``
+711    function    ``column``
+736    function    ``column``
+754    function    ``column``
+772    function    ``column``
+798    function    ``column``
+816    function    ``column``
+834    function    ``column``
+852    function    ``column``
+875    function    ``isNull``
+881    function    ``getAutoCommit``
+887    procedure   ``setAutoCommit``
+893    procedure   ``commit``
+899    procedure   ``rollback``
+908    function    ``columnCount``
+918    function    ``columnName``
+921    procedure   ``execute``
+930    function    ``libFunction``
+931    function    ``dbFunction``
+932    function    ``errCode``
+933    function    ``errMessage``
+936    function    ``driver``
+940    function    ``dbCategory``
+944    function    ``quoteTableNames``
+961    function    ``tableNamesCommand``
+983    function    ``getTableNames``
+986    array       ``tableNames``
+====== =========== ==================================================
+
+lib/stars.s7i
+-------------
+
+:Lines:    1705
+:Entities: 3
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``starDescr``
+44     function    ``genStarDescr``
+60     array       ``stars``
+====== =========== ==================================================
+
+lib/stdfont10.s7i
+-----------------
+
+:Lines:    3347
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont10``
+====== =========== ==================================================
+
+lib/stdfont12.s7i
+-----------------
+
+:Lines:    3928
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont12``
+====== =========== ==================================================
+
+lib/stdfont14.s7i
+-----------------
+
+:Lines:    4510
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont14``
+====== =========== ==================================================
+
+lib/stdfont16.s7i
+-----------------
+
+:Lines:    5092
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont16``
+====== =========== ==================================================
+
+lib/stdfont18.s7i
+-----------------
+
+:Lines:    5868
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont18``
+====== =========== ==================================================
+
+lib/stdfont20.s7i
+-----------------
+
+:Lines:    6449
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont20``
+====== =========== ==================================================
+
+lib/stdfont24.s7i
+-----------------
+
+:Lines:    7421
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont24``
+====== =========== ==================================================
+
+lib/stdfont8.s7i
+----------------
+
+:Lines:    2960
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont8``
+====== =========== ==================================================
+
+lib/stdfont9.s7i
+----------------
+
+:Lines:    3152
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genStdFont9``
+====== =========== ==================================================
+
+lib/stdio.s7i
+-------------
+
+:Lines:    192
+:Entities: 9
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     function    ``INIT_STD_FILE``
+94     procedure   ``write``
+106    procedure   ``writeln``
+118    procedure   ``writeln``
+132    procedure   ``read``
+147    procedure   ``read``
+160    procedure   ``readln``
+174    procedure   ``readln``
+186    procedure   ``readln``
+====== =========== ==================================================
+
+lib/strifile.s7i
+----------------
+
+:Lines:    345
+:Entities: 18
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``striFile``
+48     function    ``openStriFile``
+63     function    ``openStriFile``
+76     procedure   ``write``
+96     procedure   ``moveLeft``
+110    function    ``getc``
+128    function    ``gets``
+159    function    ``getTerminatedString``
+189    function    ``getwd``
+193    set         ``space_or_tab``
+194    set         ``space_tab_or_nl``
+239    function    ``getln``
+269    function    ``eof``
+279    function    ``hasNext``
+288    function    ``length``
+299    procedure   ``truncate``
+327    procedure   ``seek``
+343    function    ``tell``
+====== =========== ==================================================
+
+lib/string.s7i
+--------------
+
+:Lines:    779
+:Entities: 55
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     procedure   ``:=``
+49     function    ``mult``
+56     function    ``lpad``
+71     function    ``lpad0``
+78     function    ``rpad``
+87     function    ``&``
+99     function    ``<&``
+130    function    ``..``
+170    function    ``..``
+191    function    ``len``
+214    function    ``fixLen``
+223    procedure   ``&:=``
+231    procedure   ``&:=``
+247    procedure   ``@:=``
+266    procedure   ``@:=``
+274    function    ``=``
+282    function    ``<>``
+290    function    ``<``
+298    function    ``>``
+306    function    ``<=``
+314    function    ``>=``
+323    function    ``compare``
+330    function    ``hashCode``
+337    function    ``length``
+348    function    ``startsWith``
+360    function    ``endsWith``
+372    function    ``equalAtIndex``
+386    function    ``pos``
+397    function    ``pos``
+417    function    ``pos``
+429    function    ``pos``
+443    function    ``rpos``
+454    function    ``rpos``
+473    function    ``rpos``
+485    function    ``rpos``
+505    function    ``replace``
+514    function    ``replace1``
+543    function    ``replaceN``
+593    function    ``replace2``
+628    function    ``upper``
+641    function    ``lower``
+652    function    ``width``
+660    function    ``reverse``
+669    function    ``trim``
+678    function    ``ltrim``
+687    function    ``rtrim``
+700    function    ``trimValue``
+712    function    ``trimValue``
+720    function    ``str``
+731    function    ``literal``
+734    function    ``c_literal``
+737    function    ``getint``
+753    function    ``gets``
+766    function    ``string``
+774    function    ``parse``
+====== =========== ==================================================
+
+lib/stritext.s7i
+----------------
+
+:Lines:    352
+:Entities: 22
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``striText``
+37     array       ``content``
+49     function    ``openStriText``
+63     procedure   ``write``
+80     procedure   ``writeln``
+98     procedure   ``moveLeft``
+117    function    ``getc``
+141    function    ``gets``
+176    function    ``getwd``
+192    function    ``getln``
+214    function    ``eof``
+224    function    ``hasNext``
+233    function    ``length``
+245    procedure   ``seek``
+257    function    ``tell``
+274    function    ``height``
+282    function    ``width``
+300    function    ``line``
+308    function    ``column``
+315    procedure   ``setPos``
+325    procedure   ``setLine``
+334    procedure   ``setColumn``
+====== =========== ==================================================
+
+lib/struct.s7i
+--------------
+
+:Lines:    266
+:Entities: 30
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     procedure   ``:=``
+38     function    ``length``
+39     function    ``&``
+40     procedure   ``incl``
+41     function    ``empty``
+42     function    ``declare_elements``
+53     function    ``new``
+71     procedure   ``:=``
+72     function    ``conv``
+73     function    ``conv``
+94     function    ``new``
+105    procedure   ``:=``
+106    function    ``conv``
+107    function    ``conv``
+124    function    ``new``
+141    procedure   ``:=``
+142    function    ``conv``
+143    function    ``conv``
+166    function    ``new``
+176    procedure   ``:=``
+177    function    ``conv``
+178    function    ``conv``
+201    function    ``sub``
+218    procedure   ``:=``
+219    function    ``conv``
+220    function    ``conv``
+249    function    ``sub``
+259    procedure   ``:=``
+260    function    ``conv``
+261    function    ``conv``
+====== =========== ==================================================
+
+lib/struct_elem.s7i
+-------------------
+
+:Lines:    129
+:Entities: 10
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     procedure   ``:=``
+45     function    ``structElement``
+58     function    ``=``
+65     function    ``<>``
+74     function    ``compare``
+81     function    ``hashCode``
+91     function    ``getName``
+101    function    ``getType``
+112    function    ``symb``
+128    function    ``elements``
+====== =========== ==================================================
+
+lib/subfile.s7i
+---------------
+
+:Lines:    174
+:Entities: 9
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``subFile``
+53     function    ``openSubFile``
+72     function    ``getc``
+91     function    ``gets``
+118    function    ``eof``
+128    function    ``hasNext``
+137    function    ``length``
+156    procedure   ``seek``
+172    function    ``tell``
+====== =========== ==================================================
+
+lib/subrange.s7i
+----------------
+
+:Lines:    78
+:Entities: 4
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     procedure   ``SUBRANGE_TYPES``
+39     function    ``subrange``
+64     function    ``conv``
+67     function    ``conv``
+====== =========== ==================================================
+
+lib/syntax.s7i
+--------------
+
+:Lines:    294
+:Entities: 0
+
+(none)
+
+
+lib/tar.s7i
+-----------
+
+:Lines:    1880
+:Entities: 55
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+62     structure   ``tarHeader``
+88     procedure   ``showHeader``
+115    function    ``gets0``
+130    function    ``gets0Spc``
+150    function    ``getOct``
+170    function    ``getMetaData``
+189    procedure   ``puts0``
+198    procedure   ``putSpc``
+204    procedure   ``putOct``
+210    function    ``tarChksum``
+223    function    ``tarHeader``
+247    function    ``readHeadBlock``
+270    procedure   ``readHead``
+357    function    ``readMinimumOfHeadBlock``
+381    procedure   ``readMinimumOfHead``
+449    function    ``str``
+479    procedure   ``writeHead``
+573    structure   ``tarArchive``
+587    function    ``openTar``
+633    function    ``openTar``
+647    procedure   ``close``
+653    function    ``addToCatalog``
+667    function    ``addImplicitDir``
+682    function    ``followSymlink``
+725    function    ``followSymlink``
+739    procedure   ``fixRegisterAndCatalog``
+769    function    ``readDir``
+780    function    ``readDir``
+795    function    ``fileType``
+858    function    ``fileTypeSL``
+905    function    ``getFileMode``
+925    procedure   ``setFileMode``
+957    function    ``fileSize``
+980    function    ``getMTime``
+1003   procedure   ``setMTime``
+1036   function    ``getOwner``
+1063   procedure   ``setOwner``
+1099   function    ``getGroup``
+1126   procedure   ``setGroup``
+1163   function    ``getFileMode``
+1201   function    ``getMTime``
+1240   procedure   ``setMTime``
+1282   function    ``getOwner``
+1323   procedure   ``setOwner``
+1368   function    ``getGroup``
+1409   procedure   ``setGroup``
+1452   function    ``readLink``
+1486   procedure   ``makeLink``
+1621   function    ``getFile``
+1649   procedure   ``putFile``
+1733   procedure   ``makeDir``
+1799   procedure   ``removeFile``
+1841   procedure   ``for``
+1851   function    ``openFileInTar``
+1877   function    ``open``
+====== =========== ==================================================
+
+lib/tar_cmds.s7i
+----------------
+
+:Lines:    752
+:Entities: 23
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     procedure   ``setUpHead``
+65     function    ``openTarFileWithMagic``
+117    function    ``openTarFileByExtension``
+151    function    ``filePathIsInTarMemberList``
+184    procedure   ``tarTell``
+230    procedure   ``archiveTell``
+234    array       ``nameList``
+274    procedure   ``tarTell``
+311    procedure   ``tarXtract``
+318    array       ``dirHeaderList``
+408    procedure   ``archiveXtract``
+411    array       ``nameList``
+414    array       ``dirPathList``
+503    procedure   ``tarXtract``
+536    procedure   ``tarXtract``
+552    procedure   ``tarXtract``
+576    procedure   ``tarCreate``
+580    array       ``dirContent``
+620    procedure   ``archiveCreate``
+624    array       ``dirContent``
+685    procedure   ``tarCreate``
+732    procedure   ``tarCreate``
+748    procedure   ``tarCreate``
+====== =========== ==================================================
+
+lib/tdes.s7i
+------------
+
+:Lines:    143
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+39     structure   ``tdesState``
+65     function    ``setTdesKey``
+85     function    ``setCipherKey``
+94     function    ``encode``
+122    function    ``decode``
+====== =========== ==================================================
+
+lib/tee.s7i
+-----------
+
+:Lines:    143
+:Entities: 11
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     structure   ``teeFile``
+33     array       ``destFiles``
+42     function    ``openTee``
+59     function    ``openTee``
+67     procedure   ``write``
+81     procedure   ``writeln``
+95     procedure   ``flush``
+105    procedure   ``moveLeft``
+115    procedure   ``erase``
+125    procedure   ``cursorOn``
+135    procedure   ``cursorOff``
+====== =========== ==================================================
+
+lib/text.s7i
+------------
+
+:Lines:    135
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+49     function    ``height``
+56     function    ``width``
+63     function    ``line``
+70     function    ``column``
+78     procedure   ``clear``
+85     procedure   ``clear``
+88     procedure   ``v_scroll``
+89     procedure   ``v_scroll``
+91     procedure   ``h_scroll``
+92     procedure   ``h_scroll``
+99     procedure   ``color``
+105    procedure   ``color``
+111    procedure   ``setPos``
+117    procedure   ``setPosXY``
+123    procedure   ``setLine``
+129    procedure   ``setColumn``
+132    procedure   ``cursor``
+133    procedure   ``box``
+134    procedure   ``clear_box``
+====== =========== ==================================================
+
+lib/tga.s7i
+-----------
+
+:Lines:    676
+:Entities: 26
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+52     structure   ``tgaHeader``
+76     procedure   ``showHeader``
+97     procedure   ``readPalette``
+138    function    ``isTgaHeader``
+151    procedure   ``readHeader``
+199    procedure   ``readTgaColorMappedImageLine8``
+212    procedure   ``readTgaColorMappedImage8``
+232    procedure   ``readTgaUncompressedColorMapped``
+253    procedure   ``readTgaTrueColorImageLine16``
+270    procedure   ``readTgaTrueColorImage16``
+290    procedure   ``readTgaTrueColorImageLine24``
+305    procedure   ``readTgaTrueColorImage24``
+325    procedure   ``readTgaTrueColorImageLine32``
+340    procedure   ``readTgaTrueColorImage32``
+360    procedure   ``readTgaUncompressedTrueColor``
+397    procedure   ``readTgaGrayscaleImageLine8``
+412    procedure   ``readTgaGrayscaleImage8``
+432    procedure   ``readTgaGrayscaleImageLine16``
+447    procedure   ``readTgaGrayscaleImage16``
+467    procedure   ``readTgaUncompressedGrayscale``
+496    function    ``fromTgaRunLengthEncoding``
+528    procedure   ``readTgaRleColorMapped``
+549    procedure   ``readTgaRleTrueColor``
+586    procedure   ``readTgaRleGrayscale``
+623    function    ``readTga``
+664    function    ``readTga``
+====== =========== ==================================================
+
+lib/tiff.s7i
+------------
+
+:Lines:    2771
+:Entities: 65
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+155    structure   ``tiffHeader``
+165    array       ``bitsPerSample``
+168    array       ``stripOffsets``
+169    array       ``stripByteCounts``
+170    array       ``tileOffsets``
+171    array       ``tileByteCounts``
+181    procedure   ``showHeader``
+211    procedure   ``readHeader``
+229    function    ``tagName``
+299    function    ``fieldTypeName``
+322    function    ``tagValueAsString``
+426    function    ``tagValueAsArray``
+429    array       ``tagValues``
+540    procedure   ``readIDFEntry``
+591    procedure   ``readImageFileDirectory``
+623    procedure   ``readColorMap``
+625    array       ``colorMapData``
+646    procedure   ``differencingPredictor``
+693    procedure   ``floatPredictor``
+737    procedure   ``removeUnusedData``
+758    procedure   ``processJpegSegments``
+834    function    ``readJpeg``
+919    procedure   ``setupJpegHeader``
+946    procedure   ``loadJpegSegment``
+956    procedure   ``assignDecoder``
+960    array       ``numberOfCodesWithLength``
+982    function    ``readOldJpeg``
+1121   procedure   ``processCcittModifiedGroup3Fax``
+1149   procedure   ``processCcittT6Fax``
+1174   procedure   ``processCcittT4Fax1d``
+1202   procedure   ``processCcittT4Fax2d``
+1227   procedure   ``processRow``
+1296   procedure   ``processRowWithColorMap``
+1327   function    ``clampColor2``
+1331   procedure   ``processRowWithGrayscale``
+1419   procedure   ``processRowWithGrayscaleReversed``
+1458   procedure   ``processRowWithGrayscaleAlpha``
+1497   procedure   ``processRowWithGrayscaleAlphaReversed``
+1536   procedure   ``processRowWithRGB``
+1638   procedure   ``processRowWithRGBA``
+1714   procedure   ``processRowWithCMYK``
+1781   procedure   ``processRowWithCMYKA``
+1848   procedure   ``processRowWithYCbCr``
+1856   array       ``luminance``
+1894   procedure   ``processRowWithYCbCr2``
+1903   array       ``luminance``
+1941   procedure   ``processRow``
+2007   procedure   ``decompressStripOrTile``
+2056   procedure   ``readThunderScan``
+2066   array       ``twoBitDeltas``
+2067   array       ``threeBitDeltas``
+2140   procedure   ``readThunderScan``
+2188   procedure   ``nextTile``
+2211   procedure   ``readStripOrTile``
+2331   function    ``readTiff``
+2384   procedure   ``processRow``
+2410   procedure   ``processRowRGB``
+2467   procedure   ``processRowWithCMYK``
+2509   procedure   ``processRow``
+2524   procedure   ``readStripOrTile``
+2534   array       ``stripData``
+2537   array       ``stripDataStream``
+2602   function    ``readTiffPlanarFormat``
+2655   function    ``readTiff``
+2759   function    ``readTiff``
+====== =========== ==================================================
+
+lib/time.s7i
+------------
+
+:Lines:    1191
+:Entities: 65
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+43     structure   ``time``
+56     procedure   ``GET_TIME``
+61     procedure   ``AWAIT_TIME``
+65     procedure   ``FROM_TIMESTAMP``
+70     procedure   ``SET_LOCAL_TZ``
+79     function    ``isLeapYear``
+87     function    ``daysInYear``
+103    function    ``daysInMonth``
+107    set         ``monthsOfLength31``
+129    function    ``daysInMonth``
+137    function    ``strDate``
+147    function    ``strTime``
+160    function    ``strTimeZone``
+179    function    ``str_yyyy_mm_dd``
+185    function    ``str_yy_mm_dd``
+191    function    ``str_mm_dd_yyyy``
+197    function    ``str_mm_dd_yy``
+203    function    ``str_dd_mm_yyyy``
+209    function    ``str_dd_mm_yy``
+215    function    ``str_d_m_yyyy``
+221    function    ``str_d_m_yy``
+227    function    ``str_hh_mm``
+232    function    ``str_hh_mm_ss``
+245    function    ``strDateTime``
+262    function    ``str``
+272    function    ``literal``
+286    function    ``time``
+386    function    ``parse``
+397    function    ``=``
+412    function    ``<>``
+428    function    ``<=``
+467    function    ``>=``
+506    function    ``<``
+515    function    ``>``
+525    function    ``compare``
+565    function    ``hashCode``
+575    function    ``truncToSecond``
+588    function    ``truncToMinute``
+602    function    ``truncToHour``
+617    function    ``truncToDay``
+633    function    ``truncToMonth``
+650    function    ``truncToYear``
+668    function    ``dayOfWeek``
+690    function    ``dayOfYear``
+710    function    ``weekOfYear``
+730    function    ``weekOfYear``
+742    function    ``weekDateYear``
+767    function    ``weekDateWeek``
+781    procedure   ``NORMALIZE``
+822    function    ``toUTC``
+842    function    ``toLocalTZ``
+867    function    ``setLocalTZ``
+884    function    ``julianDayNumber``
+910    function    ``julianDayNumToTime``
+937    function    ``timestamp1970``
+964    function    ``timestamp1970ToTime``
+981    function    ``timestamp1601``
+999    function    ``timestamp1601ToTime``
+1068   function    ``rand``
+1098   function    ``time``
+1112   function    ``time``
+1129   function    ``time``
+1148   function    ``timeInTimeZone``
+1166   function    ``date``
+1182   procedure   ``await``
+====== =========== ==================================================
+
+lib/tls.s7i
+-----------
+
+:Lines:    2230
+:Entities: 71
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+63     array       ``supportedCiphers``
+84     enumeration ``keyExchangeAlgorithm``
+88     structure   ``tlsParameters``
+225    array       ``curveByNumber``
+231    array       ``signatureHashByNumber``
+243    array       ``signatureSchemes``
+246    array       ``serverSignatureSchemesRsa``
+250    array       ``serverSignatureSchemesEcdsa``
+253    structure   ``tlsParseState``
+268    structure   ``tlsFile``
+275    structure   ``clientSession``
+298    function    ``getEllipticCurveNumber``
+322    procedure   ``storeCipherSuite``
+395    procedure   ``computeMasterSecret``
+413    procedure   ``storeKeys``
+476    function    ``verifySignature``
+516    function    ``genSignature``
+545    procedure   ``validateCertificates``
+595    procedure   ``processCertificate``
+601    array       ``cert``
+636    procedure   ``processClientCertificate``
+642    array       ``cert``
+668    procedure   ``processCertificateVerify``
+683    procedure   ``processEllipticCurvesExtension``
+704    procedure   ``processSignatureAlgorithmsExtension``
+736    procedure   ``processClientExtensions``
+760    procedure   ``processClientHello``
+826    procedure   ``processServerHello``
+867    procedure   ``processServerKeyExchange``
+929    procedure   ``processCertificateRequest``
+944    procedure   ``processServerHelloDone``
+958    procedure   ``processClientKeyExchange``
+1009   procedure   ``processChangeCipherSpec``
+1016   procedure   ``processFinished``
+1077   procedure   ``getTlsMsgRecord``
+1116   procedure   ``loadCompleteHandshakeMsg``
+1156   function    ``genExtension``
+1161   function    ``serverNameExtension``
+1166   function    ``genEllipticCurvesExtension``
+1179   function    ``int16BeArrayExtension``
+1192   function    ``genClientExtensions``
+1207   function    ``genClientHello``
+1241   function    ``genServerHello``
+1272   function    ``genCertificate``
+1298   function    ``genServerKeyExchange``
+1337   function    ``genCertificateRequest``
+1372   function    ``genServerHelloDone``
+1389   function    ``genClientKeyExchange``
+1439   function    ``genChangeCipherSpec``
+1454   function    ``genFinished``
+1507   function    ``genAlert``
+1523   function    ``tlsEncryptRecord``
+1580   function    ``tlsDecryptRecord``
+1648   procedure   ``sendAlertAndClose``
+1668   procedure   ``updateClientCache``
+1682   function    ``negotiateSecurityParameters``
+1769   function    ``openNewTlsSocket``
+1798   function    ``openTlsSocket``
+1887   function    ``openTlsSocket``
+1909   function    ``openTlsSocket``
+1923   function    ``openTlsSocket``
+1942   function    ``openServerTls``
+2065   procedure   ``close``
+2079   function    ``eof``
+2083   function    ``getApplicationData``
+2119   procedure   ``write``
+2145   procedure   ``writeln``
+2158   function    ``gets``
+2197   function    ``getln``
+2225   function    ``getServerCertificate``
+2228   function    ``getServerCertificate``
+====== =========== ==================================================
+
+lib/unicode.s7i
+---------------
+
+:Lines:    575
+:Entities: 15
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+43     function    ``toUtf8``
+61     function    ``fromUtf8``
+71     function    ``toUtf16Be``
+110    function    ``fromUtf16Be``
+164    function    ``toUtf16Le``
+203    function    ``fromUtf16Le``
+264    function    ``replaceUtf16SurrogatePairs``
+306    function    ``fromNullTerminatedUtf16Be``
+334    function    ``fromNullTerminatedUtf16Le``
+366    function    ``getNullTerminatedUtf16Be``
+393    function    ``getNullTerminatedUtf16Be``
+436    function    ``getNullTerminatedUtf16Le``
+463    function    ``getNullTerminatedUtf16Le``
+498    function    ``fromUtf7``
+502    array       ``decode``
+====== =========== ==================================================
+
+lib/unionfnd.s7i
+----------------
+
+:Lines:    130
+:Entities: 9
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     structure   ``unionfind``
+36     array       ``items``
+37     array       ``ranks``
+42     procedure   ``init_unionfind``
+53     function    ``num_groups``
+60     function    ``rank``
+77     function    ``group``
+92     procedure   ``union``
+116    function    ``is_connected``
+====== =========== ==================================================
+
+lib/upper.s7i
+-------------
+
+:Lines:    142
+:Entities: 10
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``upperFile``
+66     function    ``openUpper``
+81     procedure   ``write``
+90     procedure   ``writeln``
+100    procedure   ``writeln``
+106    procedure   ``moveLeft``
+112    procedure   ``erase``
+118    procedure   ``cursorOn``
+124    procedure   ``cursorOff``
+136    function    ``gets``
+====== =========== ==================================================
+
+lib/utf16.s7i
+-------------
+
+:Lines:    540
+:Entities: 19
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     structure   ``utf16File``
+50     procedure   ``close``
+60     procedure   ``flush``
+72     function    ``eof``
+81     function    ``hasNext``
+94     function    ``length``
+110    procedure   ``truncate``
+122    function    ``seekable``
+133    procedure   ``seek``
+149    function    ``tell``
+161    structure   ``utf16leFile``
+203    function    ``openUtf16le``
+227    procedure   ``write``
+259    function    ``gets``
+324    structure   ``utf16beFile``
+366    function    ``openUtf16be``
+390    procedure   ``write``
+422    function    ``gets``
+515    function    ``openUtf16``
+====== =========== ==================================================
+
+lib/utf8.s7i
+------------
+
+:Lines:    234
+:Entities: 15
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     structure   ``utf8File``
+47     function    ``utf8_getc``
+48     function    ``utf8_gets``
+50     function    ``utf8_word_read``
+52     function    ``utf8_line_read``
+54     procedure   ``utf8_write``
+55     procedure   ``utf8_seek``
+91     function    ``openUtf8``
+111    procedure   ``write``
+122    function    ``getc``
+132    function    ``gets``
+149    function    ``getwd``
+165    function    ``getln``
+181    procedure   ``seek``
+190    function    ``INIT_STD_UTF8_FILE``
+====== =========== ==================================================
+
+lib/vecfont10.s7i
+-----------------
+
+:Lines:    1056
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genVecFont10``
+====== =========== ==================================================
+
+lib/vecfont18.s7i
+-----------------
+
+:Lines:    1119
+:Entities: 1
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+32     function    ``genVecFont18``
+====== =========== ==================================================
+
+lib/vector3d.s7i
+----------------
+
+:Lines:    293
+:Entities: 22
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+37     structure   ``vector3d``
+48     function    ``vector3d``
+63     function    ``=``
+72     function    ``<>``
+80     function    ``-``
+94     function    ``+``
+108    function    ``-``
+122    function    ``*``
+136    function    ``/``
+149    procedure   ``+:=``
+160    procedure   ``-:=``
+171    procedure   ``*:=``
+182    procedure   ``/:=``
+194    function    ``abs``
+202    function    ``sqrAbs``
+210    function    ``dot``
+218    function    ``cross``
+233    function    ``reflect``
+241    function    ``unitVector``
+260    function    ``compare``
+278    function    ``hashCode``
+288    function    ``str``
+====== =========== ==================================================
+
+lib/vectorfont.s7i
+------------------
+
+:Lines:    239
+:Entities: 13
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+35     structure   ``charVectorType``
+37     array       ``points``
+47     structure   ``vectorFont``
+58     function    ``width``
+85     function    ``numOfCharsInWidth``
+117    function    ``genPixmap``
+149    function    ``genPixmapFont``
+176    function    ``getFontCharPixmap``
+191    procedure   ``setFont``
+203    function    ``pline``
+207    function    ``fillp``
+211    procedure   ``incl``
+227    function    ``columnWidth``
+====== =========== ==================================================
+
+lib/wildcard.s7i
+----------------
+
+:Lines:    140
+:Entities: 5
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+40     function    ``wildcardMatch``
+87     function    ``findMatchingFiles``
+90     array       ``matchingFiles``
+94     array       ``dirContent``
+138    function    ``findMatchingFiles``
+====== =========== ==================================================
+
+lib/window.s7i
+--------------
+
+:Lines:    455
+:Entities: 27
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+38     structure   ``window_file``
+57     function    ``openWindow``
+87     function    ``height``
+95     function    ``width``
+103    function    ``line``
+111    function    ``column``
+119    procedure   ``flush``
+133    procedure   ``box``
+172    procedure   ``clear_box``
+219    procedure   ``clear``
+235    procedure   ``clear``
+246    procedure   ``v_scroll``
+255    procedure   ``v_scroll``
+267    procedure   ``h_scroll``
+276    procedure   ``h_scroll``
+288    procedure   ``color``
+294    procedure   ``color``
+303    procedure   ``setPos``
+313    procedure   ``setLine``
+322    procedure   ``setColumn``
+331    procedure   ``write``
+359    procedure   ``writeln``
+373    procedure   ``moveLeft``
+388    procedure   ``erase``
+412    procedure   ``backSpace``
+429    procedure   ``cursorOn``
+443    procedure   ``cursorOff``
+====== =========== ==================================================
+
+lib/wrinum.s7i
+--------------
+
+:Lines:    248
+:Entities: 17
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+33     function    ``str``
+38     function    ``str_0_to_9``
+71     function    ``str``
+75     array       ``STR_0_TO_19``
+81     array       ``STR_20_TO_90``
+85     function    ``str_99``
+99     function    ``str_1E3``
+117    function    ``str_1E6``
+135    function    ``str_1E9``
+160    function    ``str``
+164    array       ``STR_0_TO_19``
+170    array       ``STR_0_TO_9``
+174    array       ``STR_20_TO_90``
+178    function    ``str_99``
+193    function    ``str_1E3``
+211    function    ``str_1E6``
+229    function    ``str_1E9``
+====== =========== ==================================================
+
+lib/x509cert.s7i
+----------------
+
+:Lines:    1243
+:Entities: 51
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+43     structure   ``x509Validity``
+48     structure   ``subjectPublicKeyInfoType``
+56     structure   ``x509Extension``
+62     structure   ``tbsCertificateType``
+70     array       ``extensions``
+83     structure   ``x509Cert``
+95     structure   ``certAndKey``
+96     array       ``certList``
+113    function    ``getRsaKey``
+137    function    ``genX509RsaKey``
+147    function    ``getEcdsaSignature``
+176    function    ``getEllipticCurveFromOid``
+200    function    ``getEllipticCurveOid``
+224    function    ``getEllipticCurve``
+283    function    ``getPublicKeyInfo``
+334    function    ``genX509PublicKeyInfo``
+355    function    ``getX509Name``
+394    function    ``x509Name``
+418    function    ``genX509Name``
+436    function    ``getTime_yymmddhhmmssZ``
+480    function    ``getTime_yyyymmddhhmmssfffZ``
+494    function    ``x509Validity``
+503    function    ``getX509Validity``
+531    function    ``genX509Validity``
+543    function    ``getTbsCertificate``
+579    function    ``getPkcs7SignedDataCert``
+642    function    ``getTbsCertificate``
+662    function    ``toAsn1``
+675    function    ``genX509TbsCertificate``
+702    function    ``getDigestOidFromAlgorithm``
+716    function    ``getDigestAlgorithm``
+734    function    ``getDigestFromSignatureAlgorithm``
+755    function    ``getDigestOidFromSignatureAlgorithm``
+776    procedure   ``showSignatureAlgorithm``
+804    function    ``getX509Cert``
+834    function    ``genX509Cert``
+859    function    ``genX509Cert``
+890    function    ``validateSignature``
+937    function    ``createX509Cert``
+967    function    ``createX509Cert``
+1003   function    ``createX509Cert``
+1035   function    ``createX509Cert``
+1073   function    ``x509KeyUsage``
+1091   function    ``x509BasicConstraints``
+1106   function    ``x509BasicConstraints``
+1127   procedure   ``addExtension``
+1135   function    ``certAndKey``
+1144   function    ``certAndKey``
+1163   function    ``selfSignedX509Cert``
+1189   function    ``selfSignedX509Cert``
+1218   function    ``selfSignedX509Cert``
+====== =========== ==================================================
+
+lib/xml_ent.s7i
+---------------
+
+:Lines:    94
+:Entities: 2
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+31     function    ``genPredeclaredXmlEntities``
+50     function    ``decodeXmlEntities``
+====== =========== ==================================================
+
+lib/xmldom.s7i
+--------------
+
+:Lines:    303
+:Entities: 25
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+48     function    ``getAttrValue``
+54     function    ``getAttributes``
+60     function    ``getSubNodes``
+66     function    ``getContent``
+69     procedure   ``writeXml``
+70     function    ``.``
+74     procedure   ``writeXml``
+83     structure   ``xmlBaseNode``
+91     function    ``getSubNodes``
+94     procedure   ``writeXml``
+107    structure   ``xmlText``
+114    function    ``getContent``
+117    procedure   ``writeXml``
+137    structure   ``xmlElement``
+145    function    ``getAttrValue``
+148    function    ``getAttributes``
+151    procedure   ``writeXml``
+168    structure   ``xmlContainer``
+169    array       ``subNodes``
+175    function    ``getSubNodes``
+178    procedure   ``writeXml``
+202    function    ``readXmlNode``
+264    function    ``readXml``
+284    function    ``readXml``
+295    procedure   ``for``
+====== =========== ==================================================
+
+lib/xz.s7i
+----------
+
+:Lines:    442
+:Entities: 18
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+41     structure   ``xzFilterFlags``
+47     function    ``xzFilterFlags``
+63     function    ``xzDictionarySize``
+79     function    ``xzPacket``
+147    structure   ``xzBlockHeader``
+152    array       ``filterFlags``
+156    function    ``readXzBlockHeader``
+198    procedure   ``readXzBlockHeader``
+237    function    ``xzDecompress``
+269    structure   ``xzFile``
+287    function    ``openXzFile``
+320    function    ``getc``
+342    function    ``gets``
+372    function    ``eof``
+381    function    ``hasNext``
+398    function    ``length``
+424    procedure   ``seek``
+440    function    ``tell``
+====== =========== ==================================================
+
+lib/zip.s7i
+-----------
+
+:Lines:    2792
+:Entities: 91
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+104    function    ``rposOfMagic``
+129    function    ``getExtraFieldMap``
+157    function    ``extraFieldFromMap``
+171    procedure   ``writeExtraField``
+197    structure   ``local_file_header``
+216    procedure   ``write``
+235    procedure   ``considerZip64ExtraField``
+253    function    ``get_local_header``
+300    function    ``str``
+320    procedure   ``writeHead``
+326    structure   ``zip64_end_of_central_dir_locator``
+334    procedure   ``write``
+343    function    ``get_zip64_end_of_central_dir_locator``
+361    structure   ``zip64_end_of_central_directory``
+376    procedure   ``write``
+392    function    ``get_zip64_end_of_central_directory``
+419    structure   ``end_of_central_directory``
+432    procedure   ``write``
+446    function    ``get_end_of_central_directory``
+470    function    ``str``
+486    function    ``readEndOfCentralDir``
+543    structure   ``central_file_header``
+569    procedure   ``write``
+596    procedure   ``considerZip64ExtraField``
+624    function    ``get_central_header``
+680    function    ``str``
+707    procedure   ``writeHead``
+713    function    ``getCentralHeaderFilePath``
+749    function    ``toLocalHeader``
+768    procedure   ``updateLocalHeader``
+781    procedure   ``initLastModFileTime``
+802    procedure   ``assignLastModFileTime``
+833    procedure   ``assignLastModFileTime``
+864    procedure   ``assignUserId``
+886    procedure   ``assignUserId``
+908    procedure   ``assignGroupId``
+932    procedure   ``assignGroupId``
+972    structure   ``zipArchive``
+991    function    ``openZip``
+1042   function    ``openZip``
+1053   function    ``openZip``
+1070   function    ``openZip``
+1077   procedure   ``close``
+1083   function    ``addToCatalog``
+1093   function    ``addImplicitDir``
+1105   function    ``isRegularFile``
+1121   function    ``isSymlink``
+1127   function    ``followSymlink``
+1178   function    ``followSymlink``
+1192   procedure   ``fixRegisterAndCatalog``
+1219   procedure   ``initializeFileReferenceMap``
+1245   function    ``getReferencePaths``
+1248   array       ``filePathList``
+1275   function    ``readDir``
+1286   function    ``readDir``
+1301   function    ``fileType``
+1379   function    ``fileTypeSL``
+1430   function    ``getFileMode``
+1484   procedure   ``setFileMode``
+1513   function    ``fileSize``
+1535   function    ``getMTime``
+1588   procedure   ``setMTime``
+1620   function    ``getOwner``
+1663   procedure   ``setOwner``
+1701   function    ``getGroup``
+1746   procedure   ``setGroup``
+1785   function    ``getFileMode``
+1823   function    ``getMTime``
+1891   procedure   ``setMTime``
+1936   function    ``getOwner``
+1993   procedure   ``setOwner``
+2044   function    ``getGroup``
+2103   procedure   ``setGroup``
+2152   function    ``readLink``
+2211   procedure   ``makeLink``
+2272   function    ``lzwDecompressShrink``
+2286   function    ``getFile``
+2289   function    ``getReference``
+2321   function    ``crc32``
+2325   procedure   ``updateKeys``
+2334   procedure   ``initializeEncryptionKeys``
+2347   function    ``decryptByte``
+2358   function    ``decrypt``
+2373   function    ``openEncryptFile``
+2397   procedure   ``readDataDescriptor``
+2445   function    ``getFile``
+2515   procedure   ``putFile``
+2636   procedure   ``makeDir``
+2713   procedure   ``removeFile``
+2767   function    ``getZipContent``
+2784   procedure   ``for``
+====== =========== ==================================================
+
+lib/zstd.s7i
+------------
+
+:Lines:    1263
+:Entities: 69
+
+====== =========== ==================================================
+ Line   Type        Name
+====== =========== ==================================================
+36     structure   ``zstdFrameHeader``
+44     function    ``zstdWindowSize``
+57     procedure   ``readFrameHeader``
+123    structure   ``fseWeightsType``
+128    structure   ``fseTableEntry``
+135    structure   ``fseDecodingType``
+137    array       ``decodingTable``
+141    function    ``getFseCompressedHuffmanWeights``
+200    function    ``buildDecodingTable``
+204    array       ``nextStateOfSymbol``
+266    function    ``repeatingFseDecodingTable``
+277    procedure   ``symbolTranslation``
+293    function    ``peekSymbol``
+297    procedure   ``nextState``
+309    function    ``getAdditionalBits``
+313    function    ``decodeInterleavedFseStreams``
+316    array       ``weights``
+319    array       ``fseState``
+351    structure   ``zstdHuffmanDecoder``
+353    array       ``numberOfBits``
+354    array       ``symbols``
+358    function    ``createZstdHuffmanDecoder``
+368    array       ``rankIdx``
+400    function    ``createZstdHuffmanDecoder``
+411    array       ``numBits``
+412    array       ``rankCount``
+454    function    ``readZstdHuffmanTreeWeights``
+456    array       ``weights``
+492    function    ``decodeSymbol``
+507    function    ``decodeStream``
+537    structure   ``zstdLiteralSectionHeader``
+545    function    ``readZstdLiteralsSectionHeader``
+603    structure   ``zstdSequencesSectionType``
+610    structure   ``zstdBlockStateType``
+611    array       ``offsetHistory``
+617    function    ``readCompressedLiteralsBlock``
+624    array       ``weights``
+625    array       ``streamSize``
+626    array       ``compressedStream``
+662    function    ``readLiteralsSection``
+685    structure   ``zstdSequencesSectionHeader``
+693    function    ``readZstdSequencesSectionHeader``
+721    structure   ``zstdSequenceState``
+727    structure   ``zstdSequenceType``
+733    array       ``zstdLiteralLengthBaseValueTranslation``
+741    array       ``zstdLiteralLengthExtraBits``
+746    array       ``zstdMatchLengthBaseValueTranslation``
+753    array       ``zstdMatchLengthsExtraBits``
+759    function    ``buildZstdLiteralLengthsTable``
+764    array       ``literalLengthDefaultDistributions``
+782    function    ``buildZstdOffsetTable``
+787    array       ``offsetDefaultDistribution``
+802    function    ``buildZstdMatchLengthsTable``
+807    array       ``matchLengthDefaultDistribution``
+825    procedure   ``initDecodeTables``
+888    function    ``decodeSequence``
+918    procedure   ``decodeSequences``
+1012   procedure   ``readCompressedBlock``
+1035   function    ``zstdBlock``
+1071   function    ``zstdDecompress``
+1095   structure   ``zstdFile``
+1113   function    ``openZstdFile``
+1141   function    ``getc``
+1163   function    ``gets``
+1193   function    ``eof``
+1202   function    ``hasNext``
+1219   function    ``length``
+1245   procedure   ``seek``
+1261   function    ``tell``
+====== =========== ==================================================
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-05.1.rst
+++ b/reports/seed7mode-perf-05.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-23T14:10:42+0000 W26-2
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 10:15:22 local time
+:Generated on: 2026-06-23 14:26:31 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 261x90 chars
+:Window body: 261x88 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.034796            190
+seed7/prg/bas7.sd7           0.034174          11459
+seed7/prg/bifurk.sd7         0.033880             73
+seed7/prg/bigfiles.sd7       0.033509            129
+seed7/prg/brainf7.sd7        0.033691             86
+seed7/prg/calc7.sd7          0.033752            128
+seed7/prg/carddemo.sd7       0.033476            190
+seed7/prg/castle.sd7         0.033681           3148
+seed7/prg/cat.sd7            0.033787             82
+seed7/prg/cellauto.sd7       0.033511             85
+seed7/prg/celsius.sd7        0.033444             42
+seed7/prg/chk_all.sd7        0.033352            843
+seed7/prg/chkarr.sd7         0.033984           8367
+seed7/prg/chkbig.sd7         0.037948          29026
+seed7/prg/chkbin.sd7         0.034323           6469
+seed7/prg/chkbitdata.sd7     0.033666           6624
+seed7/prg/chkbool.sd7        0.032841           3157
+seed7/prg/chkbst.sd7         0.032806            722
+seed7/prg/chkchr.sd7         0.033139           2809
+seed7/prg/chkcmd.sd7         0.032508           1205
+seed7/prg/chkdb.sd7          0.033211           7454
+seed7/prg/chkdecl.sd7        0.034496            448
+seed7/prg/chkenum.sd7        0.033569           1230
+seed7/prg/chkerr.sd7         0.033429           4663
+seed7/prg/chkexc.sd7         0.033022           2627
+seed7/prg/chkfil.sd7         0.033077           1615
+seed7/prg/chkflt.sd7         0.036914          20620
+seed7/prg/chkhent.sd7        0.032417             54
+seed7/prg/chkhsh.sd7         0.033075           4548
+seed7/prg/chkidx.sd7         0.035016          19567
+seed7/prg/chkint.sd7         0.039114          38129
+seed7/prg/chkjson.sd7        0.032740           1764
+seed7/prg/chkovf.sd7         0.034049           8216
+seed7/prg/chkprc.sd7         0.032877          10111
+seed7/prg/chkscan.sd7        0.033346            714
+seed7/prg/chkset.sd7         0.034030          11974
+seed7/prg/chkstr.sd7         0.038152          26952
+seed7/prg/chktime.sd7        0.034085           2025
+seed7/prg/chktoml.sd7        0.033652           1656
+seed7/prg/clock.sd7          0.032698             47
+seed7/prg/clock2.sd7         0.033458             43
+seed7/prg/clock3.sd7         0.033704             95
+seed7/prg/cmpfil.sd7         0.033595             84
+seed7/prg/comanche.sd7       0.033667            180
+seed7/prg/confval.sd7        0.033844            175
+seed7/prg/db7.sd7            0.033076            417
+seed7/prg/diff7.sd7          0.032741            263
+seed7/prg/dirtst.sd7         0.032631             42
+seed7/prg/dirx.sd7           0.032511            152
+seed7/prg/dnafight.sd7       0.032577           1381
+seed7/prg/dragon.sd7         0.032487             73
+seed7/prg/echo.sd7           0.033905             39
+seed7/prg/eliza.sd7          0.033449            302
+seed7/prg/err.sd7            0.033961             96
+seed7/prg/fannkuch.sd7       0.034980            131
+seed7/prg/fib.sd7            0.034005             47
+seed7/prg/find7.sd7          0.033679            133
+seed7/prg/findchar.sd7       0.033437            149
+seed7/prg/fractree.sd7       0.033776             55
+seed7/prg/ftp7.sd7           0.033489            296
+seed7/prg/ftpserv.sd7        0.033538             74
+seed7/prg/gcd.sd7            0.033605            109
+seed7/prg/gkbd.sd7           0.033747            358
+seed7/prg/gtksvtst.sd7       0.035122             94
+seed7/prg/hal.sd7            0.033752            250
+seed7/prg/hamu.sd7           0.033674            573
+seed7/prg/hanoi.sd7          0.033599             55
+seed7/prg/hd.sd7             0.033778             79
+seed7/prg/hello.sd7          0.033613             32
+seed7/prg/hilbert.sd7        0.033496            108
+seed7/prg/ide7.sd7           0.035847            196
+seed7/prg/kbd.sd7            0.035248             49
+seed7/prg/klondike.sd7       0.033904            883
+seed7/prg/lander.sd7         0.033715           1551
+seed7/prg/lst80bas.sd7       0.033638            344
+seed7/prg/lst99bas.sd7       0.033251            401
+seed7/prg/lstgwbas.sd7       0.032668            577
+seed7/prg/mahjong.sd7        0.032881           1943
+seed7/prg/make7.sd7          0.033153            121
+seed7/prg/mandelbr.sd7       0.032445            237
+seed7/prg/mind.sd7           0.032368            443
+seed7/prg/mirror.sd7         0.034342            131
+seed7/prg/ms.sd7             0.033931            641
+seed7/prg/nicoma.sd7         0.033624            135
+seed7/prg/pac.sd7            0.033602            726
+seed7/prg/pairs.sd7          0.034120           2025
+seed7/prg/panic.sd7          0.033894           2634
+seed7/prg/percolation.sd7    0.033308            330
+seed7/prg/planets.sd7        0.033722           1486
+seed7/prg/portfwd7.sd7       0.033676            139
+seed7/prg/prime.sd7          0.033828             74
+seed7/prg/printpi1.sd7       0.033576             56
+seed7/prg/printpi2.sd7       0.033634             54
+seed7/prg/printpi3.sd7       0.033477             60
+seed7/prg/pv7.sd7            0.033779            337
+seed7/prg/queen.sd7          0.033260            149
+seed7/prg/rand.sd7           0.033804            121
+seed7/prg/raytrace.sd7       0.033545            538
+seed7/prg/rever.sd7          0.033531            816
+seed7/prg/roman.sd7          0.033518             38
+seed7/prg/s7c.sd7            0.034290           9060
+seed7/prg/s7check.sd7        0.033440             68
+seed7/prg/savehd7.sd7        0.033611           1110
+seed7/prg/self.sd7           0.033187             49
+seed7/prg/shisen.sd7         0.033699           1423
+seed7/prg/sl.sd7             0.033598           1029
+seed7/prg/snake.sd7          0.033345            615
+seed7/prg/sokoban.sd7        0.033026            891
+seed7/prg/spigotpi.sd7       0.032637             64
+seed7/prg/sql7.sd7           0.032235            278
+seed7/prg/startrek.sd7       0.032396            979
+seed7/prg/sudoku7.sd7        0.032639           2657
+seed7/prg/sydir7.sd7         0.032759            384
+seed7/prg/syntaxhl.sd7       0.034048            177
+seed7/prg/tak.sd7            0.032393             59
+seed7/prg/tar7.sd7           0.032783            121
+seed7/prg/tch.sd7            0.032813             55
+seed7/prg/testfont.sd7       0.032821             95
+seed7/prg/tet.sd7            0.032641            479
+seed7/prg/tetg.sd7           0.032275            501
+seed7/prg/toutf8.sd7         0.032460            240
+seed7/prg/tst_cli.sd7        0.033250             40
+seed7/prg/tst_srv.sd7        0.033530             47
+seed7/prg/wator.sd7          0.033300            651
+seed7/prg/which.sd7          0.033638             65
+seed7/prg/wiz.sd7            0.033398           2833
+seed7/prg/wordcnt.sd7        0.033471             54
+seed7/prg/wrinum.sd7         0.033655             43
+seed7/prg/wumpus.sd7         0.033425            372
+seed7/lib/aes.s7i            0.033656           1144
+seed7/lib/aes_gcm.s7i        0.033617            392
+seed7/lib/ar.s7i             0.033553           1532
+seed7/lib/arc4.s7i           0.033270            144
+seed7/lib/archive.s7i        0.033333            143
+seed7/lib/archive_base.s7i   0.033468            135
+seed7/lib/array.s7i          0.033583            610
+seed7/lib/asn1.s7i           0.033678            544
+seed7/lib/asn1oid.s7i        0.034220            157
+seed7/lib/basearray.s7i      0.033602            450
+seed7/lib/bigfile.s7i        0.033149            136
+seed7/lib/bigint.s7i         0.032450            824
+seed7/lib/bigrat.s7i         0.033007            784
+seed7/lib/bin16.s7i          0.032577            592
+seed7/lib/bin32.s7i          0.032867            490
+seed7/lib/bin64.s7i          0.033387            539
+seed7/lib/bitdata.s7i        0.035173           1330
+seed7/lib/bitmapfont.s7i     0.035052            215
+seed7/lib/bitset.s7i         0.033532            593
+seed7/lib/bitsetof.s7i       0.034038            431
+seed7/lib/blowfish.s7i       0.035319            383
+seed7/lib/bmp.s7i            0.035131            924
+seed7/lib/boolean.s7i        0.033776            403
+seed7/lib/browser.s7i        0.033906            280
+seed7/lib/bstring.s7i        0.033423            227
+seed7/lib/bytedata.s7i       0.033972            482
+seed7/lib/bzip2.s7i          0.033997            887
+seed7/lib/cards.s7i          0.033549           1342
+seed7/lib/category.s7i       0.034003            209
+seed7/lib/cc_conf.s7i        0.033599           1314
+seed7/lib/ccittfax.s7i       0.032759           1022
+seed7/lib/cgi.s7i            0.032480            109
+seed7/lib/cgidialog.s7i      0.032991           1118
+seed7/lib/char.s7i           0.032496            356
+seed7/lib/charsets.s7i       0.032765           2024
+seed7/lib/chartype.s7i       0.032706            121
+seed7/lib/cipher.s7i         0.033602            146
+seed7/lib/cli_cmds.s7i       0.032633           1360
+seed7/lib/clib_file.s7i      0.032675            301
+seed7/lib/color.s7i          0.033444            185
+seed7/lib/complex.s7i        0.035342            464
+seed7/lib/compress.s7i       0.039587            150
+seed7/lib/console.s7i        0.034477            188
+seed7/lib/cpio.s7i           0.032601           1708
+seed7/lib/crc32.s7i          0.032793            193
+seed7/lib/cronos16.s7i       0.033141           1173
+seed7/lib/cronos27.s7i       0.032748           1464
+seed7/lib/csv.s7i            0.034384            201
+seed7/lib/db_prop.s7i        0.033599            991
+seed7/lib/deflate.s7i        0.033434            740
+seed7/lib/des.s7i            0.033452            444
+seed7/lib/dialog.s7i         0.033670            311
+seed7/lib/dir.s7i            0.033843            163
+seed7/lib/draw.s7i           0.033589            854
+seed7/lib/duration.s7i       0.033629           1038
+seed7/lib/echo.s7i           0.033809            132
+seed7/lib/editline.s7i       0.033587            398
+seed7/lib/elf.s7i            0.033636           1560
+seed7/lib/elliptic.s7i       0.033922            649
+seed7/lib/enable_io.s7i      0.033416            312
+seed7/lib/encoding.s7i       0.034019            931
+seed7/lib/enumeration.s7i    0.034023            236
+seed7/lib/environment.s7i    0.033660            175
+seed7/lib/exif.s7i           0.033606            152
+seed7/lib/external_file.s7i  0.033734            340
+seed7/lib/field.s7i          0.033356            268
+seed7/lib/file.s7i           0.033731            372
+seed7/lib/filebits.s7i       0.033144             46
+seed7/lib/filesys.s7i        0.033441            601
+seed7/lib/fileutil.s7i       0.033510            144
+seed7/lib/fixarray.s7i       0.033922            307
+seed7/lib/float.s7i          0.033193            757
+seed7/lib/font.s7i           0.032749            196
+seed7/lib/font8x8.s7i        0.033163            998
+seed7/lib/forloop.s7i        0.032477            449
+seed7/lib/ftp.s7i            0.032887            969
+seed7/lib/ftpserv.s7i        0.032762            631
+seed7/lib/getf.s7i           0.034538            115
+seed7/lib/gethttp.s7i        0.033687             41
+seed7/lib/gethttps.s7i       0.033669             41
+seed7/lib/gif.s7i            0.033465            561
+seed7/lib/graph.s7i          0.033650            415
+seed7/lib/graph_file.s7i     0.033741            399
+seed7/lib/gtkserver.s7i      0.033285            161
+seed7/lib/gzip.s7i           0.033201            573
+seed7/lib/hash.s7i           0.033073            421
+seed7/lib/hashsetof.s7i      0.033522            499
+seed7/lib/hmac.s7i           0.033884            152
+seed7/lib/html.s7i           0.033568             83
+seed7/lib/html_ent.s7i       0.033708            476
+seed7/lib/htmldom.s7i        0.033298            286
+seed7/lib/http_request.s7i   0.032744            696
+seed7/lib/http_srv_resp.s7i  0.032511            380
+seed7/lib/https_request.s7i  0.032112            211
+seed7/lib/httpserv.s7i       0.032131            345
+seed7/lib/huffman.s7i        0.032680            644
+seed7/lib/ico.s7i            0.032731            221
+seed7/lib/idxarray.s7i       0.033593            232
+seed7/lib/image.s7i          0.033311            156
+seed7/lib/imagefile.s7i      0.033611            171
+seed7/lib/inflate.s7i        0.033696            411
+seed7/lib/inifile.s7i        0.033213            129
+seed7/lib/integer.s7i        0.033711            663
+seed7/lib/iobuffer.s7i       0.033307            289
+seed7/lib/jpeg.s7i           0.033367           1761
+seed7/lib/json.s7i           0.033161            891
+seed7/lib/json_serde.s7i     0.032683            783
+seed7/lib/keybd.s7i          0.032566            639
+seed7/lib/keydescr.s7i       0.032528            192
+seed7/lib/leb128.s7i         0.033836            218
+seed7/lib/line.s7i           0.032529            164
+seed7/lib/listener.s7i       0.033035            247
+seed7/lib/logfile.s7i        0.032239             73
+seed7/lib/lower.s7i          0.034259            142
+seed7/lib/lzma.s7i           0.033926            934
+seed7/lib/lzw.s7i            0.033523            861
+seed7/lib/magic.s7i          0.033619            403
+seed7/lib/mahjng32.s7i       0.033683           1500
+seed7/lib/make.s7i           0.033627            544
+seed7/lib/makedata.s7i       0.034931           1428
+seed7/lib/math.s7i           0.035446            201
+seed7/lib/mixarith.s7i       0.033477            249
+seed7/lib/modern27.s7i       0.034158           1099
+seed7/lib/more.s7i           0.033663            130
+seed7/lib/msgdigest.s7i      0.033709           1222
+seed7/lib/multiscr.s7i       0.033610             68
+seed7/lib/null_file.s7i      0.034369            345
+seed7/lib/osfiles.s7i        0.034217           1085
+seed7/lib/pbm.s7i            0.033722            230
+seed7/lib/pcx.s7i            0.033673            638
+seed7/lib/pem.s7i            0.033517            185
+seed7/lib/pgm.s7i            0.033626            238
+seed7/lib/pic16.s7i          0.033613           1037
+seed7/lib/pic32.s7i          0.033421           2060
+seed7/lib/pic_util.s7i       0.033272            144
+seed7/lib/pixelimage.s7i     0.033786            320
+seed7/lib/pixmap_file.s7i    0.032816            459
+seed7/lib/pixmapfont.s7i     0.032550            184
+seed7/lib/pkcs1.s7i          0.033123            543
+seed7/lib/png.s7i            0.032649           1064
+seed7/lib/poll.s7i           0.032754            313
+seed7/lib/ppm.s7i            0.033908            240
+seed7/lib/process.s7i        0.033854            541
+seed7/lib/progs.s7i          0.033872            789
+seed7/lib/propertyfile.s7i   0.034201            155
+seed7/lib/rational.s7i       0.033942            792
+seed7/lib/ref_list.s7i       0.033643            252
+seed7/lib/reference.s7i      0.033782            126
+seed7/lib/reverse.s7i        0.033525             94
+seed7/lib/rpm.s7i            0.033944           3487
+seed7/lib/rpmext.s7i         0.033590            318
+seed7/lib/scanfile.s7i       0.036263           1779
+seed7/lib/scanjson.s7i       0.041882            413
+seed7/lib/scanstri.s7i       0.035374           1814
+seed7/lib/scantoml.s7i       0.033136           1603
+seed7/lib/seed7_05.s7i       0.032811           1072
+seed7/lib/set.s7i            0.032618             57
+seed7/lib/shell.s7i          0.033595            615
+seed7/lib/showtls.s7i        0.033526            678
+seed7/lib/signature.s7i      0.032557            131
+seed7/lib/smtp.s7i           0.033966            261
+seed7/lib/sockbase.s7i       0.033621            217
+seed7/lib/socket.s7i         0.033524            326
+seed7/lib/sokoban1.s7i       0.033687           1519
+seed7/lib/sql_base.s7i       0.034034           1000
+seed7/lib/stars.s7i          0.033658           1705
+seed7/lib/stdfont10.s7i      0.033170           3347
+seed7/lib/stdfont12.s7i      0.032594           3928
+seed7/lib/stdfont14.s7i      0.032622           4510
+seed7/lib/stdfont16.s7i      0.033854           5092
+seed7/lib/stdfont18.s7i      0.033512           5868
+seed7/lib/stdfont20.s7i      0.032910           6449
+seed7/lib/stdfont24.s7i      0.034738           7421
+seed7/lib/stdfont8.s7i       0.041809           2960
+seed7/lib/stdfont9.s7i       0.036319           3152
+seed7/lib/stdio.s7i          0.033310            192
+seed7/lib/strifile.s7i       0.033190            345
+seed7/lib/string.s7i         0.033302            779
+seed7/lib/stritext.s7i       0.033245            352
+seed7/lib/struct.s7i         0.033511            266
+seed7/lib/struct_elem.s7i    0.033296            129
+seed7/lib/subfile.s7i        0.033590            174
+seed7/lib/subrange.s7i       0.033289             78
+seed7/lib/syntax.s7i         0.034372            294
+seed7/lib/tar.s7i            0.034790           1880
+seed7/lib/tar_cmds.s7i       0.033747            752
+seed7/lib/tdes.s7i           0.035002            143
+seed7/lib/tee.s7i            0.034242            143
+seed7/lib/text.s7i           0.033898            135
+seed7/lib/tga.s7i            0.035152            676
+seed7/lib/tiff.s7i           0.033503           2771
+seed7/lib/time.s7i           0.033433           1191
+seed7/lib/tls.s7i            0.034799           2230
+seed7/lib/unicode.s7i        0.034323            575
+seed7/lib/unionfnd.s7i       0.034569            130
+seed7/lib/upper.s7i          0.034422            142
+seed7/lib/utf16.s7i          0.033130            540
+seed7/lib/utf8.s7i           0.033679            234
+seed7/lib/vecfont10.s7i      0.032744           1056
+seed7/lib/vecfont18.s7i      0.032699           1119
+seed7/lib/vector3d.s7i       0.032616            293
+seed7/lib/vectorfont.s7i     0.033125            239
+seed7/lib/wildcard.s7i       0.032417            140
+seed7/lib/window.s7i         0.032938            455
+seed7/lib/wrinum.s7i         0.035344            248
+seed7/lib/x509cert.s7i       0.032578           1243
+seed7/lib/xml_ent.s7i        0.032608             94
+seed7/lib/xmldom.s7i         0.033463            303
+seed7/lib/xz.s7i             0.033214            442
+seed7/lib/zip.s7i            0.033248           2792
+seed7/lib/zstd.s7i           0.033585           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033634        |
++-----------+-----------------+
+| Minimum   | 0.032112        |
++-----------+-----------------+
+| Maximum   | 0.041882        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.040150            190
+seed7/prg/bas7.sd7           0.039666          11459
+seed7/prg/bifurk.sd7         0.036629             73
+seed7/prg/bigfiles.sd7       0.038249            129
+seed7/prg/brainf7.sd7        0.037301             86
+seed7/prg/calc7.sd7          0.037861            128
+seed7/prg/carddemo.sd7       0.038517            190
+seed7/prg/castle.sd7         0.039330           3148
+seed7/prg/cat.sd7            0.037022             82
+seed7/prg/cellauto.sd7       0.037723             85
+seed7/prg/celsius.sd7        0.036118             42
+seed7/prg/chk_all.sd7        0.039264            843
+seed7/prg/chkarr.sd7         0.039719           8367
+seed7/prg/chkbig.sd7         0.042809          29026
+seed7/prg/chkbin.sd7         0.041644           6469
+seed7/prg/chkbitdata.sd7     0.040797           6624
+seed7/prg/chkbool.sd7        0.038644           3157
+seed7/prg/chkbst.sd7         0.039085            722
+seed7/prg/chkchr.sd7         0.040657           2809
+seed7/prg/chkcmd.sd7         0.037235           1205
+seed7/prg/chkdb.sd7          0.040413           7454
+seed7/prg/chkdecl.sd7        0.039411            448
+seed7/prg/chkenum.sd7        0.037510           1230
+seed7/prg/chkerr.sd7         0.038413           4663
+seed7/prg/chkexc.sd7         0.036261           2627
+seed7/prg/chkfil.sd7         0.037666           1615
+seed7/prg/chkflt.sd7         0.041313          20620
+seed7/prg/chkhent.sd7        0.036742             54
+seed7/prg/chkhsh.sd7         0.040308           4548
+seed7/prg/chkidx.sd7         0.041373          19567
+seed7/prg/chkint.sd7         0.045739          38129
+seed7/prg/chkjson.sd7        0.039013           1764
+seed7/prg/chkovf.sd7         0.039786           8216
+seed7/prg/chkprc.sd7         0.038370          10111
+seed7/prg/chkscan.sd7        0.039014            714
+seed7/prg/chkset.sd7         0.040724          11974
+seed7/prg/chkstr.sd7         0.043327          26952
+seed7/prg/chktime.sd7        0.040018           2025
+seed7/prg/chktoml.sd7        0.039047           1656
+seed7/prg/clock.sd7          0.036023             47
+seed7/prg/clock2.sd7         0.035795             43
+seed7/prg/clock3.sd7         0.038875             95
+seed7/prg/cmpfil.sd7         0.036452             84
+seed7/prg/comanche.sd7       0.037622            180
+seed7/prg/confval.sd7        0.038707            175
+seed7/prg/db7.sd7            0.038058            417
+seed7/prg/diff7.sd7          0.037806            263
+seed7/prg/dirtst.sd7         0.035079             42
+seed7/prg/dirx.sd7           0.037295            152
+seed7/prg/dnafight.sd7       0.037920           1381
+seed7/prg/dragon.sd7         0.035971             73
+seed7/prg/echo.sd7           0.034540             39
+seed7/prg/eliza.sd7          0.037254            302
+seed7/prg/err.sd7            0.039810             96
+seed7/prg/fannkuch.sd7       0.038760            131
+seed7/prg/fib.sd7            0.036104             47
+seed7/prg/find7.sd7          0.038784            133
+seed7/prg/findchar.sd7       0.038867            149
+seed7/prg/fractree.sd7       0.036663             55
+seed7/prg/ftp7.sd7           0.038367            296
+seed7/prg/ftpserv.sd7        0.037173             74
+seed7/prg/gcd.sd7            0.037138            109
+seed7/prg/gkbd.sd7           0.039011            358
+seed7/prg/gtksvtst.sd7       0.039098             94
+seed7/prg/hal.sd7            0.037360            250
+seed7/prg/hamu.sd7           0.038566            573
+seed7/prg/hanoi.sd7          0.036127             55
+seed7/prg/hd.sd7             0.037910             79
+seed7/prg/hello.sd7          0.038399             32
+seed7/prg/hilbert.sd7        0.039162            108
+seed7/prg/ide7.sd7           0.038865            196
+seed7/prg/kbd.sd7            0.035993             49
+seed7/prg/klondike.sd7       0.038683            883
+seed7/prg/lander.sd7         0.039040           1551
+seed7/prg/lst80bas.sd7       0.039104            344
+seed7/prg/lst99bas.sd7       0.037465            401
+seed7/prg/lstgwbas.sd7       0.036462            577
+seed7/prg/mahjong.sd7        0.037727           1943
+seed7/prg/make7.sd7          0.038643            121
+seed7/prg/mandelbr.sd7       0.037839            237
+seed7/prg/mind.sd7           0.039497            443
+seed7/prg/mirror.sd7         0.038724            131
+seed7/prg/ms.sd7             0.038558            641
+seed7/prg/nicoma.sd7         0.038923            135
+seed7/prg/pac.sd7            0.038727            726
+seed7/prg/pairs.sd7          0.039076           2025
+seed7/prg/panic.sd7          0.039606           2634
+seed7/prg/percolation.sd7    0.038833            330
+seed7/prg/planets.sd7        0.039674           1486
+seed7/prg/portfwd7.sd7       0.038714            139
+seed7/prg/prime.sd7          0.037110             74
+seed7/prg/printpi1.sd7       0.036625             56
+seed7/prg/printpi2.sd7       0.036325             54
+seed7/prg/printpi3.sd7       0.036192             60
+seed7/prg/pv7.sd7            0.038394            337
+seed7/prg/queen.sd7          0.039050            149
+seed7/prg/rand.sd7           0.038453            121
+seed7/prg/raytrace.sd7       0.038785            538
+seed7/prg/rever.sd7          0.038842            816
+seed7/prg/roman.sd7          0.035834             38
+seed7/prg/s7c.sd7            0.038496           9060
+seed7/prg/s7check.sd7        0.036449             68
+seed7/prg/savehd7.sd7        0.037649           1110
+seed7/prg/self.sd7           0.035146             49
+seed7/prg/shisen.sd7         0.037571           1423
+seed7/prg/sl.sd7             0.037195           1029
+seed7/prg/snake.sd7          0.037750            615
+seed7/prg/sokoban.sd7        0.039539            891
+seed7/prg/spigotpi.sd7       0.036679             64
+seed7/prg/sql7.sd7           0.038496            278
+seed7/prg/startrek.sd7       0.038969            979
+seed7/prg/sudoku7.sd7        0.039065           2657
+seed7/prg/sydir7.sd7         0.039076            384
+seed7/prg/syntaxhl.sd7       0.041083            177
+seed7/prg/tak.sd7            0.036373             59
+seed7/prg/tar7.sd7           0.038899            121
+seed7/prg/tch.sd7            0.036918             55
+seed7/prg/testfont.sd7       0.039007             95
+seed7/prg/tet.sd7            0.038650            479
+seed7/prg/tetg.sd7           0.038724            501
+seed7/prg/toutf8.sd7         0.039019            240
+seed7/prg/tst_cli.sd7        0.035628             40
+seed7/prg/tst_srv.sd7        0.035739             47
+seed7/prg/wator.sd7          0.038218            651
+seed7/prg/which.sd7          0.035831             65
+seed7/prg/wiz.sd7            0.038487           2833
+seed7/prg/wordcnt.sd7        0.036544             54
+seed7/prg/wrinum.sd7         0.036215             43
+seed7/prg/wumpus.sd7         0.038682            372
+seed7/lib/aes.s7i            0.040624           1144
+seed7/lib/aes_gcm.s7i        0.038222            392
+seed7/lib/ar.s7i             0.037985           1532
+seed7/lib/arc4.s7i           0.037681            144
+seed7/lib/archive.s7i        0.038013            143
+seed7/lib/archive_base.s7i   0.038774            135
+seed7/lib/array.s7i          0.037493            610
+seed7/lib/asn1.s7i           0.036471            544
+seed7/lib/asn1oid.s7i        0.040859            157
+seed7/lib/basearray.s7i      0.038035            450
+seed7/lib/bigfile.s7i        0.038812            136
+seed7/lib/bigint.s7i         0.038401            824
+seed7/lib/bigrat.s7i         0.038958            784
+seed7/lib/bin16.s7i          0.039168            592
+seed7/lib/bin32.s7i          0.038683            490
+seed7/lib/bin64.s7i          0.038635            539
+seed7/lib/bitdata.s7i        0.044644           1330
+seed7/lib/bitmapfont.s7i     0.038896            215
+seed7/lib/bitset.s7i         0.039192            593
+seed7/lib/bitsetof.s7i       0.039338            431
+seed7/lib/blowfish.s7i       0.042049            383
+seed7/lib/bmp.s7i            0.039265            924
+seed7/lib/boolean.s7i        0.039099            403
+seed7/lib/browser.s7i        0.039591            280
+seed7/lib/bstring.s7i        0.038852            227
+seed7/lib/bytedata.s7i       0.038901            482
+seed7/lib/bzip2.s7i          0.038771            887
+seed7/lib/cards.s7i          0.035905           1342
+seed7/lib/category.s7i       0.037183            209
+seed7/lib/cc_conf.s7i        0.037319           1314
+seed7/lib/ccittfax.s7i       0.037612           1022
+seed7/lib/cgi.s7i            0.037074            109
+seed7/lib/cgidialog.s7i      0.039810           1118
+seed7/lib/char.s7i           0.039088            356
+seed7/lib/charsets.s7i       0.039992           2024
+seed7/lib/chartype.s7i       0.041518            121
+seed7/lib/cipher.s7i         0.038383            146
+seed7/lib/cli_cmds.s7i       0.039021           1360
+seed7/lib/clib_file.s7i      0.038824            301
+seed7/lib/color.s7i          0.039411            185
+seed7/lib/complex.s7i        0.040351            464
+seed7/lib/compress.s7i       0.041065            150
+seed7/lib/console.s7i        0.039206            188
+seed7/lib/cpio.s7i           0.039428           1708
+seed7/lib/crc32.s7i          0.044089            193
+seed7/lib/cronos16.s7i       0.046278           1173
+seed7/lib/cronos27.s7i       0.043925           1464
+seed7/lib/csv.s7i            0.039527            201
+seed7/lib/db_prop.s7i        0.038882            991
+seed7/lib/deflate.s7i        0.039610            740
+seed7/lib/des.s7i            0.039488            444
+seed7/lib/dialog.s7i         0.038960            311
+seed7/lib/dir.s7i            0.038570            163
+seed7/lib/draw.s7i           0.042766            854
+seed7/lib/duration.s7i       0.044088           1038
+seed7/lib/echo.s7i           0.037830            132
+seed7/lib/editline.s7i       0.037330            398
+seed7/lib/elf.s7i            0.039030           1560
+seed7/lib/elliptic.s7i       0.038258            649
+seed7/lib/enable_io.s7i      0.038392            312
+seed7/lib/encoding.s7i       0.039138            931
+seed7/lib/enumeration.s7i    0.038894            236
+seed7/lib/environment.s7i    0.038550            175
+seed7/lib/exif.s7i           0.038648            152
+seed7/lib/external_file.s7i  0.038408            340
+seed7/lib/field.s7i          0.038665            268
+seed7/lib/file.s7i           0.038536            372
+seed7/lib/filebits.s7i       0.036345             46
+seed7/lib/filesys.s7i        0.038383            601
+seed7/lib/fileutil.s7i       0.038709            144
+seed7/lib/fixarray.s7i       0.039957            307
+seed7/lib/float.s7i          0.038745            757
+seed7/lib/font.s7i           0.038348            196
+seed7/lib/font8x8.s7i        0.037477            998
+seed7/lib/forloop.s7i        0.039402            449
+seed7/lib/ftp.s7i            0.038592            969
+seed7/lib/ftpserv.s7i        0.037705            631
+seed7/lib/getf.s7i           0.037061            115
+seed7/lib/gethttp.s7i        0.035007             41
+seed7/lib/gethttps.s7i       0.035369             41
+seed7/lib/gif.s7i            0.037824            561
+seed7/lib/graph.s7i          0.039826            415
+seed7/lib/graph_file.s7i     0.037511            399
+seed7/lib/gtkserver.s7i      0.037081            161
+seed7/lib/gzip.s7i           0.037661            573
+seed7/lib/hash.s7i           0.038995            421
+seed7/lib/hashsetof.s7i      0.040800            499
+seed7/lib/hmac.s7i           0.038627            152
+seed7/lib/html.s7i           0.037277             83
+seed7/lib/html_ent.s7i       0.038800            476
+seed7/lib/htmldom.s7i        0.039160            286
+seed7/lib/http_request.s7i   0.038923            696
+seed7/lib/http_srv_resp.s7i  0.038523            380
+seed7/lib/https_request.s7i  0.038586            211
+seed7/lib/httpserv.s7i       0.038534            345
+seed7/lib/huffman.s7i        0.038491            644
+seed7/lib/ico.s7i            0.038741            221
+seed7/lib/idxarray.s7i       0.037965            232
+seed7/lib/image.s7i          0.039327            156
+seed7/lib/imagefile.s7i      0.038585            171
+seed7/lib/inflate.s7i        0.038903            411
+seed7/lib/inifile.s7i        0.038893            129
+seed7/lib/integer.s7i        0.038575            663
+seed7/lib/iobuffer.s7i       0.038341            289
+seed7/lib/jpeg.s7i           0.039180           1761
+seed7/lib/json.s7i           0.038397            891
+seed7/lib/json_serde.s7i     0.038646            783
+seed7/lib/keybd.s7i          0.037359            639
+seed7/lib/keydescr.s7i       0.038647            192
+seed7/lib/leb128.s7i         0.038105            218
+seed7/lib/line.s7i           0.037132            164
+seed7/lib/listener.s7i       0.037152            247
+seed7/lib/logfile.s7i        0.037562             73
+seed7/lib/lower.s7i          0.038326            142
+seed7/lib/lzma.s7i           0.039014            934
+seed7/lib/lzw.s7i            0.038638            861
+seed7/lib/magic.s7i          0.040630            403
+seed7/lib/mahjng32.s7i       0.037940           1500
+seed7/lib/make.s7i           0.038473            544
+seed7/lib/makedata.s7i       0.038675           1428
+seed7/lib/math.s7i           0.039575            201
+seed7/lib/mixarith.s7i       0.038885            249
+seed7/lib/modern27.s7i       0.041006           1099
+seed7/lib/more.s7i           0.038282            130
+seed7/lib/msgdigest.s7i      0.039519           1222
+seed7/lib/multiscr.s7i       0.036685             68
+seed7/lib/null_file.s7i      0.038024            345
+seed7/lib/osfiles.s7i        0.040141           1085
+seed7/lib/pbm.s7i            0.038857            230
+seed7/lib/pcx.s7i            0.039133            638
+seed7/lib/pem.s7i            0.038913            185
+seed7/lib/pgm.s7i            0.039127            238
+seed7/lib/pic16.s7i          0.037693           1037
+seed7/lib/pic32.s7i          0.038601           2060
+seed7/lib/pic_util.s7i       0.038604            144
+seed7/lib/pixelimage.s7i     0.037324            320
+seed7/lib/pixmap_file.s7i    0.037589            459
+seed7/lib/pixmapfont.s7i     0.039074            184
+seed7/lib/pkcs1.s7i          0.042745            543
+seed7/lib/png.s7i            0.038801           1064
+seed7/lib/poll.s7i           0.038838            313
+seed7/lib/ppm.s7i            0.039702            240
+seed7/lib/process.s7i        0.038934            541
+seed7/lib/progs.s7i          0.038771            789
+seed7/lib/propertyfile.s7i   0.039254            155
+seed7/lib/rational.s7i       0.039245            792
+seed7/lib/ref_list.s7i       0.038630            252
+seed7/lib/reference.s7i      0.038674            126
+seed7/lib/reverse.s7i        0.037700             94
+seed7/lib/rpm.s7i            0.039213           3487
+seed7/lib/rpmext.s7i         0.039671            318
+seed7/lib/scanfile.s7i       0.043335           1779
+seed7/lib/scanjson.s7i       0.045342            413
+seed7/lib/scanstri.s7i       0.038265           1814
+seed7/lib/scantoml.s7i       0.038358           1603
+seed7/lib/seed7_05.s7i       0.040195           1072
+seed7/lib/set.s7i            0.036252             57
+seed7/lib/shell.s7i          0.039264            615
+seed7/lib/showtls.s7i        0.038419            678
+seed7/lib/signature.s7i      0.038096            131
+seed7/lib/smtp.s7i           0.038956            261
+seed7/lib/sockbase.s7i       0.039302            217
+seed7/lib/socket.s7i         0.037581            326
+seed7/lib/sokoban1.s7i       0.036039           1519
+seed7/lib/sql_base.s7i       0.038124           1000
+seed7/lib/stars.s7i          0.039094           1705
+seed7/lib/stdfont10.s7i      0.041278           3347
+seed7/lib/stdfont12.s7i      0.039416           3928
+seed7/lib/stdfont14.s7i      0.037303           4510
+seed7/lib/stdfont16.s7i      0.037701           5092
+seed7/lib/stdfont18.s7i      0.039616           5868
+seed7/lib/stdfont20.s7i      0.039475           6449
+seed7/lib/stdfont24.s7i      0.039114           7421
+seed7/lib/stdfont8.s7i       0.037404           2960
+seed7/lib/stdfont9.s7i       0.037225           3152
+seed7/lib/stdio.s7i          0.038541            192
+seed7/lib/strifile.s7i       0.038969            345
+seed7/lib/string.s7i         0.038739            779
+seed7/lib/stritext.s7i       0.039108            352
+seed7/lib/struct.s7i         0.040320            266
+seed7/lib/struct_elem.s7i    0.038806            129
+seed7/lib/subfile.s7i        0.038825            174
+seed7/lib/subrange.s7i       0.037487             78
+seed7/lib/syntax.s7i         0.039714            294
+seed7/lib/tar.s7i            0.039922           1880
+seed7/lib/tar_cmds.s7i       0.038916            752
+seed7/lib/tdes.s7i           0.038887            143
+seed7/lib/tee.s7i            0.038897            143
+seed7/lib/text.s7i           0.038298            135
+seed7/lib/tga.s7i            0.040165            676
+seed7/lib/tiff.s7i           0.039895           2771
+seed7/lib/time.s7i           0.038274           1191
+seed7/lib/tls.s7i            0.038275           2230
+seed7/lib/unicode.s7i        0.038366            575
+seed7/lib/unionfnd.s7i       0.039491            130
+seed7/lib/upper.s7i          0.037257            142
+seed7/lib/utf16.s7i          0.038504            540
+seed7/lib/utf8.s7i           0.039379            234
+seed7/lib/vecfont10.s7i      0.038997           1056
+seed7/lib/vecfont18.s7i      0.041069           1119
+seed7/lib/vector3d.s7i       0.039812            293
+seed7/lib/vectorfont.s7i     0.038813            239
+seed7/lib/wildcard.s7i       0.038890            140
+seed7/lib/window.s7i         0.038799            455
+seed7/lib/wrinum.s7i         0.039628            248
+seed7/lib/x509cert.s7i       0.039254           1243
+seed7/lib/xml_ent.s7i        0.038700             94
+seed7/lib/xmldom.s7i         0.038573            303
+seed7/lib/xz.s7i             0.039119            442
+seed7/lib/zip.s7i            0.039436           2792
+seed7/lib/zstd.s7i           0.039296           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.038684        |
++-----------+-----------------+
+| Minimum   | 0.034540        |
++-----------+-----------------+
+| Maximum   | 0.046278        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.040771            190
+seed7/prg/bas7.sd7           0.322865          11459
+seed7/prg/bifurk.sd7         0.041548             73
+seed7/prg/bigfiles.sd7       0.036863            129
+seed7/prg/brainf7.sd7        0.035188             86
+seed7/prg/calc7.sd7          0.036405            128
+seed7/prg/carddemo.sd7       0.040221            190
+seed7/prg/castle.sd7         0.106493           3148
+seed7/prg/cat.sd7            0.036092             82
+seed7/prg/cellauto.sd7       0.036018             85
+seed7/prg/celsius.sd7        0.035053             42
+seed7/prg/chk_all.sd7        0.058109            843
+seed7/prg/chkarr.sd7         0.348747           8367
+seed7/prg/chkbig.sd7         2.034186          29026
+seed7/prg/chkbin.sd7         0.504262           6469
+seed7/prg/chkbitdata.sd7     0.602278           6624
+seed7/prg/chkbool.sd7        0.114817           3157
+seed7/prg/chkbst.sd7         0.063042            722
+seed7/prg/chkchr.sd7         0.210928           2809
+seed7/prg/chkcmd.sd7         0.064303           1205
+seed7/prg/chkdb.sd7          0.346647           7454
+seed7/prg/chkdecl.sd7        0.057570            448
+seed7/prg/chkenum.sd7        0.067242           1230
+seed7/prg/chkerr.sd7         0.190542           4663
+seed7/prg/chkexc.sd7         0.081970           2627
+seed7/prg/chkfil.sd7         0.076357           1615
+seed7/prg/chkflt.sd7         1.326595          20620
+seed7/prg/chkhent.sd7        0.037135             54
+seed7/prg/chkhsh.sd7         0.245033           4548
+seed7/prg/chkidx.sd7         1.302946          19567
+seed7/prg/chkint.sd7         2.498480          38129
+seed7/prg/chkjson.sd7        0.101593           1764
+seed7/prg/chkovf.sd7         0.554021           8216
+seed7/prg/chkprc.sd7         0.314604          10111
+seed7/prg/chkscan.sd7        0.056182            714
+seed7/prg/chkset.sd7         0.651066          11974
+seed7/prg/chkstr.sd7         1.366141          26952
+seed7/prg/chktime.sd7        0.127654           2025
+seed7/prg/chktoml.sd7        0.104115           1656
+seed7/prg/clock.sd7          0.035836             47
+seed7/prg/clock2.sd7         0.035327             43
+seed7/prg/clock3.sd7         0.037492             95
+seed7/prg/cmpfil.sd7         0.035227             84
+seed7/prg/comanche.sd7       0.039898            180
+seed7/prg/confval.sd7        0.042595            175
+seed7/prg/db7.sd7            0.046220            417
+seed7/prg/diff7.sd7          0.041927            263
+seed7/prg/dirtst.sd7         0.035186             42
+seed7/prg/dirx.sd7           0.038146            152
+seed7/prg/dnafight.sd7       0.066091           1381
+seed7/prg/dragon.sd7         0.036109             73
+seed7/prg/echo.sd7           0.035490             39
+seed7/prg/eliza.sd7          0.042457            302
+seed7/prg/err.sd7            0.039566             96
+seed7/prg/fannkuch.sd7       0.036259            131
+seed7/prg/fib.sd7            0.034153             47
+seed7/prg/find7.sd7          0.036451            133
+seed7/prg/findchar.sd7       0.036929            149
+seed7/prg/fractree.sd7       0.034503             55
+seed7/prg/ftp7.sd7           0.045675            296
+seed7/prg/ftpserv.sd7        0.037786             74
+seed7/prg/gcd.sd7            0.036704            109
+seed7/prg/gkbd.sd7           0.045947            358
+seed7/prg/gtksvtst.sd7       0.036490             94
+seed7/prg/hal.sd7            0.039707            250
+seed7/prg/hamu.sd7           0.047559            573
+seed7/prg/hanoi.sd7          0.035959             55
+seed7/prg/hd.sd7             0.036149             79
+seed7/prg/hello.sd7          0.035153             32
+seed7/prg/hilbert.sd7        0.036769            108
+seed7/prg/ide7.sd7           0.039637            196
+seed7/prg/kbd.sd7            0.035213             49
+seed7/prg/klondike.sd7       0.054150            883
+seed7/prg/lander.sd7         0.071631           1551
+seed7/prg/lst80bas.sd7       0.043212            344
+seed7/prg/lst99bas.sd7       0.044847            401
+seed7/prg/lstgwbas.sd7       0.050183            577
+seed7/prg/mahjong.sd7        0.079679           1943
+seed7/prg/make7.sd7          0.037832            121
+seed7/prg/mandelbr.sd7       0.041110            237
+seed7/prg/mind.sd7           0.043681            443
+seed7/prg/mirror.sd7         0.037420            131
+seed7/prg/ms.sd7             0.047801            641
+seed7/prg/nicoma.sd7         0.037636            135
+seed7/prg/pac.sd7            0.048606            726
+seed7/prg/pairs.sd7          0.080254           2025
+seed7/prg/panic.sd7          0.096935           2634
+seed7/prg/percolation.sd7    0.042739            330
+seed7/prg/planets.sd7        0.075914           1486
+seed7/prg/portfwd7.sd7       0.038447            139
+seed7/prg/prime.sd7          0.036617             74
+seed7/prg/printpi1.sd7       0.036383             56
+seed7/prg/printpi2.sd7       0.035529             54
+seed7/prg/printpi3.sd7       0.035648             60
+seed7/prg/pv7.sd7            0.043573            337
+seed7/prg/queen.sd7          0.037734            149
+seed7/prg/rand.sd7           0.036926            121
+seed7/prg/raytrace.sd7       0.047793            538
+seed7/prg/rever.sd7          0.053596            816
+seed7/prg/roman.sd7          0.035009             38
+seed7/prg/s7c.sd7            0.275692           9060
+seed7/prg/s7check.sd7        0.036005             68
+seed7/prg/savehd7.sd7        0.066593           1110
+seed7/prg/self.sd7           0.036458             49
+seed7/prg/shisen.sd7         0.071455           1423
+seed7/prg/sl.sd7             0.059345           1029
+seed7/prg/snake.sd7          0.046778            615
+seed7/prg/sokoban.sd7        0.055669            891
+seed7/prg/spigotpi.sd7       0.035327             64
+seed7/prg/sql7.sd7           0.040459            278
+seed7/prg/startrek.sd7       0.057453            979
+seed7/prg/sudoku7.sd7        0.097936           2657
+seed7/prg/sydir7.sd7         0.044161            384
+seed7/prg/syntaxhl.sd7       0.039456            177
+seed7/prg/tak.sd7            0.035597             59
+seed7/prg/tar7.sd7           0.037515            121
+seed7/prg/tch.sd7            0.035615             55
+seed7/prg/testfont.sd7       0.037086             95
+seed7/prg/tet.sd7            0.044888            479
+seed7/prg/tetg.sd7           0.043995            501
+seed7/prg/toutf8.sd7         0.045531            240
+seed7/prg/tst_cli.sd7        0.035990             40
+seed7/prg/tst_srv.sd7        0.040472             47
+seed7/prg/wator.sd7          0.052031            651
+seed7/prg/which.sd7          0.035578             65
+seed7/prg/wiz.sd7            0.103346           2833
+seed7/prg/wordcnt.sd7        0.035915             54
+seed7/prg/wrinum.sd7         0.034952             43
+seed7/prg/wumpus.sd7         0.042159            372
+seed7/lib/aes.s7i            0.109853           1144
+seed7/lib/aes_gcm.s7i        0.046051            392
+seed7/lib/ar.s7i             0.072361           1532
+seed7/lib/arc4.s7i           0.038020            144
+seed7/lib/archive.s7i        0.038648            143
+seed7/lib/archive_base.s7i   0.038244            135
+seed7/lib/array.s7i          0.053485            610
+seed7/lib/asn1.s7i           0.047651            544
+seed7/lib/asn1oid.s7i        0.041537            157
+seed7/lib/basearray.s7i      0.048769            450
+seed7/lib/bigfile.s7i        0.037916            136
+seed7/lib/bigint.s7i         0.053552            824
+seed7/lib/bigrat.s7i         0.052009            784
+seed7/lib/bin16.s7i          0.049022            592
+seed7/lib/bin32.s7i          0.046009            490
+seed7/lib/bin64.s7i          0.050601            539
+seed7/lib/bitdata.s7i        0.076446           1330
+seed7/lib/bitmapfont.s7i     0.040510            215
+seed7/lib/bitset.s7i         0.048530            593
+seed7/lib/bitsetof.s7i       0.047293            431
+seed7/lib/blowfish.s7i       0.055454            383
+seed7/lib/bmp.s7i            0.058208            924
+seed7/lib/boolean.s7i        0.043366            403
+seed7/lib/browser.s7i        0.041356            280
+seed7/lib/bstring.s7i        0.039787            227
+seed7/lib/bytedata.s7i       0.049608            482
+seed7/lib/bzip2.s7i          0.056751            887
+seed7/lib/cards.s7i          0.068447           1342
+seed7/lib/category.s7i       0.040783            209
+seed7/lib/cc_conf.s7i        0.077496           1314
+seed7/lib/ccittfax.s7i       0.064959           1022
+seed7/lib/cgi.s7i            0.036470            109
+seed7/lib/cgidialog.s7i      0.057996           1118
+seed7/lib/char.s7i           0.041817            356
+seed7/lib/charsets.s7i       0.080481           2024
+seed7/lib/chartype.s7i       0.040461            121
+seed7/lib/cipher.s7i         0.038528            146
+seed7/lib/cli_cmds.s7i       0.067925           1360
+seed7/lib/clib_file.s7i      0.043500            301
+seed7/lib/color.s7i          0.040848            185
+seed7/lib/complex.s7i        0.044825            464
+seed7/lib/compress.s7i       0.038302            150
+seed7/lib/console.s7i        0.038499            188
+seed7/lib/cpio.s7i           0.080979           1708
+seed7/lib/crc32.s7i          0.043534            193
+seed7/lib/cronos16.s7i       0.091981           1173
+seed7/lib/cronos27.s7i       0.119183           1464
+seed7/lib/csv.s7i            0.041472            201
+seed7/lib/db_prop.s7i        0.062270            991
+seed7/lib/deflate.s7i        0.054841            740
+seed7/lib/des.s7i            0.053740            444
+seed7/lib/dialog.s7i         0.042213            311
+seed7/lib/dir.s7i            0.036910            163
+seed7/lib/draw.s7i           0.054193            854
+seed7/lib/duration.s7i       0.062809           1038
+seed7/lib/echo.s7i           0.038039            132
+seed7/lib/editline.s7i       0.045425            398
+seed7/lib/elf.s7i            0.084749           1560
+seed7/lib/elliptic.s7i       0.052379            649
+seed7/lib/enable_io.s7i      0.043511            312
+seed7/lib/encoding.s7i       0.059413            931
+seed7/lib/enumeration.s7i    0.042799            236
+seed7/lib/environment.s7i    0.045310            175
+seed7/lib/exif.s7i           0.039590            152
+seed7/lib/external_file.s7i  0.042028            340
+seed7/lib/field.s7i          0.040854            268
+seed7/lib/file.s7i           0.043533            372
+seed7/lib/filebits.s7i       0.035765             46
+seed7/lib/filesys.s7i        0.047992            601
+seed7/lib/fileutil.s7i       0.037974            144
+seed7/lib/fixarray.s7i       0.043473            307
+seed7/lib/float.s7i          0.054789            757
+seed7/lib/font.s7i           0.037827            196
+seed7/lib/font8x8.s7i        0.047027            998
+seed7/lib/forloop.s7i        0.043877            449
+seed7/lib/ftp.s7i            0.055484            969
+seed7/lib/ftpserv.s7i        0.050982            631
+seed7/lib/getf.s7i           0.037349            115
+seed7/lib/gethttp.s7i        0.035481             41
+seed7/lib/gethttps.s7i       0.035274             41
+seed7/lib/gif.s7i            0.049470            561
+seed7/lib/graph.s7i          0.048674            415
+seed7/lib/graph_file.s7i     0.043847            399
+seed7/lib/gtkserver.s7i      0.037912            161
+seed7/lib/gzip.s7i           0.048313            573
+seed7/lib/hash.s7i           0.049426            421
+seed7/lib/hashsetof.s7i      0.048388            499
+seed7/lib/hmac.s7i           0.038765            152
+seed7/lib/html.s7i           0.036646             83
+seed7/lib/html_ent.s7i       0.046901            476
+seed7/lib/htmldom.s7i        0.043396            286
+seed7/lib/http_request.s7i   0.051366            696
+seed7/lib/http_srv_resp.s7i  0.045077            380
+seed7/lib/https_request.s7i  0.039840            211
+seed7/lib/httpserv.s7i       0.043501            345
+seed7/lib/huffman.s7i        0.052138            644
+seed7/lib/ico.s7i            0.039467            221
+seed7/lib/idxarray.s7i       0.040589            232
+seed7/lib/image.s7i          0.036167            156
+seed7/lib/imagefile.s7i      0.037903            171
+seed7/lib/inflate.s7i        0.046178            411
+seed7/lib/inifile.s7i        0.038183            129
+seed7/lib/integer.s7i        0.052067            663
+seed7/lib/iobuffer.s7i       0.041430            289
+seed7/lib/jpeg.s7i           0.085712           1761
+seed7/lib/json.s7i           0.054146            891
+seed7/lib/json_serde.s7i     0.051246            783
+seed7/lib/keybd.s7i          0.053961            639
+seed7/lib/keydescr.s7i       0.039786            192
+seed7/lib/leb128.s7i         0.038562            218
+seed7/lib/line.s7i           0.038337            164
+seed7/lib/listener.s7i       0.040434            247
+seed7/lib/logfile.s7i        0.035140             73
+seed7/lib/lower.s7i          0.038194            142
+seed7/lib/lzma.s7i           0.058675            934
+seed7/lib/lzw.s7i            0.058618            861
+seed7/lib/magic.s7i          0.047855            403
+seed7/lib/mahjng32.s7i       0.063689           1500
+seed7/lib/make.s7i           0.047705            544
+seed7/lib/makedata.s7i       0.067985           1428
+seed7/lib/math.s7i           0.038651            201
+seed7/lib/mixarith.s7i       0.038821            249
+seed7/lib/modern27.s7i       0.084379           1099
+seed7/lib/more.s7i           0.038084            130
+seed7/lib/msgdigest.s7i      0.078495           1222
+seed7/lib/multiscr.s7i       0.036483             68
+seed7/lib/null_file.s7i      0.042420            345
+seed7/lib/osfiles.s7i        0.064776           1085
+seed7/lib/pbm.s7i            0.041102            230
+seed7/lib/pcx.s7i            0.051788            638
+seed7/lib/pem.s7i            0.039903            185
+seed7/lib/pgm.s7i            0.040375            238
+seed7/lib/pic16.s7i          0.048607           1037
+seed7/lib/pic32.s7i          0.079574           2060
+seed7/lib/pic_util.s7i       0.038633            144
+seed7/lib/pixelimage.s7i     0.042288            320
+seed7/lib/pixmap_file.s7i    0.044906            459
+seed7/lib/pixmapfont.s7i     0.038982            184
+seed7/lib/pkcs1.s7i          0.057922            543
+seed7/lib/png.s7i            0.062269           1064
+seed7/lib/poll.s7i           0.042483            313
+seed7/lib/ppm.s7i            0.040759            240
+seed7/lib/process.s7i        0.047828            541
+seed7/lib/progs.s7i          0.056061            789
+seed7/lib/propertyfile.s7i   0.039112            155
+seed7/lib/rational.s7i       0.053560            792
+seed7/lib/ref_list.s7i       0.041489            252
+seed7/lib/reference.s7i      0.038069            126
+seed7/lib/reverse.s7i        0.036617             94
+seed7/lib/rpm.s7i            0.142321           3487
+seed7/lib/rpmext.s7i         0.042383            318
+seed7/lib/scanfile.s7i       0.079680           1779
+seed7/lib/scanjson.s7i       0.047062            413
+seed7/lib/scanstri.s7i       0.080171           1814
+seed7/lib/scantoml.s7i       0.070384           1603
+seed7/lib/seed7_05.s7i       0.066724           1072
+seed7/lib/set.s7i            0.036251             57
+seed7/lib/shell.s7i          0.051851            615
+seed7/lib/showtls.s7i        0.053340            678
+seed7/lib/signature.s7i      0.037431            131
+seed7/lib/smtp.s7i           0.039184            261
+seed7/lib/sockbase.s7i       0.041706            217
+seed7/lib/socket.s7i         0.043920            326
+seed7/lib/sokoban1.s7i       0.053639           1519
+seed7/lib/sql_base.s7i       0.064820           1000
+seed7/lib/stars.s7i          0.133927           1705
+seed7/lib/stdfont10.s7i      0.079742           3347
+seed7/lib/stdfont12.s7i      0.090068           3928
+seed7/lib/stdfont14.s7i      0.105504           4510
+seed7/lib/stdfont16.s7i      0.114428           5092
+seed7/lib/stdfont18.s7i      0.129987           5868
+seed7/lib/stdfont20.s7i      0.143999           6449
+seed7/lib/stdfont24.s7i      0.176167           7421
+seed7/lib/stdfont8.s7i       0.072092           2960
+seed7/lib/stdfont9.s7i       0.075682           3152
+seed7/lib/stdio.s7i          0.039544            192
+seed7/lib/strifile.s7i       0.043876            345
+seed7/lib/string.s7i         0.054948            779
+seed7/lib/stritext.s7i       0.042531            352
+seed7/lib/struct.s7i         0.043688            266
+seed7/lib/struct_elem.s7i    0.039039            129
+seed7/lib/subfile.s7i        0.038724            174
+seed7/lib/subrange.s7i       0.036502             78
+seed7/lib/syntax.s7i         0.045414            294
+seed7/lib/tar.s7i            0.081755           1880
+seed7/lib/tar_cmds.s7i       0.057618            752
+seed7/lib/tdes.s7i           0.038746            143
+seed7/lib/tee.s7i            0.036501            143
+seed7/lib/text.s7i           0.036316            135
+seed7/lib/tga.s7i            0.051923            676
+seed7/lib/tiff.s7i           0.119531           2771
+seed7/lib/time.s7i           0.062809           1191
+seed7/lib/tls.s7i            0.102898           2230
+seed7/lib/unicode.s7i        0.051413            575
+seed7/lib/unionfnd.s7i       0.037400            130
+seed7/lib/upper.s7i          0.037653            142
+seed7/lib/utf16.s7i          0.049541            540
+seed7/lib/utf8.s7i           0.041045            234
+seed7/lib/vecfont10.s7i      0.078477           1056
+seed7/lib/vecfont18.s7i      0.086701           1119
+seed7/lib/vector3d.s7i       0.040221            293
+seed7/lib/vectorfont.s7i     0.040581            239
+seed7/lib/wildcard.s7i       0.038101            140
+seed7/lib/window.s7i         0.045205            455
+seed7/lib/wrinum.s7i         0.040804            248
+seed7/lib/x509cert.s7i       0.071113           1243
+seed7/lib/xml_ent.s7i        0.036547             94
+seed7/lib/xmldom.s7i         0.039677            303
+seed7/lib/xz.s7i             0.044334            442
+seed7/lib/zip.s7i            0.116948           2792
+seed7/lib/zstd.s7i           0.068669           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.088058        |
++-----------+-----------------+
+| Minimum   | 0.034153        |
++-----------+-----------------+
+| Maximum   | 2.498480        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.045498            190
+seed7/prg/bas7.sd7           0.771059          11459
+seed7/prg/bifurk.sd7         0.044660             73
+seed7/prg/bigfiles.sd7       0.048264            129
+seed7/prg/brainf7.sd7        0.039868             86
+seed7/prg/calc7.sd7          0.040892            128
+seed7/prg/carddemo.sd7       0.046091            190
+seed7/prg/castle.sd7         0.212203           3148
+seed7/prg/cat.sd7            0.039230             82
+seed7/prg/cellauto.sd7       0.038985             85
+seed7/prg/celsius.sd7        0.037136             42
+seed7/prg/chk_all.sd7        0.080742            843
+seed7/prg/chkarr.sd7         0.851674           8367
+seed7/prg/chkbig.sd7         4.109469          29026
+seed7/prg/chkbin.sd7         1.023526           6469
+seed7/prg/chkbitdata.sd7     1.236330           6624
+seed7/prg/chkbool.sd7        0.231980           3157
+seed7/prg/chkbst.sd7         0.102467            722
+seed7/prg/chkchr.sd7         0.479880           2809
+seed7/prg/chkcmd.sd7         0.111156           1205
+seed7/prg/chkdb.sd7          0.744954           7454
+seed7/prg/chkdecl.sd7        0.092879            448
+seed7/prg/chkenum.sd7        0.119330           1230
+seed7/prg/chkerr.sd7         0.339261           4663
+seed7/prg/chkexc.sd7         0.148969           2627
+seed7/prg/chkfil.sd7         0.127993           1615
+seed7/prg/chkflt.sd7         2.813090          20620
+seed7/prg/chkhent.sd7        0.050937             54
+seed7/prg/chkhsh.sd7         0.493350           4548
+seed7/prg/chkidx.sd7         3.161414          19567
+seed7/prg/chkint.sd7         5.534495          38129
+seed7/prg/chkjson.sd7        0.189491           1764
+seed7/prg/chkovf.sd7         1.206114           8216
+seed7/prg/chkprc.sd7         0.691546          10111
+seed7/prg/chkscan.sd7        0.089912            714
+seed7/prg/chkset.sd7         1.732310          11974
+seed7/prg/chkstr.sd7         3.386721          26952
+seed7/prg/chktime.sd7        0.247271           2025
+seed7/prg/chktoml.sd7        0.193338           1656
+seed7/prg/clock.sd7          0.037499             47
+seed7/prg/clock2.sd7         0.036833             43
+seed7/prg/clock3.sd7         0.042286             95
+seed7/prg/cmpfil.sd7         0.038923             84
+seed7/prg/comanche.sd7       0.047535            180
+seed7/prg/confval.sd7        0.050298            175
+seed7/prg/db7.sd7            0.062251            417
+seed7/prg/diff7.sd7          0.053418            263
+seed7/prg/dirtst.sd7         0.036721             42
+seed7/prg/dirx.sd7           0.042914            152
+seed7/prg/dnafight.sd7       0.117227           1381
+seed7/prg/dragon.sd7         0.038496             73
+seed7/prg/echo.sd7           0.036173             39
+seed7/prg/eliza.sd7          0.052417            302
+seed7/prg/err.sd7            0.044999             96
+seed7/prg/fannkuch.sd7       0.042027            131
+seed7/prg/fib.sd7            0.036662             47
+seed7/prg/find7.sd7          0.041710            133
+seed7/prg/findchar.sd7       0.043344            149
+seed7/prg/fractree.sd7       0.037438             55
+seed7/prg/ftp7.sd7           0.053437            296
+seed7/prg/ftpserv.sd7        0.039240             74
+seed7/prg/gcd.sd7            0.041032            109
+seed7/prg/gkbd.sd7           0.061759            358
+seed7/prg/gtksvtst.sd7       0.039920             94
+seed7/prg/hal.sd7            0.047623            250
+seed7/prg/hamu.sd7           0.067099            573
+seed7/prg/hanoi.sd7          0.037382             55
+seed7/prg/hd.sd7             0.038711             79
+seed7/prg/hello.sd7          0.036268             32
+seed7/prg/hilbert.sd7        0.041602            108
+seed7/prg/ide7.sd7           0.047741            196
+seed7/prg/kbd.sd7            0.037227             49
+seed7/prg/klondike.sd7       0.087411            883
+seed7/prg/lander.sd7         0.130935           1551
+seed7/prg/lst80bas.sd7       0.056848            344
+seed7/prg/lst99bas.sd7       0.059748            401
+seed7/prg/lstgwbas.sd7       0.073000            577
+seed7/prg/mahjong.sd7        0.145416           1943
+seed7/prg/make7.sd7          0.044516            121
+seed7/prg/mandelbr.sd7       0.048812            237
+seed7/prg/mind.sd7           0.061546            443
+seed7/prg/mirror.sd7         0.044098            131
+seed7/prg/ms.sd7             0.070366            641
+seed7/prg/nicoma.sd7         0.043609            135
+seed7/prg/pac.sd7            0.072273            726
+seed7/prg/pairs.sd7          0.137698           2025
+seed7/prg/panic.sd7          0.191954           2634
+seed7/prg/percolation.sd7    0.056424            330
+seed7/prg/planets.sd7        0.136752           1486
+seed7/prg/portfwd7.sd7       0.044010            139
+seed7/prg/prime.sd7          0.046022             74
+seed7/prg/printpi1.sd7       0.042387             56
+seed7/prg/printpi2.sd7       0.038351             54
+seed7/prg/printpi3.sd7       0.037744             60
+seed7/prg/pv7.sd7            0.057640            337
+seed7/prg/queen.sd7          0.042973            149
+seed7/prg/rand.sd7           0.041641            121
+seed7/prg/raytrace.sd7       0.069046            538
+seed7/prg/rever.sd7          0.082670            816
+seed7/prg/roman.sd7          0.036734             38
+seed7/prg/s7c.sd7            0.617174           9060
+seed7/prg/s7check.sd7        0.039476             68
+seed7/prg/savehd7.sd7        0.109798           1110
+seed7/prg/self.sd7           0.037863             49
+seed7/prg/shisen.sd7         0.119485           1423
+seed7/prg/sl.sd7             0.096003           1029
+seed7/prg/snake.sd7          0.066306            615
+seed7/prg/sokoban.sd7        0.082048            891
+seed7/prg/spigotpi.sd7       0.040047             64
+seed7/prg/sql7.sd7           0.051490            278
+seed7/prg/startrek.sd7       0.093520            979
+seed7/prg/sudoku7.sd7        0.197550           2657
+seed7/prg/sydir7.sd7         0.061209            384
+seed7/prg/syntaxhl.sd7       0.049884            177
+seed7/prg/tak.sd7            0.037582             59
+seed7/prg/tar7.sd7           0.043418            121
+seed7/prg/tch.sd7            0.040094             55
+seed7/prg/testfont.sd7       0.046584             95
+seed7/prg/tet.sd7            0.059821            479
+seed7/prg/tetg.sd7           0.061474            501
+seed7/prg/toutf8.sd7         0.050833            240
+seed7/prg/tst_cli.sd7        0.036828             40
+seed7/prg/tst_srv.sd7        0.036664             47
+seed7/prg/wator.sd7          0.078392            651
+seed7/prg/which.sd7          0.038104             65
+seed7/prg/wiz.sd7            0.205680           2833
+seed7/prg/wordcnt.sd7        0.038055             54
+seed7/prg/wrinum.sd7         0.036727             43
+seed7/prg/wumpus.sd7         0.054646            372
+seed7/lib/aes.s7i            0.196291           1144
+seed7/lib/aes_gcm.s7i        0.060452            392
+seed7/lib/ar.s7i             0.122182           1532
+seed7/lib/arc4.s7i           0.043124            144
+seed7/lib/archive.s7i        0.045589            143
+seed7/lib/archive_base.s7i   0.043130            135
+seed7/lib/array.s7i          0.075847            610
+seed7/lib/asn1.s7i           0.064584            544
+seed7/lib/asn1oid.s7i        0.050068            157
+seed7/lib/basearray.s7i      0.064138            450
+seed7/lib/bigfile.s7i        0.042250            136
+seed7/lib/bigint.s7i         0.077063            824
+seed7/lib/bigrat.s7i         0.078765            784
+seed7/lib/bin16.s7i          0.067506            592
+seed7/lib/bin32.s7i          0.061688            490
+seed7/lib/bin64.s7i          0.063589            539
+seed7/lib/bitdata.s7i        0.122143           1330
+seed7/lib/bitmapfont.s7i     0.047501            215
+seed7/lib/bitset.s7i         0.063415            593
+seed7/lib/bitsetof.s7i       0.060583            431
+seed7/lib/blowfish.s7i       0.076219            383
+seed7/lib/bmp.s7i            0.097657            924
+seed7/lib/boolean.s7i        0.054929            403
+seed7/lib/browser.s7i        0.053276            280
+seed7/lib/bstring.s7i        0.047727            227
+seed7/lib/bytedata.s7i       0.065290            482
+seed7/lib/bzip2.s7i          0.088895            887
+seed7/lib/cards.s7i          0.101628           1342
+seed7/lib/category.s7i       0.048481            209
+seed7/lib/cc_conf.s7i        0.124387           1314
+seed7/lib/ccittfax.s7i       0.100150           1022
+seed7/lib/cgi.s7i            0.040844            109
+seed7/lib/cgidialog.s7i      0.095646           1118
+seed7/lib/char.s7i           0.051481            356
+seed7/lib/charsets.s7i       0.122641           2024
+seed7/lib/chartype.s7i       0.047943            121
+seed7/lib/cipher.s7i         0.043247            146
+seed7/lib/cli_cmds.s7i       0.112003           1360
+seed7/lib/clib_file.s7i      0.051879            301
+seed7/lib/color.s7i          0.047654            185
+seed7/lib/complex.s7i        0.059062            464
+seed7/lib/compress.s7i       0.043327            150
+seed7/lib/console.s7i        0.045660            188
+seed7/lib/cpio.s7i           0.143601           1708
+seed7/lib/crc32.s7i          0.054286            193
+seed7/lib/cronos16.s7i       0.192437           1173
+seed7/lib/cronos27.s7i       0.249252           1464
+seed7/lib/csv.s7i            0.048058            201
+seed7/lib/db_prop.s7i        0.101000            991
+seed7/lib/deflate.s7i        0.086333            740
+seed7/lib/des.s7i            0.084926            444
+seed7/lib/dialog.s7i         0.057228            311
+seed7/lib/dir.s7i            0.043165            163
+seed7/lib/draw.s7i           0.084894            854
+seed7/lib/duration.s7i       0.098807           1038
+seed7/lib/echo.s7i           0.042464            132
+seed7/lib/editline.s7i       0.060249            398
+seed7/lib/elf.s7i            0.152326           1560
+seed7/lib/elliptic.s7i       0.074935            649
+seed7/lib/enable_io.s7i      0.052416            312
+seed7/lib/encoding.s7i       0.095640            931
+seed7/lib/enumeration.s7i    0.049304            236
+seed7/lib/environment.s7i    0.045159            175
+seed7/lib/exif.s7i           0.046196            152
+seed7/lib/external_file.s7i  0.051439            340
+seed7/lib/field.s7i          0.052543            268
+seed7/lib/file.s7i           0.053639            372
+seed7/lib/filebits.s7i       0.038523             46
+seed7/lib/filesys.s7i        0.064518            601
+seed7/lib/fileutil.s7i       0.043828            144
+seed7/lib/fixarray.s7i       0.052695            307
+seed7/lib/float.s7i          0.073593            757
+seed7/lib/font.s7i           0.044889            196
+seed7/lib/font8x8.s7i        0.068866            998
+seed7/lib/forloop.s7i        0.058636            449
+seed7/lib/ftp.s7i            0.086904            969
+seed7/lib/ftpserv.s7i        0.078040            631
+seed7/lib/getf.s7i           0.042054            115
+seed7/lib/gethttp.s7i        0.037256             41
+seed7/lib/gethttps.s7i       0.036858             41
+seed7/lib/gif.s7i            0.076523            561
+seed7/lib/graph.s7i          0.063633            415
+seed7/lib/graph_file.s7i     0.058548            399
+seed7/lib/gtkserver.s7i      0.042218            161
+seed7/lib/gzip.s7i           0.066798            573
+seed7/lib/hash.s7i           0.065999            421
+seed7/lib/hashsetof.s7i      0.065286            499
+seed7/lib/hmac.s7i           0.043771            152
+seed7/lib/html.s7i           0.039774             83
+seed7/lib/html_ent.s7i       0.065347            476
+seed7/lib/htmldom.s7i        0.053995            286
+seed7/lib/http_request.s7i   0.078383            696
+seed7/lib/http_srv_resp.s7i  0.058684            380
+seed7/lib/https_request.s7i  0.048172            211
+seed7/lib/httpserv.s7i       0.057415            345
+seed7/lib/huffman.s7i        0.073373            644
+seed7/lib/ico.s7i            0.049222            221
+seed7/lib/idxarray.s7i       0.051296            232
+seed7/lib/image.s7i          0.041543            156
+seed7/lib/imagefile.s7i      0.045469            171
+seed7/lib/inflate.s7i        0.065262            411
+seed7/lib/inifile.s7i        0.042664            129
+seed7/lib/integer.s7i        0.067299            663
+seed7/lib/iobuffer.s7i       0.051376            289
+seed7/lib/jpeg.s7i           0.154092           1761
+seed7/lib/json.s7i           0.081376            891
+seed7/lib/json_serde.s7i     0.079375            783
+seed7/lib/keybd.s7i          0.079867            639
+seed7/lib/keydescr.s7i       0.049516            192
+seed7/lib/leb128.s7i         0.047400            218
+seed7/lib/line.s7i           0.042854            164
+seed7/lib/listener.s7i       0.048541            247
+seed7/lib/logfile.s7i        0.040862             73
+seed7/lib/lower.s7i          0.042257            142
+seed7/lib/lzma.s7i           0.096669            934
+seed7/lib/lzw.s7i            0.087873            861
+seed7/lib/magic.s7i          0.063955            403
+seed7/lib/mahjng32.s7i       0.092423           1500
+seed7/lib/make.s7i           0.070509            544
+seed7/lib/makedata.s7i       0.123931           1428
+seed7/lib/math.s7i           0.045999            201
+seed7/lib/mixarith.s7i       0.046701            249
+seed7/lib/modern27.s7i       0.166811           1099
+seed7/lib/more.s7i           0.042818            130
+seed7/lib/msgdigest.s7i      0.137454           1222
+seed7/lib/multiscr.s7i       0.037736             68
+seed7/lib/null_file.s7i      0.050367            345
+seed7/lib/osfiles.s7i        0.094825           1085
+seed7/lib/pbm.s7i            0.048011            230
+seed7/lib/pcx.s7i            0.079822            638
+seed7/lib/pem.s7i            0.047931            185
+seed7/lib/pgm.s7i            0.051860            238
+seed7/lib/pic16.s7i          0.068086           1037
+seed7/lib/pic32.s7i          0.121348           2060
+seed7/lib/pic_util.s7i       0.045298            144
+seed7/lib/pixelimage.s7i     0.055818            320
+seed7/lib/pixmap_file.s7i    0.065909            459
+seed7/lib/pixmapfont.s7i     0.050955            184
+seed7/lib/pkcs1.s7i          0.079850            543
+seed7/lib/png.s7i            0.106808           1064
+seed7/lib/poll.s7i           0.053717            313
+seed7/lib/ppm.s7i            0.048364            240
+seed7/lib/process.s7i        0.065570            541
+seed7/lib/progs.s7i          0.084140            789
+seed7/lib/propertyfile.s7i   0.045420            155
+seed7/lib/rational.s7i       0.078623            792
+seed7/lib/ref_list.s7i       0.048721            252
+seed7/lib/reference.s7i      0.042312            126
+seed7/lib/reverse.s7i        0.040395             94
+seed7/lib/rpm.s7i            0.285174           3487
+seed7/lib/rpmext.s7i         0.055358            318
+seed7/lib/scanfile.s7i       0.131422           1779
+seed7/lib/scanjson.s7i       0.069272            413
+seed7/lib/scanstri.s7i       0.136133           1814
+seed7/lib/scantoml.s7i       0.128861           1603
+seed7/lib/seed7_05.s7i       0.110123           1072
+seed7/lib/set.s7i            0.037736             57
+seed7/lib/shell.s7i          0.069572            615
+seed7/lib/showtls.s7i        0.085863            678
+seed7/lib/signature.s7i      0.042359            131
+seed7/lib/smtp.s7i           0.048707            261
+seed7/lib/sockbase.s7i       0.050294            217
+seed7/lib/socket.s7i         0.051687            326
+seed7/lib/sokoban1.s7i       0.080065           1519
+seed7/lib/sql_base.s7i       0.095065           1000
+seed7/lib/stars.s7i          0.233436           1705
+seed7/lib/stdfont10.s7i      0.142638           3347
+seed7/lib/stdfont12.s7i      0.163158           3928
+seed7/lib/stdfont14.s7i      0.187045           4510
+seed7/lib/stdfont16.s7i      0.212002           5092
+seed7/lib/stdfont18.s7i      0.243189           5868
+seed7/lib/stdfont20.s7i      0.271382           6449
+seed7/lib/stdfont24.s7i      0.325723           7421
+seed7/lib/stdfont8.s7i       0.125878           2960
+seed7/lib/stdfont9.s7i       0.131372           3152
+seed7/lib/stdio.s7i          0.043512            192
+seed7/lib/strifile.s7i       0.053527            345
+seed7/lib/string.s7i         0.076320            779
+seed7/lib/stritext.s7i       0.055212            352
+seed7/lib/struct.s7i         0.056229            266
+seed7/lib/struct_elem.s7i    0.041749            129
+seed7/lib/subfile.s7i        0.044083            174
+seed7/lib/subrange.s7i       0.038315             78
+seed7/lib/syntax.s7i         0.059773            294
+seed7/lib/tar.s7i            0.143840           1880
+seed7/lib/tar_cmds.s7i       0.085272            752
+seed7/lib/tdes.s7i           0.047650            143
+seed7/lib/tee.s7i            0.042671            143
+seed7/lib/text.s7i           0.042836            135
+seed7/lib/tga.s7i            0.079731            676
+seed7/lib/tiff.s7i           0.243382           2771
+seed7/lib/time.s7i           0.101405           1191
+seed7/lib/tls.s7i            0.198582           2230
+seed7/lib/unicode.s7i        0.072531            575
+seed7/lib/unionfnd.s7i       0.043609            130
+seed7/lib/upper.s7i          0.042029            142
+seed7/lib/utf16.s7i          0.066533            540
+seed7/lib/utf8.s7i           0.048303            234
+seed7/lib/vecfont10.s7i      0.161885           1056
+seed7/lib/vecfont18.s7i      0.178422           1119
+seed7/lib/vector3d.s7i       0.050256            293
+seed7/lib/vectorfont.s7i     0.047784            239
+seed7/lib/wildcard.s7i       0.043874            140
+seed7/lib/window.s7i         0.061678            455
+seed7/lib/wrinum.s7i         0.049120            248
+seed7/lib/x509cert.s7i       0.117711           1243
+seed7/lib/xml_ent.s7i        0.042309             94
+seed7/lib/xmldom.s7i         0.050221            303
+seed7/lib/xz.s7i             0.063562            442
+seed7/lib/zip.s7i            0.237428           2792
+seed7/lib/zstd.s7i           0.116872           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.158276        |
++-----------+-----------------+
+| Minimum   | 0.036173        |
++-----------+-----------------+
+| Maximum   | 5.534495        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033634        | 0.032112        | 0.041882        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.038684        | 0.034540        | 0.046278        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.088058        | 0.034153        | 2.498480        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.158276        | 0.036173        | 5.534495        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.295 | 00:00:57.297 | 00:01:09.592 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.796 | 00:01:05.969 | 00:01:20.766 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:35.949 | 00:02:30.896 | 00:03:06.845 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:01.030 | 00:04:30.560 | 00:05:31.591 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:08.802 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-06.1.rst
+++ b/reports/seed7mode-perf-06.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-24T13:12:22+0000 W26-3
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 09:19:36 local time
+:Generated on: 2026-06-24 13:30:48 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 254x84 chars
+:Window body: 254x82 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.035315            190
+seed7/prg/bas7.sd7           0.036636          11459
+seed7/prg/bifurk.sd7         0.035617             73
+seed7/prg/bigfiles.sd7       0.036439            129
+seed7/prg/brainf7.sd7        0.034041             86
+seed7/prg/calc7.sd7          0.033726            128
+seed7/prg/carddemo.sd7       0.034747            190
+seed7/prg/castle.sd7         0.034243           3148
+seed7/prg/cat.sd7            0.033565             82
+seed7/prg/cellauto.sd7       0.034045             85
+seed7/prg/celsius.sd7        0.032914             42
+seed7/prg/chk_all.sd7        0.033155            843
+seed7/prg/chkarr.sd7         0.033603           8367
+seed7/prg/chkbig.sd7         0.037540          29026
+seed7/prg/chkbin.sd7         0.035856           6469
+seed7/prg/chkbitdata.sd7     0.035078           6624
+seed7/prg/chkbool.sd7        0.033757           3157
+seed7/prg/chkbst.sd7         0.033445            722
+seed7/prg/chkchr.sd7         0.034260           2809
+seed7/prg/chkcmd.sd7         0.033427           1205
+seed7/prg/chkdb.sd7          0.034438           7454
+seed7/prg/chkdecl.sd7        0.034089            448
+seed7/prg/chkenum.sd7        0.033772           1230
+seed7/prg/chkerr.sd7         0.034276           4663
+seed7/prg/chkexc.sd7         0.033990           2627
+seed7/prg/chkfil.sd7         0.033275           1615
+seed7/prg/chkflt.sd7         0.035898          20620
+seed7/prg/chkhent.sd7        0.032976             54
+seed7/prg/chkhsh.sd7         0.033104           4548
+seed7/prg/chkidx.sd7         0.035624          19567
+seed7/prg/chkint.sd7         0.040137          38129
+seed7/prg/chkjson.sd7        0.034048           1764
+seed7/prg/chkovf.sd7         0.034911           8216
+seed7/prg/chkprc.sd7         0.033376          10111
+seed7/prg/chkscan.sd7        0.032939            714
+seed7/prg/chkset.sd7         0.034372          11974
+seed7/prg/chkstr.sd7         0.038254          26952
+seed7/prg/chktime.sd7        0.034469           2025
+seed7/prg/chktoml.sd7        0.033652           1656
+seed7/prg/clock.sd7          0.033458             47
+seed7/prg/clock2.sd7         0.032761             43
+seed7/prg/clock3.sd7         0.032776             95
+seed7/prg/cmpfil.sd7         0.032946             84
+seed7/prg/comanche.sd7       0.032574            180
+seed7/prg/confval.sd7        0.032733            175
+seed7/prg/db7.sd7            0.033987            417
+seed7/prg/diff7.sd7          0.034060            263
+seed7/prg/dirtst.sd7         0.033339             42
+seed7/prg/dirx.sd7           0.033202            152
+seed7/prg/dnafight.sd7       0.033441           1381
+seed7/prg/dragon.sd7         0.033869             73
+seed7/prg/echo.sd7           0.033351             39
+seed7/prg/eliza.sd7          0.037201            302
+seed7/prg/err.sd7            0.039528             96
+seed7/prg/fannkuch.sd7       0.034173            131
+seed7/prg/fib.sd7            0.033443             47
+seed7/prg/find7.sd7          0.033840            133
+seed7/prg/findchar.sd7       0.033380            149
+seed7/prg/fractree.sd7       0.033747             55
+seed7/prg/ftp7.sd7           0.034121            296
+seed7/prg/ftpserv.sd7        0.033701             74
+seed7/prg/gcd.sd7            0.033442            109
+seed7/prg/gkbd.sd7           0.033327            358
+seed7/prg/gtksvtst.sd7       0.042646             94
+seed7/prg/hal.sd7            0.036107            250
+seed7/prg/hamu.sd7           0.033640            573
+seed7/prg/hanoi.sd7          0.033887             55
+seed7/prg/hd.sd7             0.033396             79
+seed7/prg/hello.sd7          0.033272             32
+seed7/prg/hilbert.sd7        0.033645            108
+seed7/prg/ide7.sd7           0.036236            196
+seed7/prg/kbd.sd7            0.040184             49
+seed7/prg/klondike.sd7       0.032865            883
+seed7/prg/lander.sd7         0.032999           1551
+seed7/prg/lst80bas.sd7       0.032902            344
+seed7/prg/lst99bas.sd7       0.033162            401
+seed7/prg/lstgwbas.sd7       0.033937            577
+seed7/prg/mahjong.sd7        0.033329           1943
+seed7/prg/make7.sd7          0.033386            121
+seed7/prg/mandelbr.sd7       0.032905            237
+seed7/prg/mind.sd7           0.032719            443
+seed7/prg/mirror.sd7         0.032560            131
+seed7/prg/ms.sd7             0.032817            641
+seed7/prg/nicoma.sd7         0.033797            135
+seed7/prg/pac.sd7            0.033752            726
+seed7/prg/pairs.sd7          0.033842           2025
+seed7/prg/panic.sd7          0.034015           2634
+seed7/prg/percolation.sd7    0.033693            330
+seed7/prg/planets.sd7        0.034380           1486
+seed7/prg/portfwd7.sd7       0.036825            139
+seed7/prg/prime.sd7          0.039368             74
+seed7/prg/printpi1.sd7       0.034587             56
+seed7/prg/printpi2.sd7       0.033869             54
+seed7/prg/printpi3.sd7       0.033639             60
+seed7/prg/pv7.sd7            0.033422            337
+seed7/prg/queen.sd7          0.033829            149
+seed7/prg/rand.sd7           0.033531            121
+seed7/prg/raytrace.sd7       0.034019            538
+seed7/prg/rever.sd7          0.033666            816
+seed7/prg/roman.sd7          0.033529             38
+seed7/prg/s7c.sd7            0.034444           9060
+seed7/prg/s7check.sd7        0.032747             68
+seed7/prg/savehd7.sd7        0.033159           1110
+seed7/prg/self.sd7           0.032903             49
+seed7/prg/shisen.sd7         0.032731           1423
+seed7/prg/sl.sd7             0.032750           1029
+seed7/prg/snake.sd7          0.032525            615
+seed7/prg/sokoban.sd7        0.034670            891
+seed7/prg/spigotpi.sd7       0.033553             64
+seed7/prg/sql7.sd7           0.033789            278
+seed7/prg/startrek.sd7       0.033425            979
+seed7/prg/sudoku7.sd7        0.034137           2657
+seed7/prg/sydir7.sd7         0.033559            384
+seed7/prg/syntaxhl.sd7       0.033603            177
+seed7/prg/tak.sd7            0.033887             59
+seed7/prg/tar7.sd7           0.033547            121
+seed7/prg/tch.sd7            0.033687             55
+seed7/prg/testfont.sd7       0.033797             95
+seed7/prg/tet.sd7            0.033805            479
+seed7/prg/tetg.sd7           0.033825            501
+seed7/prg/toutf8.sd7         0.033406            240
+seed7/prg/tst_cli.sd7        0.033857             40
+seed7/prg/tst_srv.sd7        0.032891             47
+seed7/prg/wator.sd7          0.032559            651
+seed7/prg/which.sd7          0.032698             65
+seed7/prg/wiz.sd7            0.032622           2833
+seed7/prg/wordcnt.sd7        0.032978             54
+seed7/prg/wrinum.sd7         0.032757             43
+seed7/prg/wumpus.sd7         0.033007            372
+seed7/lib/aes.s7i            0.033036           1144
+seed7/lib/aes_gcm.s7i        0.032407            392
+seed7/lib/ar.s7i             0.033471           1532
+seed7/lib/arc4.s7i           0.032860            144
+seed7/lib/archive.s7i        0.033098            143
+seed7/lib/archive_base.s7i   0.032668            135
+seed7/lib/array.s7i          0.032745            610
+seed7/lib/asn1.s7i           0.032540            544
+seed7/lib/asn1oid.s7i        0.035235            157
+seed7/lib/basearray.s7i      0.033871            450
+seed7/lib/bigfile.s7i        0.033856            136
+seed7/lib/bigint.s7i         0.033636            824
+seed7/lib/bigrat.s7i         0.033793            784
+seed7/lib/bin16.s7i          0.033864            592
+seed7/lib/bin32.s7i          0.034188            490
+seed7/lib/bin64.s7i          0.033764            539
+seed7/lib/bitdata.s7i        0.033975           1330
+seed7/lib/bitmapfont.s7i     0.033418            215
+seed7/lib/bitset.s7i         0.033885            593
+seed7/lib/bitsetof.s7i       0.034044            431
+seed7/lib/blowfish.s7i       0.033838            383
+seed7/lib/bmp.s7i            0.033957            924
+seed7/lib/boolean.s7i        0.033406            403
+seed7/lib/browser.s7i        0.033872            280
+seed7/lib/bstring.s7i        0.033485            227
+seed7/lib/bytedata.s7i       0.033514            482
+seed7/lib/bzip2.s7i          0.034006            887
+seed7/lib/cards.s7i          0.033684           1342
+seed7/lib/category.s7i       0.033557            209
+seed7/lib/cc_conf.s7i        0.033916           1314
+seed7/lib/ccittfax.s7i       0.033653           1022
+seed7/lib/cgi.s7i            0.033391            109
+seed7/lib/cgidialog.s7i      0.032812           1118
+seed7/lib/char.s7i           0.032786            356
+seed7/lib/charsets.s7i       0.033025           2024
+seed7/lib/chartype.s7i       0.032684            121
+seed7/lib/cipher.s7i         0.032475            146
+seed7/lib/cli_cmds.s7i       0.033579           1360
+seed7/lib/clib_file.s7i      0.034348            301
+seed7/lib/color.s7i          0.033527            185
+seed7/lib/complex.s7i        0.033116            464
+seed7/lib/compress.s7i       0.032772            150
+seed7/lib/console.s7i        0.033437            188
+seed7/lib/cpio.s7i           0.033032           1708
+seed7/lib/crc32.s7i          0.032506            193
+seed7/lib/cronos16.s7i       0.032726           1173
+seed7/lib/cronos27.s7i       0.032847           1464
+seed7/lib/csv.s7i            0.032708            201
+seed7/lib/db_prop.s7i        0.033156            991
+seed7/lib/deflate.s7i        0.032742            740
+seed7/lib/des.s7i            0.033619            444
+seed7/lib/dialog.s7i         0.033590            311
+seed7/lib/dir.s7i            0.033654            163
+seed7/lib/draw.s7i           0.034054            854
+seed7/lib/duration.s7i       0.033658           1038
+seed7/lib/echo.s7i           0.033673            132
+seed7/lib/editline.s7i       0.036415            398
+seed7/lib/elf.s7i            0.036588           1560
+seed7/lib/elliptic.s7i       0.033592            649
+seed7/lib/enable_io.s7i      0.033895            312
+seed7/lib/encoding.s7i       0.033992            931
+seed7/lib/enumeration.s7i    0.033560            236
+seed7/lib/environment.s7i    0.033574            175
+seed7/lib/exif.s7i           0.032911            152
+seed7/lib/external_file.s7i  0.033002            340
+seed7/lib/field.s7i          0.032659            268
+seed7/lib/file.s7i           0.032608            372
+seed7/lib/filebits.s7i       0.032415             46
+seed7/lib/filesys.s7i        0.035452            601
+seed7/lib/fileutil.s7i       0.034125            144
+seed7/lib/fixarray.s7i       0.033540            307
+seed7/lib/float.s7i          0.033846            757
+seed7/lib/font.s7i           0.033510            196
+seed7/lib/font8x8.s7i        0.038280            998
+seed7/lib/forloop.s7i        0.037143            449
+seed7/lib/ftp.s7i            0.033824            969
+seed7/lib/ftpserv.s7i        0.033984            631
+seed7/lib/getf.s7i           0.034121            115
+seed7/lib/gethttp.s7i        0.034118             41
+seed7/lib/gethttps.s7i       0.034198             41
+seed7/lib/gif.s7i            0.033628            561
+seed7/lib/graph.s7i          0.033801            415
+seed7/lib/graph_file.s7i     0.034157            399
+seed7/lib/gtkserver.s7i      0.034063            161
+seed7/lib/gzip.s7i           0.033598            573
+seed7/lib/hash.s7i           0.033535            421
+seed7/lib/hashsetof.s7i      0.038064            499
+seed7/lib/hmac.s7i           0.037972            152
+seed7/lib/html.s7i           0.034044             83
+seed7/lib/html_ent.s7i       0.033694            476
+seed7/lib/htmldom.s7i        0.034115            286
+seed7/lib/http_request.s7i   0.034294            696
+seed7/lib/http_srv_resp.s7i  0.033894            380
+seed7/lib/https_request.s7i  0.033170            211
+seed7/lib/httpserv.s7i       0.033752            345
+seed7/lib/huffman.s7i        0.032916            644
+seed7/lib/ico.s7i            0.033150            221
+seed7/lib/idxarray.s7i       0.033574            232
+seed7/lib/image.s7i          0.033119            156
+seed7/lib/imagefile.s7i      0.035774            171
+seed7/lib/inflate.s7i        0.033768            411
+seed7/lib/inifile.s7i        0.033170            129
+seed7/lib/integer.s7i        0.032819            663
+seed7/lib/iobuffer.s7i       0.033099            289
+seed7/lib/jpeg.s7i           0.033121           1761
+seed7/lib/json.s7i           0.033055            891
+seed7/lib/json_serde.s7i     0.033348            783
+seed7/lib/keybd.s7i          0.033795            639
+seed7/lib/keydescr.s7i       0.032585            192
+seed7/lib/leb128.s7i         0.032667            218
+seed7/lib/line.s7i           0.032897            164
+seed7/lib/listener.s7i       0.033715            247
+seed7/lib/logfile.s7i        0.034042             73
+seed7/lib/lower.s7i          0.033525            142
+seed7/lib/lzma.s7i           0.033691            934
+seed7/lib/lzw.s7i            0.033740            861
+seed7/lib/magic.s7i          0.033470            403
+seed7/lib/mahjng32.s7i       0.033646           1500
+seed7/lib/make.s7i           0.033590            544
+seed7/lib/makedata.s7i       0.033432           1428
+seed7/lib/math.s7i           0.033420            201
+seed7/lib/mixarith.s7i       0.033579            249
+seed7/lib/modern27.s7i       0.033737           1099
+seed7/lib/more.s7i           0.034145            130
+seed7/lib/msgdigest.s7i      0.033542           1222
+seed7/lib/multiscr.s7i       0.033030             68
+seed7/lib/null_file.s7i      0.033002            345
+seed7/lib/osfiles.s7i        0.033073           1085
+seed7/lib/pbm.s7i            0.032963            230
+seed7/lib/pcx.s7i            0.033602            638
+seed7/lib/pem.s7i            0.032701            185
+seed7/lib/pgm.s7i            0.035222            238
+seed7/lib/pic16.s7i          0.033620           1037
+seed7/lib/pic32.s7i          0.033947           2060
+seed7/lib/pic_util.s7i       0.033470            144
+seed7/lib/pixelimage.s7i     0.034022            320
+seed7/lib/pixmap_file.s7i    0.040932            459
+seed7/lib/pixmapfont.s7i     0.035507            184
+seed7/lib/pkcs1.s7i          0.033564            543
+seed7/lib/png.s7i            0.035994           1064
+seed7/lib/poll.s7i           0.034955            313
+seed7/lib/ppm.s7i            0.033700            240
+seed7/lib/process.s7i        0.033754            541
+seed7/lib/progs.s7i          0.034871            789
+seed7/lib/propertyfile.s7i   0.034064            155
+seed7/lib/rational.s7i       0.033937            792
+seed7/lib/ref_list.s7i       0.034213            252
+seed7/lib/reference.s7i      0.033370            126
+seed7/lib/reverse.s7i        0.033053             94
+seed7/lib/rpm.s7i            0.033822           3487
+seed7/lib/rpmext.s7i         0.032481            318
+seed7/lib/scanfile.s7i       0.033102           1779
+seed7/lib/scanjson.s7i       0.033024            413
+seed7/lib/scanstri.s7i       0.032864           1814
+seed7/lib/scantoml.s7i       0.032707           1603
+seed7/lib/seed7_05.s7i       0.032683           1072
+seed7/lib/set.s7i            0.032808             57
+seed7/lib/shell.s7i          0.032842            615
+seed7/lib/showtls.s7i        0.032718            678
+seed7/lib/signature.s7i      0.032779            131
+seed7/lib/smtp.s7i           0.032716            261
+seed7/lib/sockbase.s7i       0.032515            217
+seed7/lib/socket.s7i         0.034070            326
+seed7/lib/sokoban1.s7i       0.033674           1519
+seed7/lib/sql_base.s7i       0.033825           1000
+seed7/lib/stars.s7i          0.033983           1705
+seed7/lib/stdfont10.s7i      0.033872           3347
+seed7/lib/stdfont12.s7i      0.034290           3928
+seed7/lib/stdfont14.s7i      0.033673           4510
+seed7/lib/stdfont16.s7i      0.034326           5092
+seed7/lib/stdfont18.s7i      0.034825           5868
+seed7/lib/stdfont20.s7i      0.034200           6449
+seed7/lib/stdfont24.s7i      0.034491           7421
+seed7/lib/stdfont8.s7i       0.038326           2960
+seed7/lib/stdfont9.s7i       0.038275           3152
+seed7/lib/stdio.s7i          0.033931            192
+seed7/lib/strifile.s7i       0.033920            345
+seed7/lib/string.s7i         0.034014            779
+seed7/lib/stritext.s7i       0.033839            352
+seed7/lib/struct.s7i         0.034139            266
+seed7/lib/struct_elem.s7i    0.035276            129
+seed7/lib/subfile.s7i        0.034149            174
+seed7/lib/subrange.s7i       0.033820             78
+seed7/lib/syntax.s7i         0.034147            294
+seed7/lib/tar.s7i            0.033796           1880
+seed7/lib/tar_cmds.s7i       0.033704            752
+seed7/lib/tdes.s7i           0.032741            143
+seed7/lib/tee.s7i            0.033079            143
+seed7/lib/text.s7i           0.033018            135
+seed7/lib/tga.s7i            0.033369            676
+seed7/lib/tiff.s7i           0.032983           2771
+seed7/lib/time.s7i           0.033034           1191
+seed7/lib/tls.s7i            0.034635           2230
+seed7/lib/unicode.s7i        0.032925            575
+seed7/lib/unionfnd.s7i       0.032811            130
+seed7/lib/upper.s7i          0.033231            142
+seed7/lib/utf16.s7i          0.033080            540
+seed7/lib/utf8.s7i           0.032792            234
+seed7/lib/vecfont10.s7i      0.033368           1056
+seed7/lib/vecfont18.s7i      0.033773           1119
+seed7/lib/vector3d.s7i       0.033094            293
+seed7/lib/vectorfont.s7i     0.033229            239
+seed7/lib/wildcard.s7i       0.033062            140
+seed7/lib/window.s7i         0.033427            455
+seed7/lib/wrinum.s7i         0.034018            248
+seed7/lib/x509cert.s7i       0.033834           1243
+seed7/lib/xml_ent.s7i        0.033529             94
+seed7/lib/xmldom.s7i         0.033647            303
+seed7/lib/xz.s7i             0.033616            442
+seed7/lib/zip.s7i            0.034044           2792
+seed7/lib/zstd.s7i           0.034999           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033885        |
++-----------+-----------------+
+| Minimum   | 0.032407        |
++-----------+-----------------+
+| Maximum   | 0.042646        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.047622            190
+seed7/prg/bas7.sd7           0.041024          11459
+seed7/prg/bifurk.sd7         0.036888             73
+seed7/prg/bigfiles.sd7       0.038623            129
+seed7/prg/brainf7.sd7        0.038260             86
+seed7/prg/calc7.sd7          0.039541            128
+seed7/prg/carddemo.sd7       0.038779            190
+seed7/prg/castle.sd7         0.041416           3148
+seed7/prg/cat.sd7            0.036576             82
+seed7/prg/cellauto.sd7       0.039455             85
+seed7/prg/celsius.sd7        0.037497             42
+seed7/prg/chk_all.sd7        0.039340            843
+seed7/prg/chkarr.sd7         0.038544           8367
+seed7/prg/chkbig.sd7         0.042497          29026
+seed7/prg/chkbin.sd7         0.038346           6469
+seed7/prg/chkbitdata.sd7     0.040734           6624
+seed7/prg/chkbool.sd7        0.038718           3157
+seed7/prg/chkbst.sd7         0.039465            722
+seed7/prg/chkchr.sd7         0.038915           2809
+seed7/prg/chkcmd.sd7         0.037716           1205
+seed7/prg/chkdb.sd7          0.041163           7454
+seed7/prg/chkdecl.sd7        0.038995            448
+seed7/prg/chkenum.sd7        0.037881           1230
+seed7/prg/chkerr.sd7         0.039856           4663
+seed7/prg/chkexc.sd7         0.038156           2627
+seed7/prg/chkfil.sd7         0.038840           1615
+seed7/prg/chkflt.sd7         0.040530          20620
+seed7/prg/chkhent.sd7        0.036819             54
+seed7/prg/chkhsh.sd7         0.039291           4548
+seed7/prg/chkidx.sd7         0.041426          19567
+seed7/prg/chkint.sd7         0.046295          38129
+seed7/prg/chkjson.sd7        0.038823           1764
+seed7/prg/chkovf.sd7         0.038340           8216
+seed7/prg/chkprc.sd7         0.040345          10111
+seed7/prg/chkscan.sd7        0.039592            714
+seed7/prg/chkset.sd7         0.040006          11974
+seed7/prg/chkstr.sd7         0.042362          26952
+seed7/prg/chktime.sd7        0.038984           2025
+seed7/prg/chktoml.sd7        0.041159           1656
+seed7/prg/clock.sd7          0.036230             47
+seed7/prg/clock2.sd7         0.036344             43
+seed7/prg/clock3.sd7         0.039285             95
+seed7/prg/cmpfil.sd7         0.037815             84
+seed7/prg/comanche.sd7       0.039509            180
+seed7/prg/confval.sd7        0.040039            175
+seed7/prg/db7.sd7            0.040477            417
+seed7/prg/diff7.sd7          0.038950            263
+seed7/prg/dirtst.sd7         0.036348             42
+seed7/prg/dirx.sd7           0.038169            152
+seed7/prg/dnafight.sd7       0.039657           1381
+seed7/prg/dragon.sd7         0.036811             73
+seed7/prg/echo.sd7           0.036137             39
+seed7/prg/eliza.sd7          0.038600            302
+seed7/prg/err.sd7            0.040865             96
+seed7/prg/fannkuch.sd7       0.039045            131
+seed7/prg/fib.sd7            0.038767             47
+seed7/prg/find7.sd7          0.039298            133
+seed7/prg/findchar.sd7       0.039191            149
+seed7/prg/fractree.sd7       0.036751             55
+seed7/prg/ftp7.sd7           0.039416            296
+seed7/prg/ftpserv.sd7        0.037774             74
+seed7/prg/gcd.sd7            0.037859            109
+seed7/prg/gkbd.sd7           0.037898            358
+seed7/prg/gtksvtst.sd7       0.036406             94
+seed7/prg/hal.sd7            0.036792            250
+seed7/prg/hamu.sd7           0.036801            573
+seed7/prg/hanoi.sd7          0.037234             55
+seed7/prg/hd.sd7             0.037510             79
+seed7/prg/hello.sd7          0.036004             32
+seed7/prg/hilbert.sd7        0.038209            108
+seed7/prg/ide7.sd7           0.039190            196
+seed7/prg/kbd.sd7            0.038576             49
+seed7/prg/klondike.sd7       0.040296            883
+seed7/prg/lander.sd7         0.041463           1551
+seed7/prg/lst80bas.sd7       0.038257            344
+seed7/prg/lst99bas.sd7       0.038001            401
+seed7/prg/lstgwbas.sd7       0.037564            577
+seed7/prg/mahjong.sd7        0.041238           1943
+seed7/prg/make7.sd7          0.039021            121
+seed7/prg/mandelbr.sd7       0.038597            237
+seed7/prg/mind.sd7           0.037448            443
+seed7/prg/mirror.sd7         0.038391            131
+seed7/prg/ms.sd7             0.039961            641
+seed7/prg/nicoma.sd7         0.039299            135
+seed7/prg/pac.sd7            0.035959            726
+seed7/prg/pairs.sd7          0.037662           2025
+seed7/prg/panic.sd7          0.038673           2634
+seed7/prg/percolation.sd7    0.038013            330
+seed7/prg/planets.sd7        0.040314           1486
+seed7/prg/portfwd7.sd7       0.038221            139
+seed7/prg/prime.sd7          0.036696             74
+seed7/prg/printpi1.sd7       0.035541             56
+seed7/prg/printpi2.sd7       0.035969             54
+seed7/prg/printpi3.sd7       0.037672             60
+seed7/prg/pv7.sd7            0.041338            337
+seed7/prg/queen.sd7          0.039074            149
+seed7/prg/rand.sd7           0.038358            121
+seed7/prg/raytrace.sd7       0.039513            538
+seed7/prg/rever.sd7          0.039176            816
+seed7/prg/roman.sd7          0.038295             38
+seed7/prg/s7c.sd7            0.039908           9060
+seed7/prg/s7check.sd7        0.036997             68
+seed7/prg/savehd7.sd7        0.038860           1110
+seed7/prg/self.sd7           0.036716             49
+seed7/prg/shisen.sd7         0.039090           1423
+seed7/prg/sl.sd7             0.039046           1029
+seed7/prg/snake.sd7          0.038368            615
+seed7/prg/sokoban.sd7        0.038753            891
+seed7/prg/spigotpi.sd7       0.037393             64
+seed7/prg/sql7.sd7           0.038485            278
+seed7/prg/startrek.sd7       0.039206            979
+seed7/prg/sudoku7.sd7        0.039961           2657
+seed7/prg/sydir7.sd7         0.040656            384
+seed7/prg/syntaxhl.sd7       0.041111            177
+seed7/prg/tak.sd7            0.037292             59
+seed7/prg/tar7.sd7           0.046299            121
+seed7/prg/tch.sd7            0.037630             55
+seed7/prg/testfont.sd7       0.041580             95
+seed7/prg/tet.sd7            0.040902            479
+seed7/prg/tetg.sd7           0.037621            501
+seed7/prg/toutf8.sd7         0.038430            240
+seed7/prg/tst_cli.sd7        0.037827             40
+seed7/prg/tst_srv.sd7        0.036816             47
+seed7/prg/wator.sd7          0.037190            651
+seed7/prg/which.sd7          0.035901             65
+seed7/prg/wiz.sd7            0.038435           2833
+seed7/prg/wordcnt.sd7        0.035935             54
+seed7/prg/wrinum.sd7         0.036516             43
+seed7/prg/wumpus.sd7         0.037572            372
+seed7/lib/aes.s7i            0.041270           1144
+seed7/lib/aes_gcm.s7i        0.038729            392
+seed7/lib/ar.s7i             0.038280           1532
+seed7/lib/arc4.s7i           0.039574            144
+seed7/lib/archive.s7i        0.039368            143
+seed7/lib/archive_base.s7i   0.038812            135
+seed7/lib/array.s7i          0.039305            610
+seed7/lib/asn1.s7i           0.037292            544
+seed7/lib/asn1oid.s7i        0.041456            157
+seed7/lib/basearray.s7i      0.039596            450
+seed7/lib/bigfile.s7i        0.038650            136
+seed7/lib/bigint.s7i         0.039358            824
+seed7/lib/bigrat.s7i         0.039116            784
+seed7/lib/bin16.s7i          0.039223            592
+seed7/lib/bin32.s7i          0.039488            490
+seed7/lib/bin64.s7i          0.038056            539
+seed7/lib/bitdata.s7i        0.041557           1330
+seed7/lib/bitmapfont.s7i     0.037708            215
+seed7/lib/bitset.s7i         0.040084            593
+seed7/lib/bitsetof.s7i       0.040113            431
+seed7/lib/blowfish.s7i       0.042550            383
+seed7/lib/bmp.s7i            0.039516            924
+seed7/lib/boolean.s7i        0.038150            403
+seed7/lib/browser.s7i        0.039180            280
+seed7/lib/bstring.s7i        0.039192            227
+seed7/lib/bytedata.s7i       0.041623            482
+seed7/lib/bzip2.s7i          0.040589            887
+seed7/lib/cards.s7i          0.037538           1342
+seed7/lib/category.s7i       0.039317            209
+seed7/lib/cc_conf.s7i        0.038658           1314
+seed7/lib/ccittfax.s7i       0.039659           1022
+seed7/lib/cgi.s7i            0.039249            109
+seed7/lib/cgidialog.s7i      0.039055           1118
+seed7/lib/char.s7i           0.038717            356
+seed7/lib/charsets.s7i       0.039889           2024
+seed7/lib/chartype.s7i       0.041587            121
+seed7/lib/cipher.s7i         0.040476            146
+seed7/lib/cli_cmds.s7i       0.039923           1360
+seed7/lib/clib_file.s7i      0.038763            301
+seed7/lib/color.s7i          0.039464            185
+seed7/lib/complex.s7i        0.037328            464
+seed7/lib/compress.s7i       0.039100            150
+seed7/lib/console.s7i        0.037450            188
+seed7/lib/cpio.s7i           0.038069           1708
+seed7/lib/crc32.s7i          0.038671            193
+seed7/lib/cronos16.s7i       0.039328           1173
+seed7/lib/cronos27.s7i       0.041310           1464
+seed7/lib/csv.s7i            0.039258            201
+seed7/lib/db_prop.s7i        0.037520            991
+seed7/lib/deflate.s7i        0.039719            740
+seed7/lib/des.s7i            0.038249            444
+seed7/lib/dialog.s7i         0.038506            311
+seed7/lib/dir.s7i            0.038446            163
+seed7/lib/draw.s7i           0.037967            854
+seed7/lib/duration.s7i       0.037412           1038
+seed7/lib/echo.s7i           0.038797            132
+seed7/lib/editline.s7i       0.038418            398
+seed7/lib/elf.s7i            0.039085           1560
+seed7/lib/elliptic.s7i       0.039562            649
+seed7/lib/enable_io.s7i      0.039069            312
+seed7/lib/encoding.s7i       0.039928            931
+seed7/lib/enumeration.s7i    0.039157            236
+seed7/lib/environment.s7i    0.038783            175
+seed7/lib/exif.s7i           0.040163            152
+seed7/lib/external_file.s7i  0.040740            340
+seed7/lib/field.s7i          0.040789            268
+seed7/lib/file.s7i           0.038791            372
+seed7/lib/filebits.s7i       0.036477             46
+seed7/lib/filesys.s7i        0.039451            601
+seed7/lib/fileutil.s7i       0.039113            144
+seed7/lib/fixarray.s7i       0.040093            307
+seed7/lib/float.s7i          0.041295            757
+seed7/lib/font.s7i           0.043888            196
+seed7/lib/font8x8.s7i        0.037340            998
+seed7/lib/forloop.s7i        0.040516            449
+seed7/lib/ftp.s7i            0.041954            969
+seed7/lib/ftpserv.s7i        0.039217            631
+seed7/lib/getf.s7i           0.039926            115
+seed7/lib/gethttp.s7i        0.036416             41
+seed7/lib/gethttps.s7i       0.036504             41
+seed7/lib/gif.s7i            0.040064            561
+seed7/lib/graph.s7i          0.040981            415
+seed7/lib/graph_file.s7i     0.038764            399
+seed7/lib/gtkserver.s7i      0.038355            161
+seed7/lib/gzip.s7i           0.038813            573
+seed7/lib/hash.s7i           0.041456            421
+seed7/lib/hashsetof.s7i      0.040942            499
+seed7/lib/hmac.s7i           0.038032            152
+seed7/lib/html.s7i           0.038168             83
+seed7/lib/html_ent.s7i       0.038375            476
+seed7/lib/htmldom.s7i        0.038671            286
+seed7/lib/http_request.s7i   0.039302            696
+seed7/lib/http_srv_resp.s7i  0.038791            380
+seed7/lib/https_request.s7i  0.038474            211
+seed7/lib/httpserv.s7i       0.037627            345
+seed7/lib/huffman.s7i        0.038366            644
+seed7/lib/ico.s7i            0.038123            221
+seed7/lib/idxarray.s7i       0.038178            232
+seed7/lib/image.s7i          0.036437            156
+seed7/lib/imagefile.s7i      0.037229            171
+seed7/lib/inflate.s7i        0.038400            411
+seed7/lib/inifile.s7i        0.039162            129
+seed7/lib/integer.s7i        0.040063            663
+seed7/lib/iobuffer.s7i       0.040455            289
+seed7/lib/jpeg.s7i           0.039129           1761
+seed7/lib/json.s7i           0.038214            891
+seed7/lib/json_serde.s7i     0.039201            783
+seed7/lib/keybd.s7i          0.039126            639
+seed7/lib/keydescr.s7i       0.040433            192
+seed7/lib/leb128.s7i         0.039887            218
+seed7/lib/line.s7i           0.037730            164
+seed7/lib/listener.s7i       0.038537            247
+seed7/lib/logfile.s7i        0.037981             73
+seed7/lib/lower.s7i          0.041139            142
+seed7/lib/lzma.s7i           0.040993            934
+seed7/lib/lzw.s7i            0.038916            861
+seed7/lib/magic.s7i          0.039279            403
+seed7/lib/mahjng32.s7i       0.038771           1500
+seed7/lib/make.s7i           0.039167            544
+seed7/lib/makedata.s7i       0.039760           1428
+seed7/lib/math.s7i           0.038758            201
+seed7/lib/mixarith.s7i       0.038580            249
+seed7/lib/modern27.s7i       0.040726           1099
+seed7/lib/more.s7i           0.037600            130
+seed7/lib/msgdigest.s7i      0.040458           1222
+seed7/lib/multiscr.s7i       0.038553             68
+seed7/lib/null_file.s7i      0.037485            345
+seed7/lib/osfiles.s7i        0.039306           1085
+seed7/lib/pbm.s7i            0.039730            230
+seed7/lib/pcx.s7i            0.039399            638
+seed7/lib/pem.s7i            0.038436            185
+seed7/lib/pgm.s7i            0.037884            238
+seed7/lib/pic16.s7i          0.036140           1037
+seed7/lib/pic32.s7i          0.037182           2060
+seed7/lib/pic_util.s7i       0.037608            144
+seed7/lib/pixelimage.s7i     0.040045            320
+seed7/lib/pixmap_file.s7i    0.038141            459
+seed7/lib/pixmapfont.s7i     0.037863            184
+seed7/lib/pkcs1.s7i          0.043794            543
+seed7/lib/png.s7i            0.039127           1064
+seed7/lib/poll.s7i           0.038845            313
+seed7/lib/ppm.s7i            0.043975            240
+seed7/lib/process.s7i        0.044052            541
+seed7/lib/progs.s7i          0.040016            789
+seed7/lib/propertyfile.s7i   0.039736            155
+seed7/lib/rational.s7i       0.040463            792
+seed7/lib/ref_list.s7i       0.040736            252
+seed7/lib/reference.s7i      0.041790            126
+seed7/lib/reverse.s7i        0.040755             94
+seed7/lib/rpm.s7i            0.040017           3487
+seed7/lib/rpmext.s7i         0.038455            318
+seed7/lib/scanfile.s7i       0.038905           1779
+seed7/lib/scanjson.s7i       0.038572            413
+seed7/lib/scanstri.s7i       0.038353           1814
+seed7/lib/scantoml.s7i       0.037779           1603
+seed7/lib/seed7_05.s7i       0.042089           1072
+seed7/lib/set.s7i            0.037767             57
+seed7/lib/shell.s7i          0.039344            615
+seed7/lib/showtls.s7i        0.039475            678
+seed7/lib/signature.s7i      0.039672            131
+seed7/lib/smtp.s7i           0.038957            261
+seed7/lib/sockbase.s7i       0.038636            217
+seed7/lib/socket.s7i         0.041633            326
+seed7/lib/sokoban1.s7i       0.038782           1519
+seed7/lib/sql_base.s7i       0.043575           1000
+seed7/lib/stars.s7i          0.039891           1705
+seed7/lib/stdfont10.s7i      0.038708           3347
+seed7/lib/stdfont12.s7i      0.038692           3928
+seed7/lib/stdfont14.s7i      0.038638           4510
+seed7/lib/stdfont16.s7i      0.048630           5092
+seed7/lib/stdfont18.s7i      0.036651           5868
+seed7/lib/stdfont20.s7i      0.037607           6449
+seed7/lib/stdfont24.s7i      0.038067           7421
+seed7/lib/stdfont8.s7i       0.040114           2960
+seed7/lib/stdfont9.s7i       0.037296           3152
+seed7/lib/stdio.s7i          0.037587            192
+seed7/lib/strifile.s7i       0.042192            345
+seed7/lib/string.s7i         0.043508            779
+seed7/lib/stritext.s7i       0.039303            352
+seed7/lib/struct.s7i         0.038261            266
+seed7/lib/struct_elem.s7i    0.037875            129
+seed7/lib/subfile.s7i        0.038945            174
+seed7/lib/subrange.s7i       0.038268             78
+seed7/lib/syntax.s7i         0.039741            294
+seed7/lib/tar.s7i            0.040672           1880
+seed7/lib/tar_cmds.s7i       0.039609            752
+seed7/lib/tdes.s7i           0.039016            143
+seed7/lib/tee.s7i            0.038922            143
+seed7/lib/text.s7i           0.038591            135
+seed7/lib/tga.s7i            0.041434            676
+seed7/lib/tiff.s7i           0.040306           2771
+seed7/lib/time.s7i           0.039306           1191
+seed7/lib/tls.s7i            0.039417           2230
+seed7/lib/unicode.s7i        0.039980            575
+seed7/lib/unionfnd.s7i       0.037959            130
+seed7/lib/upper.s7i          0.038708            142
+seed7/lib/utf16.s7i          0.038483            540
+seed7/lib/utf8.s7i           0.038897            234
+seed7/lib/vecfont10.s7i      0.040313           1056
+seed7/lib/vecfont18.s7i      0.040881           1119
+seed7/lib/vector3d.s7i       0.038017            293
+seed7/lib/vectorfont.s7i     0.040121            239
+seed7/lib/wildcard.s7i       0.039739            140
+seed7/lib/window.s7i         0.038764            455
+seed7/lib/wrinum.s7i         0.038114            248
+seed7/lib/x509cert.s7i       0.038119           1243
+seed7/lib/xml_ent.s7i        0.037592             94
+seed7/lib/xmldom.s7i         0.036343            303
+seed7/lib/xz.s7i             0.039598            442
+seed7/lib/zip.s7i            0.042261           2792
+seed7/lib/zstd.s7i           0.039003           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039124        |
++-----------+-----------------+
+| Minimum   | 0.035541        |
++-----------+-----------------+
+| Maximum   | 0.048630        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.038216            190
+seed7/prg/bas7.sd7           0.321793          11459
+seed7/prg/bifurk.sd7         0.036597             73
+seed7/prg/bigfiles.sd7       0.037677            129
+seed7/prg/brainf7.sd7        0.036741             86
+seed7/prg/calc7.sd7          0.038012            128
+seed7/prg/carddemo.sd7       0.039286            190
+seed7/prg/castle.sd7         0.110907           3148
+seed7/prg/cat.sd7            0.038534             82
+seed7/prg/cellauto.sd7       0.036560             85
+seed7/prg/celsius.sd7        0.035952             42
+seed7/prg/chk_all.sd7        0.058897            843
+seed7/prg/chkarr.sd7         0.348368           8367
+seed7/prg/chkbig.sd7         2.042482          29026
+seed7/prg/chkbin.sd7         0.508079           6469
+seed7/prg/chkbitdata.sd7     0.608467           6624
+seed7/prg/chkbool.sd7        0.114303           3157
+seed7/prg/chkbst.sd7         0.061707            722
+seed7/prg/chkchr.sd7         0.212260           2809
+seed7/prg/chkcmd.sd7         0.066129           1205
+seed7/prg/chkdb.sd7          0.345779           7454
+seed7/prg/chkdecl.sd7        0.056542            448
+seed7/prg/chkenum.sd7        0.068733           1230
+seed7/prg/chkerr.sd7         0.193666           4663
+seed7/prg/chkexc.sd7         0.081808           2627
+seed7/prg/chkfil.sd7         0.075304           1615
+seed7/prg/chkflt.sd7         1.329557          20620
+seed7/prg/chkhent.sd7        0.041495             54
+seed7/prg/chkhsh.sd7         0.244181           4548
+seed7/prg/chkidx.sd7         1.298338          19567
+seed7/prg/chkint.sd7         2.496066          38129
+seed7/prg/chkjson.sd7        0.099809           1764
+seed7/prg/chkovf.sd7         0.551905           8216
+seed7/prg/chkprc.sd7         0.317258          10111
+seed7/prg/chkscan.sd7        0.056527            714
+seed7/prg/chkset.sd7         0.654224          11974
+seed7/prg/chkstr.sd7         1.362559          26952
+seed7/prg/chktime.sd7        0.128463           2025
+seed7/prg/chktoml.sd7        0.105146           1656
+seed7/prg/clock.sd7          0.036132             47
+seed7/prg/clock2.sd7         0.035330             43
+seed7/prg/clock3.sd7         0.037284             95
+seed7/prg/cmpfil.sd7         0.036290             84
+seed7/prg/comanche.sd7       0.040176            180
+seed7/prg/confval.sd7        0.042613            175
+seed7/prg/db7.sd7            0.046063            417
+seed7/prg/diff7.sd7          0.042231            263
+seed7/prg/dirtst.sd7         0.034852             42
+seed7/prg/dirx.sd7           0.036692            152
+seed7/prg/dnafight.sd7       0.064727           1381
+seed7/prg/dragon.sd7         0.035616             73
+seed7/prg/echo.sd7           0.034208             39
+seed7/prg/eliza.sd7          0.043085            302
+seed7/prg/err.sd7            0.039890             96
+seed7/prg/fannkuch.sd7       0.037224            131
+seed7/prg/fib.sd7            0.035761             47
+seed7/prg/find7.sd7          0.037577            133
+seed7/prg/findchar.sd7       0.038393            149
+seed7/prg/fractree.sd7       0.035975             55
+seed7/prg/ftp7.sd7           0.048754            296
+seed7/prg/ftpserv.sd7        0.041068             74
+seed7/prg/gcd.sd7            0.036692            109
+seed7/prg/gkbd.sd7           0.045500            358
+seed7/prg/gtksvtst.sd7       0.036710             94
+seed7/prg/hal.sd7            0.039307            250
+seed7/prg/hamu.sd7           0.050282            573
+seed7/prg/hanoi.sd7          0.035917             55
+seed7/prg/hd.sd7             0.036368             79
+seed7/prg/hello.sd7          0.035473             32
+seed7/prg/hilbert.sd7        0.037047            108
+seed7/prg/ide7.sd7           0.039997            196
+seed7/prg/kbd.sd7            0.036174             49
+seed7/prg/klondike.sd7       0.054376            883
+seed7/prg/lander.sd7         0.070180           1551
+seed7/prg/lst80bas.sd7       0.043847            344
+seed7/prg/lst99bas.sd7       0.044190            401
+seed7/prg/lstgwbas.sd7       0.050536            577
+seed7/prg/mahjong.sd7        0.081087           1943
+seed7/prg/make7.sd7          0.038435            121
+seed7/prg/mandelbr.sd7       0.040789            237
+seed7/prg/mind.sd7           0.044996            443
+seed7/prg/mirror.sd7         0.039389            131
+seed7/prg/ms.sd7             0.048488            641
+seed7/prg/nicoma.sd7         0.038587            135
+seed7/prg/pac.sd7            0.048955            726
+seed7/prg/pairs.sd7          0.080319           2025
+seed7/prg/panic.sd7          0.095515           2634
+seed7/prg/percolation.sd7    0.041723            330
+seed7/prg/planets.sd7        0.074366           1486
+seed7/prg/portfwd7.sd7       0.037311            139
+seed7/prg/prime.sd7          0.035321             74
+seed7/prg/printpi1.sd7       0.035348             56
+seed7/prg/printpi2.sd7       0.034721             54
+seed7/prg/printpi3.sd7       0.035183             60
+seed7/prg/pv7.sd7            0.042405            337
+seed7/prg/queen.sd7          0.036889            149
+seed7/prg/rand.sd7           0.036035            121
+seed7/prg/raytrace.sd7       0.049796            538
+seed7/prg/rever.sd7          0.053930            816
+seed7/prg/roman.sd7          0.035834             38
+seed7/prg/s7c.sd7            0.277098           9060
+seed7/prg/s7check.sd7        0.036415             68
+seed7/prg/savehd7.sd7        0.066189           1110
+seed7/prg/self.sd7           0.036242             49
+seed7/prg/shisen.sd7         0.071587           1423
+seed7/prg/sl.sd7             0.061683           1029
+seed7/prg/snake.sd7          0.049254            615
+seed7/prg/sokoban.sd7        0.054436            891
+seed7/prg/spigotpi.sd7       0.036367             64
+seed7/prg/sql7.sd7           0.041237            278
+seed7/prg/startrek.sd7       0.060511            979
+seed7/prg/sudoku7.sd7        0.100624           2657
+seed7/prg/sydir7.sd7         0.044954            384
+seed7/prg/syntaxhl.sd7       0.041703            177
+seed7/prg/tak.sd7            0.038789             59
+seed7/prg/tar7.sd7           0.038233            121
+seed7/prg/tch.sd7            0.036004             55
+seed7/prg/testfont.sd7       0.036414             95
+seed7/prg/tet.sd7            0.043833            479
+seed7/prg/tetg.sd7           0.044076            501
+seed7/prg/toutf8.sd7         0.041075            240
+seed7/prg/tst_cli.sd7        0.035382             40
+seed7/prg/tst_srv.sd7        0.035373             47
+seed7/prg/wator.sd7          0.052347            651
+seed7/prg/which.sd7          0.036804             65
+seed7/prg/wiz.sd7            0.104459           2833
+seed7/prg/wordcnt.sd7        0.035976             54
+seed7/prg/wrinum.sd7         0.035522             43
+seed7/prg/wumpus.sd7         0.042696            372
+seed7/lib/aes.s7i            0.109084           1144
+seed7/lib/aes_gcm.s7i        0.046306            392
+seed7/lib/ar.s7i             0.071114           1532
+seed7/lib/arc4.s7i           0.037283            144
+seed7/lib/archive.s7i        0.037436            143
+seed7/lib/archive_base.s7i   0.037358            135
+seed7/lib/array.s7i          0.053864            610
+seed7/lib/asn1.s7i           0.047147            544
+seed7/lib/asn1oid.s7i        0.041868            157
+seed7/lib/basearray.s7i      0.048824            450
+seed7/lib/bigfile.s7i        0.038269            136
+seed7/lib/bigint.s7i         0.055417            824
+seed7/lib/bigrat.s7i         0.053912            784
+seed7/lib/bin16.s7i          0.050674            592
+seed7/lib/bin32.s7i          0.047970            490
+seed7/lib/bin64.s7i          0.049531            539
+seed7/lib/bitdata.s7i        0.076044           1330
+seed7/lib/bitmapfont.s7i     0.038961            215
+seed7/lib/bitset.s7i         0.047132            593
+seed7/lib/bitsetof.s7i       0.046065            431
+seed7/lib/blowfish.s7i       0.054929            383
+seed7/lib/bmp.s7i            0.059096            924
+seed7/lib/boolean.s7i        0.043314            403
+seed7/lib/browser.s7i        0.041658            280
+seed7/lib/bstring.s7i        0.040033            227
+seed7/lib/bytedata.s7i       0.048576            482
+seed7/lib/bzip2.s7i          0.057391            887
+seed7/lib/cards.s7i          0.065483           1342
+seed7/lib/category.s7i       0.042097            209
+seed7/lib/cc_conf.s7i        0.078009           1314
+seed7/lib/ccittfax.s7i       0.065228           1022
+seed7/lib/cgi.s7i            0.038263            109
+seed7/lib/cgidialog.s7i      0.060182           1118
+seed7/lib/char.s7i           0.043562            356
+seed7/lib/charsets.s7i       0.081033           2024
+seed7/lib/chartype.s7i       0.039955            121
+seed7/lib/cipher.s7i         0.038178            146
+seed7/lib/cli_cmds.s7i       0.067819           1360
+seed7/lib/clib_file.s7i      0.044232            301
+seed7/lib/color.s7i          0.048023            185
+seed7/lib/complex.s7i        0.046774            464
+seed7/lib/compress.s7i       0.038591            150
+seed7/lib/console.s7i        0.039532            188
+seed7/lib/cpio.s7i           0.079390           1708
+seed7/lib/crc32.s7i          0.042638            193
+seed7/lib/cronos16.s7i       0.091091           1173
+seed7/lib/cronos27.s7i       0.116239           1464
+seed7/lib/csv.s7i            0.039845            201
+seed7/lib/db_prop.s7i        0.061013            991
+seed7/lib/deflate.s7i        0.054276            740
+seed7/lib/des.s7i            0.053917            444
+seed7/lib/dialog.s7i         0.042713            311
+seed7/lib/dir.s7i            0.037044            163
+seed7/lib/draw.s7i           0.055744            854
+seed7/lib/duration.s7i       0.060648           1038
+seed7/lib/echo.s7i           0.038078            132
+seed7/lib/editline.s7i       0.045282            398
+seed7/lib/elf.s7i            0.085642           1560
+seed7/lib/elliptic.s7i       0.052426            649
+seed7/lib/enable_io.s7i      0.043790            312
+seed7/lib/encoding.s7i       0.060213            931
+seed7/lib/enumeration.s7i    0.040337            236
+seed7/lib/environment.s7i    0.038551            175
+seed7/lib/exif.s7i           0.039964            152
+seed7/lib/external_file.s7i  0.044560            340
+seed7/lib/field.s7i          0.041877            268
+seed7/lib/file.s7i           0.044787            372
+seed7/lib/filebits.s7i       0.039864             46
+seed7/lib/filesys.s7i        0.055519            601
+seed7/lib/fileutil.s7i       0.041788            144
+seed7/lib/fixarray.s7i       0.043976            307
+seed7/lib/float.s7i          0.055253            757
+seed7/lib/font.s7i           0.039820            196
+seed7/lib/font8x8.s7i        0.048603            998
+seed7/lib/forloop.s7i        0.045780            449
+seed7/lib/ftp.s7i            0.057613            969
+seed7/lib/ftpserv.s7i        0.051144            631
+seed7/lib/getf.s7i           0.037352            115
+seed7/lib/gethttp.s7i        0.035611             41
+seed7/lib/gethttps.s7i       0.035922             41
+seed7/lib/gif.s7i            0.056697            561
+seed7/lib/graph.s7i          0.050767            415
+seed7/lib/graph_file.s7i     0.044288            399
+seed7/lib/gtkserver.s7i      0.038391            161
+seed7/lib/gzip.s7i           0.048371            573
+seed7/lib/hash.s7i           0.048211            421
+seed7/lib/hashsetof.s7i      0.047492            499
+seed7/lib/hmac.s7i           0.041392            152
+seed7/lib/html.s7i           0.041950             83
+seed7/lib/html_ent.s7i       0.049718            476
+seed7/lib/htmldom.s7i        0.043427            286
+seed7/lib/http_request.s7i   0.051452            696
+seed7/lib/http_srv_resp.s7i  0.045325            380
+seed7/lib/https_request.s7i  0.040430            211
+seed7/lib/httpserv.s7i       0.043729            345
+seed7/lib/huffman.s7i        0.052698            644
+seed7/lib/ico.s7i            0.041239            221
+seed7/lib/idxarray.s7i       0.041838            232
+seed7/lib/image.s7i          0.037728            156
+seed7/lib/imagefile.s7i      0.039766            171
+seed7/lib/inflate.s7i        0.046668            411
+seed7/lib/inifile.s7i        0.038084            129
+seed7/lib/integer.s7i        0.052308            663
+seed7/lib/iobuffer.s7i       0.041660            289
+seed7/lib/jpeg.s7i           0.084129           1761
+seed7/lib/json.s7i           0.055318            891
+seed7/lib/json_serde.s7i     0.053186            783
+seed7/lib/keybd.s7i          0.053708            639
+seed7/lib/keydescr.s7i       0.039993            192
+seed7/lib/leb128.s7i         0.038678            218
+seed7/lib/line.s7i           0.036878            164
+seed7/lib/listener.s7i       0.041202            247
+seed7/lib/logfile.s7i        0.036933             73
+seed7/lib/lower.s7i          0.038089            142
+seed7/lib/lzma.s7i           0.059278            934
+seed7/lib/lzw.s7i            0.059450            861
+seed7/lib/magic.s7i          0.048113            403
+seed7/lib/mahjng32.s7i       0.063725           1500
+seed7/lib/make.s7i           0.049575            544
+seed7/lib/makedata.s7i       0.070050           1428
+seed7/lib/math.s7i           0.040148            201
+seed7/lib/mixarith.s7i       0.040199            249
+seed7/lib/modern27.s7i       0.084043           1099
+seed7/lib/more.s7i           0.043196            130
+seed7/lib/msgdigest.s7i      0.081018           1222
+seed7/lib/multiscr.s7i       0.037184             68
+seed7/lib/null_file.s7i      0.041408            345
+seed7/lib/osfiles.s7i        0.063603           1085
+seed7/lib/pbm.s7i            0.039204            230
+seed7/lib/pcx.s7i            0.051116            638
+seed7/lib/pem.s7i            0.038058            185
+seed7/lib/pgm.s7i            0.039293            238
+seed7/lib/pic16.s7i          0.049263           1037
+seed7/lib/pic32.s7i          0.080362           2060
+seed7/lib/pic_util.s7i       0.038820            144
+seed7/lib/pixelimage.s7i     0.042353            320
+seed7/lib/pixmap_file.s7i    0.045551            459
+seed7/lib/pixmapfont.s7i     0.039553            184
+seed7/lib/pkcs1.s7i          0.058959            543
+seed7/lib/png.s7i            0.064052           1064
+seed7/lib/poll.s7i           0.044287            313
+seed7/lib/ppm.s7i            0.040988            240
+seed7/lib/process.s7i        0.048774            541
+seed7/lib/progs.s7i          0.055966            789
+seed7/lib/propertyfile.s7i   0.038983            155
+seed7/lib/rational.s7i       0.053187            792
+seed7/lib/ref_list.s7i       0.041979            252
+seed7/lib/reference.s7i      0.038217            126
+seed7/lib/reverse.s7i        0.036629             94
+seed7/lib/rpm.s7i            0.141224           3487
+seed7/lib/rpmext.s7i         0.043984            318
+seed7/lib/scanfile.s7i       0.080045           1779
+seed7/lib/scanjson.s7i       0.046939            413
+seed7/lib/scanstri.s7i       0.081600           1814
+seed7/lib/scantoml.s7i       0.070562           1603
+seed7/lib/seed7_05.s7i       0.065922           1072
+seed7/lib/set.s7i            0.034902             57
+seed7/lib/shell.s7i          0.052670            615
+seed7/lib/showtls.s7i        0.053861            678
+seed7/lib/signature.s7i      0.037216            131
+seed7/lib/smtp.s7i           0.039514            261
+seed7/lib/sockbase.s7i       0.042205            217
+seed7/lib/socket.s7i         0.043527            326
+seed7/lib/sokoban1.s7i       0.054097           1519
+seed7/lib/sql_base.s7i       0.064246           1000
+seed7/lib/stars.s7i          0.140615           1705
+seed7/lib/stdfont10.s7i      0.080475           3347
+seed7/lib/stdfont12.s7i      0.089533           3928
+seed7/lib/stdfont14.s7i      0.100540           4510
+seed7/lib/stdfont16.s7i      0.118437           5092
+seed7/lib/stdfont18.s7i      0.134462           5868
+seed7/lib/stdfont20.s7i      0.151222           6449
+seed7/lib/stdfont24.s7i      0.177707           7421
+seed7/lib/stdfont8.s7i       0.071669           2960
+seed7/lib/stdfont9.s7i       0.075443           3152
+seed7/lib/stdio.s7i          0.038548            192
+seed7/lib/strifile.s7i       0.042383            345
+seed7/lib/string.s7i         0.053819            779
+seed7/lib/stritext.s7i       0.041823            352
+seed7/lib/struct.s7i         0.043123            266
+seed7/lib/struct_elem.s7i    0.037761            129
+seed7/lib/subfile.s7i        0.037433            174
+seed7/lib/subrange.s7i       0.037307             78
+seed7/lib/syntax.s7i         0.045920            294
+seed7/lib/tar.s7i            0.081859           1880
+seed7/lib/tar_cmds.s7i       0.056041            752
+seed7/lib/tdes.s7i           0.038815            143
+seed7/lib/tee.s7i            0.037825            143
+seed7/lib/text.s7i           0.037946            135
+seed7/lib/tga.s7i            0.053782            676
+seed7/lib/tiff.s7i           0.121850           2771
+seed7/lib/time.s7i           0.069546           1191
+seed7/lib/tls.s7i            0.104767           2230
+seed7/lib/unicode.s7i        0.051789            575
+seed7/lib/unionfnd.s7i       0.037668            130
+seed7/lib/upper.s7i          0.037764            142
+seed7/lib/utf16.s7i          0.048996            540
+seed7/lib/utf8.s7i           0.040390            234
+seed7/lib/vecfont10.s7i      0.077197           1056
+seed7/lib/vecfont18.s7i      0.085142           1119
+seed7/lib/vector3d.s7i       0.040614            293
+seed7/lib/vectorfont.s7i     0.041244            239
+seed7/lib/wildcard.s7i       0.038426            140
+seed7/lib/window.s7i         0.045312            455
+seed7/lib/wrinum.s7i         0.041523            248
+seed7/lib/x509cert.s7i       0.070663           1243
+seed7/lib/xml_ent.s7i        0.036483             94
+seed7/lib/xmldom.s7i         0.039937            303
+seed7/lib/xz.s7i             0.044546            442
+seed7/lib/zip.s7i            0.117584           2792
+seed7/lib/zstd.s7i           0.067016           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.088500        |
++-----------+-----------------+
+| Minimum   | 0.034208        |
++-----------+-----------------+
+| Maximum   | 2.496066        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.045814            190
+seed7/prg/bas7.sd7           0.759259          11459
+seed7/prg/bifurk.sd7         0.039933             73
+seed7/prg/bigfiles.sd7       0.043066            129
+seed7/prg/brainf7.sd7        0.040727             86
+seed7/prg/calc7.sd7          0.042053            128
+seed7/prg/carddemo.sd7       0.048778            190
+seed7/prg/castle.sd7         0.215410           3148
+seed7/prg/cat.sd7            0.039979             82
+seed7/prg/cellauto.sd7       0.040543             85
+seed7/prg/celsius.sd7        0.037663             42
+seed7/prg/chk_all.sd7        0.083144            843
+seed7/prg/chkarr.sd7         0.855990           8367
+seed7/prg/chkbig.sd7         4.108866          29026
+seed7/prg/chkbin.sd7         1.022505           6469
+seed7/prg/chkbitdata.sd7     1.239625           6624
+seed7/prg/chkbool.sd7        0.231546           3157
+seed7/prg/chkbst.sd7         0.102663            722
+seed7/prg/chkchr.sd7         0.481528           2809
+seed7/prg/chkcmd.sd7         0.111798           1205
+seed7/prg/chkdb.sd7          0.743925           7454
+seed7/prg/chkdecl.sd7        0.097516            448
+seed7/prg/chkenum.sd7        0.122124           1230
+seed7/prg/chkerr.sd7         0.338353           4663
+seed7/prg/chkexc.sd7         0.150023           2627
+seed7/prg/chkfil.sd7         0.130306           1615
+seed7/prg/chkflt.sd7         2.805699          20620
+seed7/prg/chkhent.sd7        0.038861             54
+seed7/prg/chkhsh.sd7         0.503419           4548
+seed7/prg/chkidx.sd7         3.177717          19567
+seed7/prg/chkint.sd7         5.546317          38129
+seed7/prg/chkjson.sd7        0.189614           1764
+seed7/prg/chkovf.sd7         1.198371           8216
+seed7/prg/chkprc.sd7         0.692983          10111
+seed7/prg/chkscan.sd7        0.089599            714
+seed7/prg/chkset.sd7         1.726069          11974
+seed7/prg/chkstr.sd7         3.393365          26952
+seed7/prg/chktime.sd7        0.249399           2025
+seed7/prg/chktoml.sd7        0.197684           1656
+seed7/prg/clock.sd7          0.038864             47
+seed7/prg/clock2.sd7         0.036620             43
+seed7/prg/clock3.sd7         0.042432             95
+seed7/prg/cmpfil.sd7         0.043468             84
+seed7/prg/comanche.sd7       0.047897            180
+seed7/prg/confval.sd7        0.052438            175
+seed7/prg/db7.sd7            0.064295            417
+seed7/prg/diff7.sd7          0.054121            263
+seed7/prg/dirtst.sd7         0.037606             42
+seed7/prg/dirx.sd7           0.042608            152
+seed7/prg/dnafight.sd7       0.116810           1381
+seed7/prg/dragon.sd7         0.039375             73
+seed7/prg/echo.sd7           0.036609             39
+seed7/prg/eliza.sd7          0.052279            302
+seed7/prg/err.sd7            0.044273             96
+seed7/prg/fannkuch.sd7       0.041666            131
+seed7/prg/fib.sd7            0.037275             47
+seed7/prg/find7.sd7          0.042410            133
+seed7/prg/findchar.sd7       0.043985            149
+seed7/prg/fractree.sd7       0.037552             55
+seed7/prg/ftp7.sd7           0.052228            296
+seed7/prg/ftpserv.sd7        0.039164             74
+seed7/prg/gcd.sd7            0.040793            109
+seed7/prg/gkbd.sd7           0.060741            358
+seed7/prg/gtksvtst.sd7       0.040637             94
+seed7/prg/hal.sd7            0.046741            250
+seed7/prg/hamu.sd7           0.067413            573
+seed7/prg/hanoi.sd7          0.037676             55
+seed7/prg/hd.sd7             0.039039             79
+seed7/prg/hello.sd7          0.036272             32
+seed7/prg/hilbert.sd7        0.040591            108
+seed7/prg/ide7.sd7           0.047431            196
+seed7/prg/kbd.sd7            0.038295             49
+seed7/prg/klondike.sd7       0.106642            883
+seed7/prg/lander.sd7         0.131374           1551
+seed7/prg/lst80bas.sd7       0.056691            344
+seed7/prg/lst99bas.sd7       0.059149            401
+seed7/prg/lstgwbas.sd7       0.072982            577
+seed7/prg/mahjong.sd7        0.145226           1943
+seed7/prg/make7.sd7          0.043416            121
+seed7/prg/mandelbr.sd7       0.049489            237
+seed7/prg/mind.sd7           0.061606            443
+seed7/prg/mirror.sd7         0.043907            131
+seed7/prg/ms.sd7             0.068926            641
+seed7/prg/nicoma.sd7         0.042754            135
+seed7/prg/pac.sd7            0.073582            726
+seed7/prg/pairs.sd7          0.139498           2025
+seed7/prg/panic.sd7          0.192024           2634
+seed7/prg/percolation.sd7    0.056474            330
+seed7/prg/planets.sd7        0.139684           1486
+seed7/prg/portfwd7.sd7       0.043590            139
+seed7/prg/prime.sd7          0.038970             74
+seed7/prg/printpi1.sd7       0.037982             56
+seed7/prg/printpi2.sd7       0.037461             54
+seed7/prg/printpi3.sd7       0.037233             60
+seed7/prg/pv7.sd7            0.058780            337
+seed7/prg/queen.sd7          0.043084            149
+seed7/prg/rand.sd7           0.041503            121
+seed7/prg/raytrace.sd7       0.069140            538
+seed7/prg/rever.sd7          0.084159            816
+seed7/prg/roman.sd7          0.037921             38
+seed7/prg/s7c.sd7            0.619302           9060
+seed7/prg/s7check.sd7        0.040384             68
+seed7/prg/savehd7.sd7        0.111154           1110
+seed7/prg/self.sd7           0.037921             49
+seed7/prg/shisen.sd7         0.119297           1423
+seed7/prg/sl.sd7             0.095115           1029
+seed7/prg/snake.sd7          0.068825            615
+seed7/prg/sokoban.sd7        0.084804            891
+seed7/prg/spigotpi.sd7       0.038812             64
+seed7/prg/sql7.sd7           0.052247            278
+seed7/prg/startrek.sd7       0.094669            979
+seed7/prg/sudoku7.sd7        0.193302           2657
+seed7/prg/sydir7.sd7         0.059955            384
+seed7/prg/syntaxhl.sd7       0.048581            177
+seed7/prg/tak.sd7            0.037509             59
+seed7/prg/tar7.sd7           0.042635            121
+seed7/prg/tch.sd7            0.038096             55
+seed7/prg/testfont.sd7       0.042051             95
+seed7/prg/tet.sd7            0.059448            479
+seed7/prg/tetg.sd7           0.061102            501
+seed7/prg/toutf8.sd7         0.050485            240
+seed7/prg/tst_cli.sd7        0.036686             40
+seed7/prg/tst_srv.sd7        0.037607             47
+seed7/prg/wator.sd7          0.079876            651
+seed7/prg/which.sd7          0.038874             65
+seed7/prg/wiz.sd7            0.209156           2833
+seed7/prg/wordcnt.sd7        0.037807             54
+seed7/prg/wrinum.sd7         0.037559             43
+seed7/prg/wumpus.sd7         0.053773            372
+seed7/lib/aes.s7i            0.195772           1144
+seed7/lib/aes_gcm.s7i        0.059945            392
+seed7/lib/ar.s7i             0.125013           1532
+seed7/lib/arc4.s7i           0.043004            144
+seed7/lib/archive.s7i        0.043402            143
+seed7/lib/archive_base.s7i   0.043668            135
+seed7/lib/array.s7i          0.075755            610
+seed7/lib/asn1.s7i           0.065927            544
+seed7/lib/asn1oid.s7i        0.050067            157
+seed7/lib/basearray.s7i      0.064246            450
+seed7/lib/bigfile.s7i        0.042182            136
+seed7/lib/bigint.s7i         0.078091            824
+seed7/lib/bigrat.s7i         0.079111            784
+seed7/lib/bin16.s7i          0.068648            592
+seed7/lib/bin32.s7i          0.061408            490
+seed7/lib/bin64.s7i          0.063982            539
+seed7/lib/bitdata.s7i        0.123491           1330
+seed7/lib/bitmapfont.s7i     0.047487            215
+seed7/lib/bitset.s7i         0.064157            593
+seed7/lib/bitsetof.s7i       0.060712            431
+seed7/lib/blowfish.s7i       0.075737            383
+seed7/lib/bmp.s7i            0.097782            924
+seed7/lib/boolean.s7i        0.054025            403
+seed7/lib/browser.s7i        0.054128            280
+seed7/lib/bstring.s7i        0.047305            227
+seed7/lib/bytedata.s7i       0.064862            482
+seed7/lib/bzip2.s7i          0.089668            887
+seed7/lib/cards.s7i          0.102965           1342
+seed7/lib/category.s7i       0.048478            209
+seed7/lib/cc_conf.s7i        0.119976           1314
+seed7/lib/ccittfax.s7i       0.101393           1022
+seed7/lib/cgi.s7i            0.041715            109
+seed7/lib/cgidialog.s7i      0.096427           1118
+seed7/lib/char.s7i           0.052247            356
+seed7/lib/charsets.s7i       0.123808           2024
+seed7/lib/chartype.s7i       0.047154            121
+seed7/lib/cipher.s7i         0.051172            146
+seed7/lib/cli_cmds.s7i       0.117781           1360
+seed7/lib/clib_file.s7i      0.052397            301
+seed7/lib/color.s7i          0.048424            185
+seed7/lib/complex.s7i        0.059886            464
+seed7/lib/compress.s7i       0.044278            150
+seed7/lib/console.s7i        0.045315            188
+seed7/lib/cpio.s7i           0.144288           1708
+seed7/lib/crc32.s7i          0.053440            193
+seed7/lib/cronos16.s7i       0.193054           1173
+seed7/lib/cronos27.s7i       0.251176           1464
+seed7/lib/csv.s7i            0.047752            201
+seed7/lib/db_prop.s7i        0.101959            991
+seed7/lib/deflate.s7i        0.087686            740
+seed7/lib/des.s7i            0.081238            444
+seed7/lib/dialog.s7i         0.056525            311
+seed7/lib/dir.s7i            0.043828            163
+seed7/lib/draw.s7i           0.086149            854
+seed7/lib/duration.s7i       0.098740           1038
+seed7/lib/echo.s7i           0.043635            132
+seed7/lib/editline.s7i       0.059537            398
+seed7/lib/elf.s7i            0.154752           1560
+seed7/lib/elliptic.s7i       0.076245            649
+seed7/lib/enable_io.s7i      0.051214            312
+seed7/lib/encoding.s7i       0.095838            931
+seed7/lib/enumeration.s7i    0.049113            236
+seed7/lib/environment.s7i    0.045731            175
+seed7/lib/exif.s7i           0.047266            152
+seed7/lib/external_file.s7i  0.052056            340
+seed7/lib/field.s7i          0.052473            268
+seed7/lib/file.s7i           0.052946            372
+seed7/lib/filebits.s7i       0.037753             46
+seed7/lib/filesys.s7i        0.063596            601
+seed7/lib/fileutil.s7i       0.043636            144
+seed7/lib/fixarray.s7i       0.053301            307
+seed7/lib/float.s7i          0.074086            757
+seed7/lib/font.s7i           0.045213            196
+seed7/lib/font8x8.s7i        0.068747            998
+seed7/lib/forloop.s7i        0.059475            449
+seed7/lib/ftp.s7i            0.087489            969
+seed7/lib/ftpserv.s7i        0.076338            631
+seed7/lib/getf.s7i           0.041746            115
+seed7/lib/gethttp.s7i        0.036980             41
+seed7/lib/gethttps.s7i       0.036848             41
+seed7/lib/gif.s7i            0.069878            561
+seed7/lib/graph.s7i          0.064903            415
+seed7/lib/graph_file.s7i     0.058235            399
+seed7/lib/gtkserver.s7i      0.042935            161
+seed7/lib/gzip.s7i           0.069235            573
+seed7/lib/hash.s7i           0.067162            421
+seed7/lib/hashsetof.s7i      0.066033            499
+seed7/lib/hmac.s7i           0.046342            152
+seed7/lib/html.s7i           0.042934             83
+seed7/lib/html_ent.s7i       0.071002            476
+seed7/lib/htmldom.s7i        0.057980            286
+seed7/lib/http_request.s7i   0.078174            696
+seed7/lib/http_srv_resp.s7i  0.058395            380
+seed7/lib/https_request.s7i  0.047636            211
+seed7/lib/httpserv.s7i       0.056122            345
+seed7/lib/huffman.s7i        0.074132            644
+seed7/lib/ico.s7i            0.048488            221
+seed7/lib/idxarray.s7i       0.050233            232
+seed7/lib/image.s7i          0.041161            156
+seed7/lib/imagefile.s7i      0.045605            171
+seed7/lib/inflate.s7i        0.064990            411
+seed7/lib/inifile.s7i        0.042897            129
+seed7/lib/integer.s7i        0.069428            663
+seed7/lib/iobuffer.s7i       0.051088            289
+seed7/lib/jpeg.s7i           0.154613           1761
+seed7/lib/json.s7i           0.083392            891
+seed7/lib/json_serde.s7i     0.082766            783
+seed7/lib/keybd.s7i          0.080360            639
+seed7/lib/keydescr.s7i       0.049511            192
+seed7/lib/leb128.s7i         0.046724            218
+seed7/lib/line.s7i           0.044144            164
+seed7/lib/listener.s7i       0.048920            247
+seed7/lib/logfile.s7i        0.038726             73
+seed7/lib/lower.s7i          0.042376            142
+seed7/lib/lzma.s7i           0.095488            934
+seed7/lib/lzw.s7i            0.092473            861
+seed7/lib/magic.s7i          0.066010            403
+seed7/lib/mahjng32.s7i       0.095342           1500
+seed7/lib/make.s7i           0.071058            544
+seed7/lib/makedata.s7i       0.119167           1428
+seed7/lib/math.s7i           0.045070            201
+seed7/lib/mixarith.s7i       0.047896            249
+seed7/lib/modern27.s7i       0.167266           1099
+seed7/lib/more.s7i           0.042423            130
+seed7/lib/msgdigest.s7i      0.136030           1222
+seed7/lib/multiscr.s7i       0.038176             68
+seed7/lib/null_file.s7i      0.051001            345
+seed7/lib/osfiles.s7i        0.097247           1085
+seed7/lib/pbm.s7i            0.048832            230
+seed7/lib/pcx.s7i            0.077864            638
+seed7/lib/pem.s7i            0.045927            185
+seed7/lib/pgm.s7i            0.049766            238
+seed7/lib/pic16.s7i          0.068420           1037
+seed7/lib/pic32.s7i          0.122665           2060
+seed7/lib/pic_util.s7i       0.044314            144
+seed7/lib/pixelimage.s7i     0.053030            320
+seed7/lib/pixmap_file.s7i    0.061917            459
+seed7/lib/pixmapfont.s7i     0.048766            184
+seed7/lib/pkcs1.s7i          0.078307            543
+seed7/lib/png.s7i            0.107736           1064
+seed7/lib/poll.s7i           0.051935            313
+seed7/lib/ppm.s7i            0.047984            240
+seed7/lib/process.s7i        0.065388            541
+seed7/lib/progs.s7i          0.078421            789
+seed7/lib/propertyfile.s7i   0.044464            155
+seed7/lib/rational.s7i       0.078339            792
+seed7/lib/ref_list.s7i       0.049630            252
+seed7/lib/reference.s7i      0.043337            126
+seed7/lib/reverse.s7i        0.040625             94
+seed7/lib/rpm.s7i            0.283252           3487
+seed7/lib/rpmext.s7i         0.052436            318
+seed7/lib/scanfile.s7i       0.132060           1779
+seed7/lib/scanjson.s7i       0.060585            413
+seed7/lib/scanstri.s7i       0.136536           1814
+seed7/lib/scantoml.s7i       0.131370           1603
+seed7/lib/seed7_05.s7i       0.113293           1072
+seed7/lib/set.s7i            0.039175             57
+seed7/lib/shell.s7i          0.070077            615
+seed7/lib/showtls.s7i        0.085968            678
+seed7/lib/signature.s7i      0.045104            131
+seed7/lib/smtp.s7i           0.050905            261
+seed7/lib/sockbase.s7i       0.051938            217
+seed7/lib/socket.s7i         0.052956            326
+seed7/lib/sokoban1.s7i       0.081290           1519
+seed7/lib/sql_base.s7i       0.094498           1000
+seed7/lib/stars.s7i          0.233408           1705
+seed7/lib/stdfont10.s7i      0.144548           3347
+seed7/lib/stdfont12.s7i      0.165737           3928
+seed7/lib/stdfont14.s7i      0.188360           4510
+seed7/lib/stdfont16.s7i      0.212618           5092
+seed7/lib/stdfont18.s7i      0.244615           5868
+seed7/lib/stdfont20.s7i      0.273818           6449
+seed7/lib/stdfont24.s7i      0.330685           7421
+seed7/lib/stdfont8.s7i       0.127027           2960
+seed7/lib/stdfont9.s7i       0.135061           3152
+seed7/lib/stdio.s7i          0.052380            192
+seed7/lib/strifile.s7i       0.055311            345
+seed7/lib/string.s7i         0.075010            779
+seed7/lib/stritext.s7i       0.054796            352
+seed7/lib/struct.s7i         0.054970            266
+seed7/lib/struct_elem.s7i    0.044107            129
+seed7/lib/subfile.s7i        0.044912            174
+seed7/lib/subrange.s7i       0.041715             78
+seed7/lib/syntax.s7i         0.060688            294
+seed7/lib/tar.s7i            0.145752           1880
+seed7/lib/tar_cmds.s7i       0.084504            752
+seed7/lib/tdes.s7i           0.044467            143
+seed7/lib/tee.s7i            0.042181            143
+seed7/lib/text.s7i           0.050834            135
+seed7/lib/tga.s7i            0.081335            676
+seed7/lib/tiff.s7i           0.242330           2771
+seed7/lib/time.s7i           0.100608           1191
+seed7/lib/tls.s7i            0.196730           2230
+seed7/lib/unicode.s7i        0.073272            575
+seed7/lib/unionfnd.s7i       0.042424            130
+seed7/lib/upper.s7i          0.041216            142
+seed7/lib/utf16.s7i          0.065471            540
+seed7/lib/utf8.s7i           0.049029            234
+seed7/lib/vecfont10.s7i      0.160663           1056
+seed7/lib/vecfont18.s7i      0.175884           1119
+seed7/lib/vector3d.s7i       0.049496            293
+seed7/lib/vectorfont.s7i     0.047971            239
+seed7/lib/wildcard.s7i       0.042499            140
+seed7/lib/window.s7i         0.060809            455
+seed7/lib/wrinum.s7i         0.051826            248
+seed7/lib/x509cert.s7i       0.119283           1243
+seed7/lib/xml_ent.s7i        0.042128             94
+seed7/lib/xmldom.s7i         0.050536            303
+seed7/lib/xz.s7i             0.061465            442
+seed7/lib/zip.s7i            0.231692           2792
+seed7/lib/zstd.s7i           0.119430           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.158620        |
++-----------+-----------------+
+| Minimum   | 0.036272        |
++-----------+-----------------+
+| Maximum   | 5.546317        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033885        | 0.032407        | 0.042646        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039124        | 0.035541        | 0.048630        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.088500        | 0.034208        | 2.496066        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.158620        | 0.036272        | 5.546317        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.478 | 00:00:57.730 | 00:01:10.209 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.846 | 00:01:06.722 | 00:01:21.569 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:36.022 | 00:02:31.633 | 00:03:07.655 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:01.324 | 00:04:31.131 | 00:05:32.455 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:11.896 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-06.2.rst
+++ b/reports/seed7mode-perf-06.2.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-24T14:48:55+0000 W26-3
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 10:50:47 local time
+:Generated on: 2026-06-24 15:02:10 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 226x84 chars
+:Window body: 226x82 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.034276            190
+seed7/prg/bas7.sd7           0.034296          11459
+seed7/prg/bifurk.sd7         0.033697             73
+seed7/prg/bigfiles.sd7       0.033487            129
+seed7/prg/brainf7.sd7        0.034276             86
+seed7/prg/calc7.sd7          0.035170            128
+seed7/prg/carddemo.sd7       0.035486            190
+seed7/prg/castle.sd7         0.033998           3148
+seed7/prg/cat.sd7            0.033508             82
+seed7/prg/cellauto.sd7       0.033736             85
+seed7/prg/celsius.sd7        0.033553             42
+seed7/prg/chk_all.sd7        0.033627            843
+seed7/prg/chkarr.sd7         0.034105           8367
+seed7/prg/chkbig.sd7         0.037687          29026
+seed7/prg/chkbin.sd7         0.034508           6469
+seed7/prg/chkbitdata.sd7     0.036918           6624
+seed7/prg/chkbool.sd7        0.034160           3157
+seed7/prg/chkbst.sd7         0.033134            722
+seed7/prg/chkchr.sd7         0.033121           2809
+seed7/prg/chkcmd.sd7         0.036349           1205
+seed7/prg/chkdb.sd7          0.034388           7454
+seed7/prg/chkdecl.sd7        0.032888            448
+seed7/prg/chkenum.sd7        0.033329           1230
+seed7/prg/chkerr.sd7         0.034682           4663
+seed7/prg/chkexc.sd7         0.033868           2627
+seed7/prg/chkfil.sd7         0.033313           1615
+seed7/prg/chkflt.sd7         0.035611          20620
+seed7/prg/chkhent.sd7        0.033480             54
+seed7/prg/chkhsh.sd7         0.038841           4548
+seed7/prg/chkidx.sd7         0.043743          19567
+seed7/prg/chkint.sd7         0.044258          38129
+seed7/prg/chkjson.sd7        0.037593           1764
+seed7/prg/chkovf.sd7         0.037578           8216
+seed7/prg/chkprc.sd7         0.035059          10111
+seed7/prg/chkscan.sd7        0.033481            714
+seed7/prg/chkset.sd7         0.034363          11974
+seed7/prg/chkstr.sd7         0.037451          26952
+seed7/prg/chktime.sd7        0.033559           2025
+seed7/prg/chktoml.sd7        0.033522           1656
+seed7/prg/clock.sd7          0.033549             47
+seed7/prg/clock2.sd7         0.035696             43
+seed7/prg/clock3.sd7         0.034488             95
+seed7/prg/cmpfil.sd7         0.034398             84
+seed7/prg/comanche.sd7       0.036595            180
+seed7/prg/confval.sd7        0.039368            175
+seed7/prg/db7.sd7            0.033859            417
+seed7/prg/diff7.sd7          0.032590            263
+seed7/prg/dirtst.sd7         0.034896             42
+seed7/prg/dirx.sd7           0.037544            152
+seed7/prg/dnafight.sd7       0.039294           1381
+seed7/prg/dragon.sd7         0.034338             73
+seed7/prg/echo.sd7           0.034650             39
+seed7/prg/eliza.sd7          0.033731            302
+seed7/prg/err.sd7            0.033473             96
+seed7/prg/fannkuch.sd7       0.033630            131
+seed7/prg/fib.sd7            0.034048             47
+seed7/prg/find7.sd7          0.033266            133
+seed7/prg/findchar.sd7       0.034574            149
+seed7/prg/fractree.sd7       0.033897             55
+seed7/prg/ftp7.sd7           0.033674            296
+seed7/prg/ftpserv.sd7        0.033128             74
+seed7/prg/gcd.sd7            0.033685            109
+seed7/prg/gkbd.sd7           0.033404            358
+seed7/prg/gtksvtst.sd7       0.033942             94
+seed7/prg/hal.sd7            0.034947            250
+seed7/prg/hamu.sd7           0.033572            573
+seed7/prg/hanoi.sd7          0.034842             55
+seed7/prg/hd.sd7             0.036127             79
+seed7/prg/hello.sd7          0.033495             32
+seed7/prg/hilbert.sd7        0.033356            108
+seed7/prg/ide7.sd7           0.034286            196
+seed7/prg/kbd.sd7            0.033691             49
+seed7/prg/klondike.sd7       0.034916            883
+seed7/prg/lander.sd7         0.033564           1551
+seed7/prg/lst80bas.sd7       0.034764            344
+seed7/prg/lst99bas.sd7       0.035412            401
+seed7/prg/lstgwbas.sd7       0.033596            577
+seed7/prg/mahjong.sd7        0.035653           1943
+seed7/prg/make7.sd7          0.033037            121
+seed7/prg/mandelbr.sd7       0.032439            237
+seed7/prg/mind.sd7           0.036203            443
+seed7/prg/mirror.sd7         0.033478            131
+seed7/prg/ms.sd7             0.032762            641
+seed7/prg/nicoma.sd7         0.032731            135
+seed7/prg/pac.sd7            0.032710            726
+seed7/prg/pairs.sd7          0.033398           2025
+seed7/prg/panic.sd7          0.033038           2634
+seed7/prg/percolation.sd7    0.033587            330
+seed7/prg/planets.sd7        0.033559           1486
+seed7/prg/portfwd7.sd7       0.033670            139
+seed7/prg/prime.sd7          0.033216             74
+seed7/prg/printpi1.sd7       0.033352             56
+seed7/prg/printpi2.sd7       0.033542             54
+seed7/prg/printpi3.sd7       0.033512             60
+seed7/prg/pv7.sd7            0.033236            337
+seed7/prg/queen.sd7          0.033912            149
+seed7/prg/rand.sd7           0.033498            121
+seed7/prg/raytrace.sd7       0.033638            538
+seed7/prg/rever.sd7          0.033778            816
+seed7/prg/roman.sd7          0.033502             38
+seed7/prg/s7c.sd7            0.034464           9060
+seed7/prg/s7check.sd7        0.033789             68
+seed7/prg/savehd7.sd7        0.034302           1110
+seed7/prg/self.sd7           0.033390             49
+seed7/prg/shisen.sd7         0.033660           1423
+seed7/prg/sl.sd7             0.033531           1029
+seed7/prg/snake.sd7          0.032955            615
+seed7/prg/sokoban.sd7        0.033869            891
+seed7/prg/spigotpi.sd7       0.032780             64
+seed7/prg/sql7.sd7           0.033158            278
+seed7/prg/startrek.sd7       0.033192            979
+seed7/prg/sudoku7.sd7        0.033617           2657
+seed7/prg/sydir7.sd7         0.033732            384
+seed7/prg/syntaxhl.sd7       0.034697            177
+seed7/prg/tak.sd7            0.034577             59
+seed7/prg/tar7.sd7           0.033615            121
+seed7/prg/tch.sd7            0.034464             55
+seed7/prg/testfont.sd7       0.034155             95
+seed7/prg/tet.sd7            0.033236            479
+seed7/prg/tetg.sd7           0.033489            501
+seed7/prg/toutf8.sd7         0.033826            240
+seed7/prg/tst_cli.sd7        0.033839             40
+seed7/prg/tst_srv.sd7        0.033946             47
+seed7/prg/wator.sd7          0.033581            651
+seed7/prg/which.sd7          0.033133             65
+seed7/prg/wiz.sd7            0.033331           2833
+seed7/prg/wordcnt.sd7        0.032933             54
+seed7/prg/wrinum.sd7         0.032441             43
+seed7/prg/wumpus.sd7         0.032743            372
+seed7/lib/aes.s7i            0.033838           1144
+seed7/lib/aes_gcm.s7i        0.032944            392
+seed7/lib/ar.s7i             0.033042           1532
+seed7/lib/arc4.s7i           0.032495            144
+seed7/lib/archive.s7i        0.033560            143
+seed7/lib/archive_base.s7i   0.033544            135
+seed7/lib/array.s7i          0.033918            610
+seed7/lib/asn1.s7i           0.034169            544
+seed7/lib/asn1oid.s7i        0.032934            157
+seed7/lib/basearray.s7i      0.033732            450
+seed7/lib/bigfile.s7i        0.032691            136
+seed7/lib/bigint.s7i         0.033447            824
+seed7/lib/bigrat.s7i         0.032462            784
+seed7/lib/bin16.s7i          0.034064            592
+seed7/lib/bin32.s7i          0.033098            490
+seed7/lib/bin64.s7i          0.032581            539
+seed7/lib/bitdata.s7i        0.033004           1330
+seed7/lib/bitmapfont.s7i     0.033603            215
+seed7/lib/bitset.s7i         0.033617            593
+seed7/lib/bitsetof.s7i       0.033411            431
+seed7/lib/blowfish.s7i       0.033443            383
+seed7/lib/bmp.s7i            0.033845            924
+seed7/lib/boolean.s7i        0.033498            403
+seed7/lib/browser.s7i        0.034470            280
+seed7/lib/bstring.s7i        0.033685            227
+seed7/lib/bytedata.s7i       0.033646            482
+seed7/lib/bzip2.s7i          0.033575            887
+seed7/lib/cards.s7i          0.033837           1342
+seed7/lib/category.s7i       0.033390            209
+seed7/lib/cc_conf.s7i        0.033614           1314
+seed7/lib/ccittfax.s7i       0.033602           1022
+seed7/lib/cgi.s7i            0.033499            109
+seed7/lib/cgidialog.s7i      0.033612           1118
+seed7/lib/char.s7i           0.034489            356
+seed7/lib/charsets.s7i       0.035926           2024
+seed7/lib/chartype.s7i       0.035407            121
+seed7/lib/cipher.s7i         0.036522            146
+seed7/lib/cli_cmds.s7i       0.034981           1360
+seed7/lib/clib_file.s7i      0.037166            301
+seed7/lib/color.s7i          0.035569            185
+seed7/lib/complex.s7i        0.033276            464
+seed7/lib/compress.s7i       0.032746            150
+seed7/lib/console.s7i        0.032522            188
+seed7/lib/cpio.s7i           0.033203           1708
+seed7/lib/crc32.s7i          0.034266            193
+seed7/lib/cronos16.s7i       0.035335           1173
+seed7/lib/cronos27.s7i       0.033189           1464
+seed7/lib/csv.s7i            0.032452            201
+seed7/lib/db_prop.s7i        0.033945            991
+seed7/lib/deflate.s7i        0.033743            740
+seed7/lib/des.s7i            0.032676            444
+seed7/lib/dialog.s7i         0.033514            311
+seed7/lib/dir.s7i            0.033517            163
+seed7/lib/draw.s7i           0.033398            854
+seed7/lib/duration.s7i       0.035411           1038
+seed7/lib/echo.s7i           0.045546            132
+seed7/lib/editline.s7i       0.037873            398
+seed7/lib/elf.s7i            0.035399           1560
+seed7/lib/elliptic.s7i       0.034722            649
+seed7/lib/enable_io.s7i      0.034292            312
+seed7/lib/encoding.s7i       0.034714            931
+seed7/lib/enumeration.s7i    0.036474            236
+seed7/lib/environment.s7i    0.033830            175
+seed7/lib/exif.s7i           0.034344            152
+seed7/lib/external_file.s7i  0.033386            340
+seed7/lib/field.s7i          0.033585            268
+seed7/lib/file.s7i           0.033605            372
+seed7/lib/filebits.s7i       0.033454             46
+seed7/lib/filesys.s7i        0.033960            601
+seed7/lib/fileutil.s7i       0.039283            144
+seed7/lib/fixarray.s7i       0.037258            307
+seed7/lib/float.s7i          0.034088            757
+seed7/lib/font.s7i           0.033034            196
+seed7/lib/font8x8.s7i        0.033460            998
+seed7/lib/forloop.s7i        0.032962            449
+seed7/lib/ftp.s7i            0.035248            969
+seed7/lib/ftpserv.s7i        0.033697            631
+seed7/lib/getf.s7i           0.033528            115
+seed7/lib/gethttp.s7i        0.033614             41
+seed7/lib/gethttps.s7i       0.033476             41
+seed7/lib/gif.s7i            0.033904            561
+seed7/lib/graph.s7i          0.033723            415
+seed7/lib/graph_file.s7i     0.033536            399
+seed7/lib/gtkserver.s7i      0.033500            161
+seed7/lib/gzip.s7i           0.033542            573
+seed7/lib/hash.s7i           0.033786            421
+seed7/lib/hashsetof.s7i      0.033521            499
+seed7/lib/hmac.s7i           0.033694            152
+seed7/lib/html.s7i           0.033304             83
+seed7/lib/html_ent.s7i       0.033170            476
+seed7/lib/htmldom.s7i        0.032376            286
+seed7/lib/http_request.s7i   0.032725            696
+seed7/lib/http_srv_resp.s7i  0.033481            380
+seed7/lib/https_request.s7i  0.037343            211
+seed7/lib/httpserv.s7i       0.034530            345
+seed7/lib/huffman.s7i        0.033919            644
+seed7/lib/ico.s7i            0.035252            221
+seed7/lib/idxarray.s7i       0.033944            232
+seed7/lib/image.s7i          0.035210            156
+seed7/lib/imagefile.s7i      0.034022            171
+seed7/lib/inflate.s7i        0.035100            411
+seed7/lib/inifile.s7i        0.039319            129
+seed7/lib/integer.s7i        0.033532            663
+seed7/lib/iobuffer.s7i       0.032581            289
+seed7/lib/jpeg.s7i           0.032926           1761
+seed7/lib/json.s7i           0.034140            891
+seed7/lib/json_serde.s7i     0.037681            783
+seed7/lib/keybd.s7i          0.035362            639
+seed7/lib/keydescr.s7i       0.033516            192
+seed7/lib/leb128.s7i         0.034009            218
+seed7/lib/line.s7i           0.033807            164
+seed7/lib/listener.s7i       0.033632            247
+seed7/lib/logfile.s7i        0.033443             73
+seed7/lib/lower.s7i          0.033751            142
+seed7/lib/lzma.s7i           0.034426            934
+seed7/lib/lzw.s7i            0.034660            861
+seed7/lib/magic.s7i          0.035108            403
+seed7/lib/mahjng32.s7i       0.034896           1500
+seed7/lib/make.s7i           0.034906            544
+seed7/lib/makedata.s7i       0.034686           1428
+seed7/lib/math.s7i           0.033658            201
+seed7/lib/mixarith.s7i       0.035690            249
+seed7/lib/modern27.s7i       0.034150           1099
+seed7/lib/more.s7i           0.034595            130
+seed7/lib/msgdigest.s7i      0.038315           1222
+seed7/lib/multiscr.s7i       0.041026             68
+seed7/lib/null_file.s7i      0.037638            345
+seed7/lib/osfiles.s7i        0.035218           1085
+seed7/lib/pbm.s7i            0.033879            230
+seed7/lib/pcx.s7i            0.033991            638
+seed7/lib/pem.s7i            0.033935            185
+seed7/lib/pgm.s7i            0.033305            238
+seed7/lib/pic16.s7i          0.033905           1037
+seed7/lib/pic32.s7i          0.034182           2060
+seed7/lib/pic_util.s7i       0.032493            144
+seed7/lib/pixelimage.s7i     0.033129            320
+seed7/lib/pixmap_file.s7i    0.033516            459
+seed7/lib/pixmapfont.s7i     0.034220            184
+seed7/lib/pkcs1.s7i          0.033111            543
+seed7/lib/png.s7i            0.032804           1064
+seed7/lib/poll.s7i           0.033228            313
+seed7/lib/ppm.s7i            0.034623            240
+seed7/lib/process.s7i        0.036616            541
+seed7/lib/progs.s7i          0.036164            789
+seed7/lib/propertyfile.s7i   0.034898            155
+seed7/lib/rational.s7i       0.035623            792
+seed7/lib/ref_list.s7i       0.038197            252
+seed7/lib/reference.s7i      0.035630            126
+seed7/lib/reverse.s7i        0.037057             94
+seed7/lib/rpm.s7i            0.040155           3487
+seed7/lib/rpmext.s7i         0.036495            318
+seed7/lib/scanfile.s7i       0.037106           1779
+seed7/lib/scanjson.s7i       0.036729            413
+seed7/lib/scanstri.s7i       0.034093           1814
+seed7/lib/scantoml.s7i       0.035379           1603
+seed7/lib/seed7_05.s7i       0.036828           1072
+seed7/lib/set.s7i            0.035976             57
+seed7/lib/shell.s7i          0.034069            615
+seed7/lib/showtls.s7i        0.036714            678
+seed7/lib/signature.s7i      0.036130            131
+seed7/lib/smtp.s7i           0.035497            261
+seed7/lib/sockbase.s7i       0.033067            217
+seed7/lib/socket.s7i         0.032533            326
+seed7/lib/sokoban1.s7i       0.032979           1519
+seed7/lib/sql_base.s7i       0.033241           1000
+seed7/lib/stars.s7i          0.035252           1705
+seed7/lib/stdfont10.s7i      0.033407           3347
+seed7/lib/stdfont12.s7i      0.036120           3928
+seed7/lib/stdfont14.s7i      0.034217           4510
+seed7/lib/stdfont16.s7i      0.033812           5092
+seed7/lib/stdfont18.s7i      0.034259           5868
+seed7/lib/stdfont20.s7i      0.036803           6449
+seed7/lib/stdfont24.s7i      0.034827           7421
+seed7/lib/stdfont8.s7i       0.037034           2960
+seed7/lib/stdfont9.s7i       0.035588           3152
+seed7/lib/stdio.s7i          0.033934            192
+seed7/lib/strifile.s7i       0.033849            345
+seed7/lib/string.s7i         0.034145            779
+seed7/lib/stritext.s7i       0.037024            352
+seed7/lib/struct.s7i         0.036100            266
+seed7/lib/struct_elem.s7i    0.035731            129
+seed7/lib/subfile.s7i        0.033950            174
+seed7/lib/subrange.s7i       0.034175             78
+seed7/lib/syntax.s7i         0.037087            294
+seed7/lib/tar.s7i            0.036461           1880
+seed7/lib/tar_cmds.s7i       0.035881            752
+seed7/lib/tdes.s7i           0.036063            143
+seed7/lib/tee.s7i            0.033662            143
+seed7/lib/text.s7i           0.033496            135
+seed7/lib/tga.s7i            0.033223            676
+seed7/lib/tiff.s7i           0.033557           2771
+seed7/lib/time.s7i           0.032670           1191
+seed7/lib/tls.s7i            0.032796           2230
+seed7/lib/unicode.s7i        0.032917            575
+seed7/lib/unionfnd.s7i       0.033056            130
+seed7/lib/upper.s7i          0.032941            142
+seed7/lib/utf16.s7i          0.032535            540
+seed7/lib/utf8.s7i           0.034810            234
+seed7/lib/vecfont10.s7i      0.037612           1056
+seed7/lib/vecfont18.s7i      0.037345           1119
+seed7/lib/vector3d.s7i       0.036516            293
+seed7/lib/vectorfont.s7i     0.036402            239
+seed7/lib/wildcard.s7i       0.034313            140
+seed7/lib/window.s7i         0.035926            455
+seed7/lib/wrinum.s7i         0.034362            248
+seed7/lib/x509cert.s7i       0.033984           1243
+seed7/lib/xml_ent.s7i        0.036182             94
+seed7/lib/xmldom.s7i         0.037736            303
+seed7/lib/xz.s7i             0.035145            442
+seed7/lib/zip.s7i            0.036679           2792
+seed7/lib/zstd.s7i           0.037386           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.034479        |
++-----------+-----------------+
+| Minimum   | 0.032376        |
++-----------+-----------------+
+| Maximum   | 0.045546        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.040224            190
+seed7/prg/bas7.sd7           0.040085          11459
+seed7/prg/bifurk.sd7         0.037520             73
+seed7/prg/bigfiles.sd7       0.042046            129
+seed7/prg/brainf7.sd7        0.040648             86
+seed7/prg/calc7.sd7          0.042183            128
+seed7/prg/carddemo.sd7       0.042473            190
+seed7/prg/castle.sd7         0.039925           3148
+seed7/prg/cat.sd7            0.040211             82
+seed7/prg/cellauto.sd7       0.040609             85
+seed7/prg/celsius.sd7        0.036754             42
+seed7/prg/chk_all.sd7        0.040357            843
+seed7/prg/chkarr.sd7         0.039863           8367
+seed7/prg/chkbig.sd7         0.041368          29026
+seed7/prg/chkbin.sd7         0.041584           6469
+seed7/prg/chkbitdata.sd7     0.046058           6624
+seed7/prg/chkbool.sd7        0.039855           3157
+seed7/prg/chkbst.sd7         0.038661            722
+seed7/prg/chkchr.sd7         0.038235           2809
+seed7/prg/chkcmd.sd7         0.036248           1205
+seed7/prg/chkdb.sd7          0.038833           7454
+seed7/prg/chkdecl.sd7        0.038990            448
+seed7/prg/chkenum.sd7        0.036233           1230
+seed7/prg/chkerr.sd7         0.038966           4663
+seed7/prg/chkexc.sd7         0.036431           2627
+seed7/prg/chkfil.sd7         0.037649           1615
+seed7/prg/chkflt.sd7         0.039888          20620
+seed7/prg/chkhent.sd7        0.035197             54
+seed7/prg/chkhsh.sd7         0.037900           4548
+seed7/prg/chkidx.sd7         0.041076          19567
+seed7/prg/chkint.sd7         0.043609          38129
+seed7/prg/chkjson.sd7        0.038932           1764
+seed7/prg/chkovf.sd7         0.038158           8216
+seed7/prg/chkprc.sd7         0.039055          10111
+seed7/prg/chkscan.sd7        0.038708            714
+seed7/prg/chkset.sd7         0.039237          11974
+seed7/prg/chkstr.sd7         0.042307          26952
+seed7/prg/chktime.sd7        0.039479           2025
+seed7/prg/chktoml.sd7        0.044670           1656
+seed7/prg/clock.sd7          0.040175             47
+seed7/prg/clock2.sd7         0.039461             43
+seed7/prg/clock3.sd7         0.039301             95
+seed7/prg/cmpfil.sd7         0.038144             84
+seed7/prg/comanche.sd7       0.040377            180
+seed7/prg/confval.sd7        0.042243            175
+seed7/prg/db7.sd7            0.040636            417
+seed7/prg/diff7.sd7          0.041418            263
+seed7/prg/dirtst.sd7         0.037228             42
+seed7/prg/dirx.sd7           0.042973            152
+seed7/prg/dnafight.sd7       0.041706           1381
+seed7/prg/dragon.sd7         0.038881             73
+seed7/prg/echo.sd7           0.035561             39
+seed7/prg/eliza.sd7          0.037763            302
+seed7/prg/err.sd7            0.040250             96
+seed7/prg/fannkuch.sd7       0.041135            131
+seed7/prg/fib.sd7            0.037155             47
+seed7/prg/find7.sd7          0.041350            133
+seed7/prg/findchar.sd7       0.041467            149
+seed7/prg/fractree.sd7       0.037075             55
+seed7/prg/ftp7.sd7           0.038700            296
+seed7/prg/ftpserv.sd7        0.037243             74
+seed7/prg/gcd.sd7            0.040090            109
+seed7/prg/gkbd.sd7           0.040934            358
+seed7/prg/gtksvtst.sd7       0.036963             94
+seed7/prg/hal.sd7            0.038551            250
+seed7/prg/hamu.sd7           0.039144            573
+seed7/prg/hanoi.sd7          0.035585             55
+seed7/prg/hd.sd7             0.041785             79
+seed7/prg/hello.sd7          0.039873             32
+seed7/prg/hilbert.sd7        0.042852            108
+seed7/prg/ide7.sd7           0.043033            196
+seed7/prg/kbd.sd7            0.037271             49
+seed7/prg/klondike.sd7       0.038838            883
+seed7/prg/lander.sd7         0.039148           1551
+seed7/prg/lst80bas.sd7       0.038602            344
+seed7/prg/lst99bas.sd7       0.038330            401
+seed7/prg/lstgwbas.sd7       0.038318            577
+seed7/prg/mahjong.sd7        0.038946           1943
+seed7/prg/make7.sd7          0.039171            121
+seed7/prg/mandelbr.sd7       0.039215            237
+seed7/prg/mind.sd7           0.037791            443
+seed7/prg/mirror.sd7         0.041126            131
+seed7/prg/ms.sd7             0.041379            641
+seed7/prg/nicoma.sd7         0.042677            135
+seed7/prg/pac.sd7            0.041004            726
+seed7/prg/pairs.sd7          0.040805           2025
+seed7/prg/panic.sd7          0.041267           2634
+seed7/prg/percolation.sd7    0.038133            330
+seed7/prg/planets.sd7        0.040922           1486
+seed7/prg/portfwd7.sd7       0.040908            139
+seed7/prg/prime.sd7          0.041503             74
+seed7/prg/printpi1.sd7       0.039531             56
+seed7/prg/printpi2.sd7       0.038977             54
+seed7/prg/printpi3.sd7       0.037665             60
+seed7/prg/pv7.sd7            0.040971            337
+seed7/prg/queen.sd7          0.040822            149
+seed7/prg/rand.sd7           0.041268            121
+seed7/prg/raytrace.sd7       0.040835            538
+seed7/prg/rever.sd7          0.042743            816
+seed7/prg/roman.sd7          0.037390             38
+seed7/prg/s7c.sd7            0.040441           9060
+seed7/prg/s7check.sd7        0.039614             68
+seed7/prg/savehd7.sd7        0.039921           1110
+seed7/prg/self.sd7           0.038913             49
+seed7/prg/shisen.sd7         0.040977           1423
+seed7/prg/sl.sd7             0.037599           1029
+seed7/prg/snake.sd7          0.036586            615
+seed7/prg/sokoban.sd7        0.037430            891
+seed7/prg/spigotpi.sd7       0.036491             64
+seed7/prg/sql7.sd7           0.038662            278
+seed7/prg/startrek.sd7       0.041205            979
+seed7/prg/sudoku7.sd7        0.041313           2657
+seed7/prg/sydir7.sd7         0.040866            384
+seed7/prg/syntaxhl.sd7       0.040892            177
+seed7/prg/tak.sd7            0.035779             59
+seed7/prg/tar7.sd7           0.038027            121
+seed7/prg/tch.sd7            0.038441             55
+seed7/prg/testfont.sd7       0.043716             95
+seed7/prg/tet.sd7            0.039881            479
+seed7/prg/tetg.sd7           0.039577            501
+seed7/prg/toutf8.sd7         0.042036            240
+seed7/prg/tst_cli.sd7        0.038462             40
+seed7/prg/tst_srv.sd7        0.039356             47
+seed7/prg/wator.sd7          0.040014            651
+seed7/prg/which.sd7          0.039667             65
+seed7/prg/wiz.sd7            0.041404           2833
+seed7/prg/wordcnt.sd7        0.038437             54
+seed7/prg/wrinum.sd7         0.043277             43
+seed7/prg/wumpus.sd7         0.041960            372
+seed7/lib/aes.s7i            0.045700           1144
+seed7/lib/aes_gcm.s7i        0.043021            392
+seed7/lib/ar.s7i             0.041500           1532
+seed7/lib/arc4.s7i           0.042113            144
+seed7/lib/archive.s7i        0.042828            143
+seed7/lib/archive_base.s7i   0.041578            135
+seed7/lib/array.s7i          0.041636            610
+seed7/lib/asn1.s7i           0.039908            544
+seed7/lib/asn1oid.s7i        0.045043            157
+seed7/lib/basearray.s7i      0.040343            450
+seed7/lib/bigfile.s7i        0.042353            136
+seed7/lib/bigint.s7i         0.041480            824
+seed7/lib/bigrat.s7i         0.038325            784
+seed7/lib/bin16.s7i          0.038491            592
+seed7/lib/bin32.s7i          0.039460            490
+seed7/lib/bin64.s7i          0.038427            539
+seed7/lib/bitdata.s7i        0.045545           1330
+seed7/lib/bitmapfont.s7i     0.041218            215
+seed7/lib/bitset.s7i         0.044649            593
+seed7/lib/bitsetof.s7i       0.042122            431
+seed7/lib/blowfish.s7i       0.046031            383
+seed7/lib/bmp.s7i            0.043149            924
+seed7/lib/boolean.s7i        0.038277            403
+seed7/lib/browser.s7i        0.039800            280
+seed7/lib/bstring.s7i        0.039125            227
+seed7/lib/bytedata.s7i       0.039679            482
+seed7/lib/bzip2.s7i          0.041624            887
+seed7/lib/cards.s7i          0.037816           1342
+seed7/lib/category.s7i       0.041697            209
+seed7/lib/cc_conf.s7i        0.046663           1314
+seed7/lib/ccittfax.s7i       0.043466           1022
+seed7/lib/cgi.s7i            0.044603            109
+seed7/lib/cgidialog.s7i      0.046618           1118
+seed7/lib/char.s7i           0.047892            356
+seed7/lib/charsets.s7i       0.044910           2024
+seed7/lib/chartype.s7i       0.049282            121
+seed7/lib/cipher.s7i         0.041719            146
+seed7/lib/cli_cmds.s7i       0.038933           1360
+seed7/lib/clib_file.s7i      0.042557            301
+seed7/lib/color.s7i          0.049120            185
+seed7/lib/complex.s7i        0.044605            464
+seed7/lib/compress.s7i       0.044964            150
+seed7/lib/console.s7i        0.041548            188
+seed7/lib/cpio.s7i           0.040889           1708
+seed7/lib/crc32.s7i          0.041267            193
+seed7/lib/cronos16.s7i       0.041415           1173
+seed7/lib/cronos27.s7i       0.045511           1464
+seed7/lib/csv.s7i            0.045815            201
+seed7/lib/db_prop.s7i        0.045959            991
+seed7/lib/deflate.s7i        0.042665            740
+seed7/lib/des.s7i            0.042191            444
+seed7/lib/dialog.s7i         0.038993            311
+seed7/lib/dir.s7i            0.037925            163
+seed7/lib/draw.s7i           0.037856            854
+seed7/lib/duration.s7i       0.038533           1038
+seed7/lib/echo.s7i           0.038759            132
+seed7/lib/editline.s7i       0.038711            398
+seed7/lib/elf.s7i            0.038830           1560
+seed7/lib/elliptic.s7i       0.036920            649
+seed7/lib/enable_io.s7i      0.037711            312
+seed7/lib/encoding.s7i       0.038294            931
+seed7/lib/enumeration.s7i    0.037871            236
+seed7/lib/environment.s7i    0.037996            175
+seed7/lib/exif.s7i           0.039282            152
+seed7/lib/external_file.s7i  0.039470            340
+seed7/lib/field.s7i          0.039053            268
+seed7/lib/file.s7i           0.038605            372
+seed7/lib/filebits.s7i       0.037180             46
+seed7/lib/filesys.s7i        0.039295            601
+seed7/lib/fileutil.s7i       0.045228            144
+seed7/lib/fixarray.s7i       0.045174            307
+seed7/lib/float.s7i          0.040652            757
+seed7/lib/font.s7i           0.040463            196
+seed7/lib/font8x8.s7i        0.037834            998
+seed7/lib/forloop.s7i        0.038821            449
+seed7/lib/ftp.s7i            0.039059            969
+seed7/lib/ftpserv.s7i        0.040257            631
+seed7/lib/getf.s7i           0.039612            115
+seed7/lib/gethttp.s7i        0.036495             41
+seed7/lib/gethttps.s7i       0.037815             41
+seed7/lib/gif.s7i            0.039306            561
+seed7/lib/graph.s7i          0.040916            415
+seed7/lib/graph_file.s7i     0.038911            399
+seed7/lib/gtkserver.s7i      0.039788            161
+seed7/lib/gzip.s7i           0.039238            573
+seed7/lib/hash.s7i           0.040051            421
+seed7/lib/hashsetof.s7i      0.039330            499
+seed7/lib/hmac.s7i           0.039997            152
+seed7/lib/html.s7i           0.036768             83
+seed7/lib/html_ent.s7i       0.037800            476
+seed7/lib/htmldom.s7i        0.041563            286
+seed7/lib/http_request.s7i   0.047115            696
+seed7/lib/http_srv_resp.s7i  0.048300            380
+seed7/lib/https_request.s7i  0.046163            211
+seed7/lib/httpserv.s7i       0.046255            345
+seed7/lib/huffman.s7i        0.047296            644
+seed7/lib/ico.s7i            0.039701            221
+seed7/lib/idxarray.s7i       0.039371            232
+seed7/lib/image.s7i          0.037989            156
+seed7/lib/imagefile.s7i      0.039634            171
+seed7/lib/inflate.s7i        0.040640            411
+seed7/lib/inifile.s7i        0.038819            129
+seed7/lib/integer.s7i        0.038837            663
+seed7/lib/iobuffer.s7i       0.038867            289
+seed7/lib/jpeg.s7i           0.039334           1761
+seed7/lib/json.s7i           0.038732            891
+seed7/lib/json_serde.s7i     0.038950            783
+seed7/lib/keybd.s7i          0.042022            639
+seed7/lib/keydescr.s7i       0.040753            192
+seed7/lib/leb128.s7i         0.040950            218
+seed7/lib/line.s7i           0.038411            164
+seed7/lib/listener.s7i       0.038628            247
+seed7/lib/logfile.s7i        0.036556             73
+seed7/lib/lower.s7i          0.037186            142
+seed7/lib/lzma.s7i           0.038348            934
+seed7/lib/lzw.s7i            0.037749            861
+seed7/lib/magic.s7i          0.039432            403
+seed7/lib/mahjng32.s7i       0.039936           1500
+seed7/lib/make.s7i           0.038836            544
+seed7/lib/makedata.s7i       0.039551           1428
+seed7/lib/math.s7i           0.039231            201
+seed7/lib/mixarith.s7i       0.038696            249
+seed7/lib/modern27.s7i       0.041814           1099
+seed7/lib/more.s7i           0.047002            130
+seed7/lib/msgdigest.s7i      0.042960           1222
+seed7/lib/multiscr.s7i       0.043069             68
+seed7/lib/null_file.s7i      0.042792            345
+seed7/lib/osfiles.s7i        0.041334           1085
+seed7/lib/pbm.s7i            0.041704            230
+seed7/lib/pcx.s7i            0.038130            638
+seed7/lib/pem.s7i            0.037901            185
+seed7/lib/pgm.s7i            0.038126            238
+seed7/lib/pic16.s7i          0.035828           1037
+seed7/lib/pic32.s7i          0.037719           2060
+seed7/lib/pic_util.s7i       0.037662            144
+seed7/lib/pixelimage.s7i     0.037314            320
+seed7/lib/pixmap_file.s7i    0.038859            459
+seed7/lib/pixmapfont.s7i     0.039236            184
+seed7/lib/pkcs1.s7i          0.043769            543
+seed7/lib/png.s7i            0.039091           1064
+seed7/lib/poll.s7i           0.037445            313
+seed7/lib/ppm.s7i            0.039092            240
+seed7/lib/process.s7i        0.037611            541
+seed7/lib/progs.s7i          0.038634            789
+seed7/lib/propertyfile.s7i   0.040116            155
+seed7/lib/rational.s7i       0.039078            792
+seed7/lib/ref_list.s7i       0.039184            252
+seed7/lib/reference.s7i      0.040082            126
+seed7/lib/reverse.s7i        0.038112             94
+seed7/lib/rpm.s7i            0.039995           3487
+seed7/lib/rpmext.s7i         0.038725            318
+seed7/lib/scanfile.s7i       0.039364           1779
+seed7/lib/scanjson.s7i       0.042996            413
+seed7/lib/scanstri.s7i       0.040399           1814
+seed7/lib/scantoml.s7i       0.040065           1603
+seed7/lib/seed7_05.s7i       0.041218           1072
+seed7/lib/set.s7i            0.037306             57
+seed7/lib/shell.s7i          0.038780            615
+seed7/lib/showtls.s7i        0.039181            678
+seed7/lib/signature.s7i      0.039620            131
+seed7/lib/smtp.s7i           0.038776            261
+seed7/lib/sockbase.s7i       0.038945            217
+seed7/lib/socket.s7i         0.039413            326
+seed7/lib/sokoban1.s7i       0.037334           1519
+seed7/lib/sql_base.s7i       0.038733           1000
+seed7/lib/stars.s7i          0.038998           1705
+seed7/lib/stdfont10.s7i      0.036332           3347
+seed7/lib/stdfont12.s7i      0.037154           3928
+seed7/lib/stdfont14.s7i      0.036461           4510
+seed7/lib/stdfont16.s7i      0.036452           5092
+seed7/lib/stdfont18.s7i      0.036614           5868
+seed7/lib/stdfont20.s7i      0.039623           6449
+seed7/lib/stdfont24.s7i      0.039558           7421
+seed7/lib/stdfont8.s7i       0.037590           2960
+seed7/lib/stdfont9.s7i       0.037517           3152
+seed7/lib/stdio.s7i          0.038443            192
+seed7/lib/strifile.s7i       0.038804            345
+seed7/lib/string.s7i         0.039498            779
+seed7/lib/stritext.s7i       0.041875            352
+seed7/lib/struct.s7i         0.042319            266
+seed7/lib/struct_elem.s7i    0.038067            129
+seed7/lib/subfile.s7i        0.039097            174
+seed7/lib/subrange.s7i       0.037904             78
+seed7/lib/syntax.s7i         0.040634            294
+seed7/lib/tar.s7i            0.044318           1880
+seed7/lib/tar_cmds.s7i       0.044963            752
+seed7/lib/tdes.s7i           0.041836            143
+seed7/lib/tee.s7i            0.040446            143
+seed7/lib/text.s7i           0.042649            135
+seed7/lib/tga.s7i            0.044176            676
+seed7/lib/tiff.s7i           0.039510           2771
+seed7/lib/time.s7i           0.039706           1191
+seed7/lib/tls.s7i            0.043038           2230
+seed7/lib/unicode.s7i        0.048589            575
+seed7/lib/unionfnd.s7i       0.042313            130
+seed7/lib/upper.s7i          0.037524            142
+seed7/lib/utf16.s7i          0.038770            540
+seed7/lib/utf8.s7i           0.040136            234
+seed7/lib/vecfont10.s7i      0.039253           1056
+seed7/lib/vecfont18.s7i      0.040446           1119
+seed7/lib/vector3d.s7i       0.037300            293
+seed7/lib/vectorfont.s7i     0.039096            239
+seed7/lib/wildcard.s7i       0.040381            140
+seed7/lib/window.s7i         0.041589            455
+seed7/lib/wrinum.s7i         0.039350            248
+seed7/lib/x509cert.s7i       0.038766           1243
+seed7/lib/xml_ent.s7i        0.040736             94
+seed7/lib/xmldom.s7i         0.038647            303
+seed7/lib/xz.s7i             0.039546            442
+seed7/lib/zip.s7i            0.039379           2792
+seed7/lib/zstd.s7i           0.039399           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.040174        |
++-----------+-----------------+
+| Minimum   | 0.035197        |
++-----------+-----------------+
+| Maximum   | 0.049282        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039589            190
+seed7/prg/bas7.sd7           0.322439          11459
+seed7/prg/bifurk.sd7         0.035897             73
+seed7/prg/bigfiles.sd7       0.036494            129
+seed7/prg/brainf7.sd7        0.036122             86
+seed7/prg/calc7.sd7          0.037410            128
+seed7/prg/carddemo.sd7       0.038996            190
+seed7/prg/castle.sd7         0.112756           3148
+seed7/prg/cat.sd7            0.037286             82
+seed7/prg/cellauto.sd7       0.036792             85
+seed7/prg/celsius.sd7        0.035577             42
+seed7/prg/chk_all.sd7        0.059473            843
+seed7/prg/chkarr.sd7         0.359256           8367
+seed7/prg/chkbig.sd7         2.056914          29026
+seed7/prg/chkbin.sd7         0.510258           6469
+seed7/prg/chkbitdata.sd7     0.615628           6624
+seed7/prg/chkbool.sd7        0.123608           3157
+seed7/prg/chkbst.sd7         0.069098            722
+seed7/prg/chkchr.sd7         0.214328           2809
+seed7/prg/chkcmd.sd7         0.069609           1205
+seed7/prg/chkdb.sd7          0.350256           7454
+seed7/prg/chkdecl.sd7        0.058512            448
+seed7/prg/chkenum.sd7        0.067545           1230
+seed7/prg/chkerr.sd7         0.195035           4663
+seed7/prg/chkexc.sd7         0.082477           2627
+seed7/prg/chkfil.sd7         0.073460           1615
+seed7/prg/chkflt.sd7         1.337076          20620
+seed7/prg/chkhent.sd7        0.038506             54
+seed7/prg/chkhsh.sd7         0.249794           4548
+seed7/prg/chkidx.sd7         1.336020          19567
+seed7/prg/chkint.sd7         2.519594          38129
+seed7/prg/chkjson.sd7        0.100987           1764
+seed7/prg/chkovf.sd7         0.565448           8216
+seed7/prg/chkprc.sd7         0.328563          10111
+seed7/prg/chkscan.sd7        0.055464            714
+seed7/prg/chkset.sd7         0.669403          11974
+seed7/prg/chkstr.sd7         1.386190          26952
+seed7/prg/chktime.sd7        0.134414           2025
+seed7/prg/chktoml.sd7        0.107542           1656
+seed7/prg/clock.sd7          0.043536             47
+seed7/prg/clock2.sd7         0.038803             43
+seed7/prg/clock3.sd7         0.038039             95
+seed7/prg/cmpfil.sd7         0.036538             84
+seed7/prg/comanche.sd7       0.041278            180
+seed7/prg/confval.sd7        0.043363            175
+seed7/prg/db7.sd7            0.049715            417
+seed7/prg/diff7.sd7          0.042367            263
+seed7/prg/dirtst.sd7         0.037053             42
+seed7/prg/dirx.sd7           0.041102            152
+seed7/prg/dnafight.sd7       0.067242           1381
+seed7/prg/dragon.sd7         0.037068             73
+seed7/prg/echo.sd7           0.036531             39
+seed7/prg/eliza.sd7          0.043017            302
+seed7/prg/err.sd7            0.041396             96
+seed7/prg/fannkuch.sd7       0.037271            131
+seed7/prg/fib.sd7            0.034924             47
+seed7/prg/find7.sd7          0.036992            133
+seed7/prg/findchar.sd7       0.037289            149
+seed7/prg/fractree.sd7       0.034586             55
+seed7/prg/ftp7.sd7           0.042585            296
+seed7/prg/ftpserv.sd7        0.038138             74
+seed7/prg/gcd.sd7            0.036757            109
+seed7/prg/gkbd.sd7           0.045893            358
+seed7/prg/gtksvtst.sd7       0.036291             94
+seed7/prg/hal.sd7            0.040080            250
+seed7/prg/hamu.sd7           0.048119            573
+seed7/prg/hanoi.sd7          0.037061             55
+seed7/prg/hd.sd7             0.037231             79
+seed7/prg/hello.sd7          0.036317             32
+seed7/prg/hilbert.sd7        0.038141            108
+seed7/prg/ide7.sd7           0.042631            196
+seed7/prg/kbd.sd7            0.038128             49
+seed7/prg/klondike.sd7       0.057840            883
+seed7/prg/lander.sd7         0.071607           1551
+seed7/prg/lst80bas.sd7       0.044495            344
+seed7/prg/lst99bas.sd7       0.051973            401
+seed7/prg/lstgwbas.sd7       0.055294            577
+seed7/prg/mahjong.sd7        0.081862           1943
+seed7/prg/make7.sd7          0.037899            121
+seed7/prg/mandelbr.sd7       0.040391            237
+seed7/prg/mind.sd7           0.044116            443
+seed7/prg/mirror.sd7         0.038337            131
+seed7/prg/ms.sd7             0.047690            641
+seed7/prg/nicoma.sd7         0.039967            135
+seed7/prg/pac.sd7            0.051355            726
+seed7/prg/pairs.sd7          0.085965           2025
+seed7/prg/panic.sd7          0.097724           2634
+seed7/prg/percolation.sd7    0.043543            330
+seed7/prg/planets.sd7        0.077282           1486
+seed7/prg/portfwd7.sd7       0.039311            139
+seed7/prg/prime.sd7          0.036412             74
+seed7/prg/printpi1.sd7       0.036797             56
+seed7/prg/printpi2.sd7       0.036692             54
+seed7/prg/printpi3.sd7       0.036833             60
+seed7/prg/pv7.sd7            0.044819            337
+seed7/prg/queen.sd7          0.041491            149
+seed7/prg/rand.sd7           0.039880            121
+seed7/prg/raytrace.sd7       0.050009            538
+seed7/prg/rever.sd7          0.054423            816
+seed7/prg/roman.sd7          0.036551             38
+seed7/prg/s7c.sd7            0.279231           9060
+seed7/prg/s7check.sd7        0.038719             68
+seed7/prg/savehd7.sd7        0.067672           1110
+seed7/prg/self.sd7           0.036607             49
+seed7/prg/shisen.sd7         0.072002           1423
+seed7/prg/sl.sd7             0.059782           1029
+seed7/prg/snake.sd7          0.046643            615
+seed7/prg/sokoban.sd7        0.054361            891
+seed7/prg/spigotpi.sd7       0.036662             64
+seed7/prg/sql7.sd7           0.041694            278
+seed7/prg/startrek.sd7       0.060353            979
+seed7/prg/sudoku7.sd7        0.102559           2657
+seed7/prg/sydir7.sd7         0.045644            384
+seed7/prg/syntaxhl.sd7       0.040925            177
+seed7/prg/tak.sd7            0.036151             59
+seed7/prg/tar7.sd7           0.041498            121
+seed7/prg/tch.sd7            0.037688             55
+seed7/prg/testfont.sd7       0.039861             95
+seed7/prg/tet.sd7            0.045831            479
+seed7/prg/tetg.sd7           0.045280            501
+seed7/prg/toutf8.sd7         0.041889            240
+seed7/prg/tst_cli.sd7        0.040191             40
+seed7/prg/tst_srv.sd7        0.037519             47
+seed7/prg/wator.sd7          0.050860            651
+seed7/prg/which.sd7          0.035643             65
+seed7/prg/wiz.sd7            0.103978           2833
+seed7/prg/wordcnt.sd7        0.034766             54
+seed7/prg/wrinum.sd7         0.035065             43
+seed7/prg/wumpus.sd7         0.042682            372
+seed7/lib/aes.s7i            0.110170           1144
+seed7/lib/aes_gcm.s7i        0.048165            392
+seed7/lib/ar.s7i             0.075113           1532
+seed7/lib/arc4.s7i           0.038901            144
+seed7/lib/archive.s7i        0.038707            143
+seed7/lib/archive_base.s7i   0.038695            135
+seed7/lib/array.s7i          0.054356            610
+seed7/lib/asn1.s7i           0.046306            544
+seed7/lib/asn1oid.s7i        0.040643            157
+seed7/lib/basearray.s7i      0.047301            450
+seed7/lib/bigfile.s7i        0.037178            136
+seed7/lib/bigint.s7i         0.053560            824
+seed7/lib/bigrat.s7i         0.055378            784
+seed7/lib/bin16.s7i          0.054702            592
+seed7/lib/bin32.s7i          0.050500            490
+seed7/lib/bin64.s7i          0.050817            539
+seed7/lib/bitdata.s7i        0.079632           1330
+seed7/lib/bitmapfont.s7i     0.041853            215
+seed7/lib/bitset.s7i         0.050331            593
+seed7/lib/bitsetof.s7i       0.048443            431
+seed7/lib/blowfish.s7i       0.055521            383
+seed7/lib/bmp.s7i            0.059776            924
+seed7/lib/boolean.s7i        0.043139            403
+seed7/lib/browser.s7i        0.041364            280
+seed7/lib/bstring.s7i        0.040487            227
+seed7/lib/bytedata.s7i       0.049998            482
+seed7/lib/bzip2.s7i          0.060722            887
+seed7/lib/cards.s7i          0.066951           1342
+seed7/lib/category.s7i       0.041474            209
+seed7/lib/cc_conf.s7i        0.076530           1314
+seed7/lib/ccittfax.s7i       0.065139           1022
+seed7/lib/cgi.s7i            0.038931            109
+seed7/lib/cgidialog.s7i      0.069346           1118
+seed7/lib/char.s7i           0.050348            356
+seed7/lib/charsets.s7i       0.084218           2024
+seed7/lib/chartype.s7i       0.040845            121
+seed7/lib/cipher.s7i         0.041861            146
+seed7/lib/cli_cmds.s7i       0.073663           1360
+seed7/lib/clib_file.s7i      0.046086            301
+seed7/lib/color.s7i          0.040789            185
+seed7/lib/complex.s7i        0.045742            464
+seed7/lib/compress.s7i       0.039285            150
+seed7/lib/console.s7i        0.040976            188
+seed7/lib/cpio.s7i           0.082000           1708
+seed7/lib/crc32.s7i          0.045303            193
+seed7/lib/cronos16.s7i       0.092220           1173
+seed7/lib/cronos27.s7i       0.114407           1464
+seed7/lib/csv.s7i            0.040532            201
+seed7/lib/db_prop.s7i        0.063386            991
+seed7/lib/deflate.s7i        0.056123            740
+seed7/lib/des.s7i            0.055481            444
+seed7/lib/dialog.s7i         0.044368            311
+seed7/lib/dir.s7i            0.038519            163
+seed7/lib/draw.s7i           0.056335            854
+seed7/lib/duration.s7i       0.061439           1038
+seed7/lib/echo.s7i           0.039292            132
+seed7/lib/editline.s7i       0.045088            398
+seed7/lib/elf.s7i            0.086778           1560
+seed7/lib/elliptic.s7i       0.054747            649
+seed7/lib/enable_io.s7i      0.046174            312
+seed7/lib/encoding.s7i       0.063466            931
+seed7/lib/enumeration.s7i    0.042279            236
+seed7/lib/environment.s7i    0.039277            175
+seed7/lib/exif.s7i           0.040046            152
+seed7/lib/external_file.s7i  0.044002            340
+seed7/lib/field.s7i          0.041864            268
+seed7/lib/file.s7i           0.043856            372
+seed7/lib/filebits.s7i       0.037305             46
+seed7/lib/filesys.s7i        0.050079            601
+seed7/lib/fileutil.s7i       0.040412            144
+seed7/lib/fixarray.s7i       0.043999            307
+seed7/lib/float.s7i          0.056097            757
+seed7/lib/font.s7i           0.040342            196
+seed7/lib/font8x8.s7i        0.049519            998
+seed7/lib/forloop.s7i        0.046424            449
+seed7/lib/ftp.s7i            0.057814            969
+seed7/lib/ftpserv.s7i        0.051732            631
+seed7/lib/getf.s7i           0.037769            115
+seed7/lib/gethttp.s7i        0.036082             41
+seed7/lib/gethttps.s7i       0.036945             41
+seed7/lib/gif.s7i            0.049718            561
+seed7/lib/graph.s7i          0.049018            415
+seed7/lib/graph_file.s7i     0.045580            399
+seed7/lib/gtkserver.s7i      0.039845            161
+seed7/lib/gzip.s7i           0.052390            573
+seed7/lib/hash.s7i           0.050521            421
+seed7/lib/hashsetof.s7i      0.053664            499
+seed7/lib/hmac.s7i           0.042406            152
+seed7/lib/html.s7i           0.037459             83
+seed7/lib/html_ent.s7i       0.049145            476
+seed7/lib/htmldom.s7i        0.043136            286
+seed7/lib/http_request.s7i   0.051844            696
+seed7/lib/http_srv_resp.s7i  0.048440            380
+seed7/lib/https_request.s7i  0.045257            211
+seed7/lib/httpserv.s7i       0.047258            345
+seed7/lib/huffman.s7i        0.054609            644
+seed7/lib/ico.s7i            0.046106            221
+seed7/lib/idxarray.s7i       0.049598            232
+seed7/lib/image.s7i          0.039848            156
+seed7/lib/imagefile.s7i      0.044909            171
+seed7/lib/inflate.s7i        0.051746            411
+seed7/lib/inifile.s7i        0.038747            129
+seed7/lib/integer.s7i        0.052921            663
+seed7/lib/iobuffer.s7i       0.041597            289
+seed7/lib/jpeg.s7i           0.082982           1761
+seed7/lib/json.s7i           0.055078            891
+seed7/lib/json_serde.s7i     0.053146            783
+seed7/lib/keybd.s7i          0.067263            639
+seed7/lib/keydescr.s7i       0.046591            192
+seed7/lib/leb128.s7i         0.040143            218
+seed7/lib/line.s7i           0.039691            164
+seed7/lib/listener.s7i       0.041953            247
+seed7/lib/logfile.s7i        0.037402             73
+seed7/lib/lower.s7i          0.041307            142
+seed7/lib/lzma.s7i           0.062867            934
+seed7/lib/lzw.s7i            0.060474            861
+seed7/lib/magic.s7i          0.058065            403
+seed7/lib/mahjng32.s7i       0.071484           1500
+seed7/lib/make.s7i           0.053929            544
+seed7/lib/makedata.s7i       0.072476           1428
+seed7/lib/math.s7i           0.041649            201
+seed7/lib/mixarith.s7i       0.040422            249
+seed7/lib/modern27.s7i       0.084737           1099
+seed7/lib/more.s7i           0.038702            130
+seed7/lib/msgdigest.s7i      0.079722           1222
+seed7/lib/multiscr.s7i       0.037409             68
+seed7/lib/null_file.s7i      0.043652            345
+seed7/lib/osfiles.s7i        0.067824           1085
+seed7/lib/pbm.s7i            0.040477            230
+seed7/lib/pcx.s7i            0.051085            638
+seed7/lib/pem.s7i            0.039043            185
+seed7/lib/pgm.s7i            0.040225            238
+seed7/lib/pic16.s7i          0.049005           1037
+seed7/lib/pic32.s7i          0.080617           2060
+seed7/lib/pic_util.s7i       0.039422            144
+seed7/lib/pixelimage.s7i     0.046285            320
+seed7/lib/pixmap_file.s7i    0.054759            459
+seed7/lib/pixmapfont.s7i     0.048499            184
+seed7/lib/pkcs1.s7i          0.062114            543
+seed7/lib/png.s7i            0.064090           1064
+seed7/lib/poll.s7i           0.044933            313
+seed7/lib/ppm.s7i            0.040011            240
+seed7/lib/process.s7i        0.050385            541
+seed7/lib/progs.s7i          0.056363            789
+seed7/lib/propertyfile.s7i   0.041868            155
+seed7/lib/rational.s7i       0.053583            792
+seed7/lib/ref_list.s7i       0.041486            252
+seed7/lib/reference.s7i      0.039407            126
+seed7/lib/reverse.s7i        0.037590             94
+seed7/lib/rpm.s7i            0.142008           3487
+seed7/lib/rpmext.s7i         0.042038            318
+seed7/lib/scanfile.s7i       0.080818           1779
+seed7/lib/scanjson.s7i       0.048518            413
+seed7/lib/scanstri.s7i       0.079671           1814
+seed7/lib/scantoml.s7i       0.073096           1603
+seed7/lib/seed7_05.s7i       0.068541           1072
+seed7/lib/set.s7i            0.037354             57
+seed7/lib/shell.s7i          0.055630            615
+seed7/lib/showtls.s7i        0.063857            678
+seed7/lib/signature.s7i      0.041023            131
+seed7/lib/smtp.s7i           0.043156            261
+seed7/lib/sockbase.s7i       0.045288            217
+seed7/lib/socket.s7i         0.045170            326
+seed7/lib/sokoban1.s7i       0.055937           1519
+seed7/lib/sql_base.s7i       0.064351           1000
+seed7/lib/stars.s7i          0.136342           1705
+seed7/lib/stdfont10.s7i      0.080937           3347
+seed7/lib/stdfont12.s7i      0.090951           3928
+seed7/lib/stdfont14.s7i      0.108754           4510
+seed7/lib/stdfont16.s7i      0.118032           5092
+seed7/lib/stdfont18.s7i      0.133994           5868
+seed7/lib/stdfont20.s7i      0.150654           6449
+seed7/lib/stdfont24.s7i      0.181111           7421
+seed7/lib/stdfont8.s7i       0.075182           2960
+seed7/lib/stdfont9.s7i       0.074868           3152
+seed7/lib/stdio.s7i          0.039073            192
+seed7/lib/strifile.s7i       0.042728            345
+seed7/lib/string.s7i         0.054230            779
+seed7/lib/stritext.s7i       0.042999            352
+seed7/lib/struct.s7i         0.042787            266
+seed7/lib/struct_elem.s7i    0.038890            129
+seed7/lib/subfile.s7i        0.038776            174
+seed7/lib/subrange.s7i       0.036418             78
+seed7/lib/syntax.s7i         0.045776            294
+seed7/lib/tar.s7i            0.081742           1880
+seed7/lib/tar_cmds.s7i       0.058215            752
+seed7/lib/tdes.s7i           0.039321            143
+seed7/lib/tee.s7i            0.038877            143
+seed7/lib/text.s7i           0.038511            135
+seed7/lib/tga.s7i            0.055026            676
+seed7/lib/tiff.s7i           0.123744           2771
+seed7/lib/time.s7i           0.063753           1191
+seed7/lib/tls.s7i            0.105132           2230
+seed7/lib/unicode.s7i        0.053077            575
+seed7/lib/unionfnd.s7i       0.038860            130
+seed7/lib/upper.s7i          0.039005            142
+seed7/lib/utf16.s7i          0.050746            540
+seed7/lib/utf8.s7i           0.041650            234
+seed7/lib/vecfont10.s7i      0.080593           1056
+seed7/lib/vecfont18.s7i      0.087404           1119
+seed7/lib/vector3d.s7i       0.040964            293
+seed7/lib/vectorfont.s7i     0.040958            239
+seed7/lib/wildcard.s7i       0.037023            140
+seed7/lib/window.s7i         0.044605            455
+seed7/lib/wrinum.s7i         0.039726            248
+seed7/lib/x509cert.s7i       0.070736           1243
+seed7/lib/xml_ent.s7i        0.037564             94
+seed7/lib/xmldom.s7i         0.041709            303
+seed7/lib/xz.s7i             0.046758            442
+seed7/lib/zip.s7i            0.121963           2792
+seed7/lib/zstd.s7i           0.069665           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.090233        |
++-----------+-----------------+
+| Minimum   | 0.034586        |
++-----------+-----------------+
+| Maximum   | 2.519594        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.043925            190
+seed7/prg/bas7.sd7           0.776081          11459
+seed7/prg/bifurk.sd7         0.038322             73
+seed7/prg/bigfiles.sd7       0.041047            129
+seed7/prg/brainf7.sd7        0.041280             86
+seed7/prg/calc7.sd7          0.041155            128
+seed7/prg/carddemo.sd7       0.047451            190
+seed7/prg/castle.sd7         0.220016           3148
+seed7/prg/cat.sd7            0.038476             82
+seed7/prg/cellauto.sd7       0.042480             85
+seed7/prg/celsius.sd7        0.042537             42
+seed7/prg/chk_all.sd7        0.089442            843
+seed7/prg/chkarr.sd7         0.878199           8367
+seed7/prg/chkbig.sd7         4.162132          29026
+seed7/prg/chkbin.sd7         1.040329           6469
+seed7/prg/chkbitdata.sd7     1.250073           6624
+seed7/prg/chkbool.sd7        0.230234           3157
+seed7/prg/chkbst.sd7         0.101835            722
+seed7/prg/chkchr.sd7         0.478209           2809
+seed7/prg/chkcmd.sd7         0.110205           1205
+seed7/prg/chkdb.sd7          0.758433           7454
+seed7/prg/chkdecl.sd7        0.094968            448
+seed7/prg/chkenum.sd7        0.128171           1230
+seed7/prg/chkerr.sd7         0.344143           4663
+seed7/prg/chkexc.sd7         0.147319           2627
+seed7/prg/chkfil.sd7         0.127951           1615
+seed7/prg/chkflt.sd7         2.831005          20620
+seed7/prg/chkhent.sd7        0.041763             54
+seed7/prg/chkhsh.sd7         0.508937           4548
+seed7/prg/chkidx.sd7         3.202210          19567
+seed7/prg/chkint.sd7         5.598503          38129
+seed7/prg/chkjson.sd7        0.196772           1764
+seed7/prg/chkovf.sd7         1.212565           8216
+seed7/prg/chkprc.sd7         0.697018          10111
+seed7/prg/chkscan.sd7        0.090185            714
+seed7/prg/chkset.sd7         1.750567          11974
+seed7/prg/chkstr.sd7         3.460525          26952
+seed7/prg/chktime.sd7        0.248998           2025
+seed7/prg/chktoml.sd7        0.193584           1656
+seed7/prg/clock.sd7          0.043275             47
+seed7/prg/clock2.sd7         0.038869             43
+seed7/prg/clock3.sd7         0.044063             95
+seed7/prg/cmpfil.sd7         0.041253             84
+seed7/prg/comanche.sd7       0.048363            180
+seed7/prg/confval.sd7        0.052060            175
+seed7/prg/db7.sd7            0.063141            417
+seed7/prg/diff7.sd7          0.052073            263
+seed7/prg/dirtst.sd7         0.039196             42
+seed7/prg/dirx.sd7           0.047443            152
+seed7/prg/dnafight.sd7       0.122515           1381
+seed7/prg/dragon.sd7         0.040818             73
+seed7/prg/echo.sd7           0.040924             39
+seed7/prg/eliza.sd7          0.051778            302
+seed7/prg/err.sd7            0.044163             96
+seed7/prg/fannkuch.sd7       0.046641            131
+seed7/prg/fib.sd7            0.044875             47
+seed7/prg/find7.sd7          0.046966            133
+seed7/prg/findchar.sd7       0.046977            149
+seed7/prg/fractree.sd7       0.041144             55
+seed7/prg/ftp7.sd7           0.055580            296
+seed7/prg/ftpserv.sd7        0.040524             74
+seed7/prg/gcd.sd7            0.039861            109
+seed7/prg/gkbd.sd7           0.060037            358
+seed7/prg/gtksvtst.sd7       0.038404             94
+seed7/prg/hal.sd7            0.052161            250
+seed7/prg/hamu.sd7           0.072559            573
+seed7/prg/hanoi.sd7          0.039598             55
+seed7/prg/hd.sd7             0.038371             79
+seed7/prg/hello.sd7          0.037938             32
+seed7/prg/hilbert.sd7        0.041577            108
+seed7/prg/ide7.sd7           0.047336            196
+seed7/prg/kbd.sd7            0.037085             49
+seed7/prg/klondike.sd7       0.086829            883
+seed7/prg/lander.sd7         0.131706           1551
+seed7/prg/lst80bas.sd7       0.061199            344
+seed7/prg/lst99bas.sd7       0.062641            401
+seed7/prg/lstgwbas.sd7       0.073870            577
+seed7/prg/mahjong.sd7        0.154398           1943
+seed7/prg/make7.sd7          0.042153            121
+seed7/prg/mandelbr.sd7       0.048077            237
+seed7/prg/mind.sd7           0.057849            443
+seed7/prg/mirror.sd7         0.042226            131
+seed7/prg/ms.sd7             0.070089            641
+seed7/prg/nicoma.sd7         0.042739            135
+seed7/prg/pac.sd7            0.074242            726
+seed7/prg/pairs.sd7          0.139648           2025
+seed7/prg/panic.sd7          0.196563           2634
+seed7/prg/percolation.sd7    0.057363            330
+seed7/prg/planets.sd7        0.136809           1486
+seed7/prg/portfwd7.sd7       0.044922            139
+seed7/prg/prime.sd7          0.038907             74
+seed7/prg/printpi1.sd7       0.037691             56
+seed7/prg/printpi2.sd7       0.037353             54
+seed7/prg/printpi3.sd7       0.036692             60
+seed7/prg/pv7.sd7            0.056372            337
+seed7/prg/queen.sd7          0.049838            149
+seed7/prg/rand.sd7           0.048522            121
+seed7/prg/raytrace.sd7       0.074041            538
+seed7/prg/rever.sd7          0.085204            816
+seed7/prg/roman.sd7          0.045123             38
+seed7/prg/s7c.sd7            0.638732           9060
+seed7/prg/s7check.sd7        0.038444             68
+seed7/prg/savehd7.sd7        0.109604           1110
+seed7/prg/self.sd7           0.038493             49
+seed7/prg/shisen.sd7         0.125085           1423
+seed7/prg/sl.sd7             0.102017           1029
+seed7/prg/snake.sd7          0.071659            615
+seed7/prg/sokoban.sd7        0.083501            891
+seed7/prg/spigotpi.sd7       0.038714             64
+seed7/prg/sql7.sd7           0.053923            278
+seed7/prg/startrek.sd7       0.094661            979
+seed7/prg/sudoku7.sd7        0.203914           2657
+seed7/prg/sydir7.sd7         0.065003            384
+seed7/prg/syntaxhl.sd7       0.055544            177
+seed7/prg/tak.sd7            0.043146             59
+seed7/prg/tar7.sd7           0.044589            121
+seed7/prg/tch.sd7            0.040506             55
+seed7/prg/testfont.sd7       0.044205             95
+seed7/prg/tet.sd7            0.059355            479
+seed7/prg/tetg.sd7           0.064139            501
+seed7/prg/toutf8.sd7         0.050270            240
+seed7/prg/tst_cli.sd7        0.035964             40
+seed7/prg/tst_srv.sd7        0.037694             47
+seed7/prg/wator.sd7          0.078834            651
+seed7/prg/which.sd7          0.038635             65
+seed7/prg/wiz.sd7            0.208004           2833
+seed7/prg/wordcnt.sd7        0.038277             54
+seed7/prg/wrinum.sd7         0.037181             43
+seed7/prg/wumpus.sd7         0.054665            372
+seed7/lib/aes.s7i            0.205505           1144
+seed7/lib/aes_gcm.s7i        0.059950            392
+seed7/lib/ar.s7i             0.124510           1532
+seed7/lib/arc4.s7i           0.041851            144
+seed7/lib/archive.s7i        0.045867            143
+seed7/lib/archive_base.s7i   0.043801            135
+seed7/lib/array.s7i          0.074185            610
+seed7/lib/asn1.s7i           0.063619            544
+seed7/lib/asn1oid.s7i        0.049385            157
+seed7/lib/basearray.s7i      0.064518            450
+seed7/lib/bigfile.s7i        0.041958            136
+seed7/lib/bigint.s7i         0.077250            824
+seed7/lib/bigrat.s7i         0.078904            784
+seed7/lib/bin16.s7i          0.068920            592
+seed7/lib/bin32.s7i          0.062294            490
+seed7/lib/bin64.s7i          0.063344            539
+seed7/lib/bitdata.s7i        0.122815           1330
+seed7/lib/bitmapfont.s7i     0.047476            215
+seed7/lib/bitset.s7i         0.062655            593
+seed7/lib/bitsetof.s7i       0.060096            431
+seed7/lib/blowfish.s7i       0.075955            383
+seed7/lib/bmp.s7i            0.099218            924
+seed7/lib/boolean.s7i        0.054223            403
+seed7/lib/browser.s7i        0.053365            280
+seed7/lib/bstring.s7i        0.047150            227
+seed7/lib/bytedata.s7i       0.065356            482
+seed7/lib/bzip2.s7i          0.089599            887
+seed7/lib/cards.s7i          0.101896           1342
+seed7/lib/category.s7i       0.046931            209
+seed7/lib/cc_conf.s7i        0.117205           1314
+seed7/lib/ccittfax.s7i       0.099678           1022
+seed7/lib/cgi.s7i            0.041380            109
+seed7/lib/cgidialog.s7i      0.097636           1118
+seed7/lib/char.s7i           0.054485            356
+seed7/lib/charsets.s7i       0.126148           2024
+seed7/lib/chartype.s7i       0.048001            121
+seed7/lib/cipher.s7i         0.042147            146
+seed7/lib/cli_cmds.s7i       0.117422           1360
+seed7/lib/clib_file.s7i      0.051709            301
+seed7/lib/color.s7i          0.049446            185
+seed7/lib/complex.s7i        0.061341            464
+seed7/lib/compress.s7i       0.045900            150
+seed7/lib/console.s7i        0.052545            188
+seed7/lib/cpio.s7i           0.151496           1708
+seed7/lib/crc32.s7i          0.055283            193
+seed7/lib/cronos16.s7i       0.193216           1173
+seed7/lib/cronos27.s7i       0.253490           1464
+seed7/lib/csv.s7i            0.047819            201
+seed7/lib/db_prop.s7i        0.100076            991
+seed7/lib/deflate.s7i        0.085123            740
+seed7/lib/des.s7i            0.081324            444
+seed7/lib/dialog.s7i         0.056807            311
+seed7/lib/dir.s7i            0.042773            163
+seed7/lib/draw.s7i           0.085140            854
+seed7/lib/duration.s7i       0.096535           1038
+seed7/lib/echo.s7i           0.041002            132
+seed7/lib/editline.s7i       0.057579            398
+seed7/lib/elf.s7i            0.151968           1560
+seed7/lib/elliptic.s7i       0.076760            649
+seed7/lib/enable_io.s7i      0.051783            312
+seed7/lib/encoding.s7i       0.096993            931
+seed7/lib/enumeration.s7i    0.048772            236
+seed7/lib/environment.s7i    0.044650            175
+seed7/lib/exif.s7i           0.045158            152
+seed7/lib/external_file.s7i  0.052856            340
+seed7/lib/field.s7i          0.052420            268
+seed7/lib/file.s7i           0.053689            372
+seed7/lib/filebits.s7i       0.037958             46
+seed7/lib/filesys.s7i        0.066127            601
+seed7/lib/fileutil.s7i       0.044084            144
+seed7/lib/fixarray.s7i       0.052058            307
+seed7/lib/float.s7i          0.072026            757
+seed7/lib/font.s7i           0.045439            196
+seed7/lib/font8x8.s7i        0.067417            998
+seed7/lib/forloop.s7i        0.059335            449
+seed7/lib/ftp.s7i            0.088525            969
+seed7/lib/ftpserv.s7i        0.076434            631
+seed7/lib/getf.s7i           0.042890            115
+seed7/lib/gethttp.s7i        0.037623             41
+seed7/lib/gethttps.s7i       0.037166             41
+seed7/lib/gif.s7i            0.071082            561
+seed7/lib/graph.s7i          0.064183            415
+seed7/lib/graph_file.s7i     0.058157            399
+seed7/lib/gtkserver.s7i      0.041520            161
+seed7/lib/gzip.s7i           0.068104            573
+seed7/lib/hash.s7i           0.066623            421
+seed7/lib/hashsetof.s7i      0.067091            499
+seed7/lib/hmac.s7i           0.045007            152
+seed7/lib/html.s7i           0.040328             83
+seed7/lib/html_ent.s7i       0.061970            476
+seed7/lib/htmldom.s7i        0.051977            286
+seed7/lib/http_request.s7i   0.075241            696
+seed7/lib/http_srv_resp.s7i  0.057412            380
+seed7/lib/https_request.s7i  0.048613            211
+seed7/lib/httpserv.s7i       0.055875            345
+seed7/lib/huffman.s7i        0.075321            644
+seed7/lib/ico.s7i            0.050663            221
+seed7/lib/idxarray.s7i       0.051302            232
+seed7/lib/image.s7i          0.041373            156
+seed7/lib/imagefile.s7i      0.045482            171
+seed7/lib/inflate.s7i        0.065669            411
+seed7/lib/inifile.s7i        0.042574            129
+seed7/lib/integer.s7i        0.068018            663
+seed7/lib/iobuffer.s7i       0.051304            289
+seed7/lib/jpeg.s7i           0.154239           1761
+seed7/lib/json.s7i           0.080308            891
+seed7/lib/json_serde.s7i     0.077305            783
+seed7/lib/keybd.s7i          0.077622            639
+seed7/lib/keydescr.s7i       0.048016            192
+seed7/lib/leb128.s7i         0.051530            218
+seed7/lib/line.s7i           0.046978            164
+seed7/lib/listener.s7i       0.051683            247
+seed7/lib/logfile.s7i        0.040479             73
+seed7/lib/lower.s7i          0.043671            142
+seed7/lib/lzma.s7i           0.097236            934
+seed7/lib/lzw.s7i            0.092432            861
+seed7/lib/magic.s7i          0.065982            403
+seed7/lib/mahjng32.s7i       0.092089           1500
+seed7/lib/make.s7i           0.070765            544
+seed7/lib/makedata.s7i       0.119742           1428
+seed7/lib/math.s7i           0.045951            201
+seed7/lib/mixarith.s7i       0.047194            249
+seed7/lib/modern27.s7i       0.166366           1099
+seed7/lib/more.s7i           0.042349            130
+seed7/lib/msgdigest.s7i      0.137774           1222
+seed7/lib/multiscr.s7i       0.040494             68
+seed7/lib/null_file.s7i      0.051670            345
+seed7/lib/osfiles.s7i        0.094946           1085
+seed7/lib/pbm.s7i            0.047653            230
+seed7/lib/pcx.s7i            0.077165            638
+seed7/lib/pem.s7i            0.045553            185
+seed7/lib/pgm.s7i            0.048127            238
+seed7/lib/pic16.s7i          0.066462           1037
+seed7/lib/pic32.s7i          0.120485           2060
+seed7/lib/pic_util.s7i       0.042303            144
+seed7/lib/pixelimage.s7i     0.050839            320
+seed7/lib/pixmap_file.s7i    0.060086            459
+seed7/lib/pixmapfont.s7i     0.047657            184
+seed7/lib/pkcs1.s7i          0.076508            543
+seed7/lib/png.s7i            0.109681           1064
+seed7/lib/poll.s7i           0.067546            313
+seed7/lib/ppm.s7i            0.059130            240
+seed7/lib/process.s7i        0.070145            541
+seed7/lib/progs.s7i          0.090712            789
+seed7/lib/propertyfile.s7i   0.046443            155
+seed7/lib/rational.s7i       0.080296            792
+seed7/lib/ref_list.s7i       0.050583            252
+seed7/lib/reference.s7i      0.044561            126
+seed7/lib/reverse.s7i        0.040613             94
+seed7/lib/rpm.s7i            0.283201           3487
+seed7/lib/rpmext.s7i         0.050751            318
+seed7/lib/scanfile.s7i       0.131453           1779
+seed7/lib/scanjson.s7i       0.061601            413
+seed7/lib/scanstri.s7i       0.136127           1814
+seed7/lib/scantoml.s7i       0.131560           1603
+seed7/lib/seed7_05.s7i       0.111854           1072
+seed7/lib/set.s7i            0.038412             57
+seed7/lib/shell.s7i          0.069093            615
+seed7/lib/showtls.s7i        0.084061            678
+seed7/lib/signature.s7i      0.041508            131
+seed7/lib/smtp.s7i           0.047664            261
+seed7/lib/sockbase.s7i       0.048506            217
+seed7/lib/socket.s7i         0.053147            326
+seed7/lib/sokoban1.s7i       0.082198           1519
+seed7/lib/sql_base.s7i       0.097949           1000
+seed7/lib/stars.s7i          0.239553           1705
+seed7/lib/stdfont10.s7i      0.152090           3347
+seed7/lib/stdfont12.s7i      0.171668           3928
+seed7/lib/stdfont14.s7i      0.190284           4510
+seed7/lib/stdfont16.s7i      0.208493           5092
+seed7/lib/stdfont18.s7i      0.248535           5868
+seed7/lib/stdfont20.s7i      0.272550           6449
+seed7/lib/stdfont24.s7i      0.329836           7421
+seed7/lib/stdfont8.s7i       0.125942           2960
+seed7/lib/stdfont9.s7i       0.134537           3152
+seed7/lib/stdio.s7i          0.047038            192
+seed7/lib/strifile.s7i       0.060564            345
+seed7/lib/string.s7i         0.078481            779
+seed7/lib/stritext.s7i       0.054687            352
+seed7/lib/struct.s7i         0.055315            266
+seed7/lib/struct_elem.s7i    0.041860            129
+seed7/lib/subfile.s7i        0.042850            174
+seed7/lib/subrange.s7i       0.038697             78
+seed7/lib/syntax.s7i         0.058706            294
+seed7/lib/tar.s7i            0.146596           1880
+seed7/lib/tar_cmds.s7i       0.082884            752
+seed7/lib/tdes.s7i           0.048767            143
+seed7/lib/tee.s7i            0.042477            143
+seed7/lib/text.s7i           0.041325            135
+seed7/lib/tga.s7i            0.080996            676
+seed7/lib/tiff.s7i           0.256643           2771
+seed7/lib/time.s7i           0.103197           1191
+seed7/lib/tls.s7i            0.195574           2230
+seed7/lib/unicode.s7i        0.072995            575
+seed7/lib/unionfnd.s7i       0.042449            130
+seed7/lib/upper.s7i          0.041687            142
+seed7/lib/utf16.s7i          0.065297            540
+seed7/lib/utf8.s7i           0.047955            234
+seed7/lib/vecfont10.s7i      0.158958           1056
+seed7/lib/vecfont18.s7i      0.176027           1119
+seed7/lib/vector3d.s7i       0.048541            293
+seed7/lib/vectorfont.s7i     0.046442            239
+seed7/lib/wildcard.s7i       0.044058            140
+seed7/lib/window.s7i         0.060569            455
+seed7/lib/wrinum.s7i         0.049726            248
+seed7/lib/x509cert.s7i       0.118490           1243
+seed7/lib/xml_ent.s7i        0.041020             94
+seed7/lib/xmldom.s7i         0.050514            303
+seed7/lib/xz.s7i             0.060112            442
+seed7/lib/zip.s7i            0.229966           2792
+seed7/lib/zstd.s7i           0.117448           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.160164        |
++-----------+-----------------+
+| Minimum   | 0.035964        |
++-----------+-----------------+
+| Maximum   | 5.598503        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.034479        | 0.032376        | 0.045546        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.040174        | 0.035197        | 0.049282        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.090233        | 0.034586        | 2.519594        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.160164        | 0.035964        | 5.598503        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.657 | 00:00:58.742 | 00:01:11.400 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:15.630 | 00:01:08.503 | 00:01:24.133 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:36.669 | 00:02:34.602 | 00:03:11.271 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:02.532 | 00:04:33.779 | 00:05:36.312 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:23.124 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-06.3.rst
+++ b/reports/seed7mode-perf-06.3.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-24T14:48:55+0000 W26-3
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 11:07:20 local time
+:Generated on: 2026-06-24 15:18:41 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 226x84 chars
+:Window body: 226x82 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.035594            190
+seed7/prg/bas7.sd7           0.035403          11459
+seed7/prg/bifurk.sd7         0.034456             73
+seed7/prg/bigfiles.sd7       0.036377            129
+seed7/prg/brainf7.sd7        0.035754             86
+seed7/prg/calc7.sd7          0.036259            128
+seed7/prg/carddemo.sd7       0.039538            190
+seed7/prg/castle.sd7         0.037112           3148
+seed7/prg/cat.sd7            0.036318             82
+seed7/prg/cellauto.sd7       0.035969             85
+seed7/prg/celsius.sd7        0.032922             42
+seed7/prg/chk_all.sd7        0.033062            843
+seed7/prg/chkarr.sd7         0.033552           8367
+seed7/prg/chkbig.sd7         0.036702          29026
+seed7/prg/chkbin.sd7         0.035476           6469
+seed7/prg/chkbitdata.sd7     0.035640           6624
+seed7/prg/chkbool.sd7        0.032949           3157
+seed7/prg/chkbst.sd7         0.033629            722
+seed7/prg/chkchr.sd7         0.034002           2809
+seed7/prg/chkcmd.sd7         0.034565           1205
+seed7/prg/chkdb.sd7          0.035034           7454
+seed7/prg/chkdecl.sd7        0.034366            448
+seed7/prg/chkenum.sd7        0.034944           1230
+seed7/prg/chkerr.sd7         0.034395           4663
+seed7/prg/chkexc.sd7         0.033862           2627
+seed7/prg/chkfil.sd7         0.033501           1615
+seed7/prg/chkflt.sd7         0.040666          20620
+seed7/prg/chkhent.sd7        0.041429             54
+seed7/prg/chkhsh.sd7         0.035995           4548
+seed7/prg/chkidx.sd7         0.036853          19567
+seed7/prg/chkint.sd7         0.040707          38129
+seed7/prg/chkjson.sd7        0.034532           1764
+seed7/prg/chkovf.sd7         0.036238           8216
+seed7/prg/chkprc.sd7         0.034320          10111
+seed7/prg/chkscan.sd7        0.033989            714
+seed7/prg/chkset.sd7         0.035156          11974
+seed7/prg/chkstr.sd7         0.038518          26952
+seed7/prg/chktime.sd7        0.033828           2025
+seed7/prg/chktoml.sd7        0.035550           1656
+seed7/prg/clock.sd7          0.034677             47
+seed7/prg/clock2.sd7         0.032500             43
+seed7/prg/clock3.sd7         0.036676             95
+seed7/prg/cmpfil.sd7         0.040462             84
+seed7/prg/comanche.sd7       0.035482            180
+seed7/prg/confval.sd7        0.036312            175
+seed7/prg/db7.sd7            0.035637            417
+seed7/prg/diff7.sd7          0.034713            263
+seed7/prg/dirtst.sd7         0.033501             42
+seed7/prg/dirx.sd7           0.033640            152
+seed7/prg/dnafight.sd7       0.034632           1381
+seed7/prg/dragon.sd7         0.035173             73
+seed7/prg/echo.sd7           0.034884             39
+seed7/prg/eliza.sd7          0.033964            302
+seed7/prg/err.sd7            0.034315             96
+seed7/prg/fannkuch.sd7       0.033475            131
+seed7/prg/fib.sd7            0.035026             47
+seed7/prg/find7.sd7          0.033275            133
+seed7/prg/findchar.sd7       0.033152            149
+seed7/prg/fractree.sd7       0.032793             55
+seed7/prg/ftp7.sd7           0.033190            296
+seed7/prg/ftpserv.sd7        0.034053             74
+seed7/prg/gcd.sd7            0.033381            109
+seed7/prg/gkbd.sd7           0.034184            358
+seed7/prg/gtksvtst.sd7       0.033022             94
+seed7/prg/hal.sd7            0.033945            250
+seed7/prg/hamu.sd7           0.034552            573
+seed7/prg/hanoi.sd7          0.034638             55
+seed7/prg/hd.sd7             0.036516             79
+seed7/prg/hello.sd7          0.036363             32
+seed7/prg/hilbert.sd7        0.034876            108
+seed7/prg/ide7.sd7           0.034423            196
+seed7/prg/kbd.sd7            0.032291             49
+seed7/prg/klondike.sd7       0.033526            883
+seed7/prg/lander.sd7         0.033135           1551
+seed7/prg/lst80bas.sd7       0.035038            344
+seed7/prg/lst99bas.sd7       0.034032            401
+seed7/prg/lstgwbas.sd7       0.034654            577
+seed7/prg/mahjong.sd7        0.034173           1943
+seed7/prg/make7.sd7          0.037993            121
+seed7/prg/mandelbr.sd7       0.040190            237
+seed7/prg/mind.sd7           0.034984            443
+seed7/prg/mirror.sd7         0.036126            131
+seed7/prg/ms.sd7             0.034260            641
+seed7/prg/nicoma.sd7         0.034052            135
+seed7/prg/pac.sd7            0.034582            726
+seed7/prg/pairs.sd7          0.034947           2025
+seed7/prg/panic.sd7          0.035784           2634
+seed7/prg/percolation.sd7    0.034689            330
+seed7/prg/planets.sd7        0.033240           1486
+seed7/prg/portfwd7.sd7       0.034332            139
+seed7/prg/prime.sd7          0.033859             74
+seed7/prg/printpi1.sd7       0.034142             56
+seed7/prg/printpi2.sd7       0.036631             54
+seed7/prg/printpi3.sd7       0.034861             60
+seed7/prg/pv7.sd7            0.033688            337
+seed7/prg/queen.sd7          0.033401            149
+seed7/prg/rand.sd7           0.034373            121
+seed7/prg/raytrace.sd7       0.035161            538
+seed7/prg/rever.sd7          0.034376            816
+seed7/prg/roman.sd7          0.033484             38
+seed7/prg/s7c.sd7            0.033217           9060
+seed7/prg/s7check.sd7        0.032484             68
+seed7/prg/savehd7.sd7        0.033228           1110
+seed7/prg/self.sd7           0.033363             49
+seed7/prg/shisen.sd7         0.034469           1423
+seed7/prg/sl.sd7             0.032440           1029
+seed7/prg/snake.sd7          0.033188            615
+seed7/prg/sokoban.sd7        0.037307            891
+seed7/prg/spigotpi.sd7       0.036058             64
+seed7/prg/sql7.sd7           0.033680            278
+seed7/prg/startrek.sd7       0.035365            979
+seed7/prg/sudoku7.sd7        0.034025           2657
+seed7/prg/sydir7.sd7         0.033587            384
+seed7/prg/syntaxhl.sd7       0.034551            177
+seed7/prg/tak.sd7            0.035962             59
+seed7/prg/tar7.sd7           0.039568            121
+seed7/prg/tch.sd7            0.040085             55
+seed7/prg/testfont.sd7       0.035289             95
+seed7/prg/tet.sd7            0.034531            479
+seed7/prg/tetg.sd7           0.035140            501
+seed7/prg/toutf8.sd7         0.038924            240
+seed7/prg/tst_cli.sd7        0.043373             40
+seed7/prg/tst_srv.sd7        0.041734             47
+seed7/prg/wator.sd7          0.040171            651
+seed7/prg/which.sd7          0.039395             65
+seed7/prg/wiz.sd7            0.038358           2833
+seed7/prg/wordcnt.sd7        0.036961             54
+seed7/prg/wrinum.sd7         0.035687             43
+seed7/prg/wumpus.sd7         0.033694            372
+seed7/lib/aes.s7i            0.034676           1144
+seed7/lib/aes_gcm.s7i        0.035696            392
+seed7/lib/ar.s7i             0.038349           1532
+seed7/lib/arc4.s7i           0.037152            144
+seed7/lib/archive.s7i        0.038020            143
+seed7/lib/archive_base.s7i   0.038168            135
+seed7/lib/array.s7i          0.037025            610
+seed7/lib/asn1.s7i           0.042344            544
+seed7/lib/asn1oid.s7i        0.038700            157
+seed7/lib/basearray.s7i      0.038570            450
+seed7/lib/bigfile.s7i        0.035807            136
+seed7/lib/bigint.s7i         0.035898            824
+seed7/lib/bigrat.s7i         0.039025            784
+seed7/lib/bin16.s7i          0.035619            592
+seed7/lib/bin32.s7i          0.036374            490
+seed7/lib/bin64.s7i          0.038664            539
+seed7/lib/bitdata.s7i        0.035999           1330
+seed7/lib/bitmapfont.s7i     0.035299            215
+seed7/lib/bitset.s7i         0.036993            593
+seed7/lib/bitsetof.s7i       0.037818            431
+seed7/lib/blowfish.s7i       0.039544            383
+seed7/lib/bmp.s7i            0.042315            924
+seed7/lib/boolean.s7i        0.040404            403
+seed7/lib/browser.s7i        0.042269            280
+seed7/lib/bstring.s7i        0.035950            227
+seed7/lib/bytedata.s7i       0.036934            482
+seed7/lib/bzip2.s7i          0.036558            887
+seed7/lib/cards.s7i          0.035430           1342
+seed7/lib/category.s7i       0.037921            209
+seed7/lib/cc_conf.s7i        0.037462           1314
+seed7/lib/ccittfax.s7i       0.037991           1022
+seed7/lib/cgi.s7i            0.037240            109
+seed7/lib/cgidialog.s7i      0.036963           1118
+seed7/lib/char.s7i           0.036611            356
+seed7/lib/charsets.s7i       0.033612           2024
+seed7/lib/chartype.s7i       0.034032            121
+seed7/lib/cipher.s7i         0.033591            146
+seed7/lib/cli_cmds.s7i       0.034817           1360
+seed7/lib/clib_file.s7i      0.034230            301
+seed7/lib/color.s7i          0.033180            185
+seed7/lib/complex.s7i        0.033383            464
+seed7/lib/compress.s7i       0.033300            150
+seed7/lib/console.s7i        0.033323            188
+seed7/lib/cpio.s7i           0.036147           1708
+seed7/lib/crc32.s7i          0.034604            193
+seed7/lib/cronos16.s7i       0.033937           1173
+seed7/lib/cronos27.s7i       0.034038           1464
+seed7/lib/csv.s7i            0.034012            201
+seed7/lib/db_prop.s7i        0.033424            991
+seed7/lib/deflate.s7i        0.035719            740
+seed7/lib/des.s7i            0.040578            444
+seed7/lib/dialog.s7i         0.041708            311
+seed7/lib/dir.s7i            0.041339            163
+seed7/lib/draw.s7i           0.035989            854
+seed7/lib/duration.s7i       0.036544           1038
+seed7/lib/echo.s7i           0.036667            132
+seed7/lib/editline.s7i       0.035114            398
+seed7/lib/elf.s7i            0.033422           1560
+seed7/lib/elliptic.s7i       0.032821            649
+seed7/lib/enable_io.s7i      0.033509            312
+seed7/lib/encoding.s7i       0.034666            931
+seed7/lib/enumeration.s7i    0.035095            236
+seed7/lib/environment.s7i    0.033511            175
+seed7/lib/exif.s7i           0.033158            152
+seed7/lib/external_file.s7i  0.032832            340
+seed7/lib/field.s7i          0.034145            268
+seed7/lib/file.s7i           0.035796            372
+seed7/lib/filebits.s7i       0.036405             46
+seed7/lib/filesys.s7i        0.034739            601
+seed7/lib/fileutil.s7i       0.034024            144
+seed7/lib/fixarray.s7i       0.033474            307
+seed7/lib/float.s7i          0.033668            757
+seed7/lib/font.s7i           0.034483            196
+seed7/lib/font8x8.s7i        0.035746            998
+seed7/lib/forloop.s7i        0.040899            449
+seed7/lib/ftp.s7i            0.042195            969
+seed7/lib/ftpserv.s7i        0.039491            631
+seed7/lib/getf.s7i           0.035464            115
+seed7/lib/gethttp.s7i        0.034818             41
+seed7/lib/gethttps.s7i       0.034106             41
+seed7/lib/gif.s7i            0.035735            561
+seed7/lib/graph.s7i          0.033825            415
+seed7/lib/graph_file.s7i     0.033352            399
+seed7/lib/gtkserver.s7i      0.033708            161
+seed7/lib/gzip.s7i           0.033638            573
+seed7/lib/hash.s7i           0.033619            421
+seed7/lib/hashsetof.s7i      0.034278            499
+seed7/lib/hmac.s7i           0.035803            152
+seed7/lib/html.s7i           0.035488             83
+seed7/lib/html_ent.s7i       0.033522            476
+seed7/lib/htmldom.s7i        0.035136            286
+seed7/lib/http_request.s7i   0.036068            696
+seed7/lib/http_srv_resp.s7i  0.032791            380
+seed7/lib/https_request.s7i  0.032535            211
+seed7/lib/httpserv.s7i       0.039107            345
+seed7/lib/huffman.s7i        0.039923            644
+seed7/lib/ico.s7i            0.036201            221
+seed7/lib/idxarray.s7i       0.033521            232
+seed7/lib/image.s7i          0.033703            156
+seed7/lib/imagefile.s7i      0.035195            171
+seed7/lib/inflate.s7i        0.034495            411
+seed7/lib/inifile.s7i        0.039846            129
+seed7/lib/integer.s7i        0.043167            663
+seed7/lib/iobuffer.s7i       0.038160            289
+seed7/lib/jpeg.s7i           0.036293           1761
+seed7/lib/json.s7i           0.035234            891
+seed7/lib/json_serde.s7i     0.034460            783
+seed7/lib/keybd.s7i          0.037701            639
+seed7/lib/keydescr.s7i       0.035584            192
+seed7/lib/leb128.s7i         0.037039            218
+seed7/lib/line.s7i           0.041223            164
+seed7/lib/listener.s7i       0.041742            247
+seed7/lib/logfile.s7i        0.038508             73
+seed7/lib/lower.s7i          0.034371            142
+seed7/lib/lzma.s7i           0.033585            934
+seed7/lib/lzw.s7i            0.034455            861
+seed7/lib/magic.s7i          0.033326            403
+seed7/lib/mahjng32.s7i       0.032873           1500
+seed7/lib/make.s7i           0.033003            544
+seed7/lib/makedata.s7i       0.032887           1428
+seed7/lib/math.s7i           0.032688            201
+seed7/lib/mixarith.s7i       0.034784            249
+seed7/lib/modern27.s7i       0.034977           1099
+seed7/lib/more.s7i           0.037249            130
+seed7/lib/msgdigest.s7i      0.034621           1222
+seed7/lib/multiscr.s7i       0.033247             68
+seed7/lib/null_file.s7i      0.033519            345
+seed7/lib/osfiles.s7i        0.035381           1085
+seed7/lib/pbm.s7i            0.035676            230
+seed7/lib/pcx.s7i            0.035324            638
+seed7/lib/pem.s7i            0.036401            185
+seed7/lib/pgm.s7i            0.036210            238
+seed7/lib/pic16.s7i          0.034446           1037
+seed7/lib/pic32.s7i          0.034524           2060
+seed7/lib/pic_util.s7i       0.034113            144
+seed7/lib/pixelimage.s7i     0.033795            320
+seed7/lib/pixmap_file.s7i    0.033302            459
+seed7/lib/pixmapfont.s7i     0.033725            184
+seed7/lib/pkcs1.s7i          0.035753            543
+seed7/lib/png.s7i            0.033549           1064
+seed7/lib/poll.s7i           0.033223            313
+seed7/lib/ppm.s7i            0.033388            240
+seed7/lib/process.s7i        0.036031            541
+seed7/lib/progs.s7i          0.034058            789
+seed7/lib/propertyfile.s7i   0.034624            155
+seed7/lib/rational.s7i       0.033623            792
+seed7/lib/ref_list.s7i       0.034320            252
+seed7/lib/reference.s7i      0.036162            126
+seed7/lib/reverse.s7i        0.040570             94
+seed7/lib/rpm.s7i            0.037480           3487
+seed7/lib/rpmext.s7i         0.034997            318
+seed7/lib/scanfile.s7i       0.033835           1779
+seed7/lib/scanjson.s7i       0.033373            413
+seed7/lib/scanstri.s7i       0.033893           1814
+seed7/lib/scantoml.s7i       0.033879           1603
+seed7/lib/seed7_05.s7i       0.034062           1072
+seed7/lib/set.s7i            0.034624             57
+seed7/lib/shell.s7i          0.033147            615
+seed7/lib/showtls.s7i        0.033272            678
+seed7/lib/signature.s7i      0.033094            131
+seed7/lib/smtp.s7i           0.033910            261
+seed7/lib/sockbase.s7i       0.033883            217
+seed7/lib/socket.s7i         0.033931            326
+seed7/lib/sokoban1.s7i       0.034827           1519
+seed7/lib/sql_base.s7i       0.034080           1000
+seed7/lib/stars.s7i          0.033790           1705
+seed7/lib/stdfont10.s7i      0.035165           3347
+seed7/lib/stdfont12.s7i      0.034993           3928
+seed7/lib/stdfont14.s7i      0.034137           4510
+seed7/lib/stdfont16.s7i      0.034392           5092
+seed7/lib/stdfont18.s7i      0.033824           5868
+seed7/lib/stdfont20.s7i      0.035067           6449
+seed7/lib/stdfont24.s7i      0.034733           7421
+seed7/lib/stdfont8.s7i       0.033640           2960
+seed7/lib/stdfont9.s7i       0.034808           3152
+seed7/lib/stdio.s7i          0.035463            192
+seed7/lib/strifile.s7i       0.033848            345
+seed7/lib/string.s7i         0.034254            779
+seed7/lib/stritext.s7i       0.035085            352
+seed7/lib/struct.s7i         0.034239            266
+seed7/lib/struct_elem.s7i    0.033680            129
+seed7/lib/subfile.s7i        0.032922            174
+seed7/lib/subrange.s7i       0.032998             78
+seed7/lib/syntax.s7i         0.032428            294
+seed7/lib/tar.s7i            0.035191           1880
+seed7/lib/tar_cmds.s7i       0.040420            752
+seed7/lib/tdes.s7i           0.037652            143
+seed7/lib/tee.s7i            0.034918            143
+seed7/lib/text.s7i           0.034152            135
+seed7/lib/tga.s7i            0.035391            676
+seed7/lib/tiff.s7i           0.035671           2771
+seed7/lib/time.s7i           0.034523           1191
+seed7/lib/tls.s7i            0.034476           2230
+seed7/lib/unicode.s7i        0.033469            575
+seed7/lib/unionfnd.s7i       0.033530            130
+seed7/lib/upper.s7i          0.033236            142
+seed7/lib/utf16.s7i          0.033656            540
+seed7/lib/utf8.s7i           0.033717            234
+seed7/lib/vecfont10.s7i      0.034546           1056
+seed7/lib/vecfont18.s7i      0.034405           1119
+seed7/lib/vector3d.s7i       0.033278            293
+seed7/lib/vectorfont.s7i     0.033457            239
+seed7/lib/wildcard.s7i       0.035019            140
+seed7/lib/window.s7i         0.034623            455
+seed7/lib/wrinum.s7i         0.033750            248
+seed7/lib/x509cert.s7i       0.033343           1243
+seed7/lib/xml_ent.s7i        0.033122             94
+seed7/lib/xmldom.s7i         0.034095            303
+seed7/lib/xz.s7i             0.033480            442
+seed7/lib/zip.s7i            0.034244           2792
+seed7/lib/zstd.s7i           0.032437           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.035323        |
++-----------+-----------------+
+| Minimum   | 0.032291        |
++-----------+-----------------+
+| Maximum   | 0.043373        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039020            190
+seed7/prg/bas7.sd7           0.040676          11459
+seed7/prg/bifurk.sd7         0.038119             73
+seed7/prg/bigfiles.sd7       0.041402            129
+seed7/prg/brainf7.sd7        0.041350             86
+seed7/prg/calc7.sd7          0.040805            128
+seed7/prg/carddemo.sd7       0.040808            190
+seed7/prg/castle.sd7         0.040219           3148
+seed7/prg/cat.sd7            0.037602             82
+seed7/prg/cellauto.sd7       0.038103             85
+seed7/prg/celsius.sd7        0.036373             42
+seed7/prg/chk_all.sd7        0.038899            843
+seed7/prg/chkarr.sd7         0.040206           8367
+seed7/prg/chkbig.sd7         0.043480          29026
+seed7/prg/chkbin.sd7         0.038881           6469
+seed7/prg/chkbitdata.sd7     0.040442           6624
+seed7/prg/chkbool.sd7        0.037625           3157
+seed7/prg/chkbst.sd7         0.038789            722
+seed7/prg/chkchr.sd7         0.040344           2809
+seed7/prg/chkcmd.sd7         0.038924           1205
+seed7/prg/chkdb.sd7          0.040545           7454
+seed7/prg/chkdecl.sd7        0.038888            448
+seed7/prg/chkenum.sd7        0.036778           1230
+seed7/prg/chkerr.sd7         0.039011           4663
+seed7/prg/chkexc.sd7         0.036578           2627
+seed7/prg/chkfil.sd7         0.038629           1615
+seed7/prg/chkflt.sd7         0.040331          20620
+seed7/prg/chkhent.sd7        0.037163             54
+seed7/prg/chkhsh.sd7         0.045504           4548
+seed7/prg/chkidx.sd7         0.048085          19567
+seed7/prg/chkint.sd7         0.046597          38129
+seed7/prg/chkjson.sd7        0.039626           1764
+seed7/prg/chkovf.sd7         0.039135           8216
+seed7/prg/chkprc.sd7         0.038884          10111
+seed7/prg/chkscan.sd7        0.040093            714
+seed7/prg/chkset.sd7         0.042556          11974
+seed7/prg/chkstr.sd7         0.043063          26952
+seed7/prg/chktime.sd7        0.044123           2025
+seed7/prg/chktoml.sd7        0.040176           1656
+seed7/prg/clock.sd7          0.035884             47
+seed7/prg/clock2.sd7         0.035958             43
+seed7/prg/clock3.sd7         0.038626             95
+seed7/prg/cmpfil.sd7         0.038231             84
+seed7/prg/comanche.sd7       0.039138            180
+seed7/prg/confval.sd7        0.039751            175
+seed7/prg/db7.sd7            0.038140            417
+seed7/prg/diff7.sd7          0.039606            263
+seed7/prg/dirtst.sd7         0.036135             42
+seed7/prg/dirx.sd7           0.039986            152
+seed7/prg/dnafight.sd7       0.040553           1381
+seed7/prg/dragon.sd7         0.036725             73
+seed7/prg/echo.sd7           0.034920             39
+seed7/prg/eliza.sd7          0.037825            302
+seed7/prg/err.sd7            0.040724             96
+seed7/prg/fannkuch.sd7       0.038222            131
+seed7/prg/fib.sd7            0.035491             47
+seed7/prg/find7.sd7          0.042042            133
+seed7/prg/findchar.sd7       0.039845            149
+seed7/prg/fractree.sd7       0.040380             55
+seed7/prg/ftp7.sd7           0.042248            296
+seed7/prg/ftpserv.sd7        0.045178             74
+seed7/prg/gcd.sd7            0.041874            109
+seed7/prg/gkbd.sd7           0.041353            358
+seed7/prg/gtksvtst.sd7       0.038659             94
+seed7/prg/hal.sd7            0.036252            250
+seed7/prg/hamu.sd7           0.038410            573
+seed7/prg/hanoi.sd7          0.036520             55
+seed7/prg/hd.sd7             0.036255             79
+seed7/prg/hello.sd7          0.035245             32
+seed7/prg/hilbert.sd7        0.038345            108
+seed7/prg/ide7.sd7           0.038505            196
+seed7/prg/kbd.sd7            0.035624             49
+seed7/prg/klondike.sd7       0.038489            883
+seed7/prg/lander.sd7         0.039270           1551
+seed7/prg/lst80bas.sd7       0.037894            344
+seed7/prg/lst99bas.sd7       0.038957            401
+seed7/prg/lstgwbas.sd7       0.037793            577
+seed7/prg/mahjong.sd7        0.038667           1943
+seed7/prg/make7.sd7          0.047618            121
+seed7/prg/mandelbr.sd7       0.046283            237
+seed7/prg/mind.sd7           0.043009            443
+seed7/prg/mirror.sd7         0.040447            131
+seed7/prg/ms.sd7             0.039583            641
+seed7/prg/nicoma.sd7         0.046028            135
+seed7/prg/pac.sd7            0.042906            726
+seed7/prg/pairs.sd7          0.047167           2025
+seed7/prg/panic.sd7          0.048456           2634
+seed7/prg/percolation.sd7    0.047218            330
+seed7/prg/planets.sd7        0.044452           1486
+seed7/prg/portfwd7.sd7       0.041850            139
+seed7/prg/prime.sd7          0.040629             74
+seed7/prg/printpi1.sd7       0.037209             56
+seed7/prg/printpi2.sd7       0.036057             54
+seed7/prg/printpi3.sd7       0.036373             60
+seed7/prg/pv7.sd7            0.043664            337
+seed7/prg/queen.sd7          0.038547            149
+seed7/prg/rand.sd7           0.040069            121
+seed7/prg/raytrace.sd7       0.044979            538
+seed7/prg/rever.sd7          0.045898            816
+seed7/prg/roman.sd7          0.039740             38
+seed7/prg/s7c.sd7            0.040210           9060
+seed7/prg/s7check.sd7        0.042154             68
+seed7/prg/savehd7.sd7        0.042582           1110
+seed7/prg/self.sd7           0.037328             49
+seed7/prg/shisen.sd7         0.039906           1423
+seed7/prg/sl.sd7             0.041114           1029
+seed7/prg/snake.sd7          0.045005            615
+seed7/prg/sokoban.sd7        0.046616            891
+seed7/prg/spigotpi.sd7       0.039896             64
+seed7/prg/sql7.sd7           0.039360            278
+seed7/prg/startrek.sd7       0.037182            979
+seed7/prg/sudoku7.sd7        0.040123           2657
+seed7/prg/sydir7.sd7         0.039409            384
+seed7/prg/syntaxhl.sd7       0.043729            177
+seed7/prg/tak.sd7            0.037636             59
+seed7/prg/tar7.sd7           0.038580            121
+seed7/prg/tch.sd7            0.036191             55
+seed7/prg/testfont.sd7       0.038270             95
+seed7/prg/tet.sd7            0.038609            479
+seed7/prg/tetg.sd7           0.046769            501
+seed7/prg/toutf8.sd7         0.046775            240
+seed7/prg/tst_cli.sd7        0.037456             40
+seed7/prg/tst_srv.sd7        0.037281             47
+seed7/prg/wator.sd7          0.037714            651
+seed7/prg/which.sd7          0.036690             65
+seed7/prg/wiz.sd7            0.040361           2833
+seed7/prg/wordcnt.sd7        0.046913             54
+seed7/prg/wrinum.sd7         0.044092             43
+seed7/prg/wumpus.sd7         0.048046            372
+seed7/lib/aes.s7i            0.044960           1144
+seed7/lib/aes_gcm.s7i        0.043274            392
+seed7/lib/ar.s7i             0.045073           1532
+seed7/lib/arc4.s7i           0.042343            144
+seed7/lib/archive.s7i        0.040173            143
+seed7/lib/archive_base.s7i   0.039744            135
+seed7/lib/array.s7i          0.039374            610
+seed7/lib/asn1.s7i           0.037686            544
+seed7/lib/asn1oid.s7i        0.041300            157
+seed7/lib/basearray.s7i      0.038885            450
+seed7/lib/bigfile.s7i        0.039304            136
+seed7/lib/bigint.s7i         0.038702            824
+seed7/lib/bigrat.s7i         0.041735            784
+seed7/lib/bin16.s7i          0.041570            592
+seed7/lib/bin32.s7i          0.042761            490
+seed7/lib/bin64.s7i          0.039386            539
+seed7/lib/bitdata.s7i        0.042295           1330
+seed7/lib/bitmapfont.s7i     0.038814            215
+seed7/lib/bitset.s7i         0.038260            593
+seed7/lib/bitsetof.s7i       0.038152            431
+seed7/lib/blowfish.s7i       0.040960            383
+seed7/lib/bmp.s7i            0.043392            924
+seed7/lib/boolean.s7i        0.040307            403
+seed7/lib/browser.s7i        0.042201            280
+seed7/lib/bstring.s7i        0.040463            227
+seed7/lib/bytedata.s7i       0.039180            482
+seed7/lib/bzip2.s7i          0.039718            887
+seed7/lib/cards.s7i          0.037314           1342
+seed7/lib/category.s7i       0.038068            209
+seed7/lib/cc_conf.s7i        0.044731           1314
+seed7/lib/ccittfax.s7i       0.043315           1022
+seed7/lib/cgi.s7i            0.038790            109
+seed7/lib/cgidialog.s7i      0.044242           1118
+seed7/lib/char.s7i           0.042941            356
+seed7/lib/charsets.s7i       0.041020           2024
+seed7/lib/chartype.s7i       0.043300            121
+seed7/lib/cipher.s7i         0.039377            146
+seed7/lib/cli_cmds.s7i       0.040940           1360
+seed7/lib/clib_file.s7i      0.040483            301
+seed7/lib/color.s7i          0.039726            185
+seed7/lib/complex.s7i        0.037519            464
+seed7/lib/compress.s7i       0.038968            150
+seed7/lib/console.s7i        0.043449            188
+seed7/lib/cpio.s7i           0.043691           1708
+seed7/lib/crc32.s7i          0.048360            193
+seed7/lib/cronos16.s7i       0.040947           1173
+seed7/lib/cronos27.s7i       0.039592           1464
+seed7/lib/csv.s7i            0.038228            201
+seed7/lib/db_prop.s7i        0.038987            991
+seed7/lib/deflate.s7i        0.038037            740
+seed7/lib/des.s7i            0.040848            444
+seed7/lib/dialog.s7i         0.038716            311
+seed7/lib/dir.s7i            0.038729            163
+seed7/lib/draw.s7i           0.038658            854
+seed7/lib/duration.s7i       0.037448           1038
+seed7/lib/echo.s7i           0.037236            132
+seed7/lib/editline.s7i       0.037154            398
+seed7/lib/elf.s7i            0.040987           1560
+seed7/lib/elliptic.s7i       0.042075            649
+seed7/lib/enable_io.s7i      0.043595            312
+seed7/lib/encoding.s7i       0.041398            931
+seed7/lib/enumeration.s7i    0.040548            236
+seed7/lib/environment.s7i    0.040948            175
+seed7/lib/exif.s7i           0.043349            152
+seed7/lib/external_file.s7i  0.040221            340
+seed7/lib/field.s7i          0.038530            268
+seed7/lib/file.s7i           0.040735            372
+seed7/lib/filebits.s7i       0.036783             46
+seed7/lib/filesys.s7i        0.037796            601
+seed7/lib/fileutil.s7i       0.038289            144
+seed7/lib/fixarray.s7i       0.039350            307
+seed7/lib/float.s7i          0.039143            757
+seed7/lib/font.s7i           0.039351            196
+seed7/lib/font8x8.s7i        0.038505            998
+seed7/lib/forloop.s7i        0.038971            449
+seed7/lib/ftp.s7i            0.038715            969
+seed7/lib/ftpserv.s7i        0.038084            631
+seed7/lib/getf.s7i           0.039611            115
+seed7/lib/gethttp.s7i        0.038531             41
+seed7/lib/gethttps.s7i       0.038047             41
+seed7/lib/gif.s7i            0.042464            561
+seed7/lib/graph.s7i          0.042273            415
+seed7/lib/graph_file.s7i     0.039791            399
+seed7/lib/gtkserver.s7i      0.038961            161
+seed7/lib/gzip.s7i           0.039041            573
+seed7/lib/hash.s7i           0.043196            421
+seed7/lib/hashsetof.s7i      0.041041            499
+seed7/lib/hmac.s7i           0.039251            152
+seed7/lib/html.s7i           0.037885             83
+seed7/lib/html_ent.s7i       0.039427            476
+seed7/lib/htmldom.s7i        0.038990            286
+seed7/lib/http_request.s7i   0.039230            696
+seed7/lib/http_srv_resp.s7i  0.038647            380
+seed7/lib/https_request.s7i  0.040999            211
+seed7/lib/httpserv.s7i       0.039247            345
+seed7/lib/huffman.s7i        0.038982            644
+seed7/lib/ico.s7i            0.038653            221
+seed7/lib/idxarray.s7i       0.038948            232
+seed7/lib/image.s7i          0.037864            156
+seed7/lib/imagefile.s7i      0.038930            171
+seed7/lib/inflate.s7i        0.038827            411
+seed7/lib/inifile.s7i        0.038810            129
+seed7/lib/integer.s7i        0.039030            663
+seed7/lib/iobuffer.s7i       0.038609            289
+seed7/lib/jpeg.s7i           0.041159           1761
+seed7/lib/json.s7i           0.038894            891
+seed7/lib/json_serde.s7i     0.039059            783
+seed7/lib/keybd.s7i          0.037928            639
+seed7/lib/keydescr.s7i       0.038694            192
+seed7/lib/leb128.s7i         0.038469            218
+seed7/lib/line.s7i           0.036824            164
+seed7/lib/listener.s7i       0.037532            247
+seed7/lib/logfile.s7i        0.037416             73
+seed7/lib/lower.s7i          0.038799            142
+seed7/lib/lzma.s7i           0.042361            934
+seed7/lib/lzw.s7i            0.039497            861
+seed7/lib/magic.s7i          0.039018            403
+seed7/lib/mahjng32.s7i       0.038539           1500
+seed7/lib/make.s7i           0.039115            544
+seed7/lib/makedata.s7i       0.039274           1428
+seed7/lib/math.s7i           0.039112            201
+seed7/lib/mixarith.s7i       0.038983            249
+seed7/lib/modern27.s7i       0.040621           1099
+seed7/lib/more.s7i           0.038131            130
+seed7/lib/msgdigest.s7i      0.041588           1222
+seed7/lib/multiscr.s7i       0.037899             68
+seed7/lib/null_file.s7i      0.038527            345
+seed7/lib/osfiles.s7i        0.040385           1085
+seed7/lib/pbm.s7i            0.038933            230
+seed7/lib/pcx.s7i            0.039062            638
+seed7/lib/pem.s7i            0.038504            185
+seed7/lib/pgm.s7i            0.039578            238
+seed7/lib/pic16.s7i          0.037282           1037
+seed7/lib/pic32.s7i          0.038909           2060
+seed7/lib/pic_util.s7i       0.038865            144
+seed7/lib/pixelimage.s7i     0.038097            320
+seed7/lib/pixmap_file.s7i    0.038068            459
+seed7/lib/pixmapfont.s7i     0.037858            184
+seed7/lib/pkcs1.s7i          0.043151            543
+seed7/lib/png.s7i            0.039001           1064
+seed7/lib/poll.s7i           0.038651            313
+seed7/lib/ppm.s7i            0.039241            240
+seed7/lib/process.s7i        0.039988            541
+seed7/lib/progs.s7i          0.039383            789
+seed7/lib/propertyfile.s7i   0.038653            155
+seed7/lib/rational.s7i       0.038619            792
+seed7/lib/ref_list.s7i       0.039194            252
+seed7/lib/reference.s7i      0.038363            126
+seed7/lib/reverse.s7i        0.037906             94
+seed7/lib/rpm.s7i            0.039787           3487
+seed7/lib/rpmext.s7i         0.038565            318
+seed7/lib/scanfile.s7i       0.038283           1779
+seed7/lib/scanjson.s7i       0.040312            413
+seed7/lib/scanstri.s7i       0.040334           1814
+seed7/lib/scantoml.s7i       0.039858           1603
+seed7/lib/seed7_05.s7i       0.043672           1072
+seed7/lib/set.s7i            0.038228             57
+seed7/lib/shell.s7i          0.039467            615
+seed7/lib/showtls.s7i        0.041200            678
+seed7/lib/signature.s7i      0.039499            131
+seed7/lib/smtp.s7i           0.040155            261
+seed7/lib/sockbase.s7i       0.040726            217
+seed7/lib/socket.s7i         0.038708            326
+seed7/lib/sokoban1.s7i       0.036889           1519
+seed7/lib/sql_base.s7i       0.039094           1000
+seed7/lib/stars.s7i          0.038492           1705
+seed7/lib/stdfont10.s7i      0.039212           3347
+seed7/lib/stdfont12.s7i      0.037509           3928
+seed7/lib/stdfont14.s7i      0.038562           4510
+seed7/lib/stdfont16.s7i      0.039188           5092
+seed7/lib/stdfont18.s7i      0.038574           5868
+seed7/lib/stdfont20.s7i      0.038365           6449
+seed7/lib/stdfont24.s7i      0.038796           7421
+seed7/lib/stdfont8.s7i       0.037546           2960
+seed7/lib/stdfont9.s7i       0.037603           3152
+seed7/lib/stdio.s7i          0.040003            192
+seed7/lib/strifile.s7i       0.039971            345
+seed7/lib/string.s7i         0.040708            779
+seed7/lib/stritext.s7i       0.041028            352
+seed7/lib/struct.s7i         0.042067            266
+seed7/lib/struct_elem.s7i    0.038516            129
+seed7/lib/subfile.s7i        0.038471            174
+seed7/lib/subrange.s7i       0.037414             78
+seed7/lib/syntax.s7i         0.039449            294
+seed7/lib/tar.s7i            0.043578           1880
+seed7/lib/tar_cmds.s7i       0.038988            752
+seed7/lib/tdes.s7i           0.040280            143
+seed7/lib/tee.s7i            0.038771            143
+seed7/lib/text.s7i           0.037836            135
+seed7/lib/tga.s7i            0.039842            676
+seed7/lib/tiff.s7i           0.038526           2771
+seed7/lib/time.s7i           0.037663           1191
+seed7/lib/tls.s7i            0.037787           2230
+seed7/lib/unicode.s7i        0.039706            575
+seed7/lib/unionfnd.s7i       0.036792            130
+seed7/lib/upper.s7i          0.037061            142
+seed7/lib/utf16.s7i          0.037886            540
+seed7/lib/utf8.s7i           0.037783            234
+seed7/lib/vecfont10.s7i      0.038734           1056
+seed7/lib/vecfont18.s7i      0.039884           1119
+seed7/lib/vector3d.s7i       0.038378            293
+seed7/lib/vectorfont.s7i     0.038524            239
+seed7/lib/wildcard.s7i       0.038670            140
+seed7/lib/window.s7i         0.039080            455
+seed7/lib/wrinum.s7i         0.040675            248
+seed7/lib/x509cert.s7i       0.039681           1243
+seed7/lib/xml_ent.s7i        0.038506             94
+seed7/lib/xmldom.s7i         0.037147            303
+seed7/lib/xz.s7i             0.040634            442
+seed7/lib/zip.s7i            0.038791           2792
+seed7/lib/zstd.s7i           0.039465           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039857        |
++-----------+-----------------+
+| Minimum   | 0.034920        |
++-----------+-----------------+
+| Maximum   | 0.048456        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.038999            190
+seed7/prg/bas7.sd7           0.321413          11459
+seed7/prg/bifurk.sd7         0.035316             73
+seed7/prg/bigfiles.sd7       0.037754            129
+seed7/prg/brainf7.sd7        0.037171             86
+seed7/prg/calc7.sd7          0.037919            128
+seed7/prg/carddemo.sd7       0.039270            190
+seed7/prg/castle.sd7         0.107272           3148
+seed7/prg/cat.sd7            0.036809             82
+seed7/prg/cellauto.sd7       0.038913             85
+seed7/prg/celsius.sd7        0.035936             42
+seed7/prg/chk_all.sd7        0.058206            843
+seed7/prg/chkarr.sd7         0.349531           8367
+seed7/prg/chkbig.sd7         2.051240          29026
+seed7/prg/chkbin.sd7         0.515162           6469
+seed7/prg/chkbitdata.sd7     0.610977           6624
+seed7/prg/chkbool.sd7        0.116065           3157
+seed7/prg/chkbst.sd7         0.063002            722
+seed7/prg/chkchr.sd7         0.229591           2809
+seed7/prg/chkcmd.sd7         0.073440           1205
+seed7/prg/chkdb.sd7          0.346644           7454
+seed7/prg/chkdecl.sd7        0.062265            448
+seed7/prg/chkenum.sd7        0.069345           1230
+seed7/prg/chkerr.sd7         0.195841           4663
+seed7/prg/chkexc.sd7         0.080299           2627
+seed7/prg/chkfil.sd7         0.075236           1615
+seed7/prg/chkflt.sd7         1.339872          20620
+seed7/prg/chkhent.sd7        0.036485             54
+seed7/prg/chkhsh.sd7         0.245091           4548
+seed7/prg/chkidx.sd7         1.297783          19567
+seed7/prg/chkint.sd7         2.488218          38129
+seed7/prg/chkjson.sd7        0.099763           1764
+seed7/prg/chkovf.sd7         0.553486           8216
+seed7/prg/chkprc.sd7         0.313401          10111
+seed7/prg/chkscan.sd7        0.055978            714
+seed7/prg/chkset.sd7         0.650508          11974
+seed7/prg/chkstr.sd7         1.686104          26952
+seed7/prg/chktime.sd7        0.195035           2025
+seed7/prg/chktoml.sd7        0.149317           1656
+seed7/prg/clock.sd7          0.082980             47
+seed7/prg/clock2.sd7         0.063590             43
+seed7/prg/clock3.sd7         0.063801             95
+seed7/prg/cmpfil.sd7         0.064934             84
+seed7/prg/comanche.sd7       0.071372            180
+seed7/prg/confval.sd7        0.070027            175
+seed7/prg/db7.sd7            0.072481            417
+seed7/prg/diff7.sd7          0.080326            263
+seed7/prg/dirtst.sd7         0.058542             42
+seed7/prg/dirx.sd7           0.068718            152
+seed7/prg/dnafight.sd7       0.069792           1381
+seed7/prg/dragon.sd7         0.036326             73
+seed7/prg/echo.sd7           0.035253             39
+seed7/prg/eliza.sd7          0.042298            302
+seed7/prg/err.sd7            0.039871             96
+seed7/prg/fannkuch.sd7       0.037053            131
+seed7/prg/fib.sd7            0.035270             47
+seed7/prg/find7.sd7          0.038299            133
+seed7/prg/findchar.sd7       0.038403            149
+seed7/prg/fractree.sd7       0.035831             55
+seed7/prg/ftp7.sd7           0.042404            296
+seed7/prg/ftpserv.sd7        0.037089             74
+seed7/prg/gcd.sd7            0.036060            109
+seed7/prg/gkbd.sd7           0.044713            358
+seed7/prg/gtksvtst.sd7       0.035560             94
+seed7/prg/hal.sd7            0.038258            250
+seed7/prg/hamu.sd7           0.046794            573
+seed7/prg/hanoi.sd7          0.036032             55
+seed7/prg/hd.sd7             0.037142             79
+seed7/prg/hello.sd7          0.035155             32
+seed7/prg/hilbert.sd7        0.036979            108
+seed7/prg/ide7.sd7           0.040599            196
+seed7/prg/kbd.sd7            0.035968             49
+seed7/prg/klondike.sd7       0.054785            883
+seed7/prg/lander.sd7         0.071741           1551
+seed7/prg/lst80bas.sd7       0.043751            344
+seed7/prg/lst99bas.sd7       0.044927            401
+seed7/prg/lstgwbas.sd7       0.051213            577
+seed7/prg/mahjong.sd7        0.079532           1943
+seed7/prg/make7.sd7          0.038197            121
+seed7/prg/mandelbr.sd7       0.040102            237
+seed7/prg/mind.sd7           0.043474            443
+seed7/prg/mirror.sd7         0.040278            131
+seed7/prg/ms.sd7             0.047442            641
+seed7/prg/nicoma.sd7         0.037757            135
+seed7/prg/pac.sd7            0.047742            726
+seed7/prg/pairs.sd7          0.080611           2025
+seed7/prg/panic.sd7          0.094793           2634
+seed7/prg/percolation.sd7    0.043558            330
+seed7/prg/planets.sd7        0.076777           1486
+seed7/prg/portfwd7.sd7       0.038556            139
+seed7/prg/prime.sd7          0.036339             74
+seed7/prg/printpi1.sd7       0.037395             56
+seed7/prg/printpi2.sd7       0.038859             54
+seed7/prg/printpi3.sd7       0.037364             60
+seed7/prg/pv7.sd7            0.044200            337
+seed7/prg/queen.sd7          0.038531            149
+seed7/prg/rand.sd7           0.037024            121
+seed7/prg/raytrace.sd7       0.048346            538
+seed7/prg/rever.sd7          0.054644            816
+seed7/prg/roman.sd7          0.035768             38
+seed7/prg/s7c.sd7            0.276417           9060
+seed7/prg/s7check.sd7        0.036052             68
+seed7/prg/savehd7.sd7        0.065490           1110
+seed7/prg/self.sd7           0.035660             49
+seed7/prg/shisen.sd7         0.069551           1423
+seed7/prg/sl.sd7             0.059241           1029
+seed7/prg/snake.sd7          0.046601            615
+seed7/prg/sokoban.sd7        0.054561            891
+seed7/prg/spigotpi.sd7       0.035950             64
+seed7/prg/sql7.sd7           0.040280            278
+seed7/prg/startrek.sd7       0.057656            979
+seed7/prg/sudoku7.sd7        0.097671           2657
+seed7/prg/sydir7.sd7         0.044181            384
+seed7/prg/syntaxhl.sd7       0.040240            177
+seed7/prg/tak.sd7            0.035780             59
+seed7/prg/tar7.sd7           0.038636            121
+seed7/prg/tch.sd7            0.036289             55
+seed7/prg/testfont.sd7       0.037522             95
+seed7/prg/tet.sd7            0.044585            479
+seed7/prg/tetg.sd7           0.045576            501
+seed7/prg/toutf8.sd7         0.042869            240
+seed7/prg/tst_cli.sd7        0.035240             40
+seed7/prg/tst_srv.sd7        0.036160             47
+seed7/prg/wator.sd7          0.051066            651
+seed7/prg/which.sd7          0.035462             65
+seed7/prg/wiz.sd7            0.104857           2833
+seed7/prg/wordcnt.sd7        0.035860             54
+seed7/prg/wrinum.sd7         0.036907             43
+seed7/prg/wumpus.sd7         0.047048            372
+seed7/lib/aes.s7i            0.110929           1144
+seed7/lib/aes_gcm.s7i        0.046629            392
+seed7/lib/ar.s7i             0.079025           1532
+seed7/lib/arc4.s7i           0.040192            144
+seed7/lib/archive.s7i        0.038112            143
+seed7/lib/archive_base.s7i   0.038143            135
+seed7/lib/array.s7i          0.053688            610
+seed7/lib/asn1.s7i           0.047475            544
+seed7/lib/asn1oid.s7i        0.041964            157
+seed7/lib/basearray.s7i      0.048821            450
+seed7/lib/bigfile.s7i        0.038364            136
+seed7/lib/bigint.s7i         0.055357            824
+seed7/lib/bigrat.s7i         0.053578            784
+seed7/lib/bin16.s7i          0.050678            592
+seed7/lib/bin32.s7i          0.047921            490
+seed7/lib/bin64.s7i          0.049056            539
+seed7/lib/bitdata.s7i        0.074786           1330
+seed7/lib/bitmapfont.s7i     0.039125            215
+seed7/lib/bitset.s7i         0.049027            593
+seed7/lib/bitsetof.s7i       0.047591            431
+seed7/lib/blowfish.s7i       0.054613            383
+seed7/lib/bmp.s7i            0.060381            924
+seed7/lib/boolean.s7i        0.043300            403
+seed7/lib/browser.s7i        0.041350            280
+seed7/lib/bstring.s7i        0.040065            227
+seed7/lib/bytedata.s7i       0.049100            482
+seed7/lib/bzip2.s7i          0.057860            887
+seed7/lib/cards.s7i          0.066279           1342
+seed7/lib/category.s7i       0.041348            209
+seed7/lib/cc_conf.s7i        0.077186           1314
+seed7/lib/ccittfax.s7i       0.066326           1022
+seed7/lib/cgi.s7i            0.037793            109
+seed7/lib/cgidialog.s7i      0.060212           1118
+seed7/lib/char.s7i           0.043219            356
+seed7/lib/charsets.s7i       0.080344           2024
+seed7/lib/chartype.s7i       0.039481            121
+seed7/lib/cipher.s7i         0.037112            146
+seed7/lib/cli_cmds.s7i       0.068457           1360
+seed7/lib/clib_file.s7i      0.044500            301
+seed7/lib/color.s7i          0.040448            185
+seed7/lib/complex.s7i        0.045141            464
+seed7/lib/compress.s7i       0.038953            150
+seed7/lib/console.s7i        0.039635            188
+seed7/lib/cpio.s7i           0.080834           1708
+seed7/lib/crc32.s7i          0.044598            193
+seed7/lib/cronos16.s7i       0.092907           1173
+seed7/lib/cronos27.s7i       0.115630           1464
+seed7/lib/csv.s7i            0.040671            201
+seed7/lib/db_prop.s7i        0.062759            991
+seed7/lib/deflate.s7i        0.055787            740
+seed7/lib/des.s7i            0.055567            444
+seed7/lib/dialog.s7i         0.044189            311
+seed7/lib/dir.s7i            0.038247            163
+seed7/lib/draw.s7i           0.054903            854
+seed7/lib/duration.s7i       0.059485           1038
+seed7/lib/echo.s7i           0.037520            132
+seed7/lib/editline.s7i       0.044435            398
+seed7/lib/elf.s7i            0.085209           1560
+seed7/lib/elliptic.s7i       0.052794            649
+seed7/lib/enable_io.s7i      0.045961            312
+seed7/lib/encoding.s7i       0.063662            931
+seed7/lib/enumeration.s7i    0.042090            236
+seed7/lib/environment.s7i    0.039381            175
+seed7/lib/exif.s7i           0.039402            152
+seed7/lib/external_file.s7i  0.046221            340
+seed7/lib/field.s7i          0.046528            268
+seed7/lib/file.s7i           0.044525            372
+seed7/lib/filebits.s7i       0.041165             46
+seed7/lib/filesys.s7i        0.048511            601
+seed7/lib/fileutil.s7i       0.037213            144
+seed7/lib/fixarray.s7i       0.042307            307
+seed7/lib/float.s7i          0.054946            757
+seed7/lib/font.s7i           0.042590            196
+seed7/lib/font8x8.s7i        0.049857            998
+seed7/lib/forloop.s7i        0.046427            449
+seed7/lib/ftp.s7i            0.060252            969
+seed7/lib/ftpserv.s7i        0.051590            631
+seed7/lib/getf.s7i           0.037427            115
+seed7/lib/gethttp.s7i        0.035265             41
+seed7/lib/gethttps.s7i       0.037631             41
+seed7/lib/gif.s7i            0.049555            561
+seed7/lib/graph.s7i          0.048951            415
+seed7/lib/graph_file.s7i     0.044474            399
+seed7/lib/gtkserver.s7i      0.038695            161
+seed7/lib/gzip.s7i           0.052315            573
+seed7/lib/hash.s7i           0.054756            421
+seed7/lib/hashsetof.s7i      0.050858            499
+seed7/lib/hmac.s7i           0.044686            152
+seed7/lib/html.s7i           0.037058             83
+seed7/lib/html_ent.s7i       0.047048            476
+seed7/lib/htmldom.s7i        0.043100            286
+seed7/lib/http_request.s7i   0.051279            696
+seed7/lib/http_srv_resp.s7i  0.045652            380
+seed7/lib/https_request.s7i  0.040324            211
+seed7/lib/httpserv.s7i       0.044113            345
+seed7/lib/huffman.s7i        0.053011            644
+seed7/lib/ico.s7i            0.041681            221
+seed7/lib/idxarray.s7i       0.042455            232
+seed7/lib/image.s7i          0.036644            156
+seed7/lib/imagefile.s7i      0.038493            171
+seed7/lib/inflate.s7i        0.045883            411
+seed7/lib/inifile.s7i        0.036830            129
+seed7/lib/integer.s7i        0.052540            663
+seed7/lib/iobuffer.s7i       0.042727            289
+seed7/lib/jpeg.s7i           0.084016           1761
+seed7/lib/json.s7i           0.055828            891
+seed7/lib/json_serde.s7i     0.053155            783
+seed7/lib/keybd.s7i          0.055260            639
+seed7/lib/keydescr.s7i       0.041385            192
+seed7/lib/leb128.s7i         0.040003            218
+seed7/lib/line.s7i           0.037987            164
+seed7/lib/listener.s7i       0.040896            247
+seed7/lib/logfile.s7i        0.036577             73
+seed7/lib/lower.s7i          0.038356            142
+seed7/lib/lzma.s7i           0.059714            934
+seed7/lib/lzw.s7i            0.059117            861
+seed7/lib/magic.s7i          0.048118            403
+seed7/lib/mahjng32.s7i       0.065437           1500
+seed7/lib/make.s7i           0.049400            544
+seed7/lib/makedata.s7i       0.069295           1428
+seed7/lib/math.s7i           0.043108            201
+seed7/lib/mixarith.s7i       0.039412            249
+seed7/lib/modern27.s7i       0.082820           1099
+seed7/lib/more.s7i           0.038225            130
+seed7/lib/msgdigest.s7i      0.083962           1222
+seed7/lib/multiscr.s7i       0.040582             68
+seed7/lib/null_file.s7i      0.041015            345
+seed7/lib/osfiles.s7i        0.063503           1085
+seed7/lib/pbm.s7i            0.041450            230
+seed7/lib/pcx.s7i            0.053857            638
+seed7/lib/pem.s7i            0.039643            185
+seed7/lib/pgm.s7i            0.041349            238
+seed7/lib/pic16.s7i          0.058236           1037
+seed7/lib/pic32.s7i          0.091860           2060
+seed7/lib/pic_util.s7i       0.043155            144
+seed7/lib/pixelimage.s7i     0.044579            320
+seed7/lib/pixmap_file.s7i    0.046926            459
+seed7/lib/pixmapfont.s7i     0.039793            184
+seed7/lib/pkcs1.s7i          0.060956            543
+seed7/lib/png.s7i            0.065812           1064
+seed7/lib/poll.s7i           0.048524            313
+seed7/lib/ppm.s7i            0.042282            240
+seed7/lib/process.s7i        0.049701            541
+seed7/lib/progs.s7i          0.057181            789
+seed7/lib/propertyfile.s7i   0.041873            155
+seed7/lib/rational.s7i       0.053520            792
+seed7/lib/ref_list.s7i       0.042119            252
+seed7/lib/reference.s7i      0.037818            126
+seed7/lib/reverse.s7i        0.042229             94
+seed7/lib/rpm.s7i            0.142203           3487
+seed7/lib/rpmext.s7i         0.042807            318
+seed7/lib/scanfile.s7i       0.079420           1779
+seed7/lib/scanjson.s7i       0.046817            413
+seed7/lib/scanstri.s7i       0.079622           1814
+seed7/lib/scantoml.s7i       0.070934           1603
+seed7/lib/seed7_05.s7i       0.066070           1072
+seed7/lib/set.s7i            0.035747             57
+seed7/lib/shell.s7i          0.051466            615
+seed7/lib/showtls.s7i        0.053336            678
+seed7/lib/signature.s7i      0.037287            131
+seed7/lib/smtp.s7i           0.039987            261
+seed7/lib/sockbase.s7i       0.043024            217
+seed7/lib/socket.s7i         0.045045            326
+seed7/lib/sokoban1.s7i       0.055407           1519
+seed7/lib/sql_base.s7i       0.064130           1000
+seed7/lib/stars.s7i          0.133787           1705
+seed7/lib/stdfont10.s7i      0.080749           3347
+seed7/lib/stdfont12.s7i      0.090935           3928
+seed7/lib/stdfont14.s7i      0.102267           4510
+seed7/lib/stdfont16.s7i      0.115979           5092
+seed7/lib/stdfont18.s7i      0.131071           5868
+seed7/lib/stdfont20.s7i      0.147057           6449
+seed7/lib/stdfont24.s7i      0.175359           7421
+seed7/lib/stdfont8.s7i       0.071708           2960
+seed7/lib/stdfont9.s7i       0.075333           3152
+seed7/lib/stdio.s7i          0.038501            192
+seed7/lib/strifile.s7i       0.042673            345
+seed7/lib/string.s7i         0.054042            779
+seed7/lib/stritext.s7i       0.042522            352
+seed7/lib/struct.s7i         0.046330            266
+seed7/lib/struct_elem.s7i    0.042090            129
+seed7/lib/subfile.s7i        0.043782            174
+seed7/lib/subrange.s7i       0.041096             78
+seed7/lib/syntax.s7i         0.051763            294
+seed7/lib/tar.s7i            0.090573           1880
+seed7/lib/tar_cmds.s7i       0.060450            752
+seed7/lib/tdes.s7i           0.039397            143
+seed7/lib/tee.s7i            0.037778            143
+seed7/lib/text.s7i           0.037727            135
+seed7/lib/tga.s7i            0.052460            676
+seed7/lib/tiff.s7i           0.121820           2771
+seed7/lib/time.s7i           0.063515           1191
+seed7/lib/tls.s7i            0.110476           2230
+seed7/lib/unicode.s7i        0.055329            575
+seed7/lib/unionfnd.s7i       0.043899            130
+seed7/lib/upper.s7i          0.048857            142
+seed7/lib/utf16.s7i          0.055501            540
+seed7/lib/utf8.s7i           0.047357            234
+seed7/lib/vecfont10.s7i      0.084116           1056
+seed7/lib/vecfont18.s7i      0.092679           1119
+seed7/lib/vector3d.s7i       0.045644            293
+seed7/lib/vectorfont.s7i     0.043825            239
+seed7/lib/wildcard.s7i       0.040037            140
+seed7/lib/window.s7i         0.047691            455
+seed7/lib/wrinum.s7i         0.040976            248
+seed7/lib/x509cert.s7i       0.069880           1243
+seed7/lib/xml_ent.s7i        0.036620             94
+seed7/lib/xmldom.s7i         0.040008            303
+seed7/lib/xz.s7i             0.045234            442
+seed7/lib/zip.s7i            0.126749           2792
+seed7/lib/zstd.s7i           0.072699           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.091343        |
++-----------+-----------------+
+| Minimum   | 0.035155        |
++-----------+-----------------+
+| Maximum   | 2.488218        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.054674            190
+seed7/prg/bas7.sd7           0.771152          11459
+seed7/prg/bifurk.sd7         0.046046             73
+seed7/prg/bigfiles.sd7       0.044948            129
+seed7/prg/brainf7.sd7        0.041694             86
+seed7/prg/calc7.sd7          0.044447            128
+seed7/prg/carddemo.sd7       0.050845            190
+seed7/prg/castle.sd7         0.223607           3148
+seed7/prg/cat.sd7            0.045036             82
+seed7/prg/cellauto.sd7       0.047860             85
+seed7/prg/celsius.sd7        0.043438             42
+seed7/prg/chk_all.sd7        0.084570            843
+seed7/prg/chkarr.sd7         0.863140           8367
+seed7/prg/chkbig.sd7         4.111285          29026
+seed7/prg/chkbin.sd7         1.077292           6469
+seed7/prg/chkbitdata.sd7     1.320369           6624
+seed7/prg/chkbool.sd7        0.246169           3157
+seed7/prg/chkbst.sd7         0.106771            722
+seed7/prg/chkchr.sd7         0.511049           2809
+seed7/prg/chkcmd.sd7         0.122366           1205
+seed7/prg/chkdb.sd7          0.748435           7454
+seed7/prg/chkdecl.sd7        0.094481            448
+seed7/prg/chkenum.sd7        0.121293           1230
+seed7/prg/chkerr.sd7         0.334644           4663
+seed7/prg/chkexc.sd7         0.145321           2627
+seed7/prg/chkfil.sd7         0.126770           1615
+seed7/prg/chkflt.sd7         2.792998          20620
+seed7/prg/chkhent.sd7        0.037206             54
+seed7/prg/chkhsh.sd7         0.502534           4548
+seed7/prg/chkidx.sd7         3.144744          19567
+seed7/prg/chkint.sd7         5.501658          38129
+seed7/prg/chkjson.sd7        0.186151           1764
+seed7/prg/chkovf.sd7         1.193264           8216
+seed7/prg/chkprc.sd7         0.694862          10111
+seed7/prg/chkscan.sd7        0.089474            714
+seed7/prg/chkset.sd7         1.734940          11974
+seed7/prg/chkstr.sd7         3.382754          26952
+seed7/prg/chktime.sd7        0.245544           2025
+seed7/prg/chktoml.sd7        0.192865           1656
+seed7/prg/clock.sd7          0.035975             47
+seed7/prg/clock2.sd7         0.035495             43
+seed7/prg/clock3.sd7         0.040783             95
+seed7/prg/cmpfil.sd7         0.039654             84
+seed7/prg/comanche.sd7       0.046883            180
+seed7/prg/confval.sd7        0.051099            175
+seed7/prg/db7.sd7            0.061851            417
+seed7/prg/diff7.sd7          0.050519            263
+seed7/prg/dirtst.sd7         0.035801             42
+seed7/prg/dirx.sd7           0.041331            152
+seed7/prg/dnafight.sd7       0.116419           1381
+seed7/prg/dragon.sd7         0.038118             73
+seed7/prg/echo.sd7           0.036187             39
+seed7/prg/eliza.sd7          0.051485            302
+seed7/prg/err.sd7            0.044208             96
+seed7/prg/fannkuch.sd7       0.041430            131
+seed7/prg/fib.sd7            0.036566             47
+seed7/prg/find7.sd7          0.041888            133
+seed7/prg/findchar.sd7       0.043540            149
+seed7/prg/fractree.sd7       0.037118             55
+seed7/prg/ftp7.sd7           0.051171            296
+seed7/prg/ftpserv.sd7        0.037540             74
+seed7/prg/gcd.sd7            0.039124            109
+seed7/prg/gkbd.sd7           0.059843            358
+seed7/prg/gtksvtst.sd7       0.040431             94
+seed7/prg/hal.sd7            0.047383            250
+seed7/prg/hamu.sd7           0.066876            573
+seed7/prg/hanoi.sd7          0.037438             55
+seed7/prg/hd.sd7             0.038469             79
+seed7/prg/hello.sd7          0.036209             32
+seed7/prg/hilbert.sd7        0.040896            108
+seed7/prg/ide7.sd7           0.047670            196
+seed7/prg/kbd.sd7            0.036700             49
+seed7/prg/klondike.sd7       0.086238            883
+seed7/prg/lander.sd7         0.130539           1551
+seed7/prg/lst80bas.sd7       0.054778            344
+seed7/prg/lst99bas.sd7       0.057539            401
+seed7/prg/lstgwbas.sd7       0.071257            577
+seed7/prg/mahjong.sd7        0.145116           1943
+seed7/prg/make7.sd7          0.040841            121
+seed7/prg/mandelbr.sd7       0.046961            237
+seed7/prg/mind.sd7           0.059210            443
+seed7/prg/mirror.sd7         0.043856            131
+seed7/prg/ms.sd7             0.068693            641
+seed7/prg/nicoma.sd7         0.041902            135
+seed7/prg/pac.sd7            0.071876            726
+seed7/prg/pairs.sd7          0.139138           2025
+seed7/prg/panic.sd7          0.194876           2634
+seed7/prg/percolation.sd7    0.056163            330
+seed7/prg/planets.sd7        0.135284           1486
+seed7/prg/portfwd7.sd7       0.041526            139
+seed7/prg/prime.sd7          0.038019             74
+seed7/prg/printpi1.sd7       0.036253             56
+seed7/prg/printpi2.sd7       0.036362             54
+seed7/prg/printpi3.sd7       0.037229             60
+seed7/prg/pv7.sd7            0.058111            337
+seed7/prg/queen.sd7          0.042922            149
+seed7/prg/rand.sd7           0.041101            121
+seed7/prg/raytrace.sd7       0.067920            538
+seed7/prg/rever.sd7          0.080943            816
+seed7/prg/roman.sd7          0.036217             38
+seed7/prg/s7c.sd7            0.615778           9060
+seed7/prg/s7check.sd7        0.037945             68
+seed7/prg/savehd7.sd7        0.109018           1110
+seed7/prg/self.sd7           0.038160             49
+seed7/prg/shisen.sd7         0.117799           1423
+seed7/prg/sl.sd7             0.096958           1029
+seed7/prg/snake.sd7          0.065703            615
+seed7/prg/sokoban.sd7        0.082197            891
+seed7/prg/spigotpi.sd7       0.037815             64
+seed7/prg/sql7.sd7           0.051683            278
+seed7/prg/startrek.sd7       0.095368            979
+seed7/prg/sudoku7.sd7        0.194684           2657
+seed7/prg/sydir7.sd7         0.058257            384
+seed7/prg/syntaxhl.sd7       0.047901            177
+seed7/prg/tak.sd7            0.036287             59
+seed7/prg/tar7.sd7           0.040901            121
+seed7/prg/tch.sd7            0.037780             55
+seed7/prg/testfont.sd7       0.040301             95
+seed7/prg/tet.sd7            0.057438            479
+seed7/prg/tetg.sd7           0.060191            501
+seed7/prg/toutf8.sd7         0.049741            240
+seed7/prg/tst_cli.sd7        0.037223             40
+seed7/prg/tst_srv.sd7        0.036772             47
+seed7/prg/wator.sd7          0.077812            651
+seed7/prg/which.sd7          0.038056             65
+seed7/prg/wiz.sd7            0.206772           2833
+seed7/prg/wordcnt.sd7        0.037668             54
+seed7/prg/wrinum.sd7         0.036486             43
+seed7/prg/wumpus.sd7         0.052913            372
+seed7/lib/aes.s7i            0.200207           1144
+seed7/lib/aes_gcm.s7i        0.059120            392
+seed7/lib/ar.s7i             0.122547           1532
+seed7/lib/arc4.s7i           0.042764            144
+seed7/lib/archive.s7i        0.042571            143
+seed7/lib/archive_base.s7i   0.043301            135
+seed7/lib/array.s7i          0.074912            610
+seed7/lib/asn1.s7i           0.064395            544
+seed7/lib/asn1oid.s7i        0.049386            157
+seed7/lib/basearray.s7i      0.062721            450
+seed7/lib/bigfile.s7i        0.040275            136
+seed7/lib/bigint.s7i         0.079169            824
+seed7/lib/bigrat.s7i         0.078395            784
+seed7/lib/bin16.s7i          0.066534            592
+seed7/lib/bin32.s7i          0.059732            490
+seed7/lib/bin64.s7i          0.061565            539
+seed7/lib/bitdata.s7i        0.120772           1330
+seed7/lib/bitmapfont.s7i     0.045259            215
+seed7/lib/bitset.s7i         0.062140            593
+seed7/lib/bitsetof.s7i       0.062400            431
+seed7/lib/blowfish.s7i       0.076942            383
+seed7/lib/bmp.s7i            0.098533            924
+seed7/lib/boolean.s7i        0.054172            403
+seed7/lib/browser.s7i        0.055974            280
+seed7/lib/bstring.s7i        0.048724            227
+seed7/lib/bytedata.s7i       0.065268            482
+seed7/lib/bzip2.s7i          0.090478            887
+seed7/lib/cards.s7i          0.101763           1342
+seed7/lib/category.s7i       0.048289            209
+seed7/lib/cc_conf.s7i        0.118342           1314
+seed7/lib/ccittfax.s7i       0.098301           1022
+seed7/lib/cgi.s7i            0.040154            109
+seed7/lib/cgidialog.s7i      0.094835           1118
+seed7/lib/char.s7i           0.051176            356
+seed7/lib/charsets.s7i       0.125613           2024
+seed7/lib/chartype.s7i       0.047318            121
+seed7/lib/cipher.s7i         0.040798            146
+seed7/lib/cli_cmds.s7i       0.111383           1360
+seed7/lib/clib_file.s7i      0.051292            301
+seed7/lib/color.s7i          0.048009            185
+seed7/lib/complex.s7i        0.058403            464
+seed7/lib/compress.s7i       0.043109            150
+seed7/lib/console.s7i        0.045010            188
+seed7/lib/cpio.s7i           0.143635           1708
+seed7/lib/crc32.s7i          0.053196            193
+seed7/lib/cronos16.s7i       0.190615           1173
+seed7/lib/cronos27.s7i       0.252658           1464
+seed7/lib/csv.s7i            0.048093            201
+seed7/lib/db_prop.s7i        0.101614            991
+seed7/lib/deflate.s7i        0.085877            740
+seed7/lib/des.s7i            0.078687            444
+seed7/lib/dialog.s7i         0.055957            311
+seed7/lib/dir.s7i            0.041634            163
+seed7/lib/draw.s7i           0.083811            854
+seed7/lib/duration.s7i       0.096610           1038
+seed7/lib/echo.s7i           0.041246            132
+seed7/lib/editline.s7i       0.057513            398
+seed7/lib/elf.s7i            0.154945           1560
+seed7/lib/elliptic.s7i       0.077437            649
+seed7/lib/enable_io.s7i      0.052137            312
+seed7/lib/encoding.s7i       0.095921            931
+seed7/lib/enumeration.s7i    0.048455            236
+seed7/lib/environment.s7i    0.043719            175
+seed7/lib/exif.s7i           0.045746            152
+seed7/lib/external_file.s7i  0.052416            340
+seed7/lib/field.s7i          0.052659            268
+seed7/lib/file.s7i           0.053586            372
+seed7/lib/filebits.s7i       0.037698             46
+seed7/lib/filesys.s7i        0.063753            601
+seed7/lib/fileutil.s7i       0.043076            144
+seed7/lib/fixarray.s7i       0.052959            307
+seed7/lib/float.s7i          0.073428            757
+seed7/lib/font.s7i           0.043896            196
+seed7/lib/font8x8.s7i        0.065614            998
+seed7/lib/forloop.s7i        0.057697            449
+seed7/lib/ftp.s7i            0.085878            969
+seed7/lib/ftpserv.s7i        0.075318            631
+seed7/lib/getf.s7i           0.039730            115
+seed7/lib/gethttp.s7i        0.035936             41
+seed7/lib/gethttps.s7i       0.035803             41
+seed7/lib/gif.s7i            0.068292            561
+seed7/lib/graph.s7i          0.062908            415
+seed7/lib/graph_file.s7i     0.055513            399
+seed7/lib/gtkserver.s7i      0.040326            161
+seed7/lib/gzip.s7i           0.067178            573
+seed7/lib/hash.s7i           0.065740            421
+seed7/lib/hashsetof.s7i      0.065512            499
+seed7/lib/hmac.s7i           0.044076            152
+seed7/lib/html.s7i           0.039392             83
+seed7/lib/html_ent.s7i       0.062341            476
+seed7/lib/htmldom.s7i        0.051449            286
+seed7/lib/http_request.s7i   0.075119            696
+seed7/lib/http_srv_resp.s7i  0.057255            380
+seed7/lib/https_request.s7i  0.045931            211
+seed7/lib/httpserv.s7i       0.055066            345
+seed7/lib/huffman.s7i        0.074019            644
+seed7/lib/ico.s7i            0.049041            221
+seed7/lib/idxarray.s7i       0.050650            232
+seed7/lib/image.s7i          0.041412            156
+seed7/lib/imagefile.s7i      0.045707            171
+seed7/lib/inflate.s7i        0.063614            411
+seed7/lib/inifile.s7i        0.041897            129
+seed7/lib/integer.s7i        0.067740            663
+seed7/lib/iobuffer.s7i       0.050547            289
+seed7/lib/jpeg.s7i           0.152310           1761
+seed7/lib/json.s7i           0.079122            891
+seed7/lib/json_serde.s7i     0.076460            783
+seed7/lib/keybd.s7i          0.078092            639
+seed7/lib/keydescr.s7i       0.049371            192
+seed7/lib/leb128.s7i         0.045043            218
+seed7/lib/line.s7i           0.050565            164
+seed7/lib/listener.s7i       0.050312            247
+seed7/lib/logfile.s7i        0.040035             73
+seed7/lib/lower.s7i          0.041860            142
+seed7/lib/lzma.s7i           0.095794            934
+seed7/lib/lzw.s7i            0.087937            861
+seed7/lib/magic.s7i          0.063020            403
+seed7/lib/mahjng32.s7i       0.091460           1500
+seed7/lib/make.s7i           0.069472            544
+seed7/lib/makedata.s7i       0.120252           1428
+seed7/lib/math.s7i           0.044728            201
+seed7/lib/mixarith.s7i       0.047051            249
+seed7/lib/modern27.s7i       0.166813           1099
+seed7/lib/more.s7i           0.043035            130
+seed7/lib/msgdigest.s7i      0.139411           1222
+seed7/lib/multiscr.s7i       0.038738             68
+seed7/lib/null_file.s7i      0.051708            345
+seed7/lib/osfiles.s7i        0.095552           1085
+seed7/lib/pbm.s7i            0.046444            230
+seed7/lib/pcx.s7i            0.075900            638
+seed7/lib/pem.s7i            0.044324            185
+seed7/lib/pgm.s7i            0.047752            238
+seed7/lib/pic16.s7i          0.065553           1037
+seed7/lib/pic32.s7i          0.119730           2060
+seed7/lib/pic_util.s7i       0.043184            144
+seed7/lib/pixelimage.s7i     0.052165            320
+seed7/lib/pixmap_file.s7i    0.060826            459
+seed7/lib/pixmapfont.s7i     0.047823            184
+seed7/lib/pkcs1.s7i          0.076254            543
+seed7/lib/png.s7i            0.106137           1064
+seed7/lib/poll.s7i           0.050723            313
+seed7/lib/ppm.s7i            0.047856            240
+seed7/lib/process.s7i        0.063959            541
+seed7/lib/progs.s7i          0.078305            789
+seed7/lib/propertyfile.s7i   0.043649            155
+seed7/lib/rational.s7i       0.078187            792
+seed7/lib/ref_list.s7i       0.049003            252
+seed7/lib/reference.s7i      0.041842            126
+seed7/lib/reverse.s7i        0.040020             94
+seed7/lib/rpm.s7i            0.283106           3487
+seed7/lib/rpmext.s7i         0.056112            318
+seed7/lib/scanfile.s7i       0.134620           1779
+seed7/lib/scanjson.s7i       0.059752            413
+seed7/lib/scanstri.s7i       0.137130           1814
+seed7/lib/scantoml.s7i       0.130133           1603
+seed7/lib/seed7_05.s7i       0.111397           1072
+seed7/lib/set.s7i            0.037816             57
+seed7/lib/shell.s7i          0.068534            615
+seed7/lib/showtls.s7i        0.084440            678
+seed7/lib/signature.s7i      0.042663            131
+seed7/lib/smtp.s7i           0.049460            261
+seed7/lib/sockbase.s7i       0.050137            217
+seed7/lib/socket.s7i         0.052812            326
+seed7/lib/sokoban1.s7i       0.080320           1519
+seed7/lib/sql_base.s7i       0.094058           1000
+seed7/lib/stars.s7i          0.232607           1705
+seed7/lib/stdfont10.s7i      0.142922           3347
+seed7/lib/stdfont12.s7i      0.163757           3928
+seed7/lib/stdfont14.s7i      0.187813           4510
+seed7/lib/stdfont16.s7i      0.211224           5092
+seed7/lib/stdfont18.s7i      0.242302           5868
+seed7/lib/stdfont20.s7i      0.270682           6449
+seed7/lib/stdfont24.s7i      0.326395           7421
+seed7/lib/stdfont8.s7i       0.124936           2960
+seed7/lib/stdfont9.s7i       0.131249           3152
+seed7/lib/stdio.s7i          0.042704            192
+seed7/lib/strifile.s7i       0.052637            345
+seed7/lib/string.s7i         0.073714            779
+seed7/lib/stritext.s7i       0.053716            352
+seed7/lib/struct.s7i         0.054300            266
+seed7/lib/struct_elem.s7i    0.040955            129
+seed7/lib/subfile.s7i        0.044301            174
+seed7/lib/subrange.s7i       0.038786             78
+seed7/lib/syntax.s7i         0.059386            294
+seed7/lib/tar.s7i            0.148219           1880
+seed7/lib/tar_cmds.s7i       0.084377            752
+seed7/lib/tdes.s7i           0.043431            143
+seed7/lib/tee.s7i            0.041989            143
+seed7/lib/text.s7i           0.042177            135
+seed7/lib/tga.s7i            0.079409            676
+seed7/lib/tiff.s7i           0.241703           2771
+seed7/lib/time.s7i           0.099443           1191
+seed7/lib/tls.s7i            0.192275           2230
+seed7/lib/unicode.s7i        0.074339            575
+seed7/lib/unionfnd.s7i       0.042285            130
+seed7/lib/upper.s7i          0.040699            142
+seed7/lib/utf16.s7i          0.064206            540
+seed7/lib/utf8.s7i           0.045911            234
+seed7/lib/vecfont10.s7i      0.161657           1056
+seed7/lib/vecfont18.s7i      0.174390           1119
+seed7/lib/vector3d.s7i       0.049289            293
+seed7/lib/vectorfont.s7i     0.047734            239
+seed7/lib/wildcard.s7i       0.042635            140
+seed7/lib/window.s7i         0.059966            455
+seed7/lib/wrinum.s7i         0.048457            248
+seed7/lib/x509cert.s7i       0.115982           1243
+seed7/lib/xml_ent.s7i        0.039816             94
+seed7/lib/xmldom.s7i         0.051142            303
+seed7/lib/xz.s7i             0.060483            442
+seed7/lib/zip.s7i            0.230054           2792
+seed7/lib/zstd.s7i           0.117273           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.157956        |
++-----------+-----------------+
+| Minimum   | 0.035495        |
++-----------+-----------------+
+| Maximum   | 5.501658        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.035323        | 0.032291        | 0.043373        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039857        | 0.034920        | 0.048456        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.091343        | 0.035155        | 2.488218        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.157956        | 0.035495        | 5.501658        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.809 | 00:01:00.177 | 00:01:12.986 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:15.460 | 00:01:07.952 | 00:01:23.413 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:36.353 | 00:02:36.464 | 00:03:12.817 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:02.083 | 00:04:29.932 | 00:05:32.016 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:21.240 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-07.1.rst
+++ b/reports/seed7mode-perf-07.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-24T17:02:38+0000 W26-3
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 13:10:54 local time
+:Generated on: 2026-06-24 17:22:11 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 226x84 chars
+:Window body: 226x82 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.038476            190
+seed7/prg/bas7.sd7           0.037397          11459
+seed7/prg/bifurk.sd7         0.035129             73
+seed7/prg/bigfiles.sd7       0.037488            129
+seed7/prg/brainf7.sd7        0.039315             86
+seed7/prg/calc7.sd7          0.037047            128
+seed7/prg/carddemo.sd7       0.038673            190
+seed7/prg/castle.sd7         0.037708           3148
+seed7/prg/cat.sd7            0.033860             82
+seed7/prg/cellauto.sd7       0.035135             85
+seed7/prg/celsius.sd7        0.034116             42
+seed7/prg/chk_all.sd7        0.033522            843
+seed7/prg/chkarr.sd7         0.034427           8367
+seed7/prg/chkbig.sd7         0.037854          29026
+seed7/prg/chkbin.sd7         0.034833           6469
+seed7/prg/chkbitdata.sd7     0.035195           6624
+seed7/prg/chkbool.sd7        0.034736           3157
+seed7/prg/chkbst.sd7         0.033640            722
+seed7/prg/chkchr.sd7         0.034786           2809
+seed7/prg/chkcmd.sd7         0.038468           1205
+seed7/prg/chkdb.sd7          0.036233           7454
+seed7/prg/chkdecl.sd7        0.034669            448
+seed7/prg/chkenum.sd7        0.033473           1230
+seed7/prg/chkerr.sd7         0.033191           4663
+seed7/prg/chkexc.sd7         0.033014           2627
+seed7/prg/chkfil.sd7         0.032889           1615
+seed7/prg/chkflt.sd7         0.037614          20620
+seed7/prg/chkhent.sd7        0.033299             54
+seed7/prg/chkhsh.sd7         0.037203           4548
+seed7/prg/chkidx.sd7         0.039206          19567
+seed7/prg/chkint.sd7         0.040483          38129
+seed7/prg/chkjson.sd7        0.034065           1764
+seed7/prg/chkovf.sd7         0.034823           8216
+seed7/prg/chkprc.sd7         0.034055          10111
+seed7/prg/chkscan.sd7        0.033387            714
+seed7/prg/chkset.sd7         0.037497          11974
+seed7/prg/chkstr.sd7         0.040727          26952
+seed7/prg/chktime.sd7        0.034337           2025
+seed7/prg/chktoml.sd7        0.033581           1656
+seed7/prg/clock.sd7          0.033305             47
+seed7/prg/clock2.sd7         0.033468             43
+seed7/prg/clock3.sd7         0.034909             95
+seed7/prg/cmpfil.sd7         0.040240             84
+seed7/prg/comanche.sd7       0.041455            180
+seed7/prg/confval.sd7        0.040830            175
+seed7/prg/db7.sd7            0.036299            417
+seed7/prg/diff7.sd7          0.033362            263
+seed7/prg/dirtst.sd7         0.033497             42
+seed7/prg/dirx.sd7           0.033470            152
+seed7/prg/dnafight.sd7       0.033465           1381
+seed7/prg/dragon.sd7         0.033386             73
+seed7/prg/echo.sd7           0.032811             39
+seed7/prg/eliza.sd7          0.032761            302
+seed7/prg/err.sd7            0.033024             96
+seed7/prg/fannkuch.sd7       0.035972            131
+seed7/prg/fib.sd7            0.035568             47
+seed7/prg/find7.sd7          0.032780            133
+seed7/prg/findchar.sd7       0.035333            149
+seed7/prg/fractree.sd7       0.033583             55
+seed7/prg/ftp7.sd7           0.037172            296
+seed7/prg/ftpserv.sd7        0.035058             74
+seed7/prg/gcd.sd7            0.036854            109
+seed7/prg/gkbd.sd7           0.035208            358
+seed7/prg/gtksvtst.sd7       0.034745             94
+seed7/prg/hal.sd7            0.036249            250
+seed7/prg/hamu.sd7           0.034760            573
+seed7/prg/hanoi.sd7          0.034631             55
+seed7/prg/hd.sd7             0.033715             79
+seed7/prg/hello.sd7          0.034005             32
+seed7/prg/hilbert.sd7        0.034058            108
+seed7/prg/ide7.sd7           0.034960            196
+seed7/prg/kbd.sd7            0.033782             49
+seed7/prg/klondike.sd7       0.033425            883
+seed7/prg/lander.sd7         0.033664           1551
+seed7/prg/lst80bas.sd7       0.033400            344
+seed7/prg/lst99bas.sd7       0.033903            401
+seed7/prg/lstgwbas.sd7       0.035291            577
+seed7/prg/mahjong.sd7        0.036493           1943
+seed7/prg/make7.sd7          0.035124            121
+seed7/prg/mandelbr.sd7       0.035446            237
+seed7/prg/mind.sd7           0.034222            443
+seed7/prg/mirror.sd7         0.034656            131
+seed7/prg/ms.sd7             0.033657            641
+seed7/prg/nicoma.sd7         0.033414            135
+seed7/prg/pac.sd7            0.032746            726
+seed7/prg/pairs.sd7          0.032586           2025
+seed7/prg/panic.sd7          0.032895           2634
+seed7/prg/percolation.sd7    0.033377            330
+seed7/prg/planets.sd7        0.036507           1486
+seed7/prg/portfwd7.sd7       0.034190            139
+seed7/prg/prime.sd7          0.033610             74
+seed7/prg/printpi1.sd7       0.033622             56
+seed7/prg/printpi2.sd7       0.034082             54
+seed7/prg/printpi3.sd7       0.034604             60
+seed7/prg/pv7.sd7            0.034793            337
+seed7/prg/queen.sd7          0.034616            149
+seed7/prg/rand.sd7           0.033529            121
+seed7/prg/raytrace.sd7       0.033727            538
+seed7/prg/rever.sd7          0.033723            816
+seed7/prg/roman.sd7          0.033534             38
+seed7/prg/s7c.sd7            0.034809           9060
+seed7/prg/s7check.sd7        0.033840             68
+seed7/prg/savehd7.sd7        0.033653           1110
+seed7/prg/self.sd7           0.033481             49
+seed7/prg/shisen.sd7         0.033906           1423
+seed7/prg/sl.sd7             0.034474           1029
+seed7/prg/snake.sd7          0.035385            615
+seed7/prg/sokoban.sd7        0.034076            891
+seed7/prg/spigotpi.sd7       0.033458             64
+seed7/prg/sql7.sd7           0.033620            278
+seed7/prg/startrek.sd7       0.033634            979
+seed7/prg/sudoku7.sd7        0.033980           2657
+seed7/prg/sydir7.sd7         0.034687            384
+seed7/prg/syntaxhl.sd7       0.034866            177
+seed7/prg/tak.sd7            0.032864             59
+seed7/prg/tar7.sd7           0.032717            121
+seed7/prg/tch.sd7            0.033117             55
+seed7/prg/testfont.sd7       0.032524             95
+seed7/prg/tet.sd7            0.032489            479
+seed7/prg/tetg.sd7           0.035685            501
+seed7/prg/toutf8.sd7         0.033921            240
+seed7/prg/tst_cli.sd7        0.033590             40
+seed7/prg/tst_srv.sd7        0.033435             47
+seed7/prg/wator.sd7          0.034092            651
+seed7/prg/which.sd7          0.033869             65
+seed7/prg/wiz.sd7            0.040184           2833
+seed7/prg/wordcnt.sd7        0.035929             54
+seed7/prg/wrinum.sd7         0.034456             43
+seed7/prg/wumpus.sd7         0.034509            372
+seed7/lib/aes.s7i            0.033840           1144
+seed7/lib/aes_gcm.s7i        0.033750            392
+seed7/lib/ar.s7i             0.034819           1532
+seed7/lib/arc4.s7i           0.034356            144
+seed7/lib/archive.s7i        0.033800            143
+seed7/lib/archive_base.s7i   0.033412            135
+seed7/lib/array.s7i          0.034536            610
+seed7/lib/asn1.s7i           0.033881            544
+seed7/lib/asn1oid.s7i        0.033778            157
+seed7/lib/basearray.s7i      0.034238            450
+seed7/lib/bigfile.s7i        0.033712            136
+seed7/lib/bigint.s7i         0.038036            824
+seed7/lib/bigrat.s7i         0.038948            784
+seed7/lib/bin16.s7i          0.034459            592
+seed7/lib/bin32.s7i          0.034069            490
+seed7/lib/bin64.s7i          0.033282            539
+seed7/lib/bitdata.s7i        0.032695           1330
+seed7/lib/bitmapfont.s7i     0.032682            215
+seed7/lib/bitset.s7i         0.033105            593
+seed7/lib/bitsetof.s7i       0.032580            431
+seed7/lib/blowfish.s7i       0.033559            383
+seed7/lib/bmp.s7i            0.035731            924
+seed7/lib/boolean.s7i        0.033544            403
+seed7/lib/browser.s7i        0.033883            280
+seed7/lib/bstring.s7i        0.034155            227
+seed7/lib/bytedata.s7i       0.033910            482
+seed7/lib/bzip2.s7i          0.033570            887
+seed7/lib/cards.s7i          0.034608           1342
+seed7/lib/category.s7i       0.033675            209
+seed7/lib/cc_conf.s7i        0.033702           1314
+seed7/lib/ccittfax.s7i       0.035140           1022
+seed7/lib/cgi.s7i            0.034591            109
+seed7/lib/cgidialog.s7i      0.035944           1118
+seed7/lib/char.s7i           0.033872            356
+seed7/lib/charsets.s7i       0.035879           2024
+seed7/lib/chartype.s7i       0.034193            121
+seed7/lib/cipher.s7i         0.033657            146
+seed7/lib/cli_cmds.s7i       0.034776           1360
+seed7/lib/clib_file.s7i      0.039642            301
+seed7/lib/color.s7i          0.034133            185
+seed7/lib/complex.s7i        0.038660            464
+seed7/lib/compress.s7i       0.035349            150
+seed7/lib/console.s7i        0.034517            188
+seed7/lib/cpio.s7i           0.033517           1708
+seed7/lib/crc32.s7i          0.033485            193
+seed7/lib/cronos16.s7i       0.033586           1173
+seed7/lib/cronos27.s7i       0.034768           1464
+seed7/lib/csv.s7i            0.033668            201
+seed7/lib/db_prop.s7i        0.033447            991
+seed7/lib/deflate.s7i        0.033378            740
+seed7/lib/des.s7i            0.032729            444
+seed7/lib/dialog.s7i         0.033820            311
+seed7/lib/dir.s7i            0.035274            163
+seed7/lib/draw.s7i           0.034068            854
+seed7/lib/duration.s7i       0.034965           1038
+seed7/lib/echo.s7i           0.035181            132
+seed7/lib/editline.s7i       0.033663            398
+seed7/lib/elf.s7i            0.033407           1560
+seed7/lib/elliptic.s7i       0.034361            649
+seed7/lib/enable_io.s7i      0.034119            312
+seed7/lib/encoding.s7i       0.033604            931
+seed7/lib/enumeration.s7i    0.035940            236
+seed7/lib/environment.s7i    0.033363            175
+seed7/lib/exif.s7i           0.033163            152
+seed7/lib/external_file.s7i  0.033573            340
+seed7/lib/field.s7i          0.034892            268
+seed7/lib/file.s7i           0.033878            372
+seed7/lib/filebits.s7i       0.035211             46
+seed7/lib/filesys.s7i        0.033820            601
+seed7/lib/fileutil.s7i       0.033802            144
+seed7/lib/fixarray.s7i       0.033741            307
+seed7/lib/float.s7i          0.035928            757
+seed7/lib/font.s7i           0.033835            196
+seed7/lib/font8x8.s7i        0.034232            998
+seed7/lib/forloop.s7i        0.033701            449
+seed7/lib/ftp.s7i            0.033554            969
+seed7/lib/ftpserv.s7i        0.033569            631
+seed7/lib/getf.s7i           0.035208            115
+seed7/lib/gethttp.s7i        0.033327             41
+seed7/lib/gethttps.s7i       0.034111             41
+seed7/lib/gif.s7i            0.035114            561
+seed7/lib/graph.s7i          0.032846            415
+seed7/lib/graph_file.s7i     0.032542            399
+seed7/lib/gtkserver.s7i      0.036615            161
+seed7/lib/gzip.s7i           0.034504            573
+seed7/lib/hash.s7i           0.034041            421
+seed7/lib/hashsetof.s7i      0.033874            499
+seed7/lib/hmac.s7i           0.033678            152
+seed7/lib/html.s7i           0.033587             83
+seed7/lib/html_ent.s7i       0.034933            476
+seed7/lib/htmldom.s7i        0.033621            286
+seed7/lib/http_request.s7i   0.035201            696
+seed7/lib/http_srv_resp.s7i  0.034363            380
+seed7/lib/https_request.s7i  0.033666            211
+seed7/lib/httpserv.s7i       0.033785            345
+seed7/lib/huffman.s7i        0.034174            644
+seed7/lib/ico.s7i            0.034788            221
+seed7/lib/idxarray.s7i       0.034615            232
+seed7/lib/image.s7i          0.033923            156
+seed7/lib/imagefile.s7i      0.033607            171
+seed7/lib/inflate.s7i        0.033810            411
+seed7/lib/inifile.s7i        0.034132            129
+seed7/lib/integer.s7i        0.034160            663
+seed7/lib/iobuffer.s7i       0.035391            289
+seed7/lib/jpeg.s7i           0.034635           1761
+seed7/lib/json.s7i           0.033581            891
+seed7/lib/json_serde.s7i     0.033582            783
+seed7/lib/keybd.s7i          0.034755            639
+seed7/lib/keydescr.s7i       0.035050            192
+seed7/lib/leb128.s7i         0.032729            218
+seed7/lib/line.s7i           0.033680            164
+seed7/lib/listener.s7i       0.033119            247
+seed7/lib/logfile.s7i        0.033186             73
+seed7/lib/lower.s7i          0.033060            142
+seed7/lib/lzma.s7i           0.034952            934
+seed7/lib/lzw.s7i            0.035146            861
+seed7/lib/magic.s7i          0.035885            403
+seed7/lib/mahjng32.s7i       0.033972           1500
+seed7/lib/make.s7i           0.033651            544
+seed7/lib/makedata.s7i       0.034766           1428
+seed7/lib/math.s7i           0.035007            201
+seed7/lib/mixarith.s7i       0.035254            249
+seed7/lib/modern27.s7i       0.034823           1099
+seed7/lib/more.s7i           0.035820            130
+seed7/lib/msgdigest.s7i      0.033957           1222
+seed7/lib/multiscr.s7i       0.033602             68
+seed7/lib/null_file.s7i      0.035050            345
+seed7/lib/osfiles.s7i        0.034132           1085
+seed7/lib/pbm.s7i            0.033942            230
+seed7/lib/pcx.s7i            0.033703            638
+seed7/lib/pem.s7i            0.033699            185
+seed7/lib/pgm.s7i            0.034249            238
+seed7/lib/pic16.s7i          0.035136           1037
+seed7/lib/pic32.s7i          0.034371           2060
+seed7/lib/pic_util.s7i       0.033815            144
+seed7/lib/pixelimage.s7i     0.033900            320
+seed7/lib/pixmap_file.s7i    0.033489            459
+seed7/lib/pixmapfont.s7i     0.033018            184
+seed7/lib/pkcs1.s7i          0.033605            543
+seed7/lib/png.s7i            0.033475           1064
+seed7/lib/poll.s7i           0.034469            313
+seed7/lib/ppm.s7i            0.036409            240
+seed7/lib/process.s7i        0.033626            541
+seed7/lib/progs.s7i          0.036544            789
+seed7/lib/propertyfile.s7i   0.035751            155
+seed7/lib/rational.s7i       0.033747            792
+seed7/lib/ref_list.s7i       0.034102            252
+seed7/lib/reference.s7i      0.034500            126
+seed7/lib/reverse.s7i        0.033682             94
+seed7/lib/rpm.s7i            0.033723           3487
+seed7/lib/rpmext.s7i         0.035007            318
+seed7/lib/scanfile.s7i       0.034205           1779
+seed7/lib/scanjson.s7i       0.033941            413
+seed7/lib/scanstri.s7i       0.034833           1814
+seed7/lib/scantoml.s7i       0.035055           1603
+seed7/lib/seed7_05.s7i       0.037228           1072
+seed7/lib/set.s7i            0.035660             57
+seed7/lib/shell.s7i          0.034832            615
+seed7/lib/showtls.s7i        0.033893            678
+seed7/lib/signature.s7i      0.037063            131
+seed7/lib/smtp.s7i           0.034017            261
+seed7/lib/sockbase.s7i       0.034516            217
+seed7/lib/socket.s7i         0.034749            326
+seed7/lib/sokoban1.s7i       0.033845           1519
+seed7/lib/sql_base.s7i       0.033738           1000
+seed7/lib/stars.s7i          0.034157           1705
+seed7/lib/stdfont10.s7i      0.037065           3347
+seed7/lib/stdfont12.s7i      0.040374           3928
+seed7/lib/stdfont14.s7i      0.036963           4510
+seed7/lib/stdfont16.s7i      0.034066           5092
+seed7/lib/stdfont18.s7i      0.033395           5868
+seed7/lib/stdfont20.s7i      0.033515           6449
+seed7/lib/stdfont24.s7i      0.036935           7421
+seed7/lib/stdfont8.s7i       0.033958           2960
+seed7/lib/stdfont9.s7i       0.038783           3152
+seed7/lib/stdio.s7i          0.034580            192
+seed7/lib/strifile.s7i       0.034561            345
+seed7/lib/string.s7i         0.034800            779
+seed7/lib/stritext.s7i       0.033637            352
+seed7/lib/struct.s7i         0.033589            266
+seed7/lib/struct_elem.s7i    0.034394            129
+seed7/lib/subfile.s7i        0.033653            174
+seed7/lib/subrange.s7i       0.034498             78
+seed7/lib/syntax.s7i         0.033850            294
+seed7/lib/tar.s7i            0.033616           1880
+seed7/lib/tar_cmds.s7i       0.033572            752
+seed7/lib/tdes.s7i           0.035120            143
+seed7/lib/tee.s7i            0.033835            143
+seed7/lib/text.s7i           0.033819            135
+seed7/lib/tga.s7i            0.034087            676
+seed7/lib/tiff.s7i           0.034265           2771
+seed7/lib/time.s7i           0.033914           1191
+seed7/lib/tls.s7i            0.035265           2230
+seed7/lib/unicode.s7i        0.033946            575
+seed7/lib/unionfnd.s7i       0.033799            130
+seed7/lib/upper.s7i          0.034114            142
+seed7/lib/utf16.s7i          0.033571            540
+seed7/lib/utf8.s7i           0.032624            234
+seed7/lib/vecfont10.s7i      0.033767           1056
+seed7/lib/vecfont18.s7i      0.033265           1119
+seed7/lib/vector3d.s7i       0.032711            293
+seed7/lib/vectorfont.s7i     0.033421            239
+seed7/lib/wildcard.s7i       0.033790            140
+seed7/lib/window.s7i         0.035860            455
+seed7/lib/wrinum.s7i         0.035445            248
+seed7/lib/x509cert.s7i       0.034028           1243
+seed7/lib/xml_ent.s7i        0.033622             94
+seed7/lib/xmldom.s7i         0.035751            303
+seed7/lib/xz.s7i             0.034172            442
+seed7/lib/zip.s7i            0.033954           2792
+seed7/lib/zstd.s7i           0.035221           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.034553        |
++-----------+-----------------+
+| Minimum   | 0.032489        |
++-----------+-----------------+
+| Maximum   | 0.041455        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.048607            190
+seed7/prg/bas7.sd7           0.041931          11459
+seed7/prg/bifurk.sd7         0.037029             73
+seed7/prg/bigfiles.sd7       0.038974            129
+seed7/prg/brainf7.sd7        0.038170             86
+seed7/prg/calc7.sd7          0.039103            128
+seed7/prg/carddemo.sd7       0.038918            190
+seed7/prg/castle.sd7         0.039299           3148
+seed7/prg/cat.sd7            0.037317             82
+seed7/prg/cellauto.sd7       0.037356             85
+seed7/prg/celsius.sd7        0.035887             42
+seed7/prg/chk_all.sd7        0.038382            843
+seed7/prg/chkarr.sd7         0.038856           8367
+seed7/prg/chkbig.sd7         0.041874          29026
+seed7/prg/chkbin.sd7         0.037867           6469
+seed7/prg/chkbitdata.sd7     0.041092           6624
+seed7/prg/chkbool.sd7        0.038292           3157
+seed7/prg/chkbst.sd7         0.038024            722
+seed7/prg/chkchr.sd7         0.038690           2809
+seed7/prg/chkcmd.sd7         0.036105           1205
+seed7/prg/chkdb.sd7          0.038790           7454
+seed7/prg/chkdecl.sd7        0.038019            448
+seed7/prg/chkenum.sd7        0.036736           1230
+seed7/prg/chkerr.sd7         0.038638           4663
+seed7/prg/chkexc.sd7         0.037574           2627
+seed7/prg/chkfil.sd7         0.039596           1615
+seed7/prg/chkflt.sd7         0.041485          20620
+seed7/prg/chkhent.sd7        0.036675             54
+seed7/prg/chkhsh.sd7         0.039469           4548
+seed7/prg/chkidx.sd7         0.041407          19567
+seed7/prg/chkint.sd7         0.044618          38129
+seed7/prg/chkjson.sd7        0.039152           1764
+seed7/prg/chkovf.sd7         0.038767           8216
+seed7/prg/chkprc.sd7         0.038925          10111
+seed7/prg/chkscan.sd7        0.039304            714
+seed7/prg/chkset.sd7         0.040678          11974
+seed7/prg/chkstr.sd7         0.043067          26952
+seed7/prg/chktime.sd7        0.047366           2025
+seed7/prg/chktoml.sd7        0.043536           1656
+seed7/prg/clock.sd7          0.037258             47
+seed7/prg/clock2.sd7         0.036340             43
+seed7/prg/clock3.sd7         0.038954             95
+seed7/prg/cmpfil.sd7         0.038130             84
+seed7/prg/comanche.sd7       0.039484            180
+seed7/prg/confval.sd7        0.040360            175
+seed7/prg/db7.sd7            0.039337            417
+seed7/prg/diff7.sd7          0.038149            263
+seed7/prg/dirtst.sd7         0.034768             42
+seed7/prg/dirx.sd7           0.040015            152
+seed7/prg/dnafight.sd7       0.038317           1381
+seed7/prg/dragon.sd7         0.036837             73
+seed7/prg/echo.sd7           0.036774             39
+seed7/prg/eliza.sd7          0.038806            302
+seed7/prg/err.sd7            0.043656             96
+seed7/prg/fannkuch.sd7       0.041761            131
+seed7/prg/fib.sd7            0.035278             47
+seed7/prg/find7.sd7          0.038515            133
+seed7/prg/findchar.sd7       0.038648            149
+seed7/prg/fractree.sd7       0.036836             55
+seed7/prg/ftp7.sd7           0.038715            296
+seed7/prg/ftpserv.sd7        0.038166             74
+seed7/prg/gcd.sd7            0.037591            109
+seed7/prg/gkbd.sd7           0.039252            358
+seed7/prg/gtksvtst.sd7       0.037774             94
+seed7/prg/hal.sd7            0.037897            250
+seed7/prg/hamu.sd7           0.038002            573
+seed7/prg/hanoi.sd7          0.036180             55
+seed7/prg/hd.sd7             0.037389             79
+seed7/prg/hello.sd7          0.035695             32
+seed7/prg/hilbert.sd7        0.038028            108
+seed7/prg/ide7.sd7           0.038678            196
+seed7/prg/kbd.sd7            0.036689             49
+seed7/prg/klondike.sd7       0.039639            883
+seed7/prg/lander.sd7         0.039577           1551
+seed7/prg/lst80bas.sd7       0.036887            344
+seed7/prg/lst99bas.sd7       0.036906            401
+seed7/prg/lstgwbas.sd7       0.037783            577
+seed7/prg/mahjong.sd7        0.037782           1943
+seed7/prg/make7.sd7          0.037417            121
+seed7/prg/mandelbr.sd7       0.039427            237
+seed7/prg/mind.sd7           0.039598            443
+seed7/prg/mirror.sd7         0.039025            131
+seed7/prg/ms.sd7             0.038517            641
+seed7/prg/nicoma.sd7         0.038920            135
+seed7/prg/pac.sd7            0.038123            726
+seed7/prg/pairs.sd7          0.039072           2025
+seed7/prg/panic.sd7          0.039808           2634
+seed7/prg/percolation.sd7    0.038865            330
+seed7/prg/planets.sd7        0.039515           1486
+seed7/prg/portfwd7.sd7       0.038341            139
+seed7/prg/prime.sd7          0.037085             74
+seed7/prg/printpi1.sd7       0.036873             56
+seed7/prg/printpi2.sd7       0.036463             54
+seed7/prg/printpi3.sd7       0.036879             60
+seed7/prg/pv7.sd7            0.038560            337
+seed7/prg/queen.sd7          0.037419            149
+seed7/prg/rand.sd7           0.038568            121
+seed7/prg/raytrace.sd7       0.039268            538
+seed7/prg/rever.sd7          0.038857            816
+seed7/prg/roman.sd7          0.035394             38
+seed7/prg/s7c.sd7            0.038988           9060
+seed7/prg/s7check.sd7        0.036944             68
+seed7/prg/savehd7.sd7        0.038139           1110
+seed7/prg/self.sd7           0.035633             49
+seed7/prg/shisen.sd7         0.037897           1423
+seed7/prg/sl.sd7             0.036415           1029
+seed7/prg/snake.sd7          0.036624            615
+seed7/prg/sokoban.sd7        0.039733            891
+seed7/prg/spigotpi.sd7       0.037103             64
+seed7/prg/sql7.sd7           0.039100            278
+seed7/prg/startrek.sd7       0.038587            979
+seed7/prg/sudoku7.sd7        0.041013           2657
+seed7/prg/sydir7.sd7         0.047306            384
+seed7/prg/syntaxhl.sd7       0.044959            177
+seed7/prg/tak.sd7            0.038202             59
+seed7/prg/tar7.sd7           0.039523            121
+seed7/prg/tch.sd7            0.036896             55
+seed7/prg/testfont.sd7       0.039220             95
+seed7/prg/tet.sd7            0.041155            479
+seed7/prg/tetg.sd7           0.039232            501
+seed7/prg/toutf8.sd7         0.039291            240
+seed7/prg/tst_cli.sd7        0.036284             40
+seed7/prg/tst_srv.sd7        0.036512             47
+seed7/prg/wator.sd7          0.038681            651
+seed7/prg/which.sd7          0.037289             65
+seed7/prg/wiz.sd7            0.038851           2833
+seed7/prg/wordcnt.sd7        0.036657             54
+seed7/prg/wrinum.sd7         0.036247             43
+seed7/prg/wumpus.sd7         0.040622            372
+seed7/lib/aes.s7i            0.040908           1144
+seed7/lib/aes_gcm.s7i        0.039458            392
+seed7/lib/ar.s7i             0.037988           1532
+seed7/lib/arc4.s7i           0.037745            144
+seed7/lib/archive.s7i        0.037444            143
+seed7/lib/archive_base.s7i   0.039845            135
+seed7/lib/array.s7i          0.039082            610
+seed7/lib/asn1.s7i           0.037604            544
+seed7/lib/asn1oid.s7i        0.041042            157
+seed7/lib/basearray.s7i      0.039303            450
+seed7/lib/bigfile.s7i        0.038531            136
+seed7/lib/bigint.s7i         0.038722            824
+seed7/lib/bigrat.s7i         0.038725            784
+seed7/lib/bin16.s7i          0.039176            592
+seed7/lib/bin32.s7i          0.039078            490
+seed7/lib/bin64.s7i          0.039009            539
+seed7/lib/bitdata.s7i        0.042890           1330
+seed7/lib/bitmapfont.s7i     0.039525            215
+seed7/lib/bitset.s7i         0.039212            593
+seed7/lib/bitsetof.s7i       0.039301            431
+seed7/lib/blowfish.s7i       0.042222            383
+seed7/lib/bmp.s7i            0.039634            924
+seed7/lib/boolean.s7i        0.041692            403
+seed7/lib/browser.s7i        0.043885            280
+seed7/lib/bstring.s7i        0.040949            227
+seed7/lib/bytedata.s7i       0.038687            482
+seed7/lib/bzip2.s7i          0.038454            887
+seed7/lib/cards.s7i          0.036394           1342
+seed7/lib/category.s7i       0.037530            209
+seed7/lib/cc_conf.s7i        0.038146           1314
+seed7/lib/ccittfax.s7i       0.040267           1022
+seed7/lib/cgi.s7i            0.038500            109
+seed7/lib/cgidialog.s7i      0.038972           1118
+seed7/lib/char.s7i           0.039051            356
+seed7/lib/charsets.s7i       0.039690           2024
+seed7/lib/chartype.s7i       0.041832            121
+seed7/lib/cipher.s7i         0.038670            146
+seed7/lib/cli_cmds.s7i       0.038921           1360
+seed7/lib/clib_file.s7i      0.038714            301
+seed7/lib/color.s7i          0.040011            185
+seed7/lib/complex.s7i        0.037617            464
+seed7/lib/compress.s7i       0.039271            150
+seed7/lib/console.s7i        0.038736            188
+seed7/lib/cpio.s7i           0.038976           1708
+seed7/lib/crc32.s7i          0.040566            193
+seed7/lib/cronos16.s7i       0.042039           1173
+seed7/lib/cronos27.s7i       0.040699           1464
+seed7/lib/csv.s7i            0.038628            201
+seed7/lib/db_prop.s7i        0.040200            991
+seed7/lib/deflate.s7i        0.039843            740
+seed7/lib/des.s7i            0.045705            444
+seed7/lib/dialog.s7i         0.047338            311
+seed7/lib/dir.s7i            0.038963            163
+seed7/lib/draw.s7i           0.038329            854
+seed7/lib/duration.s7i       0.041277           1038
+seed7/lib/echo.s7i           0.045514            132
+seed7/lib/editline.s7i       0.039712            398
+seed7/lib/elf.s7i            0.039290           1560
+seed7/lib/elliptic.s7i       0.037929            649
+seed7/lib/enable_io.s7i      0.038834            312
+seed7/lib/encoding.s7i       0.039795            931
+seed7/lib/enumeration.s7i    0.039072            236
+seed7/lib/environment.s7i    0.038726            175
+seed7/lib/exif.s7i           0.039067            152
+seed7/lib/external_file.s7i  0.039392            340
+seed7/lib/field.s7i          0.039016            268
+seed7/lib/file.s7i           0.038791            372
+seed7/lib/filebits.s7i       0.037215             46
+seed7/lib/filesys.s7i        0.043205            601
+seed7/lib/fileutil.s7i       0.039172            144
+seed7/lib/fixarray.s7i       0.041730            307
+seed7/lib/float.s7i          0.042176            757
+seed7/lib/font.s7i           0.038653            196
+seed7/lib/font8x8.s7i        0.038064            998
+seed7/lib/forloop.s7i        0.039196            449
+seed7/lib/ftp.s7i            0.038152            969
+seed7/lib/ftpserv.s7i        0.037889            631
+seed7/lib/getf.s7i           0.037672            115
+seed7/lib/gethttp.s7i        0.035636             41
+seed7/lib/gethttps.s7i       0.035853             41
+seed7/lib/gif.s7i            0.039743            561
+seed7/lib/graph.s7i          0.041920            415
+seed7/lib/graph_file.s7i     0.039553            399
+seed7/lib/gtkserver.s7i      0.038872            161
+seed7/lib/gzip.s7i           0.039106            573
+seed7/lib/hash.s7i           0.040876            421
+seed7/lib/hashsetof.s7i      0.042575            499
+seed7/lib/hmac.s7i           0.038887            152
+seed7/lib/html.s7i           0.037841             83
+seed7/lib/html_ent.s7i       0.039472            476
+seed7/lib/htmldom.s7i        0.038851            286
+seed7/lib/http_request.s7i   0.039420            696
+seed7/lib/http_srv_resp.s7i  0.039039            380
+seed7/lib/https_request.s7i  0.038815            211
+seed7/lib/httpserv.s7i       0.038821            345
+seed7/lib/huffman.s7i        0.039259            644
+seed7/lib/ico.s7i            0.041681            221
+seed7/lib/idxarray.s7i       0.044626            232
+seed7/lib/image.s7i          0.040124            156
+seed7/lib/imagefile.s7i      0.039655            171
+seed7/lib/inflate.s7i        0.039022            411
+seed7/lib/inifile.s7i        0.038600            129
+seed7/lib/integer.s7i        0.037962            663
+seed7/lib/iobuffer.s7i       0.038071            289
+seed7/lib/jpeg.s7i           0.038061           1761
+seed7/lib/json.s7i           0.037545            891
+seed7/lib/json_serde.s7i     0.041265            783
+seed7/lib/keybd.s7i          0.038860            639
+seed7/lib/keydescr.s7i       0.039128            192
+seed7/lib/leb128.s7i         0.039146            218
+seed7/lib/line.s7i           0.037455            164
+seed7/lib/listener.s7i       0.039100            247
+seed7/lib/logfile.s7i        0.039666             73
+seed7/lib/lower.s7i          0.038536            142
+seed7/lib/lzma.s7i           0.040030            934
+seed7/lib/lzw.s7i            0.039261            861
+seed7/lib/magic.s7i          0.039377            403
+seed7/lib/mahjng32.s7i       0.039571           1500
+seed7/lib/make.s7i           0.039032            544
+seed7/lib/makedata.s7i       0.039374           1428
+seed7/lib/math.s7i           0.039131            201
+seed7/lib/mixarith.s7i       0.039129            249
+seed7/lib/modern27.s7i       0.040227           1099
+seed7/lib/more.s7i           0.038738            130
+seed7/lib/msgdigest.s7i      0.040053           1222
+seed7/lib/multiscr.s7i       0.037648             68
+seed7/lib/null_file.s7i      0.038770            345
+seed7/lib/osfiles.s7i        0.039834           1085
+seed7/lib/pbm.s7i            0.038915            230
+seed7/lib/pcx.s7i            0.038658            638
+seed7/lib/pem.s7i            0.037569            185
+seed7/lib/pgm.s7i            0.037845            238
+seed7/lib/pic16.s7i          0.038219           1037
+seed7/lib/pic32.s7i          0.039133           2060
+seed7/lib/pic_util.s7i       0.039114            144
+seed7/lib/pixelimage.s7i     0.039113            320
+seed7/lib/pixmap_file.s7i    0.038919            459
+seed7/lib/pixmapfont.s7i     0.039235            184
+seed7/lib/pkcs1.s7i          0.044668            543
+seed7/lib/png.s7i            0.039281           1064
+seed7/lib/poll.s7i           0.039239            313
+seed7/lib/ppm.s7i            0.038774            240
+seed7/lib/process.s7i        0.039178            541
+seed7/lib/progs.s7i          0.040028            789
+seed7/lib/propertyfile.s7i   0.040742            155
+seed7/lib/rational.s7i       0.039314            792
+seed7/lib/ref_list.s7i       0.038680            252
+seed7/lib/reference.s7i      0.038849            126
+seed7/lib/reverse.s7i        0.038259             94
+seed7/lib/rpm.s7i            0.039682           3487
+seed7/lib/rpmext.s7i         0.040672            318
+seed7/lib/scanfile.s7i       0.039670           1779
+seed7/lib/scanjson.s7i       0.041180            413
+seed7/lib/scanstri.s7i       0.040211           1814
+seed7/lib/scantoml.s7i       0.037953           1603
+seed7/lib/seed7_05.s7i       0.039728           1072
+seed7/lib/set.s7i            0.036067             57
+seed7/lib/shell.s7i          0.037589            615
+seed7/lib/showtls.s7i        0.038238            678
+seed7/lib/signature.s7i      0.040288            131
+seed7/lib/smtp.s7i           0.039267            261
+seed7/lib/sockbase.s7i       0.038988            217
+seed7/lib/socket.s7i         0.039239            326
+seed7/lib/sokoban1.s7i       0.037671           1519
+seed7/lib/sql_base.s7i       0.039462           1000
+seed7/lib/stars.s7i          0.039754           1705
+seed7/lib/stdfont10.s7i      0.037668           3347
+seed7/lib/stdfont12.s7i      0.037772           3928
+seed7/lib/stdfont14.s7i      0.039318           4510
+seed7/lib/stdfont16.s7i      0.038359           5092
+seed7/lib/stdfont18.s7i      0.037926           5868
+seed7/lib/stdfont20.s7i      0.038037           6449
+seed7/lib/stdfont24.s7i      0.039029           7421
+seed7/lib/stdfont8.s7i       0.038260           2960
+seed7/lib/stdfont9.s7i       0.038215           3152
+seed7/lib/stdio.s7i          0.039383            192
+seed7/lib/strifile.s7i       0.039593            345
+seed7/lib/string.s7i         0.039370            779
+seed7/lib/stritext.s7i       0.039542            352
+seed7/lib/struct.s7i         0.039219            266
+seed7/lib/struct_elem.s7i    0.039381            129
+seed7/lib/subfile.s7i        0.038352            174
+seed7/lib/subrange.s7i       0.036800             78
+seed7/lib/syntax.s7i         0.038464            294
+seed7/lib/tar.s7i            0.039183           1880
+seed7/lib/tar_cmds.s7i       0.039166            752
+seed7/lib/tdes.s7i           0.038416            143
+seed7/lib/tee.s7i            0.039357            143
+seed7/lib/text.s7i           0.038745            135
+seed7/lib/tga.s7i            0.041102            676
+seed7/lib/tiff.s7i           0.040272           2771
+seed7/lib/time.s7i           0.039431           1191
+seed7/lib/tls.s7i            0.040795           2230
+seed7/lib/unicode.s7i        0.042513            575
+seed7/lib/unionfnd.s7i       0.040878            130
+seed7/lib/upper.s7i          0.039047            142
+seed7/lib/utf16.s7i          0.040177            540
+seed7/lib/utf8.s7i           0.039054            234
+seed7/lib/vecfont10.s7i      0.041343           1056
+seed7/lib/vecfont18.s7i      0.041808           1119
+seed7/lib/vector3d.s7i       0.040510            293
+seed7/lib/vectorfont.s7i     0.046149            239
+seed7/lib/wildcard.s7i       0.040246            140
+seed7/lib/window.s7i         0.039233            455
+seed7/lib/wrinum.s7i         0.038879            248
+seed7/lib/x509cert.s7i       0.039262           1243
+seed7/lib/xml_ent.s7i        0.039766             94
+seed7/lib/xmldom.s7i         0.037493            303
+seed7/lib/xz.s7i             0.040355            442
+seed7/lib/zip.s7i            0.038464           2792
+seed7/lib/zstd.s7i           0.038349           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039171        |
++-----------+-----------------+
+| Minimum   | 0.034768        |
++-----------+-----------------+
+| Maximum   | 0.048607        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.041202            190
+seed7/prg/bas7.sd7           0.320383          11459
+seed7/prg/bifurk.sd7         0.036868             73
+seed7/prg/bigfiles.sd7       0.038366            129
+seed7/prg/brainf7.sd7        0.036960             86
+seed7/prg/calc7.sd7          0.038667            128
+seed7/prg/carddemo.sd7       0.039378            190
+seed7/prg/castle.sd7         0.107083           3148
+seed7/prg/cat.sd7            0.036553             82
+seed7/prg/cellauto.sd7       0.036452             85
+seed7/prg/celsius.sd7        0.039544             42
+seed7/prg/chk_all.sd7        0.060820            843
+seed7/prg/chkarr.sd7         0.350835           8367
+seed7/prg/chkbig.sd7         2.058439          29026
+seed7/prg/chkbin.sd7         0.589870           6469
+seed7/prg/chkbitdata.sd7     0.627145           6624
+seed7/prg/chkbool.sd7        0.133666           3157
+seed7/prg/chkbst.sd7         0.069906            722
+seed7/prg/chkchr.sd7         0.214920           2809
+seed7/prg/chkcmd.sd7         0.073425           1205
+seed7/prg/chkdb.sd7          0.364949           7454
+seed7/prg/chkdecl.sd7        0.062728            448
+seed7/prg/chkenum.sd7        0.070471           1230
+seed7/prg/chkerr.sd7         0.197261           4663
+seed7/prg/chkexc.sd7         0.086169           2627
+seed7/prg/chkfil.sd7         0.077761           1615
+seed7/prg/chkflt.sd7         1.335764          20620
+seed7/prg/chkhent.sd7        0.042144             54
+seed7/prg/chkhsh.sd7         0.253184           4548
+seed7/prg/chkidx.sd7         1.317565          19567
+seed7/prg/chkint.sd7         2.528488          38129
+seed7/prg/chkjson.sd7        0.107567           1764
+seed7/prg/chkovf.sd7         0.554221           8216
+seed7/prg/chkprc.sd7         0.322573          10111
+seed7/prg/chkscan.sd7        0.060217            714
+seed7/prg/chkset.sd7         0.682202          11974
+seed7/prg/chkstr.sd7         1.465762          26952
+seed7/prg/chktime.sd7        0.139117           2025
+seed7/prg/chktoml.sd7        0.112861           1656
+seed7/prg/clock.sd7          0.042745             47
+seed7/prg/clock2.sd7         0.041995             43
+seed7/prg/clock3.sd7         0.039851             95
+seed7/prg/cmpfil.sd7         0.038207             84
+seed7/prg/comanche.sd7       0.042267            180
+seed7/prg/confval.sd7        0.046012            175
+seed7/prg/db7.sd7            0.052057            417
+seed7/prg/diff7.sd7          0.046262            263
+seed7/prg/dirtst.sd7         0.038278             42
+seed7/prg/dirx.sd7           0.041458            152
+seed7/prg/dnafight.sd7       0.071743           1381
+seed7/prg/dragon.sd7         0.039649             73
+seed7/prg/echo.sd7           0.038641             39
+seed7/prg/eliza.sd7          0.045765            302
+seed7/prg/err.sd7            0.042609             96
+seed7/prg/fannkuch.sd7       0.040177            131
+seed7/prg/fib.sd7            0.037942             47
+seed7/prg/find7.sd7          0.040442            133
+seed7/prg/findchar.sd7       0.041227            149
+seed7/prg/fractree.sd7       0.038847             55
+seed7/prg/ftp7.sd7           0.045159            296
+seed7/prg/ftpserv.sd7        0.040934             74
+seed7/prg/gcd.sd7            0.040564            109
+seed7/prg/gkbd.sd7           0.050338            358
+seed7/prg/gtksvtst.sd7       0.038767             94
+seed7/prg/hal.sd7            0.041848            250
+seed7/prg/hamu.sd7           0.048573            573
+seed7/prg/hanoi.sd7          0.035401             55
+seed7/prg/hd.sd7             0.035936             79
+seed7/prg/hello.sd7          0.038010             32
+seed7/prg/hilbert.sd7        0.041551            108
+seed7/prg/ide7.sd7           0.043704            196
+seed7/prg/kbd.sd7            0.037930             49
+seed7/prg/klondike.sd7       0.055810            883
+seed7/prg/lander.sd7         0.072948           1551
+seed7/prg/lst80bas.sd7       0.044208            344
+seed7/prg/lst99bas.sd7       0.045020            401
+seed7/prg/lstgwbas.sd7       0.050208            577
+seed7/prg/mahjong.sd7        0.079882           1943
+seed7/prg/make7.sd7          0.038811            121
+seed7/prg/mandelbr.sd7       0.040643            237
+seed7/prg/mind.sd7           0.044917            443
+seed7/prg/mirror.sd7         0.038892            131
+seed7/prg/ms.sd7             0.048129            641
+seed7/prg/nicoma.sd7         0.037710            135
+seed7/prg/pac.sd7            0.049410            726
+seed7/prg/pairs.sd7          0.080240           2025
+seed7/prg/panic.sd7          0.096279           2634
+seed7/prg/percolation.sd7    0.041978            330
+seed7/prg/planets.sd7        0.077846           1486
+seed7/prg/portfwd7.sd7       0.038997            139
+seed7/prg/prime.sd7          0.036345             74
+seed7/prg/printpi1.sd7       0.036920             56
+seed7/prg/printpi2.sd7       0.035840             54
+seed7/prg/printpi3.sd7       0.036112             60
+seed7/prg/pv7.sd7            0.044374            337
+seed7/prg/queen.sd7          0.038188            149
+seed7/prg/rand.sd7           0.037749            121
+seed7/prg/raytrace.sd7       0.048306            538
+seed7/prg/rever.sd7          0.053993            816
+seed7/prg/roman.sd7          0.035892             38
+seed7/prg/s7c.sd7            0.277893           9060
+seed7/prg/s7check.sd7        0.036751             68
+seed7/prg/savehd7.sd7        0.065008           1110
+seed7/prg/self.sd7           0.035793             49
+seed7/prg/shisen.sd7         0.069916           1423
+seed7/prg/sl.sd7             0.058496           1029
+seed7/prg/snake.sd7          0.047847            615
+seed7/prg/sokoban.sd7        0.054642            891
+seed7/prg/spigotpi.sd7       0.036671             64
+seed7/prg/sql7.sd7           0.041928            278
+seed7/prg/startrek.sd7       0.058852            979
+seed7/prg/sudoku7.sd7        0.100516           2657
+seed7/prg/sydir7.sd7         0.047604            384
+seed7/prg/syntaxhl.sd7       0.047811            177
+seed7/prg/tak.sd7            0.036921             59
+seed7/prg/tar7.sd7           0.037578            121
+seed7/prg/tch.sd7            0.035994             55
+seed7/prg/testfont.sd7       0.037360             95
+seed7/prg/tet.sd7            0.044426            479
+seed7/prg/tetg.sd7           0.045663            501
+seed7/prg/toutf8.sd7         0.042355            240
+seed7/prg/tst_cli.sd7        0.035424             40
+seed7/prg/tst_srv.sd7        0.035378             47
+seed7/prg/wator.sd7          0.051631            651
+seed7/prg/which.sd7          0.035677             65
+seed7/prg/wiz.sd7            0.102836           2833
+seed7/prg/wordcnt.sd7        0.034797             54
+seed7/prg/wrinum.sd7         0.034144             43
+seed7/prg/wumpus.sd7         0.044026            372
+seed7/lib/aes.s7i            0.109156           1144
+seed7/lib/aes_gcm.s7i        0.046550            392
+seed7/lib/ar.s7i             0.073386           1532
+seed7/lib/arc4.s7i           0.038510            144
+seed7/lib/archive.s7i        0.040725            143
+seed7/lib/archive_base.s7i   0.038545            135
+seed7/lib/array.s7i          0.054332            610
+seed7/lib/asn1.s7i           0.047278            544
+seed7/lib/asn1oid.s7i        0.041504            157
+seed7/lib/basearray.s7i      0.050250            450
+seed7/lib/bigfile.s7i        0.040984            136
+seed7/lib/bigint.s7i         0.055585            824
+seed7/lib/bigrat.s7i         0.053523            784
+seed7/lib/bin16.s7i          0.050571            592
+seed7/lib/bin32.s7i          0.048416            490
+seed7/lib/bin64.s7i          0.049179            539
+seed7/lib/bitdata.s7i        0.074813           1330
+seed7/lib/bitmapfont.s7i     0.038927            215
+seed7/lib/bitset.s7i         0.047924            593
+seed7/lib/bitsetof.s7i       0.047530            431
+seed7/lib/blowfish.s7i       0.056229            383
+seed7/lib/bmp.s7i            0.061019            924
+seed7/lib/boolean.s7i        0.044633            403
+seed7/lib/browser.s7i        0.042834            280
+seed7/lib/bstring.s7i        0.041157            227
+seed7/lib/bytedata.s7i       0.050267            482
+seed7/lib/bzip2.s7i          0.059674            887
+seed7/lib/cards.s7i          0.066744           1342
+seed7/lib/category.s7i       0.042000            209
+seed7/lib/cc_conf.s7i        0.078801           1314
+seed7/lib/ccittfax.s7i       0.064963           1022
+seed7/lib/cgi.s7i            0.037414            109
+seed7/lib/cgidialog.s7i      0.060071           1118
+seed7/lib/char.s7i           0.043578            356
+seed7/lib/charsets.s7i       0.082123           2024
+seed7/lib/chartype.s7i       0.039838            121
+seed7/lib/cipher.s7i         0.036929            146
+seed7/lib/cli_cmds.s7i       0.066637           1360
+seed7/lib/clib_file.s7i      0.042352            301
+seed7/lib/color.s7i          0.040564            185
+seed7/lib/complex.s7i        0.045232            464
+seed7/lib/compress.s7i       0.038360            150
+seed7/lib/console.s7i        0.040825            188
+seed7/lib/cpio.s7i           0.082969           1708
+seed7/lib/crc32.s7i          0.043833            193
+seed7/lib/cronos16.s7i       0.092190           1173
+seed7/lib/cronos27.s7i       0.115617           1464
+seed7/lib/csv.s7i            0.040552            201
+seed7/lib/db_prop.s7i        0.063405            991
+seed7/lib/deflate.s7i        0.055131            740
+seed7/lib/des.s7i            0.055326            444
+seed7/lib/dialog.s7i         0.046233            311
+seed7/lib/dir.s7i            0.039161            163
+seed7/lib/draw.s7i           0.055753            854
+seed7/lib/duration.s7i       0.059846           1038
+seed7/lib/echo.s7i           0.037191            132
+seed7/lib/editline.s7i       0.045742            398
+seed7/lib/elf.s7i            0.085662           1560
+seed7/lib/elliptic.s7i       0.053613            649
+seed7/lib/enable_io.s7i      0.043742            312
+seed7/lib/encoding.s7i       0.061802            931
+seed7/lib/enumeration.s7i    0.042285            236
+seed7/lib/environment.s7i    0.040410            175
+seed7/lib/exif.s7i           0.039977            152
+seed7/lib/external_file.s7i  0.043804            340
+seed7/lib/field.s7i          0.041658            268
+seed7/lib/file.s7i           0.044560            372
+seed7/lib/filebits.s7i       0.036077             46
+seed7/lib/filesys.s7i        0.047960            601
+seed7/lib/fileutil.s7i       0.038385            144
+seed7/lib/fixarray.s7i       0.047910            307
+seed7/lib/float.s7i          0.067264            757
+seed7/lib/font.s7i           0.040901            196
+seed7/lib/font8x8.s7i        0.048664            998
+seed7/lib/forloop.s7i        0.056395            449
+seed7/lib/ftp.s7i            0.057588            969
+seed7/lib/ftpserv.s7i        0.050295            631
+seed7/lib/getf.s7i           0.038031            115
+seed7/lib/gethttp.s7i        0.034886             41
+seed7/lib/gethttps.s7i       0.034777             41
+seed7/lib/gif.s7i            0.048546            561
+seed7/lib/graph.s7i          0.050121            415
+seed7/lib/graph_file.s7i     0.044033            399
+seed7/lib/gtkserver.s7i      0.038526            161
+seed7/lib/gzip.s7i           0.048749            573
+seed7/lib/hash.s7i           0.049809            421
+seed7/lib/hashsetof.s7i      0.049063            499
+seed7/lib/hmac.s7i           0.039305            152
+seed7/lib/html.s7i           0.036761             83
+seed7/lib/html_ent.s7i       0.046750            476
+seed7/lib/htmldom.s7i        0.044926            286
+seed7/lib/http_request.s7i   0.059755            696
+seed7/lib/http_srv_resp.s7i  0.047034            380
+seed7/lib/https_request.s7i  0.040690            211
+seed7/lib/httpserv.s7i       0.043878            345
+seed7/lib/huffman.s7i        0.052384            644
+seed7/lib/ico.s7i            0.041218            221
+seed7/lib/idxarray.s7i       0.042583            232
+seed7/lib/image.s7i          0.037785            156
+seed7/lib/imagefile.s7i      0.040125            171
+seed7/lib/inflate.s7i        0.046204            411
+seed7/lib/inifile.s7i        0.036720            129
+seed7/lib/integer.s7i        0.051360            663
+seed7/lib/iobuffer.s7i       0.041308            289
+seed7/lib/jpeg.s7i           0.084840           1761
+seed7/lib/json.s7i           0.056602            891
+seed7/lib/json_serde.s7i     0.052872            783
+seed7/lib/keybd.s7i          0.055419            639
+seed7/lib/keydescr.s7i       0.042011            192
+seed7/lib/leb128.s7i         0.040926            218
+seed7/lib/line.s7i           0.039160            164
+seed7/lib/listener.s7i       0.045273            247
+seed7/lib/logfile.s7i        0.069936             73
+seed7/lib/lower.s7i          0.052023            142
+seed7/lib/lzma.s7i           0.074952            934
+seed7/lib/lzw.s7i            0.064017            861
+seed7/lib/magic.s7i          0.053257            403
+seed7/lib/mahjng32.s7i       0.072653           1500
+seed7/lib/make.s7i           0.059352            544
+seed7/lib/makedata.s7i       0.076013           1428
+seed7/lib/math.s7i           0.041151            201
+seed7/lib/mixarith.s7i       0.042450            249
+seed7/lib/modern27.s7i       0.084057           1099
+seed7/lib/more.s7i           0.040706            130
+seed7/lib/msgdigest.s7i      0.081202           1222
+seed7/lib/multiscr.s7i       0.038001             68
+seed7/lib/null_file.s7i      0.045330            345
+seed7/lib/osfiles.s7i        0.067510           1085
+seed7/lib/pbm.s7i            0.041882            230
+seed7/lib/pcx.s7i            0.052872            638
+seed7/lib/pem.s7i            0.040884            185
+seed7/lib/pgm.s7i            0.041257            238
+seed7/lib/pic16.s7i          0.049295           1037
+seed7/lib/pic32.s7i          0.084953           2060
+seed7/lib/pic_util.s7i       0.039105            144
+seed7/lib/pixelimage.s7i     0.043044            320
+seed7/lib/pixmap_file.s7i    0.045895            459
+seed7/lib/pixmapfont.s7i     0.040852            184
+seed7/lib/pkcs1.s7i          0.059594            543
+seed7/lib/png.s7i            0.063984           1064
+seed7/lib/poll.s7i           0.047528            313
+seed7/lib/ppm.s7i            0.044003            240
+seed7/lib/process.s7i        0.049452            541
+seed7/lib/progs.s7i          0.056269            789
+seed7/lib/propertyfile.s7i   0.038533            155
+seed7/lib/rational.s7i       0.061763            792
+seed7/lib/ref_list.s7i       0.046961            252
+seed7/lib/reference.s7i      0.038728            126
+seed7/lib/reverse.s7i        0.039671             94
+seed7/lib/rpm.s7i            0.146435           3487
+seed7/lib/rpmext.s7i         0.042390            318
+seed7/lib/scanfile.s7i       0.081867           1779
+seed7/lib/scanjson.s7i       0.047166            413
+seed7/lib/scanstri.s7i       0.079737           1814
+seed7/lib/scantoml.s7i       0.073479           1603
+seed7/lib/seed7_05.s7i       0.069460           1072
+seed7/lib/set.s7i            0.036522             57
+seed7/lib/shell.s7i          0.052893            615
+seed7/lib/showtls.s7i        0.054326            678
+seed7/lib/signature.s7i      0.038417            131
+seed7/lib/smtp.s7i           0.040501            261
+seed7/lib/sockbase.s7i       0.043609            217
+seed7/lib/socket.s7i         0.044544            326
+seed7/lib/sokoban1.s7i       0.054870           1519
+seed7/lib/sql_base.s7i       0.064330           1000
+seed7/lib/stars.s7i          0.139439           1705
+seed7/lib/stdfont10.s7i      0.082079           3347
+seed7/lib/stdfont12.s7i      0.092737           3928
+seed7/lib/stdfont14.s7i      0.103031           4510
+seed7/lib/stdfont16.s7i      0.114627           5092
+seed7/lib/stdfont18.s7i      0.130430           5868
+seed7/lib/stdfont20.s7i      0.146374           6449
+seed7/lib/stdfont24.s7i      0.178378           7421
+seed7/lib/stdfont8.s7i       0.072047           2960
+seed7/lib/stdfont9.s7i       0.084100           3152
+seed7/lib/stdio.s7i          0.041120            192
+seed7/lib/strifile.s7i       0.043729            345
+seed7/lib/string.s7i         0.055488            779
+seed7/lib/stritext.s7i       0.043378            352
+seed7/lib/struct.s7i         0.044703            266
+seed7/lib/struct_elem.s7i    0.038554            129
+seed7/lib/subfile.s7i        0.039155            174
+seed7/lib/subrange.s7i       0.038566             78
+seed7/lib/syntax.s7i         0.046397            294
+seed7/lib/tar.s7i            0.082574           1880
+seed7/lib/tar_cmds.s7i       0.056283            752
+seed7/lib/tdes.s7i           0.038865            143
+seed7/lib/tee.s7i            0.038081            143
+seed7/lib/text.s7i           0.038150            135
+seed7/lib/tga.s7i            0.054121            676
+seed7/lib/tiff.s7i           0.123917           2771
+seed7/lib/time.s7i           0.063954           1191
+seed7/lib/tls.s7i            0.105642           2230
+seed7/lib/unicode.s7i        0.052877            575
+seed7/lib/unionfnd.s7i       0.038881            130
+seed7/lib/upper.s7i          0.039174            142
+seed7/lib/utf16.s7i          0.050978            540
+seed7/lib/utf8.s7i           0.041651            234
+seed7/lib/vecfont10.s7i      0.080280           1056
+seed7/lib/vecfont18.s7i      0.088391           1119
+seed7/lib/vector3d.s7i       0.040806            293
+seed7/lib/vectorfont.s7i     0.043188            239
+seed7/lib/wildcard.s7i       0.038643            140
+seed7/lib/window.s7i         0.046628            455
+seed7/lib/wrinum.s7i         0.040680            248
+seed7/lib/x509cert.s7i       0.071689           1243
+seed7/lib/xml_ent.s7i        0.038163             94
+seed7/lib/xmldom.s7i         0.041087            303
+seed7/lib/xz.s7i             0.046991            442
+seed7/lib/zip.s7i            0.119518           2792
+seed7/lib/zstd.s7i           0.069662           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.090868        |
++-----------+-----------------+
+| Minimum   | 0.034144        |
++-----------+-----------------+
+| Maximum   | 2.528488        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.045739            190
+seed7/prg/bas7.sd7           0.769191          11459
+seed7/prg/bifurk.sd7         0.039581             73
+seed7/prg/bigfiles.sd7       0.042495            129
+seed7/prg/brainf7.sd7        0.039700             86
+seed7/prg/calc7.sd7          0.043113            128
+seed7/prg/carddemo.sd7       0.046248            190
+seed7/prg/castle.sd7         0.215859           3148
+seed7/prg/cat.sd7            0.039223             82
+seed7/prg/cellauto.sd7       0.041305             85
+seed7/prg/celsius.sd7        0.037419             42
+seed7/prg/chk_all.sd7        0.083461            843
+seed7/prg/chkarr.sd7         0.855962           8367
+seed7/prg/chkbig.sd7         4.091371          29026
+seed7/prg/chkbin.sd7         1.016466           6469
+seed7/prg/chkbitdata.sd7     1.233249           6624
+seed7/prg/chkbool.sd7        0.229919           3157
+seed7/prg/chkbst.sd7         0.102153            722
+seed7/prg/chkchr.sd7         0.475011           2809
+seed7/prg/chkcmd.sd7         0.110632           1205
+seed7/prg/chkdb.sd7          0.745011           7454
+seed7/prg/chkdecl.sd7        0.094278            448
+seed7/prg/chkenum.sd7        0.120089           1230
+seed7/prg/chkerr.sd7         0.337179           4663
+seed7/prg/chkexc.sd7         0.146785           2627
+seed7/prg/chkfil.sd7         0.126691           1615
+seed7/prg/chkflt.sd7         2.784296          20620
+seed7/prg/chkhent.sd7        0.038491             54
+seed7/prg/chkhsh.sd7         0.493381           4548
+seed7/prg/chkidx.sd7         3.140209          19567
+seed7/prg/chkint.sd7         5.516850          38129
+seed7/prg/chkjson.sd7        0.183980           1764
+seed7/prg/chkovf.sd7         1.195186           8216
+seed7/prg/chkprc.sd7         0.696850          10111
+seed7/prg/chkscan.sd7        0.088922            714
+seed7/prg/chkset.sd7         1.736956          11974
+seed7/prg/chkstr.sd7         3.408790          26952
+seed7/prg/chktime.sd7        0.246344           2025
+seed7/prg/chktoml.sd7        0.195300           1656
+seed7/prg/clock.sd7          0.037469             47
+seed7/prg/clock2.sd7         0.037275             43
+seed7/prg/clock3.sd7         0.042991             95
+seed7/prg/cmpfil.sd7         0.040022             84
+seed7/prg/comanche.sd7       0.051861            180
+seed7/prg/confval.sd7        0.053881            175
+seed7/prg/db7.sd7            0.064839            417
+seed7/prg/diff7.sd7          0.053082            263
+seed7/prg/dirtst.sd7         0.037104             42
+seed7/prg/dirx.sd7           0.042826            152
+seed7/prg/dnafight.sd7       0.116433           1381
+seed7/prg/dragon.sd7         0.039569             73
+seed7/prg/echo.sd7           0.036517             39
+seed7/prg/eliza.sd7          0.051773            302
+seed7/prg/err.sd7            0.045248             96
+seed7/prg/fannkuch.sd7       0.043247            131
+seed7/prg/fib.sd7            0.038943             47
+seed7/prg/find7.sd7          0.042078            133
+seed7/prg/findchar.sd7       0.042736            149
+seed7/prg/fractree.sd7       0.037289             55
+seed7/prg/ftp7.sd7           0.052798            296
+seed7/prg/ftpserv.sd7        0.040794             74
+seed7/prg/gcd.sd7            0.040992            109
+seed7/prg/gkbd.sd7           0.062141            358
+seed7/prg/gtksvtst.sd7       0.040317             94
+seed7/prg/hal.sd7            0.048176            250
+seed7/prg/hamu.sd7           0.067241            573
+seed7/prg/hanoi.sd7          0.042429             55
+seed7/prg/hd.sd7             0.040991             79
+seed7/prg/hello.sd7          0.039034             32
+seed7/prg/hilbert.sd7        0.042308            108
+seed7/prg/ide7.sd7           0.048514            196
+seed7/prg/kbd.sd7            0.036733             49
+seed7/prg/klondike.sd7       0.088892            883
+seed7/prg/lander.sd7         0.132378           1551
+seed7/prg/lst80bas.sd7       0.062143            344
+seed7/prg/lst99bas.sd7       0.061760            401
+seed7/prg/lstgwbas.sd7       0.073958            577
+seed7/prg/mahjong.sd7        0.148125           1943
+seed7/prg/make7.sd7          0.043174            121
+seed7/prg/mandelbr.sd7       0.049677            237
+seed7/prg/mind.sd7           0.063526            443
+seed7/prg/mirror.sd7         0.044145            131
+seed7/prg/ms.sd7             0.069432            641
+seed7/prg/nicoma.sd7         0.042784            135
+seed7/prg/pac.sd7            0.072814            726
+seed7/prg/pairs.sd7          0.138858           2025
+seed7/prg/panic.sd7          0.196288           2634
+seed7/prg/percolation.sd7    0.057925            330
+seed7/prg/planets.sd7        0.136521           1486
+seed7/prg/portfwd7.sd7       0.044183            139
+seed7/prg/prime.sd7          0.038563             74
+seed7/prg/printpi1.sd7       0.037893             56
+seed7/prg/printpi2.sd7       0.038391             54
+seed7/prg/printpi3.sd7       0.039721             60
+seed7/prg/pv7.sd7            0.058729            337
+seed7/prg/queen.sd7          0.043485            149
+seed7/prg/rand.sd7           0.041984            121
+seed7/prg/raytrace.sd7       0.069671            538
+seed7/prg/rever.sd7          0.084202            816
+seed7/prg/roman.sd7          0.036540             38
+seed7/prg/s7c.sd7            0.622911           9060
+seed7/prg/s7check.sd7        0.038788             68
+seed7/prg/savehd7.sd7        0.109286           1110
+seed7/prg/self.sd7           0.036947             49
+seed7/prg/shisen.sd7         0.117501           1423
+seed7/prg/sl.sd7             0.095540           1029
+seed7/prg/snake.sd7          0.065626            615
+seed7/prg/sokoban.sd7        0.082225            891
+seed7/prg/spigotpi.sd7       0.038236             64
+seed7/prg/sql7.sd7           0.053315            278
+seed7/prg/startrek.sd7       0.094979            979
+seed7/prg/sudoku7.sd7        0.196954           2657
+seed7/prg/sydir7.sd7         0.059983            384
+seed7/prg/syntaxhl.sd7       0.049275            177
+seed7/prg/tak.sd7            0.037711             59
+seed7/prg/tar7.sd7           0.042338            121
+seed7/prg/tch.sd7            0.038553             55
+seed7/prg/testfont.sd7       0.042151             95
+seed7/prg/tet.sd7            0.059259            479
+seed7/prg/tetg.sd7           0.062268            501
+seed7/prg/toutf8.sd7         0.051224            240
+seed7/prg/tst_cli.sd7        0.036543             40
+seed7/prg/tst_srv.sd7        0.037049             47
+seed7/prg/wator.sd7          0.078242            651
+seed7/prg/which.sd7          0.038161             65
+seed7/prg/wiz.sd7            0.207762           2833
+seed7/prg/wordcnt.sd7        0.039156             54
+seed7/prg/wrinum.sd7         0.036130             43
+seed7/prg/wumpus.sd7         0.053038            372
+seed7/lib/aes.s7i            0.194900           1144
+seed7/lib/aes_gcm.s7i        0.059108            392
+seed7/lib/ar.s7i             0.124009           1532
+seed7/lib/arc4.s7i           0.043126            144
+seed7/lib/archive.s7i        0.043271            143
+seed7/lib/archive_base.s7i   0.043885            135
+seed7/lib/array.s7i          0.075707            610
+seed7/lib/asn1.s7i           0.063293            544
+seed7/lib/asn1oid.s7i        0.049174            157
+seed7/lib/basearray.s7i      0.063157            450
+seed7/lib/bigfile.s7i        0.041970            136
+seed7/lib/bigint.s7i         0.079944            824
+seed7/lib/bigrat.s7i         0.079401            784
+seed7/lib/bin16.s7i          0.068332            592
+seed7/lib/bin32.s7i          0.061477            490
+seed7/lib/bin64.s7i          0.063656            539
+seed7/lib/bitdata.s7i        0.123168           1330
+seed7/lib/bitmapfont.s7i     0.047936            215
+seed7/lib/bitset.s7i         0.064145            593
+seed7/lib/bitsetof.s7i       0.061759            431
+seed7/lib/blowfish.s7i       0.076485            383
+seed7/lib/bmp.s7i            0.099742            924
+seed7/lib/boolean.s7i        0.054628            403
+seed7/lib/browser.s7i        0.052818            280
+seed7/lib/bstring.s7i        0.046715            227
+seed7/lib/bytedata.s7i       0.064749            482
+seed7/lib/bzip2.s7i          0.092368            887
+seed7/lib/cards.s7i          0.102677           1342
+seed7/lib/category.s7i       0.048379            209
+seed7/lib/cc_conf.s7i        0.118571           1314
+seed7/lib/ccittfax.s7i       0.100993           1022
+seed7/lib/cgi.s7i            0.040920            109
+seed7/lib/cgidialog.s7i      0.096229           1118
+seed7/lib/char.s7i           0.051377            356
+seed7/lib/charsets.s7i       0.126606           2024
+seed7/lib/chartype.s7i       0.047902            121
+seed7/lib/cipher.s7i         0.044933            146
+seed7/lib/cli_cmds.s7i       0.119180           1360
+seed7/lib/clib_file.s7i      0.050770            301
+seed7/lib/color.s7i          0.047382            185
+seed7/lib/complex.s7i        0.060039            464
+seed7/lib/compress.s7i       0.043899            150
+seed7/lib/console.s7i        0.045420            188
+seed7/lib/cpio.s7i           0.144807           1708
+seed7/lib/crc32.s7i          0.054342            193
+seed7/lib/cronos16.s7i       0.194459           1173
+seed7/lib/cronos27.s7i       0.255776           1464
+seed7/lib/csv.s7i            0.048142            201
+seed7/lib/db_prop.s7i        0.100541            991
+seed7/lib/deflate.s7i        0.085897            740
+seed7/lib/des.s7i            0.080144            444
+seed7/lib/dialog.s7i         0.057627            311
+seed7/lib/dir.s7i            0.042848            163
+seed7/lib/draw.s7i           0.084890            854
+seed7/lib/duration.s7i       0.096071           1038
+seed7/lib/echo.s7i           0.041486            132
+seed7/lib/editline.s7i       0.059310            398
+seed7/lib/elf.s7i            0.153873           1560
+seed7/lib/elliptic.s7i       0.076132            649
+seed7/lib/enable_io.s7i      0.051896            312
+seed7/lib/encoding.s7i       0.097493            931
+seed7/lib/enumeration.s7i    0.048982            236
+seed7/lib/environment.s7i    0.044375            175
+seed7/lib/exif.s7i           0.045864            152
+seed7/lib/external_file.s7i  0.051761            340
+seed7/lib/field.s7i          0.052092            268
+seed7/lib/file.s7i           0.054247            372
+seed7/lib/filebits.s7i       0.039011             46
+seed7/lib/filesys.s7i        0.064697            601
+seed7/lib/fileutil.s7i       0.043329            144
+seed7/lib/fixarray.s7i       0.053760            307
+seed7/lib/float.s7i          0.074580            757
+seed7/lib/font.s7i           0.045204            196
+seed7/lib/font8x8.s7i        0.067796            998
+seed7/lib/forloop.s7i        0.060840            449
+seed7/lib/ftp.s7i            0.088979            969
+seed7/lib/ftpserv.s7i        0.075434            631
+seed7/lib/getf.s7i           0.040953            115
+seed7/lib/gethttp.s7i        0.036882             41
+seed7/lib/gethttps.s7i       0.037210             41
+seed7/lib/gif.s7i            0.070469            561
+seed7/lib/graph.s7i          0.065378            415
+seed7/lib/graph_file.s7i     0.057152            399
+seed7/lib/gtkserver.s7i      0.041534            161
+seed7/lib/gzip.s7i           0.070450            573
+seed7/lib/hash.s7i           0.068922            421
+seed7/lib/hashsetof.s7i      0.066381            499
+seed7/lib/hmac.s7i           0.044492            152
+seed7/lib/html.s7i           0.040058             83
+seed7/lib/html_ent.s7i       0.062717            476
+seed7/lib/htmldom.s7i        0.053047            286
+seed7/lib/http_request.s7i   0.077289            696
+seed7/lib/http_srv_resp.s7i  0.060024            380
+seed7/lib/https_request.s7i  0.047580            211
+seed7/lib/httpserv.s7i       0.057068            345
+seed7/lib/huffman.s7i        0.075006            644
+seed7/lib/ico.s7i            0.049066            221
+seed7/lib/idxarray.s7i       0.052569            232
+seed7/lib/image.s7i          0.044790            156
+seed7/lib/imagefile.s7i      0.048132            171
+seed7/lib/inflate.s7i        0.064368            411
+seed7/lib/inifile.s7i        0.043182            129
+seed7/lib/integer.s7i        0.068209            663
+seed7/lib/iobuffer.s7i       0.050529            289
+seed7/lib/jpeg.s7i           0.153309           1761
+seed7/lib/json.s7i           0.080085            891
+seed7/lib/json_serde.s7i     0.078583            783
+seed7/lib/keybd.s7i          0.079500            639
+seed7/lib/keydescr.s7i       0.049283            192
+seed7/lib/leb128.s7i         0.046122            218
+seed7/lib/line.s7i           0.044941            164
+seed7/lib/listener.s7i       0.048950            247
+seed7/lib/logfile.s7i        0.041747             73
+seed7/lib/lower.s7i          0.044368            142
+seed7/lib/lzma.s7i           0.103788            934
+seed7/lib/lzw.s7i            0.092467            861
+seed7/lib/magic.s7i          0.063226            403
+seed7/lib/mahjng32.s7i       0.090832           1500
+seed7/lib/make.s7i           0.070354            544
+seed7/lib/makedata.s7i       0.119696           1428
+seed7/lib/math.s7i           0.044801            201
+seed7/lib/mixarith.s7i       0.046687            249
+seed7/lib/modern27.s7i       0.166479           1099
+seed7/lib/more.s7i           0.042083            130
+seed7/lib/msgdigest.s7i      0.135728           1222
+seed7/lib/multiscr.s7i       0.038111             68
+seed7/lib/null_file.s7i      0.050990            345
+seed7/lib/osfiles.s7i        0.094693           1085
+seed7/lib/pbm.s7i            0.047664            230
+seed7/lib/pcx.s7i            0.076147            638
+seed7/lib/pem.s7i            0.046156            185
+seed7/lib/pgm.s7i            0.048870            238
+seed7/lib/pic16.s7i          0.065438           1037
+seed7/lib/pic32.s7i          0.122312           2060
+seed7/lib/pic_util.s7i       0.045533            144
+seed7/lib/pixelimage.s7i     0.051880            320
+seed7/lib/pixmap_file.s7i    0.061870            459
+seed7/lib/pixmapfont.s7i     0.048149            184
+seed7/lib/pkcs1.s7i          0.076950            543
+seed7/lib/png.s7i            0.107656           1064
+seed7/lib/poll.s7i           0.057371            313
+seed7/lib/ppm.s7i            0.053437            240
+seed7/lib/process.s7i        0.064290            541
+seed7/lib/progs.s7i          0.079027            789
+seed7/lib/propertyfile.s7i   0.043633            155
+seed7/lib/rational.s7i       0.078603            792
+seed7/lib/ref_list.s7i       0.049006            252
+seed7/lib/reference.s7i      0.043488            126
+seed7/lib/reverse.s7i        0.040264             94
+seed7/lib/rpm.s7i            0.282731           3487
+seed7/lib/rpmext.s7i         0.051445            318
+seed7/lib/scanfile.s7i       0.131690           1779
+seed7/lib/scanjson.s7i       0.060681            413
+seed7/lib/scanstri.s7i       0.137956           1814
+seed7/lib/scantoml.s7i       0.130593           1603
+seed7/lib/seed7_05.s7i       0.111208           1072
+seed7/lib/set.s7i            0.038624             57
+seed7/lib/shell.s7i          0.068747            615
+seed7/lib/showtls.s7i        0.086078            678
+seed7/lib/signature.s7i      0.043432            131
+seed7/lib/smtp.s7i           0.049197            261
+seed7/lib/sockbase.s7i       0.051064            217
+seed7/lib/socket.s7i         0.052624            326
+seed7/lib/sokoban1.s7i       0.079800           1519
+seed7/lib/sql_base.s7i       0.094667           1000
+seed7/lib/stars.s7i          0.234783           1705
+seed7/lib/stdfont10.s7i      0.143070           3347
+seed7/lib/stdfont12.s7i      0.164147           3928
+seed7/lib/stdfont14.s7i      0.190334           4510
+seed7/lib/stdfont16.s7i      0.210348           5092
+seed7/lib/stdfont18.s7i      0.243086           5868
+seed7/lib/stdfont20.s7i      0.269706           6449
+seed7/lib/stdfont24.s7i      0.328453           7421
+seed7/lib/stdfont8.s7i       0.127434           2960
+seed7/lib/stdfont9.s7i       0.132634           3152
+seed7/lib/stdio.s7i          0.044332            192
+seed7/lib/strifile.s7i       0.054401            345
+seed7/lib/string.s7i         0.075992            779
+seed7/lib/stritext.s7i       0.054097            352
+seed7/lib/struct.s7i         0.055679            266
+seed7/lib/struct_elem.s7i    0.042940            129
+seed7/lib/subfile.s7i        0.044423            174
+seed7/lib/subrange.s7i       0.038711             78
+seed7/lib/syntax.s7i         0.059559            294
+seed7/lib/tar.s7i            0.144150           1880
+seed7/lib/tar_cmds.s7i       0.085810            752
+seed7/lib/tdes.s7i           0.043657            143
+seed7/lib/tee.s7i            0.041013            143
+seed7/lib/text.s7i           0.041440            135
+seed7/lib/tga.s7i            0.087471            676
+seed7/lib/tiff.s7i           0.246402           2771
+seed7/lib/time.s7i           0.101182           1191
+seed7/lib/tls.s7i            0.194742           2230
+seed7/lib/unicode.s7i        0.075772            575
+seed7/lib/unionfnd.s7i       0.042102            130
+seed7/lib/upper.s7i          0.041933            142
+seed7/lib/utf16.s7i          0.066979            540
+seed7/lib/utf8.s7i           0.048602            234
+seed7/lib/vecfont10.s7i      0.162111           1056
+seed7/lib/vecfont18.s7i      0.178030           1119
+seed7/lib/vector3d.s7i       0.050351            293
+seed7/lib/vectorfont.s7i     0.049122            239
+seed7/lib/wildcard.s7i       0.042229            140
+seed7/lib/window.s7i         0.060949            455
+seed7/lib/wrinum.s7i         0.050578            248
+seed7/lib/x509cert.s7i       0.117786           1243
+seed7/lib/xml_ent.s7i        0.041472             94
+seed7/lib/xmldom.s7i         0.050512            303
+seed7/lib/xz.s7i             0.060643            442
+seed7/lib/zip.s7i            0.231414           2792
+seed7/lib/zstd.s7i           0.116255           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.158102        |
++-----------+-----------------+
+| Minimum   | 0.036130        |
++-----------+-----------------+
+| Maximum   | 5.516850        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.034553        | 0.032489        | 0.041455        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039171        | 0.034768        | 0.048607        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.090868        | 0.034144        | 2.528488        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.158102        | 0.036130        | 5.516850        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:13.421 | 00:00:58.868 | 00:01:12.290 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:15.162 | 00:01:06.790 | 00:01:21.952 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:36.398 | 00:02:35.785 | 00:03:12.183 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:01.199 | 00:04:30.256 | 00:05:31.456 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:17.888 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-07.2.rst
+++ b/reports/seed7mode-perf-07.2.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-24T18:30:15+0000 W26-3
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 14:45:50 local time
+:Generated on: 2026-06-24 18:57:05 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 300x84 chars
+:Window body: 300x82 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.043033            190
+seed7/prg/bas7.sd7           0.041685          11459
+seed7/prg/bifurk.sd7         0.035718             73
+seed7/prg/bigfiles.sd7       0.034653            129
+seed7/prg/brainf7.sd7        0.034271             86
+seed7/prg/calc7.sd7          0.033698            128
+seed7/prg/carddemo.sd7       0.033657            190
+seed7/prg/castle.sd7         0.033807           3148
+seed7/prg/cat.sd7            0.032493             82
+seed7/prg/cellauto.sd7       0.036500             85
+seed7/prg/celsius.sd7        0.034512             42
+seed7/prg/chk_all.sd7        0.034140            843
+seed7/prg/chkarr.sd7         0.038329           8367
+seed7/prg/chkbig.sd7         0.039335          29026
+seed7/prg/chkbin.sd7         0.040990           6469
+seed7/prg/chkbitdata.sd7     0.039314           6624
+seed7/prg/chkbool.sd7        0.041714           3157
+seed7/prg/chkbst.sd7         0.039285            722
+seed7/prg/chkchr.sd7         0.042684           2809
+seed7/prg/chkcmd.sd7         0.040771           1205
+seed7/prg/chkdb.sd7          0.037836           7454
+seed7/prg/chkdecl.sd7        0.036387            448
+seed7/prg/chkenum.sd7        0.037775           1230
+seed7/prg/chkerr.sd7         0.046100           4663
+seed7/prg/chkexc.sd7         0.034645           2627
+seed7/prg/chkfil.sd7         0.033924           1615
+seed7/prg/chkflt.sd7         0.036091          20620
+seed7/prg/chkhent.sd7        0.033001             54
+seed7/prg/chkhsh.sd7         0.033428           4548
+seed7/prg/chkidx.sd7         0.038379          19567
+seed7/prg/chkint.sd7         0.045446          38129
+seed7/prg/chkjson.sd7        0.034328           1764
+seed7/prg/chkovf.sd7         0.034182           8216
+seed7/prg/chkprc.sd7         0.033888          10111
+seed7/prg/chkscan.sd7        0.033368            714
+seed7/prg/chkset.sd7         0.041861          11974
+seed7/prg/chkstr.sd7         0.046170          26952
+seed7/prg/chktime.sd7        0.034422           2025
+seed7/prg/chktoml.sd7        0.034257           1656
+seed7/prg/clock.sd7          0.033572             47
+seed7/prg/clock2.sd7         0.033715             43
+seed7/prg/clock3.sd7         0.034371             95
+seed7/prg/cmpfil.sd7         0.033685             84
+seed7/prg/comanche.sd7       0.033630            180
+seed7/prg/confval.sd7        0.033482            175
+seed7/prg/db7.sd7            0.033861            417
+seed7/prg/diff7.sd7          0.033981            263
+seed7/prg/dirtst.sd7         0.034526             42
+seed7/prg/dirx.sd7           0.033495            152
+seed7/prg/dnafight.sd7       0.032875           1381
+seed7/prg/dragon.sd7         0.033013             73
+seed7/prg/echo.sd7           0.032424             39
+seed7/prg/eliza.sd7          0.037365            302
+seed7/prg/err.sd7            0.040722             96
+seed7/prg/fannkuch.sd7       0.036664            131
+seed7/prg/fib.sd7            0.033589             47
+seed7/prg/find7.sd7          0.033463            133
+seed7/prg/findchar.sd7       0.033430            149
+seed7/prg/fractree.sd7       0.033630             55
+seed7/prg/ftp7.sd7           0.033782            296
+seed7/prg/ftpserv.sd7        0.034042             74
+seed7/prg/gcd.sd7            0.033443            109
+seed7/prg/gkbd.sd7           0.038747            358
+seed7/prg/gtksvtst.sd7       0.034398             94
+seed7/prg/hal.sd7            0.033511            250
+seed7/prg/hamu.sd7           0.033798            573
+seed7/prg/hanoi.sd7          0.033575             55
+seed7/prg/hd.sd7             0.033519             79
+seed7/prg/hello.sd7          0.033739             32
+seed7/prg/hilbert.sd7        0.033484            108
+seed7/prg/ide7.sd7           0.033838            196
+seed7/prg/kbd.sd7            0.033380             49
+seed7/prg/klondike.sd7       0.033788            883
+seed7/prg/lander.sd7         0.033876           1551
+seed7/prg/lst80bas.sd7       0.033711            344
+seed7/prg/lst99bas.sd7       0.033780            401
+seed7/prg/lstgwbas.sd7       0.033440            577
+seed7/prg/mahjong.sd7        0.033799           1943
+seed7/prg/make7.sd7          0.033584            121
+seed7/prg/mandelbr.sd7       0.033377            237
+seed7/prg/mind.sd7           0.032697            443
+seed7/prg/mirror.sd7         0.032696            131
+seed7/prg/ms.sd7             0.033473            641
+seed7/prg/nicoma.sd7         0.032566            135
+seed7/prg/pac.sd7            0.032719            726
+seed7/prg/pairs.sd7          0.034221           2025
+seed7/prg/panic.sd7          0.034008           2634
+seed7/prg/percolation.sd7    0.033879            330
+seed7/prg/planets.sd7        0.033821           1486
+seed7/prg/portfwd7.sd7       0.034805            139
+seed7/prg/prime.sd7          0.035095             74
+seed7/prg/printpi1.sd7       0.033931             56
+seed7/prg/printpi2.sd7       0.033592             54
+seed7/prg/printpi3.sd7       0.034320             60
+seed7/prg/pv7.sd7            0.033565            337
+seed7/prg/queen.sd7          0.034015            149
+seed7/prg/rand.sd7           0.033650            121
+seed7/prg/raytrace.sd7       0.033538            538
+seed7/prg/rever.sd7          0.033290            816
+seed7/prg/roman.sd7          0.033635             38
+seed7/prg/s7c.sd7            0.034648           9060
+seed7/prg/s7check.sd7        0.033762             68
+seed7/prg/savehd7.sd7        0.034349           1110
+seed7/prg/self.sd7           0.040301             49
+seed7/prg/shisen.sd7         0.036612           1423
+seed7/prg/sl.sd7             0.034353           1029
+seed7/prg/snake.sd7          0.033606            615
+seed7/prg/sokoban.sd7        0.033693            891
+seed7/prg/spigotpi.sd7       0.033756             64
+seed7/prg/sql7.sd7           0.033298            278
+seed7/prg/startrek.sd7       0.033095            979
+seed7/prg/sudoku7.sd7        0.033401           2657
+seed7/prg/sydir7.sd7         0.033061            384
+seed7/prg/syntaxhl.sd7       0.032853            177
+seed7/prg/tak.sd7            0.033065             59
+seed7/prg/tar7.sd7           0.033653            121
+seed7/prg/tch.sd7            0.034096             55
+seed7/prg/testfont.sd7       0.033381             95
+seed7/prg/tet.sd7            0.032555            479
+seed7/prg/tetg.sd7           0.033435            501
+seed7/prg/toutf8.sd7         0.033691            240
+seed7/prg/tst_cli.sd7        0.033622             40
+seed7/prg/tst_srv.sd7        0.033896             47
+seed7/prg/wator.sd7          0.033614            651
+seed7/prg/which.sd7          0.033739             65
+seed7/prg/wiz.sd7            0.033811           2833
+seed7/prg/wordcnt.sd7        0.033708             54
+seed7/prg/wrinum.sd7         0.033386             43
+seed7/prg/wumpus.sd7         0.033822            372
+seed7/lib/aes.s7i            0.033815           1144
+seed7/lib/aes_gcm.s7i        0.033847            392
+seed7/lib/ar.s7i             0.034211           1532
+seed7/lib/arc4.s7i           0.034262            144
+seed7/lib/archive.s7i        0.033708            143
+seed7/lib/archive_base.s7i   0.033836            135
+seed7/lib/array.s7i          0.033451            610
+seed7/lib/asn1.s7i           0.033423            544
+seed7/lib/asn1oid.s7i        0.033580            157
+seed7/lib/basearray.s7i      0.033616            450
+seed7/lib/bigfile.s7i        0.032915            136
+seed7/lib/bigint.s7i         0.032590            824
+seed7/lib/bigrat.s7i         0.033214            784
+seed7/lib/bin16.s7i          0.032784            592
+seed7/lib/bin32.s7i          0.032988            490
+seed7/lib/bin64.s7i          0.033196            539
+seed7/lib/bitdata.s7i        0.034498           1330
+seed7/lib/bitmapfont.s7i     0.033660            215
+seed7/lib/bitset.s7i         0.033695            593
+seed7/lib/bitsetof.s7i       0.033589            431
+seed7/lib/blowfish.s7i       0.034506            383
+seed7/lib/bmp.s7i            0.034021            924
+seed7/lib/boolean.s7i        0.033941            403
+seed7/lib/browser.s7i        0.034050            280
+seed7/lib/bstring.s7i        0.033796            227
+seed7/lib/bytedata.s7i       0.033661            482
+seed7/lib/bzip2.s7i          0.033967            887
+seed7/lib/cards.s7i          0.033757           1342
+seed7/lib/category.s7i       0.033933            209
+seed7/lib/cc_conf.s7i        0.033504           1314
+seed7/lib/ccittfax.s7i       0.033457           1022
+seed7/lib/cgi.s7i            0.037011            109
+seed7/lib/cgidialog.s7i      0.039962           1118
+seed7/lib/char.s7i           0.034610            356
+seed7/lib/charsets.s7i       0.034107           2024
+seed7/lib/chartype.s7i       0.033861            121
+seed7/lib/cipher.s7i         0.034070            146
+seed7/lib/cli_cmds.s7i       0.033753           1360
+seed7/lib/clib_file.s7i      0.033860            301
+seed7/lib/color.s7i          0.033928            185
+seed7/lib/complex.s7i        0.034064            464
+seed7/lib/compress.s7i       0.033740            150
+seed7/lib/console.s7i        0.033498            188
+seed7/lib/cpio.s7i           0.033208           1708
+seed7/lib/crc32.s7i          0.033160            193
+seed7/lib/cronos16.s7i       0.032720           1173
+seed7/lib/cronos27.s7i       0.032881           1464
+seed7/lib/csv.s7i            0.034329            201
+seed7/lib/db_prop.s7i        0.034023            991
+seed7/lib/deflate.s7i        0.034306            740
+seed7/lib/des.s7i            0.034703            444
+seed7/lib/dialog.s7i         0.034509            311
+seed7/lib/dir.s7i            0.033914            163
+seed7/lib/draw.s7i           0.034024            854
+seed7/lib/duration.s7i       0.033684           1038
+seed7/lib/echo.s7i           0.033369            132
+seed7/lib/editline.s7i       0.033948            398
+seed7/lib/elf.s7i            0.034568           1560
+seed7/lib/elliptic.s7i       0.034636            649
+seed7/lib/enable_io.s7i      0.033829            312
+seed7/lib/encoding.s7i       0.033868            931
+seed7/lib/enumeration.s7i    0.033795            236
+seed7/lib/environment.s7i    0.033604            175
+seed7/lib/exif.s7i           0.034344            152
+seed7/lib/external_file.s7i  0.034234            340
+seed7/lib/field.s7i          0.034289            268
+seed7/lib/file.s7i           0.033609            372
+seed7/lib/filebits.s7i       0.033789             46
+seed7/lib/filesys.s7i        0.033745            601
+seed7/lib/fileutil.s7i       0.033441            144
+seed7/lib/fixarray.s7i       0.033868            307
+seed7/lib/float.s7i          0.033328            757
+seed7/lib/font.s7i           0.033634            196
+seed7/lib/font8x8.s7i        0.034143            998
+seed7/lib/forloop.s7i        0.033076            449
+seed7/lib/ftp.s7i            0.033419            969
+seed7/lib/ftpserv.s7i        0.034715            631
+seed7/lib/getf.s7i           0.033924            115
+seed7/lib/gethttp.s7i        0.034663             41
+seed7/lib/gethttps.s7i       0.038350             41
+seed7/lib/gif.s7i            0.033316            561
+seed7/lib/graph.s7i          0.034075            415
+seed7/lib/graph_file.s7i     0.033681            399
+seed7/lib/gtkserver.s7i      0.033457            161
+seed7/lib/gzip.s7i           0.033327            573
+seed7/lib/hash.s7i           0.034079            421
+seed7/lib/hashsetof.s7i      0.034424            499
+seed7/lib/hmac.s7i           0.034678            152
+seed7/lib/html.s7i           0.034561             83
+seed7/lib/html_ent.s7i       0.033963            476
+seed7/lib/htmldom.s7i        0.033673            286
+seed7/lib/http_request.s7i   0.033613            696
+seed7/lib/http_srv_resp.s7i  0.033521            380
+seed7/lib/https_request.s7i  0.033784            211
+seed7/lib/httpserv.s7i       0.033696            345
+seed7/lib/huffman.s7i        0.034592            644
+seed7/lib/ico.s7i            0.034070            221
+seed7/lib/idxarray.s7i       0.033677            232
+seed7/lib/image.s7i          0.033792            156
+seed7/lib/imagefile.s7i      0.033862            171
+seed7/lib/inflate.s7i        0.033576            411
+seed7/lib/inifile.s7i        0.033875            129
+seed7/lib/integer.s7i        0.033739            663
+seed7/lib/iobuffer.s7i       0.033855            289
+seed7/lib/jpeg.s7i           0.033259           1761
+seed7/lib/json.s7i           0.032729            891
+seed7/lib/json_serde.s7i     0.033379            783
+seed7/lib/keybd.s7i          0.033869            639
+seed7/lib/keydescr.s7i       0.033695            192
+seed7/lib/leb128.s7i         0.033225            218
+seed7/lib/line.s7i           0.033918            164
+seed7/lib/listener.s7i       0.034103            247
+seed7/lib/logfile.s7i        0.033697             73
+seed7/lib/lower.s7i          0.033735            142
+seed7/lib/lzma.s7i           0.033661            934
+seed7/lib/lzw.s7i            0.033915            861
+seed7/lib/magic.s7i          0.033720            403
+seed7/lib/mahjng32.s7i       0.033684           1500
+seed7/lib/make.s7i           0.033417            544
+seed7/lib/makedata.s7i       0.033946           1428
+seed7/lib/math.s7i           0.033229            201
+seed7/lib/mixarith.s7i       0.033014            249
+seed7/lib/modern27.s7i       0.033055           1099
+seed7/lib/more.s7i           0.032709            130
+seed7/lib/msgdigest.s7i      0.033277           1222
+seed7/lib/multiscr.s7i       0.033234             68
+seed7/lib/null_file.s7i      0.033124            345
+seed7/lib/osfiles.s7i        0.033226           1085
+seed7/lib/pbm.s7i            0.033272            230
+seed7/lib/pcx.s7i            0.033351            638
+seed7/lib/pem.s7i            0.033612            185
+seed7/lib/pgm.s7i            0.033487            238
+seed7/lib/pic16.s7i          0.034093           1037
+seed7/lib/pic32.s7i          0.034229           2060
+seed7/lib/pic_util.s7i       0.033952            144
+seed7/lib/pixelimage.s7i     0.033881            320
+seed7/lib/pixmap_file.s7i    0.032858            459
+seed7/lib/pixmapfont.s7i     0.037275            184
+seed7/lib/pkcs1.s7i          0.035086            543
+seed7/lib/png.s7i            0.033586           1064
+seed7/lib/poll.s7i           0.033366            313
+seed7/lib/ppm.s7i            0.033863            240
+seed7/lib/process.s7i        0.034830            541
+seed7/lib/progs.s7i          0.035491            789
+seed7/lib/propertyfile.s7i   0.033817            155
+seed7/lib/rational.s7i       0.033695            792
+seed7/lib/ref_list.s7i       0.033923            252
+seed7/lib/reference.s7i      0.033828            126
+seed7/lib/reverse.s7i        0.034064             94
+seed7/lib/rpm.s7i            0.034294           3487
+seed7/lib/rpmext.s7i         0.033804            318
+seed7/lib/scanfile.s7i       0.033726           1779
+seed7/lib/scanjson.s7i       0.033559            413
+seed7/lib/scanstri.s7i       0.033635           1814
+seed7/lib/scantoml.s7i       0.033433           1603
+seed7/lib/seed7_05.s7i       0.033684           1072
+seed7/lib/set.s7i            0.033622             57
+seed7/lib/shell.s7i          0.033890            615
+seed7/lib/showtls.s7i        0.033666            678
+seed7/lib/signature.s7i      0.033564            131
+seed7/lib/smtp.s7i           0.033493            261
+seed7/lib/sockbase.s7i       0.033699            217
+seed7/lib/socket.s7i         0.033578            326
+seed7/lib/sokoban1.s7i       0.033773           1519
+seed7/lib/sql_base.s7i       0.033774           1000
+seed7/lib/stars.s7i          0.033514           1705
+seed7/lib/stdfont10.s7i      0.033039           3347
+seed7/lib/stdfont12.s7i      0.033224           3928
+seed7/lib/stdfont14.s7i      0.033145           4510
+seed7/lib/stdfont16.s7i      0.033098           5092
+seed7/lib/stdfont18.s7i      0.033265           5868
+seed7/lib/stdfont20.s7i      0.033775           6449
+seed7/lib/stdfont24.s7i      0.033744           7421
+seed7/lib/stdfont8.s7i       0.034723           2960
+seed7/lib/stdfont9.s7i       0.035340           3152
+seed7/lib/stdio.s7i          0.033550            192
+seed7/lib/strifile.s7i       0.033959            345
+seed7/lib/string.s7i         0.033787            779
+seed7/lib/stritext.s7i       0.033984            352
+seed7/lib/struct.s7i         0.033931            266
+seed7/lib/struct_elem.s7i    0.033898            129
+seed7/lib/subfile.s7i        0.033780            174
+seed7/lib/subrange.s7i       0.033865             78
+seed7/lib/syntax.s7i         0.034012            294
+seed7/lib/tar.s7i            0.033877           1880
+seed7/lib/tar_cmds.s7i       0.033674            752
+seed7/lib/tdes.s7i           0.033732            143
+seed7/lib/tee.s7i            0.033755            143
+seed7/lib/text.s7i           0.033991            135
+seed7/lib/tga.s7i            0.033760            676
+seed7/lib/tiff.s7i           0.033879           2771
+seed7/lib/time.s7i           0.033947           1191
+seed7/lib/tls.s7i            0.034006           2230
+seed7/lib/unicode.s7i        0.033588            575
+seed7/lib/unionfnd.s7i       0.034082            130
+seed7/lib/upper.s7i          0.033868            142
+seed7/lib/utf16.s7i          0.035523            540
+seed7/lib/utf8.s7i           0.034289            234
+seed7/lib/vecfont10.s7i      0.034019           1056
+seed7/lib/vecfont18.s7i      0.032853           1119
+seed7/lib/vector3d.s7i       0.032764            293
+seed7/lib/vectorfont.s7i     0.036920            239
+seed7/lib/wildcard.s7i       0.035958            140
+seed7/lib/window.s7i         0.033199            455
+seed7/lib/wrinum.s7i         0.033708            248
+seed7/lib/x509cert.s7i       0.034932           1243
+seed7/lib/xml_ent.s7i        0.033599             94
+seed7/lib/xmldom.s7i         0.033467            303
+seed7/lib/xz.s7i             0.033777            442
+seed7/lib/zip.s7i            0.033879           2792
+seed7/lib/zstd.s7i           0.033879           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.034296        |
++-----------+-----------------+
+| Minimum   | 0.032424        |
++-----------+-----------------+
+| Maximum   | 0.046170        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039753            190
+seed7/prg/bas7.sd7           0.041555          11459
+seed7/prg/bifurk.sd7         0.037630             73
+seed7/prg/bigfiles.sd7       0.039280            129
+seed7/prg/brainf7.sd7        0.037919             86
+seed7/prg/calc7.sd7          0.038822            128
+seed7/prg/carddemo.sd7       0.040122            190
+seed7/prg/castle.sd7         0.040005           3148
+seed7/prg/cat.sd7            0.037603             82
+seed7/prg/cellauto.sd7       0.037800             85
+seed7/prg/celsius.sd7        0.036886             42
+seed7/prg/chk_all.sd7        0.038547            843
+seed7/prg/chkarr.sd7         0.038187           8367
+seed7/prg/chkbig.sd7         0.042727          29026
+seed7/prg/chkbin.sd7         0.039329           6469
+seed7/prg/chkbitdata.sd7     0.040425           6624
+seed7/prg/chkbool.sd7        0.037792           3157
+seed7/prg/chkbst.sd7         0.037857            722
+seed7/prg/chkchr.sd7         0.038338           2809
+seed7/prg/chkcmd.sd7         0.036893           1205
+seed7/prg/chkdb.sd7          0.039567           7454
+seed7/prg/chkdecl.sd7        0.037718            448
+seed7/prg/chkenum.sd7        0.036349           1230
+seed7/prg/chkerr.sd7         0.038713           4663
+seed7/prg/chkexc.sd7         0.036921           2627
+seed7/prg/chkfil.sd7         0.038687           1615
+seed7/prg/chkflt.sd7         0.040259          20620
+seed7/prg/chkhent.sd7        0.035317             54
+seed7/prg/chkhsh.sd7         0.038369           4548
+seed7/prg/chkidx.sd7         0.042367          19567
+seed7/prg/chkint.sd7         0.044500          38129
+seed7/prg/chkjson.sd7        0.038542           1764
+seed7/prg/chkovf.sd7         0.038112           8216
+seed7/prg/chkprc.sd7         0.038355          10111
+seed7/prg/chkscan.sd7        0.039365            714
+seed7/prg/chkset.sd7         0.040721          11974
+seed7/prg/chkstr.sd7         0.042164          26952
+seed7/prg/chktime.sd7        0.039844           2025
+seed7/prg/chktoml.sd7        0.039202           1656
+seed7/prg/clock.sd7          0.036305             47
+seed7/prg/clock2.sd7         0.036880             43
+seed7/prg/clock3.sd7         0.039264             95
+seed7/prg/cmpfil.sd7         0.037448             84
+seed7/prg/comanche.sd7       0.038430            180
+seed7/prg/confval.sd7        0.039148            175
+seed7/prg/db7.sd7            0.038841            417
+seed7/prg/diff7.sd7          0.039008            263
+seed7/prg/dirtst.sd7         0.035753             42
+seed7/prg/dirx.sd7           0.038433            152
+seed7/prg/dnafight.sd7       0.038498           1381
+seed7/prg/dragon.sd7         0.036623             73
+seed7/prg/echo.sd7           0.035306             39
+seed7/prg/eliza.sd7          0.037566            302
+seed7/prg/err.sd7            0.039888             96
+seed7/prg/fannkuch.sd7       0.036677            131
+seed7/prg/fib.sd7            0.034987             47
+seed7/prg/find7.sd7          0.038578            133
+seed7/prg/findchar.sd7       0.038846            149
+seed7/prg/fractree.sd7       0.036946             55
+seed7/prg/ftp7.sd7           0.039114            296
+seed7/prg/ftpserv.sd7        0.037670             74
+seed7/prg/gcd.sd7            0.037230            109
+seed7/prg/gkbd.sd7           0.039190            358
+seed7/prg/gtksvtst.sd7       0.037485             94
+seed7/prg/hal.sd7            0.037009            250
+seed7/prg/hamu.sd7           0.037331            573
+seed7/prg/hanoi.sd7          0.036639             55
+seed7/prg/hd.sd7             0.038020             79
+seed7/prg/hello.sd7          0.037128             32
+seed7/prg/hilbert.sd7        0.038242            108
+seed7/prg/ide7.sd7           0.038524            196
+seed7/prg/kbd.sd7            0.035953             49
+seed7/prg/klondike.sd7       0.038835            883
+seed7/prg/lander.sd7         0.039649           1551
+seed7/prg/lst80bas.sd7       0.037135            344
+seed7/prg/lst99bas.sd7       0.036951            401
+seed7/prg/lstgwbas.sd7       0.036726            577
+seed7/prg/mahjong.sd7        0.037720           1943
+seed7/prg/make7.sd7          0.038285            121
+seed7/prg/mandelbr.sd7       0.038460            237
+seed7/prg/mind.sd7           0.036472            443
+seed7/prg/mirror.sd7         0.037507            131
+seed7/prg/ms.sd7             0.037992            641
+seed7/prg/nicoma.sd7         0.037620            135
+seed7/prg/pac.sd7            0.038804            726
+seed7/prg/pairs.sd7          0.039020           2025
+seed7/prg/panic.sd7          0.039242           2634
+seed7/prg/percolation.sd7    0.039381            330
+seed7/prg/planets.sd7        0.039637           1486
+seed7/prg/portfwd7.sd7       0.038729            139
+seed7/prg/prime.sd7          0.037949             74
+seed7/prg/printpi1.sd7       0.036943             56
+seed7/prg/printpi2.sd7       0.036771             54
+seed7/prg/printpi3.sd7       0.036814             60
+seed7/prg/pv7.sd7            0.038508            337
+seed7/prg/queen.sd7          0.037172            149
+seed7/prg/rand.sd7           0.037442            121
+seed7/prg/raytrace.sd7       0.038936            538
+seed7/prg/rever.sd7          0.038656            816
+seed7/prg/roman.sd7          0.035956             38
+seed7/prg/s7c.sd7            0.038831           9060
+seed7/prg/s7check.sd7        0.036760             68
+seed7/prg/savehd7.sd7        0.038874           1110
+seed7/prg/self.sd7           0.036285             49
+seed7/prg/shisen.sd7         0.038276           1423
+seed7/prg/sl.sd7             0.036470           1029
+seed7/prg/snake.sd7          0.036778            615
+seed7/prg/sokoban.sd7        0.037678            891
+seed7/prg/spigotpi.sd7       0.035394             64
+seed7/prg/sql7.sd7           0.037061            278
+seed7/prg/startrek.sd7       0.038785            979
+seed7/prg/sudoku7.sd7        0.039105           2657
+seed7/prg/sydir7.sd7         0.038876            384
+seed7/prg/syntaxhl.sd7       0.039633            177
+seed7/prg/tak.sd7            0.036387             59
+seed7/prg/tar7.sd7           0.038528            121
+seed7/prg/tch.sd7            0.036090             55
+seed7/prg/testfont.sd7       0.040160             95
+seed7/prg/tet.sd7            0.040756            479
+seed7/prg/tetg.sd7           0.039084            501
+seed7/prg/toutf8.sd7         0.038646            240
+seed7/prg/tst_cli.sd7        0.035571             40
+seed7/prg/tst_srv.sd7        0.035862             47
+seed7/prg/wator.sd7          0.036965            651
+seed7/prg/which.sd7          0.037012             65
+seed7/prg/wiz.sd7            0.038711           2833
+seed7/prg/wordcnt.sd7        0.037477             54
+seed7/prg/wrinum.sd7         0.035530             43
+seed7/prg/wumpus.sd7         0.038473            372
+seed7/lib/aes.s7i            0.041854           1144
+seed7/lib/aes_gcm.s7i        0.039766            392
+seed7/lib/ar.s7i             0.039185           1532
+seed7/lib/arc4.s7i           0.037980            144
+seed7/lib/archive.s7i        0.037639            143
+seed7/lib/archive_base.s7i   0.037667            135
+seed7/lib/array.s7i          0.037593            610
+seed7/lib/asn1.s7i           0.036148            544
+seed7/lib/asn1oid.s7i        0.041671            157
+seed7/lib/basearray.s7i      0.044325            450
+seed7/lib/bigfile.s7i        0.042385            136
+seed7/lib/bigint.s7i         0.039508            824
+seed7/lib/bigrat.s7i         0.039300            784
+seed7/lib/bin16.s7i          0.039115            592
+seed7/lib/bin32.s7i          0.038727            490
+seed7/lib/bin64.s7i          0.039159            539
+seed7/lib/bitdata.s7i        0.042865           1330
+seed7/lib/bitmapfont.s7i     0.038918            215
+seed7/lib/bitset.s7i         0.038644            593
+seed7/lib/bitsetof.s7i       0.039379            431
+seed7/lib/blowfish.s7i       0.042697            383
+seed7/lib/bmp.s7i            0.038905            924
+seed7/lib/boolean.s7i        0.037447            403
+seed7/lib/browser.s7i        0.039010            280
+seed7/lib/bstring.s7i        0.038651            227
+seed7/lib/bytedata.s7i       0.040102            482
+seed7/lib/bzip2.s7i          0.039067            887
+seed7/lib/cards.s7i          0.036923           1342
+seed7/lib/category.s7i       0.038963            209
+seed7/lib/cc_conf.s7i        0.038469           1314
+seed7/lib/ccittfax.s7i       0.038251           1022
+seed7/lib/cgi.s7i            0.037287            109
+seed7/lib/cgidialog.s7i      0.037597           1118
+seed7/lib/char.s7i           0.037601            356
+seed7/lib/charsets.s7i       0.038172           2024
+seed7/lib/chartype.s7i       0.042617            121
+seed7/lib/cipher.s7i         0.038485            146
+seed7/lib/cli_cmds.s7i       0.037998           1360
+seed7/lib/clib_file.s7i      0.038063            301
+seed7/lib/color.s7i          0.038870            185
+seed7/lib/complex.s7i        0.037622            464
+seed7/lib/compress.s7i       0.039586            150
+seed7/lib/console.s7i        0.038909            188
+seed7/lib/cpio.s7i           0.038868           1708
+seed7/lib/crc32.s7i          0.040081            193
+seed7/lib/cronos16.s7i       0.040699           1173
+seed7/lib/cronos27.s7i       0.048164           1464
+seed7/lib/csv.s7i            0.041386            201
+seed7/lib/db_prop.s7i        0.039258            991
+seed7/lib/deflate.s7i        0.038818            740
+seed7/lib/des.s7i            0.039484            444
+seed7/lib/dialog.s7i         0.038853            311
+seed7/lib/dir.s7i            0.038760            163
+seed7/lib/draw.s7i           0.039271            854
+seed7/lib/duration.s7i       0.038938           1038
+seed7/lib/echo.s7i           0.038734            132
+seed7/lib/editline.s7i       0.038382            398
+seed7/lib/elf.s7i            0.038140           1560
+seed7/lib/elliptic.s7i       0.036360            649
+seed7/lib/enable_io.s7i      0.037583            312
+seed7/lib/encoding.s7i       0.037955            931
+seed7/lib/enumeration.s7i    0.037983            236
+seed7/lib/environment.s7i    0.038024            175
+seed7/lib/exif.s7i           0.039070            152
+seed7/lib/external_file.s7i  0.038704            340
+seed7/lib/field.s7i          0.038714            268
+seed7/lib/file.s7i           0.038786            372
+seed7/lib/filebits.s7i       0.039450             46
+seed7/lib/filesys.s7i        0.041036            601
+seed7/lib/fileutil.s7i       0.039278            144
+seed7/lib/fixarray.s7i       0.038955            307
+seed7/lib/float.s7i          0.039285            757
+seed7/lib/font.s7i           0.039595            196
+seed7/lib/font8x8.s7i        0.038364            998
+seed7/lib/forloop.s7i        0.039217            449
+seed7/lib/ftp.s7i            0.039234            969
+seed7/lib/ftpserv.s7i        0.039182            631
+seed7/lib/getf.s7i           0.039949            115
+seed7/lib/gethttp.s7i        0.036855             41
+seed7/lib/gethttps.s7i       0.036521             41
+seed7/lib/gif.s7i            0.038939            561
+seed7/lib/graph.s7i          0.040994            415
+seed7/lib/graph_file.s7i     0.037842            399
+seed7/lib/gtkserver.s7i      0.037533            161
+seed7/lib/gzip.s7i           0.037640            573
+seed7/lib/hash.s7i           0.039237            421
+seed7/lib/hashsetof.s7i      0.039623            499
+seed7/lib/hmac.s7i           0.037620            152
+seed7/lib/html.s7i           0.036974             83
+seed7/lib/html_ent.s7i       0.038403            476
+seed7/lib/htmldom.s7i        0.039003            286
+seed7/lib/http_request.s7i   0.039353            696
+seed7/lib/http_srv_resp.s7i  0.040192            380
+seed7/lib/https_request.s7i  0.038919            211
+seed7/lib/httpserv.s7i       0.038636            345
+seed7/lib/huffman.s7i        0.038464            644
+seed7/lib/ico.s7i            0.039330            221
+seed7/lib/idxarray.s7i       0.042599            232
+seed7/lib/image.s7i          0.037206            156
+seed7/lib/imagefile.s7i      0.038581            171
+seed7/lib/inflate.s7i        0.039003            411
+seed7/lib/inifile.s7i        0.038505            129
+seed7/lib/integer.s7i        0.038492            663
+seed7/lib/iobuffer.s7i       0.041205            289
+seed7/lib/jpeg.s7i           0.040801           1761
+seed7/lib/json.s7i           0.039662            891
+seed7/lib/json_serde.s7i     0.040577            783
+seed7/lib/keybd.s7i          0.040039            639
+seed7/lib/keydescr.s7i       0.040451            192
+seed7/lib/leb128.s7i         0.039415            218
+seed7/lib/line.s7i           0.036190            164
+seed7/lib/listener.s7i       0.037307            247
+seed7/lib/logfile.s7i        0.036789             73
+seed7/lib/lower.s7i          0.037142            142
+seed7/lib/lzma.s7i           0.037909            934
+seed7/lib/lzw.s7i            0.041378            861
+seed7/lib/magic.s7i          0.040429            403
+seed7/lib/mahjng32.s7i       0.038869           1500
+seed7/lib/make.s7i           0.040349            544
+seed7/lib/makedata.s7i       0.039176           1428
+seed7/lib/math.s7i           0.038531            201
+seed7/lib/mixarith.s7i       0.038893            249
+seed7/lib/modern27.s7i       0.040737           1099
+seed7/lib/more.s7i           0.038839            130
+seed7/lib/msgdigest.s7i      0.038705           1222
+seed7/lib/multiscr.s7i       0.036366             68
+seed7/lib/null_file.s7i      0.037529            345
+seed7/lib/osfiles.s7i        0.041197           1085
+seed7/lib/pbm.s7i            0.041685            230
+seed7/lib/pcx.s7i            0.042431            638
+seed7/lib/pem.s7i            0.042551            185
+seed7/lib/pgm.s7i            0.041731            238
+seed7/lib/pic16.s7i          0.039777           1037
+seed7/lib/pic32.s7i          0.039096           2060
+seed7/lib/pic_util.s7i       0.039483            144
+seed7/lib/pixelimage.s7i     0.041963            320
+seed7/lib/pixmap_file.s7i    0.039909            459
+seed7/lib/pixmapfont.s7i     0.038367            184
+seed7/lib/pkcs1.s7i          0.045543            543
+seed7/lib/png.s7i            0.037950           1064
+seed7/lib/poll.s7i           0.038906            313
+seed7/lib/ppm.s7i            0.038001            240
+seed7/lib/process.s7i        0.039250            541
+seed7/lib/progs.s7i          0.039604            789
+seed7/lib/propertyfile.s7i   0.039109            155
+seed7/lib/rational.s7i       0.039092            792
+seed7/lib/ref_list.s7i       0.038720            252
+seed7/lib/reference.s7i      0.038735            126
+seed7/lib/reverse.s7i        0.038520             94
+seed7/lib/rpm.s7i            0.038305           3487
+seed7/lib/rpmext.s7i         0.038044            318
+seed7/lib/scanfile.s7i       0.038576           1779
+seed7/lib/scanjson.s7i       0.038196            413
+seed7/lib/scanstri.s7i       0.038326           1814
+seed7/lib/scantoml.s7i       0.037807           1603
+seed7/lib/seed7_05.s7i       0.039927           1072
+seed7/lib/set.s7i            0.036599             57
+seed7/lib/shell.s7i          0.038251            615
+seed7/lib/showtls.s7i        0.040036            678
+seed7/lib/signature.s7i      0.038874            131
+seed7/lib/smtp.s7i           0.039363            261
+seed7/lib/sockbase.s7i       0.038822            217
+seed7/lib/socket.s7i         0.038951            326
+seed7/lib/sokoban1.s7i       0.037727           1519
+seed7/lib/sql_base.s7i       0.037993           1000
+seed7/lib/stars.s7i          0.044302           1705
+seed7/lib/stdfont10.s7i      0.041817           3347
+seed7/lib/stdfont12.s7i      0.037486           3928
+seed7/lib/stdfont14.s7i      0.036656           4510
+seed7/lib/stdfont16.s7i      0.039157           5092
+seed7/lib/stdfont18.s7i      0.037853           5868
+seed7/lib/stdfont20.s7i      0.037775           6449
+seed7/lib/stdfont24.s7i      0.040054           7421
+seed7/lib/stdfont8.s7i       0.037754           2960
+seed7/lib/stdfont9.s7i       0.037522           3152
+seed7/lib/stdio.s7i          0.038571            192
+seed7/lib/strifile.s7i       0.038754            345
+seed7/lib/string.s7i         0.038992            779
+seed7/lib/stritext.s7i       0.039248            352
+seed7/lib/struct.s7i         0.039589            266
+seed7/lib/struct_elem.s7i    0.038639            129
+seed7/lib/subfile.s7i        0.038730            174
+seed7/lib/subrange.s7i       0.037917             78
+seed7/lib/syntax.s7i         0.039794            294
+seed7/lib/tar.s7i            0.039294           1880
+seed7/lib/tar_cmds.s7i       0.039125            752
+seed7/lib/tdes.s7i           0.039130            143
+seed7/lib/tee.s7i            0.038802            143
+seed7/lib/text.s7i           0.038743            135
+seed7/lib/tga.s7i            0.041054            676
+seed7/lib/tiff.s7i           0.039945           2771
+seed7/lib/time.s7i           0.038752           1191
+seed7/lib/tls.s7i            0.037861           2230
+seed7/lib/unicode.s7i        0.038555            575
+seed7/lib/unionfnd.s7i       0.036656            130
+seed7/lib/upper.s7i          0.038736            142
+seed7/lib/utf16.s7i          0.037634            540
+seed7/lib/utf8.s7i           0.039190            234
+seed7/lib/vecfont10.s7i      0.039294           1056
+seed7/lib/vecfont18.s7i      0.039543           1119
+seed7/lib/vector3d.s7i       0.037734            293
+seed7/lib/vectorfont.s7i     0.038953            239
+seed7/lib/wildcard.s7i       0.038359            140
+seed7/lib/window.s7i         0.038754            455
+seed7/lib/wrinum.s7i         0.038809            248
+seed7/lib/x509cert.s7i       0.040093           1243
+seed7/lib/xml_ent.s7i        0.038877             94
+seed7/lib/xmldom.s7i         0.037670            303
+seed7/lib/xz.s7i             0.039098            442
+seed7/lib/zip.s7i            0.039275           2792
+seed7/lib/zstd.s7i           0.039208           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.038740        |
++-----------+-----------------+
+| Minimum   | 0.034987        |
++-----------+-----------------+
+| Maximum   | 0.048164        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039510            190
+seed7/prg/bas7.sd7           0.324084          11459
+seed7/prg/bifurk.sd7         0.036801             73
+seed7/prg/bigfiles.sd7       0.036685            129
+seed7/prg/brainf7.sd7        0.036176             86
+seed7/prg/calc7.sd7          0.037237            128
+seed7/prg/carddemo.sd7       0.038004            190
+seed7/prg/castle.sd7         0.109823           3148
+seed7/prg/cat.sd7            0.039826             82
+seed7/prg/cellauto.sd7       0.041919             85
+seed7/prg/celsius.sd7        0.041773             42
+seed7/prg/chk_all.sd7        0.065823            843
+seed7/prg/chkarr.sd7         0.366574           8367
+seed7/prg/chkbig.sd7         2.170022          29026
+seed7/prg/chkbin.sd7         0.519614           6469
+seed7/prg/chkbitdata.sd7     0.607730           6624
+seed7/prg/chkbool.sd7        0.115121           3157
+seed7/prg/chkbst.sd7         0.061152            722
+seed7/prg/chkchr.sd7         0.211585           2809
+seed7/prg/chkcmd.sd7         0.067677           1205
+seed7/prg/chkdb.sd7          0.348250           7454
+seed7/prg/chkdecl.sd7        0.057952            448
+seed7/prg/chkenum.sd7        0.067576           1230
+seed7/prg/chkerr.sd7         0.192183           4663
+seed7/prg/chkexc.sd7         0.083943           2627
+seed7/prg/chkfil.sd7         0.073946           1615
+seed7/prg/chkflt.sd7         1.327770          20620
+seed7/prg/chkhent.sd7        0.037734             54
+seed7/prg/chkhsh.sd7         0.244878           4548
+seed7/prg/chkidx.sd7         1.303036          19567
+seed7/prg/chkint.sd7         2.496171          38129
+seed7/prg/chkjson.sd7        0.104529           1764
+seed7/prg/chkovf.sd7         0.557039           8216
+seed7/prg/chkprc.sd7         0.317987          10111
+seed7/prg/chkscan.sd7        0.058005            714
+seed7/prg/chkset.sd7         0.659361          11974
+seed7/prg/chkstr.sd7         1.364678          26952
+seed7/prg/chktime.sd7        0.128089           2025
+seed7/prg/chktoml.sd7        0.105794           1656
+seed7/prg/clock.sd7          0.038507             47
+seed7/prg/clock2.sd7         0.042753             43
+seed7/prg/clock3.sd7         0.037545             95
+seed7/prg/cmpfil.sd7         0.035606             84
+seed7/prg/comanche.sd7       0.040775            180
+seed7/prg/confval.sd7        0.041659            175
+seed7/prg/db7.sd7            0.045616            417
+seed7/prg/diff7.sd7          0.042534            263
+seed7/prg/dirtst.sd7         0.035942             42
+seed7/prg/dirx.sd7           0.037310            152
+seed7/prg/dnafight.sd7       0.064727           1381
+seed7/prg/dragon.sd7         0.035454             73
+seed7/prg/echo.sd7           0.034406             39
+seed7/prg/eliza.sd7          0.042352            302
+seed7/prg/err.sd7            0.040617             96
+seed7/prg/fannkuch.sd7       0.037488            131
+seed7/prg/fib.sd7            0.035832             47
+seed7/prg/find7.sd7          0.038059            133
+seed7/prg/findchar.sd7       0.038738            149
+seed7/prg/fractree.sd7       0.036105             55
+seed7/prg/ftp7.sd7           0.042360            296
+seed7/prg/ftpserv.sd7        0.037034             74
+seed7/prg/gcd.sd7            0.036826            109
+seed7/prg/gkbd.sd7           0.049407            358
+seed7/prg/gtksvtst.sd7       0.037426             94
+seed7/prg/hal.sd7            0.039782            250
+seed7/prg/hamu.sd7           0.048688            573
+seed7/prg/hanoi.sd7          0.036244             55
+seed7/prg/hd.sd7             0.036450             79
+seed7/prg/hello.sd7          0.035494             32
+seed7/prg/hilbert.sd7        0.037175            108
+seed7/prg/ide7.sd7           0.039859            196
+seed7/prg/kbd.sd7            0.035653             49
+seed7/prg/klondike.sd7       0.055306            883
+seed7/prg/lander.sd7         0.071911           1551
+seed7/prg/lst80bas.sd7       0.042621            344
+seed7/prg/lst99bas.sd7       0.043981            401
+seed7/prg/lstgwbas.sd7       0.049187            577
+seed7/prg/mahjong.sd7        0.078274           1943
+seed7/prg/make7.sd7          0.039404            121
+seed7/prg/mandelbr.sd7       0.039345            237
+seed7/prg/mind.sd7           0.043819            443
+seed7/prg/mirror.sd7         0.037800            131
+seed7/prg/ms.sd7             0.047901            641
+seed7/prg/nicoma.sd7         0.038871            135
+seed7/prg/pac.sd7            0.049507            726
+seed7/prg/pairs.sd7          0.082312           2025
+seed7/prg/panic.sd7          0.097169           2634
+seed7/prg/percolation.sd7    0.043424            330
+seed7/prg/planets.sd7        0.076163           1486
+seed7/prg/portfwd7.sd7       0.038706            139
+seed7/prg/prime.sd7          0.036139             74
+seed7/prg/printpi1.sd7       0.040481             56
+seed7/prg/printpi2.sd7       0.040092             54
+seed7/prg/printpi3.sd7       0.039605             60
+seed7/prg/pv7.sd7            0.045407            337
+seed7/prg/queen.sd7          0.037908            149
+seed7/prg/rand.sd7           0.036655            121
+seed7/prg/raytrace.sd7       0.047225            538
+seed7/prg/rever.sd7          0.052517            816
+seed7/prg/roman.sd7          0.035603             38
+seed7/prg/s7c.sd7            0.279481           9060
+seed7/prg/s7check.sd7        0.036879             68
+seed7/prg/savehd7.sd7        0.069273           1110
+seed7/prg/self.sd7           0.037886             49
+seed7/prg/shisen.sd7         0.071535           1423
+seed7/prg/sl.sd7             0.059962           1029
+seed7/prg/snake.sd7          0.046736            615
+seed7/prg/sokoban.sd7        0.054822            891
+seed7/prg/spigotpi.sd7       0.036108             64
+seed7/prg/sql7.sd7           0.041887            278
+seed7/prg/startrek.sd7       0.058688            979
+seed7/prg/sudoku7.sd7        0.098125           2657
+seed7/prg/sydir7.sd7         0.044339            384
+seed7/prg/syntaxhl.sd7       0.041072            177
+seed7/prg/tak.sd7            0.035492             59
+seed7/prg/tar7.sd7           0.038005            121
+seed7/prg/tch.sd7            0.037016             55
+seed7/prg/testfont.sd7       0.036629             95
+seed7/prg/tet.sd7            0.044924            479
+seed7/prg/tetg.sd7           0.045809            501
+seed7/prg/toutf8.sd7         0.043010            240
+seed7/prg/tst_cli.sd7        0.035760             40
+seed7/prg/tst_srv.sd7        0.035419             47
+seed7/prg/wator.sd7          0.052473            651
+seed7/prg/which.sd7          0.036337             65
+seed7/prg/wiz.sd7            0.104269           2833
+seed7/prg/wordcnt.sd7        0.036399             54
+seed7/prg/wrinum.sd7         0.035339             43
+seed7/prg/wumpus.sd7         0.042575            372
+seed7/lib/aes.s7i            0.109494           1144
+seed7/lib/aes_gcm.s7i        0.046527            392
+seed7/lib/ar.s7i             0.073270           1532
+seed7/lib/arc4.s7i           0.038166            144
+seed7/lib/archive.s7i        0.037774            143
+seed7/lib/archive_base.s7i   0.038116            135
+seed7/lib/array.s7i          0.053386            610
+seed7/lib/asn1.s7i           0.046800            544
+seed7/lib/asn1oid.s7i        0.042060            157
+seed7/lib/basearray.s7i      0.048698            450
+seed7/lib/bigfile.s7i        0.038633            136
+seed7/lib/bigint.s7i         0.055971            824
+seed7/lib/bigrat.s7i         0.054123            784
+seed7/lib/bin16.s7i          0.052170            592
+seed7/lib/bin32.s7i          0.048652            490
+seed7/lib/bin64.s7i          0.050486            539
+seed7/lib/bitdata.s7i        0.076364           1330
+seed7/lib/bitmapfont.s7i     0.041023            215
+seed7/lib/bitset.s7i         0.049424            593
+seed7/lib/bitsetof.s7i       0.047919            431
+seed7/lib/blowfish.s7i       0.056990            383
+seed7/lib/bmp.s7i            0.060244            924
+seed7/lib/boolean.s7i        0.045697            403
+seed7/lib/browser.s7i        0.043108            280
+seed7/lib/bstring.s7i        0.041199            227
+seed7/lib/bytedata.s7i       0.056549            482
+seed7/lib/bzip2.s7i          0.060584            887
+seed7/lib/cards.s7i          0.064838           1342
+seed7/lib/category.s7i       0.040060            209
+seed7/lib/cc_conf.s7i        0.078277           1314
+seed7/lib/ccittfax.s7i       0.066704           1022
+seed7/lib/cgi.s7i            0.038293            109
+seed7/lib/cgidialog.s7i      0.059559           1118
+seed7/lib/char.s7i           0.043720            356
+seed7/lib/charsets.s7i       0.081608           2024
+seed7/lib/chartype.s7i       0.040284            121
+seed7/lib/cipher.s7i         0.038727            146
+seed7/lib/cli_cmds.s7i       0.069219           1360
+seed7/lib/clib_file.s7i      0.043813            301
+seed7/lib/color.s7i          0.040774            185
+seed7/lib/complex.s7i        0.045220            464
+seed7/lib/compress.s7i       0.038646            150
+seed7/lib/console.s7i        0.039630            188
+seed7/lib/cpio.s7i           0.081765           1708
+seed7/lib/crc32.s7i          0.045779            193
+seed7/lib/cronos16.s7i       0.093175           1173
+seed7/lib/cronos27.s7i       0.114209           1464
+seed7/lib/csv.s7i            0.041726            201
+seed7/lib/db_prop.s7i        0.063037            991
+seed7/lib/deflate.s7i        0.056044            740
+seed7/lib/des.s7i            0.055564            444
+seed7/lib/dialog.s7i         0.043690            311
+seed7/lib/dir.s7i            0.039385            163
+seed7/lib/draw.s7i           0.057367            854
+seed7/lib/duration.s7i       0.060964           1038
+seed7/lib/echo.s7i           0.037689            132
+seed7/lib/editline.s7i       0.044639            398
+seed7/lib/elf.s7i            0.085438           1560
+seed7/lib/elliptic.s7i       0.051987            649
+seed7/lib/enable_io.s7i      0.043313            312
+seed7/lib/encoding.s7i       0.059457            931
+seed7/lib/enumeration.s7i    0.041822            236
+seed7/lib/environment.s7i    0.040007            175
+seed7/lib/exif.s7i           0.040886            152
+seed7/lib/external_file.s7i  0.044214            340
+seed7/lib/field.s7i          0.041440            268
+seed7/lib/file.s7i           0.043078            372
+seed7/lib/filebits.s7i       0.035275             46
+seed7/lib/filesys.s7i        0.047118            601
+seed7/lib/fileutil.s7i       0.039214            144
+seed7/lib/fixarray.s7i       0.043883            307
+seed7/lib/float.s7i          0.055109            757
+seed7/lib/font.s7i           0.039499            196
+seed7/lib/font8x8.s7i        0.048153            998
+seed7/lib/forloop.s7i        0.045862            449
+seed7/lib/ftp.s7i            0.058117            969
+seed7/lib/ftpserv.s7i        0.051477            631
+seed7/lib/getf.s7i           0.038182            115
+seed7/lib/gethttp.s7i        0.036014             41
+seed7/lib/gethttps.s7i       0.035870             41
+seed7/lib/gif.s7i            0.049928            561
+seed7/lib/graph.s7i          0.049139            415
+seed7/lib/graph_file.s7i     0.044258            399
+seed7/lib/gtkserver.s7i      0.038470            161
+seed7/lib/gzip.s7i           0.048869            573
+seed7/lib/hash.s7i           0.049862            421
+seed7/lib/hashsetof.s7i      0.048633            499
+seed7/lib/hmac.s7i           0.039043            152
+seed7/lib/html.s7i           0.035660             83
+seed7/lib/html_ent.s7i       0.046984            476
+seed7/lib/htmldom.s7i        0.041681            286
+seed7/lib/http_request.s7i   0.050496            696
+seed7/lib/http_srv_resp.s7i  0.045311            380
+seed7/lib/https_request.s7i  0.044570            211
+seed7/lib/httpserv.s7i       0.044552            345
+seed7/lib/huffman.s7i        0.053092            644
+seed7/lib/ico.s7i            0.041329            221
+seed7/lib/idxarray.s7i       0.042528            232
+seed7/lib/image.s7i          0.037772            156
+seed7/lib/imagefile.s7i      0.039131            171
+seed7/lib/inflate.s7i        0.046395            411
+seed7/lib/inifile.s7i        0.038969            129
+seed7/lib/integer.s7i        0.052813            663
+seed7/lib/iobuffer.s7i       0.043900            289
+seed7/lib/jpeg.s7i           0.082995           1761
+seed7/lib/json.s7i           0.058265            891
+seed7/lib/json_serde.s7i     0.052029            783
+seed7/lib/keybd.s7i          0.055291            639
+seed7/lib/keydescr.s7i       0.056097            192
+seed7/lib/leb128.s7i         0.040648            218
+seed7/lib/line.s7i           0.038338            164
+seed7/lib/listener.s7i       0.040361            247
+seed7/lib/logfile.s7i        0.035610             73
+seed7/lib/lower.s7i          0.037140            142
+seed7/lib/lzma.s7i           0.058298            934
+seed7/lib/lzw.s7i            0.059093            861
+seed7/lib/magic.s7i          0.048402            403
+seed7/lib/mahjng32.s7i       0.063829           1500
+seed7/lib/make.s7i           0.049282            544
+seed7/lib/makedata.s7i       0.070591           1428
+seed7/lib/math.s7i           0.040492            201
+seed7/lib/mixarith.s7i       0.040617            249
+seed7/lib/modern27.s7i       0.085425           1099
+seed7/lib/more.s7i           0.038313            130
+seed7/lib/msgdigest.s7i      0.079045           1222
+seed7/lib/multiscr.s7i       0.036785             68
+seed7/lib/null_file.s7i      0.043915            345
+seed7/lib/osfiles.s7i        0.065068           1085
+seed7/lib/pbm.s7i            0.040481            230
+seed7/lib/pcx.s7i            0.052245            638
+seed7/lib/pem.s7i            0.039688            185
+seed7/lib/pgm.s7i            0.040283            238
+seed7/lib/pic16.s7i          0.047465           1037
+seed7/lib/pic32.s7i          0.078138           2060
+seed7/lib/pic_util.s7i       0.037638            144
+seed7/lib/pixelimage.s7i     0.041235            320
+seed7/lib/pixmap_file.s7i    0.046328            459
+seed7/lib/pixmapfont.s7i     0.040310            184
+seed7/lib/pkcs1.s7i          0.059609            543
+seed7/lib/png.s7i            0.064221           1064
+seed7/lib/poll.s7i           0.044113            313
+seed7/lib/ppm.s7i            0.040455            240
+seed7/lib/process.s7i        0.049164            541
+seed7/lib/progs.s7i          0.056109            789
+seed7/lib/propertyfile.s7i   0.038584            155
+seed7/lib/rational.s7i       0.054055            792
+seed7/lib/ref_list.s7i       0.041781            252
+seed7/lib/reference.s7i      0.038120            126
+seed7/lib/reverse.s7i        0.036521             94
+seed7/lib/rpm.s7i            0.141779           3487
+seed7/lib/rpmext.s7i         0.041589            318
+seed7/lib/scanfile.s7i       0.080508           1779
+seed7/lib/scanjson.s7i       0.046875            413
+seed7/lib/scanstri.s7i       0.080889           1814
+seed7/lib/scantoml.s7i       0.069726           1603
+seed7/lib/seed7_05.s7i       0.066666           1072
+seed7/lib/set.s7i            0.040107             57
+seed7/lib/shell.s7i          0.053247            615
+seed7/lib/showtls.s7i        0.055448            678
+seed7/lib/signature.s7i      0.038409            131
+seed7/lib/smtp.s7i           0.041372            261
+seed7/lib/sockbase.s7i       0.045582            217
+seed7/lib/socket.s7i         0.043808            326
+seed7/lib/sokoban1.s7i       0.060174           1519
+seed7/lib/sql_base.s7i       0.073708           1000
+seed7/lib/stars.s7i          0.135234           1705
+seed7/lib/stdfont10.s7i      0.081112           3347
+seed7/lib/stdfont12.s7i      0.091408           3928
+seed7/lib/stdfont14.s7i      0.103348           4510
+seed7/lib/stdfont16.s7i      0.113775           5092
+seed7/lib/stdfont18.s7i      0.132990           5868
+seed7/lib/stdfont20.s7i      0.149299           6449
+seed7/lib/stdfont24.s7i      0.176378           7421
+seed7/lib/stdfont8.s7i       0.071841           2960
+seed7/lib/stdfont9.s7i       0.075336           3152
+seed7/lib/stdio.s7i          0.039194            192
+seed7/lib/strifile.s7i       0.043203            345
+seed7/lib/string.s7i         0.055536            779
+seed7/lib/stritext.s7i       0.042782            352
+seed7/lib/struct.s7i         0.044153            266
+seed7/lib/struct_elem.s7i    0.037716            129
+seed7/lib/subfile.s7i        0.037787            174
+seed7/lib/subrange.s7i       0.035745             78
+seed7/lib/syntax.s7i         0.043984            294
+seed7/lib/tar.s7i            0.080044           1880
+seed7/lib/tar_cmds.s7i       0.057586            752
+seed7/lib/tdes.s7i           0.039015            143
+seed7/lib/tee.s7i            0.037460            143
+seed7/lib/text.s7i           0.037603            135
+seed7/lib/tga.s7i            0.053236            676
+seed7/lib/tiff.s7i           0.134740           2771
+seed7/lib/time.s7i           0.072735           1191
+seed7/lib/tls.s7i            0.113704           2230
+seed7/lib/unicode.s7i        0.055039            575
+seed7/lib/unionfnd.s7i       0.038785            130
+seed7/lib/upper.s7i          0.038191            142
+seed7/lib/utf16.s7i          0.049407            540
+seed7/lib/utf8.s7i           0.040309            234
+seed7/lib/vecfont10.s7i      0.076328           1056
+seed7/lib/vecfont18.s7i      0.084755           1119
+seed7/lib/vector3d.s7i       0.040299            293
+seed7/lib/vectorfont.s7i     0.039101            239
+seed7/lib/wildcard.s7i       0.036769            140
+seed7/lib/window.s7i         0.045329            455
+seed7/lib/wrinum.s7i         0.041868            248
+seed7/lib/x509cert.s7i       0.071450           1243
+seed7/lib/xml_ent.s7i        0.037724             94
+seed7/lib/xmldom.s7i         0.041574            303
+seed7/lib/xz.s7i             0.045782            442
+seed7/lib/zip.s7i            0.119727           2792
+seed7/lib/zstd.s7i           0.073320           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.089429        |
++-----------+-----------------+
+| Minimum   | 0.034406        |
++-----------+-----------------+
+| Maximum   | 2.496171        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.044043            190
+seed7/prg/bas7.sd7           0.761290          11459
+seed7/prg/bifurk.sd7         0.037806             73
+seed7/prg/bigfiles.sd7       0.040720            129
+seed7/prg/brainf7.sd7        0.038809             86
+seed7/prg/calc7.sd7          0.041359            128
+seed7/prg/carddemo.sd7       0.046302            190
+seed7/prg/castle.sd7         0.216848           3148
+seed7/prg/cat.sd7            0.040526             82
+seed7/prg/cellauto.sd7       0.039652             85
+seed7/prg/celsius.sd7        0.036889             42
+seed7/prg/chk_all.sd7        0.081366            843
+seed7/prg/chkarr.sd7         0.851535           8367
+seed7/prg/chkbig.sd7         4.084797          29026
+seed7/prg/chkbin.sd7         1.018055           6469
+seed7/prg/chkbitdata.sd7     1.233478           6624
+seed7/prg/chkbool.sd7        0.228829           3157
+seed7/prg/chkbst.sd7         0.099843            722
+seed7/prg/chkchr.sd7         0.474373           2809
+seed7/prg/chkcmd.sd7         0.115977           1205
+seed7/prg/chkdb.sd7          0.744669           7454
+seed7/prg/chkdecl.sd7        0.093474            448
+seed7/prg/chkenum.sd7        0.123918           1230
+seed7/prg/chkerr.sd7         0.338435           4663
+seed7/prg/chkexc.sd7         0.147061           2627
+seed7/prg/chkfil.sd7         0.127299           1615
+seed7/prg/chkflt.sd7         2.801449          20620
+seed7/prg/chkhent.sd7        0.038329             54
+seed7/prg/chkhsh.sd7         0.505229           4548
+seed7/prg/chkidx.sd7         3.228355          19567
+seed7/prg/chkint.sd7         5.568652          38129
+seed7/prg/chkjson.sd7        0.192956           1764
+seed7/prg/chkovf.sd7         1.200365           8216
+seed7/prg/chkprc.sd7         0.693852          10111
+seed7/prg/chkscan.sd7        0.092691            714
+seed7/prg/chkset.sd7         1.728276          11974
+seed7/prg/chkstr.sd7         3.432734          26952
+seed7/prg/chktime.sd7        0.260754           2025
+seed7/prg/chktoml.sd7        0.214876           1656
+seed7/prg/clock.sd7          0.044160             47
+seed7/prg/clock2.sd7         0.044262             43
+seed7/prg/clock3.sd7         0.050889             95
+seed7/prg/cmpfil.sd7         0.042903             84
+seed7/prg/comanche.sd7       0.048117            180
+seed7/prg/confval.sd7        0.052390            175
+seed7/prg/db7.sd7            0.064471            417
+seed7/prg/diff7.sd7          0.055104            263
+seed7/prg/dirtst.sd7         0.041120             42
+seed7/prg/dirx.sd7           0.049810            152
+seed7/prg/dnafight.sd7       0.126617           1381
+seed7/prg/dragon.sd7         0.039337             73
+seed7/prg/echo.sd7           0.039400             39
+seed7/prg/eliza.sd7          0.052310            302
+seed7/prg/err.sd7            0.044755             96
+seed7/prg/fannkuch.sd7       0.043158            131
+seed7/prg/fib.sd7            0.037299             47
+seed7/prg/find7.sd7          0.042370            133
+seed7/prg/findchar.sd7       0.044761            149
+seed7/prg/fractree.sd7       0.039631             55
+seed7/prg/ftp7.sd7           0.054607            296
+seed7/prg/ftpserv.sd7        0.039435             74
+seed7/prg/gcd.sd7            0.040399            109
+seed7/prg/gkbd.sd7           0.061395            358
+seed7/prg/gtksvtst.sd7       0.039491             94
+seed7/prg/hal.sd7            0.048104            250
+seed7/prg/hamu.sd7           0.065818            573
+seed7/prg/hanoi.sd7          0.036324             55
+seed7/prg/hd.sd7             0.038379             79
+seed7/prg/hello.sd7          0.036382             32
+seed7/prg/hilbert.sd7        0.040083            108
+seed7/prg/ide7.sd7           0.046804            196
+seed7/prg/kbd.sd7            0.036049             49
+seed7/prg/klondike.sd7       0.086149            883
+seed7/prg/lander.sd7         0.130705           1551
+seed7/prg/lst80bas.sd7       0.056570            344
+seed7/prg/lst99bas.sd7       0.059755            401
+seed7/prg/lstgwbas.sd7       0.073587            577
+seed7/prg/mahjong.sd7        0.146112           1943
+seed7/prg/make7.sd7          0.042296            121
+seed7/prg/mandelbr.sd7       0.047678            237
+seed7/prg/mind.sd7           0.059419            443
+seed7/prg/mirror.sd7         0.042765            131
+seed7/prg/ms.sd7             0.067610            641
+seed7/prg/nicoma.sd7         0.040922            135
+seed7/prg/pac.sd7            0.072125            726
+seed7/prg/pairs.sd7          0.138775           2025
+seed7/prg/panic.sd7          0.191222           2634
+seed7/prg/percolation.sd7    0.055884            330
+seed7/prg/planets.sd7        0.135523           1486
+seed7/prg/portfwd7.sd7       0.042853            139
+seed7/prg/prime.sd7          0.038143             74
+seed7/prg/printpi1.sd7       0.037563             56
+seed7/prg/printpi2.sd7       0.037249             54
+seed7/prg/printpi3.sd7       0.037699             60
+seed7/prg/pv7.sd7            0.059087            337
+seed7/prg/queen.sd7          0.042949            149
+seed7/prg/rand.sd7           0.039565            121
+seed7/prg/raytrace.sd7       0.067138            538
+seed7/prg/rever.sd7          0.080913            816
+seed7/prg/roman.sd7          0.035310             38
+seed7/prg/s7c.sd7            0.625425           9060
+seed7/prg/s7check.sd7        0.040886             68
+seed7/prg/savehd7.sd7        0.110824           1110
+seed7/prg/self.sd7           0.037695             49
+seed7/prg/shisen.sd7         0.124520           1423
+seed7/prg/sl.sd7             0.095575           1029
+seed7/prg/snake.sd7          0.070423            615
+seed7/prg/sokoban.sd7        0.088764            891
+seed7/prg/spigotpi.sd7       0.037769             64
+seed7/prg/sql7.sd7           0.051405            278
+seed7/prg/startrek.sd7       0.094862            979
+seed7/prg/sudoku7.sd7        0.199585           2657
+seed7/prg/sydir7.sd7         0.064351            384
+seed7/prg/syntaxhl.sd7       0.051085            177
+seed7/prg/tak.sd7            0.039519             59
+seed7/prg/tar7.sd7           0.043091            121
+seed7/prg/tch.sd7            0.037877             55
+seed7/prg/testfont.sd7       0.041535             95
+seed7/prg/tet.sd7            0.060080            479
+seed7/prg/tetg.sd7           0.062963            501
+seed7/prg/toutf8.sd7         0.051079            240
+seed7/prg/tst_cli.sd7        0.036252             40
+seed7/prg/tst_srv.sd7        0.038750             47
+seed7/prg/wator.sd7          0.081767            651
+seed7/prg/which.sd7          0.036830             65
+seed7/prg/wiz.sd7            0.205001           2833
+seed7/prg/wordcnt.sd7        0.036438             54
+seed7/prg/wrinum.sd7         0.039229             43
+seed7/prg/wumpus.sd7         0.056501            372
+seed7/lib/aes.s7i            0.196393           1144
+seed7/lib/aes_gcm.s7i        0.059567            392
+seed7/lib/ar.s7i             0.124379           1532
+seed7/lib/arc4.s7i           0.045942            144
+seed7/lib/archive.s7i        0.045434            143
+seed7/lib/archive_base.s7i   0.044834            135
+seed7/lib/array.s7i          0.076218            610
+seed7/lib/asn1.s7i           0.066125            544
+seed7/lib/asn1oid.s7i        0.049419            157
+seed7/lib/basearray.s7i      0.063225            450
+seed7/lib/bigfile.s7i        0.041269            136
+seed7/lib/bigint.s7i         0.078021            824
+seed7/lib/bigrat.s7i         0.077024            784
+seed7/lib/bin16.s7i          0.066102            592
+seed7/lib/bin32.s7i          0.062429            490
+seed7/lib/bin64.s7i          0.065742            539
+seed7/lib/bitdata.s7i        0.122960           1330
+seed7/lib/bitmapfont.s7i     0.046797            215
+seed7/lib/bitset.s7i         0.065207            593
+seed7/lib/bitsetof.s7i       0.061556            431
+seed7/lib/blowfish.s7i       0.075349            383
+seed7/lib/bmp.s7i            0.099732            924
+seed7/lib/boolean.s7i        0.053085            403
+seed7/lib/browser.s7i        0.054674            280
+seed7/lib/bstring.s7i        0.048790            227
+seed7/lib/bytedata.s7i       0.065982            482
+seed7/lib/bzip2.s7i          0.088645            887
+seed7/lib/cards.s7i          0.103983           1342
+seed7/lib/category.s7i       0.048680            209
+seed7/lib/cc_conf.s7i        0.121028           1314
+seed7/lib/ccittfax.s7i       0.100516           1022
+seed7/lib/cgi.s7i            0.040969            109
+seed7/lib/cgidialog.s7i      0.102216           1118
+seed7/lib/char.s7i           0.052243            356
+seed7/lib/charsets.s7i       0.125377           2024
+seed7/lib/chartype.s7i       0.049462            121
+seed7/lib/cipher.s7i         0.042020            146
+seed7/lib/cli_cmds.s7i       0.119669           1360
+seed7/lib/clib_file.s7i      0.052086            301
+seed7/lib/color.s7i          0.048158            185
+seed7/lib/complex.s7i        0.058405            464
+seed7/lib/compress.s7i       0.044190            150
+seed7/lib/console.s7i        0.046481            188
+seed7/lib/cpio.s7i           0.147173           1708
+seed7/lib/crc32.s7i          0.057249            193
+seed7/lib/cronos16.s7i       0.196019           1173
+seed7/lib/cronos27.s7i       0.257794           1464
+seed7/lib/csv.s7i            0.047730            201
+seed7/lib/db_prop.s7i        0.104501            991
+seed7/lib/deflate.s7i        0.089899            740
+seed7/lib/des.s7i            0.080493            444
+seed7/lib/dialog.s7i         0.056441            311
+seed7/lib/dir.s7i            0.042988            163
+seed7/lib/draw.s7i           0.085588            854
+seed7/lib/duration.s7i       0.110294           1038
+seed7/lib/echo.s7i           0.041104            132
+seed7/lib/editline.s7i       0.058000            398
+seed7/lib/elf.s7i            0.151105           1560
+seed7/lib/elliptic.s7i       0.074565            649
+seed7/lib/enable_io.s7i      0.050040            312
+seed7/lib/encoding.s7i       0.094896            931
+seed7/lib/enumeration.s7i    0.049185            236
+seed7/lib/environment.s7i    0.044357            175
+seed7/lib/exif.s7i           0.045313            152
+seed7/lib/external_file.s7i  0.052170            340
+seed7/lib/field.s7i          0.052184            268
+seed7/lib/file.s7i           0.053542            372
+seed7/lib/filebits.s7i       0.038446             46
+seed7/lib/filesys.s7i        0.064451            601
+seed7/lib/fileutil.s7i       0.049495            144
+seed7/lib/fixarray.s7i       0.057296            307
+seed7/lib/float.s7i          0.074604            757
+seed7/lib/font.s7i           0.045066            196
+seed7/lib/font8x8.s7i        0.071063            998
+seed7/lib/forloop.s7i        0.059519            449
+seed7/lib/ftp.s7i            0.086566            969
+seed7/lib/ftpserv.s7i        0.074657            631
+seed7/lib/getf.s7i           0.039761            115
+seed7/lib/gethttp.s7i        0.035736             41
+seed7/lib/gethttps.s7i       0.035994             41
+seed7/lib/gif.s7i            0.070212            561
+seed7/lib/graph.s7i          0.062322            415
+seed7/lib/graph_file.s7i     0.055790            399
+seed7/lib/gtkserver.s7i      0.040408            161
+seed7/lib/gzip.s7i           0.068386            573
+seed7/lib/hash.s7i           0.064031            421
+seed7/lib/hashsetof.s7i      0.065339            499
+seed7/lib/hmac.s7i           0.044045            152
+seed7/lib/html.s7i           0.038831             83
+seed7/lib/html_ent.s7i       0.062614            476
+seed7/lib/htmldom.s7i        0.051804            286
+seed7/lib/http_request.s7i   0.077055            696
+seed7/lib/http_srv_resp.s7i  0.058525            380
+seed7/lib/https_request.s7i  0.047858            211
+seed7/lib/httpserv.s7i       0.055744            345
+seed7/lib/huffman.s7i        0.075352            644
+seed7/lib/ico.s7i            0.049664            221
+seed7/lib/idxarray.s7i       0.051990            232
+seed7/lib/image.s7i          0.045121            156
+seed7/lib/imagefile.s7i      0.046944            171
+seed7/lib/inflate.s7i        0.064192            411
+seed7/lib/inifile.s7i        0.044656            129
+seed7/lib/integer.s7i        0.071362            663
+seed7/lib/iobuffer.s7i       0.051453            289
+seed7/lib/jpeg.s7i           0.159663           1761
+seed7/lib/json.s7i           0.084975            891
+seed7/lib/json_serde.s7i     0.078812            783
+seed7/lib/keybd.s7i          0.078735            639
+seed7/lib/keydescr.s7i       0.048812            192
+seed7/lib/leb128.s7i         0.046395            218
+seed7/lib/line.s7i           0.044031            164
+seed7/lib/listener.s7i       0.049332            247
+seed7/lib/logfile.s7i        0.039351             73
+seed7/lib/lower.s7i          0.047881            142
+seed7/lib/lzma.s7i           0.098320            934
+seed7/lib/lzw.s7i            0.097149            861
+seed7/lib/magic.s7i          0.066686            403
+seed7/lib/mahjng32.s7i       0.100803           1500
+seed7/lib/make.s7i           0.081508            544
+seed7/lib/makedata.s7i       0.129069           1428
+seed7/lib/math.s7i           0.050899            201
+seed7/lib/mixarith.s7i       0.053948            249
+seed7/lib/modern27.s7i       0.170187           1099
+seed7/lib/more.s7i           0.043061            130
+seed7/lib/msgdigest.s7i      0.140929           1222
+seed7/lib/multiscr.s7i       0.039469             68
+seed7/lib/null_file.s7i      0.051229            345
+seed7/lib/osfiles.s7i        0.096713           1085
+seed7/lib/pbm.s7i            0.053124            230
+seed7/lib/pcx.s7i            0.077503            638
+seed7/lib/pem.s7i            0.046304            185
+seed7/lib/pgm.s7i            0.048565            238
+seed7/lib/pic16.s7i          0.066738           1037
+seed7/lib/pic32.s7i          0.121116           2060
+seed7/lib/pic_util.s7i       0.043748            144
+seed7/lib/pixelimage.s7i     0.052286            320
+seed7/lib/pixmap_file.s7i    0.061152            459
+seed7/lib/pixmapfont.s7i     0.047814            184
+seed7/lib/pkcs1.s7i          0.077292            543
+seed7/lib/png.s7i            0.106897           1064
+seed7/lib/poll.s7i           0.050749            313
+seed7/lib/ppm.s7i            0.046732            240
+seed7/lib/process.s7i        0.064112            541
+seed7/lib/progs.s7i          0.079950            789
+seed7/lib/propertyfile.s7i   0.043563            155
+seed7/lib/rational.s7i       0.076479            792
+seed7/lib/ref_list.s7i       0.047926            252
+seed7/lib/reference.s7i      0.040281            126
+seed7/lib/reverse.s7i        0.039306             94
+seed7/lib/rpm.s7i            0.283729           3487
+seed7/lib/rpmext.s7i         0.051510            318
+seed7/lib/scanfile.s7i       0.132139           1779
+seed7/lib/scanjson.s7i       0.059605            413
+seed7/lib/scanstri.s7i       0.135661           1814
+seed7/lib/scantoml.s7i       0.138296           1603
+seed7/lib/seed7_05.s7i       0.124148           1072
+seed7/lib/set.s7i            0.044556             57
+seed7/lib/shell.s7i          0.079783            615
+seed7/lib/showtls.s7i        0.089101            678
+seed7/lib/signature.s7i      0.045465            131
+seed7/lib/smtp.s7i           0.053324            261
+seed7/lib/sockbase.s7i       0.050600            217
+seed7/lib/socket.s7i         0.052448            326
+seed7/lib/sokoban1.s7i       0.080155           1519
+seed7/lib/sql_base.s7i       0.093349           1000
+seed7/lib/stars.s7i          0.232391           1705
+seed7/lib/stdfont10.s7i      0.144228           3347
+seed7/lib/stdfont12.s7i      0.167185           3928
+seed7/lib/stdfont14.s7i      0.188558           4510
+seed7/lib/stdfont16.s7i      0.222554           5092
+seed7/lib/stdfont18.s7i      0.251189           5868
+seed7/lib/stdfont20.s7i      0.281307           6449
+seed7/lib/stdfont24.s7i      0.339444           7421
+seed7/lib/stdfont8.s7i       0.130051           2960
+seed7/lib/stdfont9.s7i       0.136156           3152
+seed7/lib/stdio.s7i          0.046398            192
+seed7/lib/strifile.s7i       0.055347            345
+seed7/lib/string.s7i         0.079022            779
+seed7/lib/stritext.s7i       0.060105            352
+seed7/lib/struct.s7i         0.058091            266
+seed7/lib/struct_elem.s7i    0.042407            129
+seed7/lib/subfile.s7i        0.045478            174
+seed7/lib/subrange.s7i       0.040622             78
+seed7/lib/syntax.s7i         0.061688            294
+seed7/lib/tar.s7i            0.147378           1880
+seed7/lib/tar_cmds.s7i       0.085014            752
+seed7/lib/tdes.s7i           0.044914            143
+seed7/lib/tee.s7i            0.041910            143
+seed7/lib/text.s7i           0.041526            135
+seed7/lib/tga.s7i            0.081030            676
+seed7/lib/tiff.s7i           0.243364           2771
+seed7/lib/time.s7i           0.100108           1191
+seed7/lib/tls.s7i            0.195651           2230
+seed7/lib/unicode.s7i        0.071961            575
+seed7/lib/unionfnd.s7i       0.042839            130
+seed7/lib/upper.s7i          0.041995            142
+seed7/lib/utf16.s7i          0.065447            540
+seed7/lib/utf8.s7i           0.047258            234
+seed7/lib/vecfont10.s7i      0.159098           1056
+seed7/lib/vecfont18.s7i      0.182680           1119
+seed7/lib/vector3d.s7i       0.051794            293
+seed7/lib/vectorfont.s7i     0.047042            239
+seed7/lib/wildcard.s7i       0.042381            140
+seed7/lib/window.s7i         0.079210            455
+seed7/lib/wrinum.s7i         0.050407            248
+seed7/lib/x509cert.s7i       0.118430           1243
+seed7/lib/xml_ent.s7i        0.041746             94
+seed7/lib/xmldom.s7i         0.050891            303
+seed7/lib/xz.s7i             0.060305            442
+seed7/lib/zip.s7i            0.229137           2792
+seed7/lib/zstd.s7i           0.115733           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.159359        |
++-----------+-----------------+
+| Minimum   | 0.035310        |
++-----------+-----------------+
+| Maximum   | 5.568652        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.034296        | 0.032424        | 0.046170        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.038740        | 0.034987        | 0.048164        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.089429        | 0.034406        | 2.496171        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.159359        | 0.035310        | 5.568652        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.843 | 00:00:58.432 | 00:01:11.276 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.727 | 00:01:06.059 | 00:01:20.787 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:35.941 | 00:02:33.310 | 00:03:09.251 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:00.844 | 00:04:32.461 | 00:05:33.306 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:14.628 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-08.1.rst
+++ b/reports/seed7mode-perf-08.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-24T20:06:11+0000 W26-3
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 16:16:15 local time
+:Generated on: 2026-06-24 20:27:37 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 230x84 chars
+:Window body: 230x82 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.035241            190
+seed7/prg/bas7.sd7           0.038376          11459
+seed7/prg/bifurk.sd7         0.037395             73
+seed7/prg/bigfiles.sd7       0.039219            129
+seed7/prg/brainf7.sd7        0.037962             86
+seed7/prg/calc7.sd7          0.038670            128
+seed7/prg/carddemo.sd7       0.039275            190
+seed7/prg/castle.sd7         0.037289           3148
+seed7/prg/cat.sd7            0.036480             82
+seed7/prg/cellauto.sd7       0.038929             85
+seed7/prg/celsius.sd7        0.037035             42
+seed7/prg/chk_all.sd7        0.034584            843
+seed7/prg/chkarr.sd7         0.038375           8367
+seed7/prg/chkbig.sd7         0.042510          29026
+seed7/prg/chkbin.sd7         0.037422           6469
+seed7/prg/chkbitdata.sd7     0.036582           6624
+seed7/prg/chkbool.sd7        0.036234           3157
+seed7/prg/chkbst.sd7         0.035026            722
+seed7/prg/chkchr.sd7         0.035250           2809
+seed7/prg/chkcmd.sd7         0.036530           1205
+seed7/prg/chkdb.sd7          0.038499           7454
+seed7/prg/chkdecl.sd7        0.039028            448
+seed7/prg/chkenum.sd7        0.036263           1230
+seed7/prg/chkerr.sd7         0.037605           4663
+seed7/prg/chkexc.sd7         0.034370           2627
+seed7/prg/chkfil.sd7         0.034859           1615
+seed7/prg/chkflt.sd7         0.037251          20620
+seed7/prg/chkhent.sd7        0.034141             54
+seed7/prg/chkhsh.sd7         0.034528           4548
+seed7/prg/chkidx.sd7         0.037448          19567
+seed7/prg/chkint.sd7         0.042845          38129
+seed7/prg/chkjson.sd7        0.036518           1764
+seed7/prg/chkovf.sd7         0.035646           8216
+seed7/prg/chkprc.sd7         0.038502          10111
+seed7/prg/chkscan.sd7        0.037379            714
+seed7/prg/chkset.sd7         0.039252          11974
+seed7/prg/chkstr.sd7         0.042594          26952
+seed7/prg/chktime.sd7        0.036842           2025
+seed7/prg/chktoml.sd7        0.038461           1656
+seed7/prg/clock.sd7          0.039058             47
+seed7/prg/clock2.sd7         0.036827             43
+seed7/prg/clock3.sd7         0.038126             95
+seed7/prg/cmpfil.sd7         0.039354             84
+seed7/prg/comanche.sd7       0.037296            180
+seed7/prg/confval.sd7        0.037637            175
+seed7/prg/db7.sd7            0.039785            417
+seed7/prg/diff7.sd7          0.043105            263
+seed7/prg/dirtst.sd7         0.035440             42
+seed7/prg/dirx.sd7           0.035194            152
+seed7/prg/dnafight.sd7       0.033811           1381
+seed7/prg/dragon.sd7         0.037449             73
+seed7/prg/echo.sd7           0.039672             39
+seed7/prg/eliza.sd7          0.041850            302
+seed7/prg/err.sd7            0.040254             96
+seed7/prg/fannkuch.sd7       0.036702            131
+seed7/prg/fib.sd7            0.036128             47
+seed7/prg/find7.sd7          0.036158            133
+seed7/prg/findchar.sd7       0.035612            149
+seed7/prg/fractree.sd7       0.034141             55
+seed7/prg/ftp7.sd7           0.036745            296
+seed7/prg/ftpserv.sd7        0.039154             74
+seed7/prg/gcd.sd7            0.038448            109
+seed7/prg/gkbd.sd7           0.033284            358
+seed7/prg/gtksvtst.sd7       0.032541             94
+seed7/prg/hal.sd7            0.032904            250
+seed7/prg/hamu.sd7           0.032855            573
+seed7/prg/hanoi.sd7          0.033611             55
+seed7/prg/hd.sd7             0.033659             79
+seed7/prg/hello.sd7          0.033550             32
+seed7/prg/hilbert.sd7        0.039784            108
+seed7/prg/ide7.sd7           0.038864            196
+seed7/prg/kbd.sd7            0.036629             49
+seed7/prg/klondike.sd7       0.038635            883
+seed7/prg/lander.sd7         0.036310           1551
+seed7/prg/lst80bas.sd7       0.033830            344
+seed7/prg/lst99bas.sd7       0.033506            401
+seed7/prg/lstgwbas.sd7       0.033321            577
+seed7/prg/mahjong.sd7        0.037900           1943
+seed7/prg/make7.sd7          0.037232            121
+seed7/prg/mandelbr.sd7       0.037995            237
+seed7/prg/mind.sd7           0.036958            443
+seed7/prg/mirror.sd7         0.033868            131
+seed7/prg/ms.sd7             0.036356            641
+seed7/prg/nicoma.sd7         0.036693            135
+seed7/prg/pac.sd7            0.036025            726
+seed7/prg/pairs.sd7          0.037780           2025
+seed7/prg/panic.sd7          0.038203           2634
+seed7/prg/percolation.sd7    0.039838            330
+seed7/prg/planets.sd7        0.036715           1486
+seed7/prg/portfwd7.sd7       0.037517            139
+seed7/prg/prime.sd7          0.036263             74
+seed7/prg/printpi1.sd7       0.039065             56
+seed7/prg/printpi2.sd7       0.039221             54
+seed7/prg/printpi3.sd7       0.037425             60
+seed7/prg/pv7.sd7            0.038217            337
+seed7/prg/queen.sd7          0.037499            149
+seed7/prg/rand.sd7           0.036803            121
+seed7/prg/raytrace.sd7       0.037882            538
+seed7/prg/rever.sd7          0.039364            816
+seed7/prg/roman.sd7          0.036049             38
+seed7/prg/s7c.sd7            0.036163           9060
+seed7/prg/s7check.sd7        0.035309             68
+seed7/prg/savehd7.sd7        0.035994           1110
+seed7/prg/self.sd7           0.035792             49
+seed7/prg/shisen.sd7         0.035134           1423
+seed7/prg/sl.sd7             0.035013           1029
+seed7/prg/snake.sd7          0.035422            615
+seed7/prg/sokoban.sd7        0.035848            891
+seed7/prg/spigotpi.sd7       0.035297             64
+seed7/prg/sql7.sd7           0.035384            278
+seed7/prg/startrek.sd7       0.035636            979
+seed7/prg/sudoku7.sd7        0.035731           2657
+seed7/prg/sydir7.sd7         0.035634            384
+seed7/prg/syntaxhl.sd7       0.035416            177
+seed7/prg/tak.sd7            0.036308             59
+seed7/prg/tar7.sd7           0.036031            121
+seed7/prg/tch.sd7            0.035544             55
+seed7/prg/testfont.sd7       0.035349             95
+seed7/prg/tet.sd7            0.035913            479
+seed7/prg/tetg.sd7           0.035778            501
+seed7/prg/toutf8.sd7         0.035574            240
+seed7/prg/tst_cli.sd7        0.035636             40
+seed7/prg/tst_srv.sd7        0.035361             47
+seed7/prg/wator.sd7          0.035606            651
+seed7/prg/which.sd7          0.035293             65
+seed7/prg/wiz.sd7            0.035968           2833
+seed7/prg/wordcnt.sd7        0.035715             54
+seed7/prg/wrinum.sd7         0.036109             43
+seed7/prg/wumpus.sd7         0.035628            372
+seed7/lib/aes.s7i            0.036033           1144
+seed7/lib/aes_gcm.s7i        0.035703            392
+seed7/lib/ar.s7i             0.035649           1532
+seed7/lib/arc4.s7i           0.035693            144
+seed7/lib/archive.s7i        0.038287            143
+seed7/lib/archive_base.s7i   0.037539            135
+seed7/lib/array.s7i          0.035550            610
+seed7/lib/asn1.s7i           0.035646            544
+seed7/lib/asn1oid.s7i        0.035394            157
+seed7/lib/basearray.s7i      0.035490            450
+seed7/lib/bigfile.s7i        0.036883            136
+seed7/lib/bigint.s7i         0.037139            824
+seed7/lib/bigrat.s7i         0.037357            784
+seed7/lib/bin16.s7i          0.037513            592
+seed7/lib/bin32.s7i          0.036003            490
+seed7/lib/bin64.s7i          0.035610            539
+seed7/lib/bitdata.s7i        0.037295           1330
+seed7/lib/bitmapfont.s7i     0.038779            215
+seed7/lib/bitset.s7i         0.036625            593
+seed7/lib/bitsetof.s7i       0.036407            431
+seed7/lib/blowfish.s7i       0.036031            383
+seed7/lib/bmp.s7i            0.035643            924
+seed7/lib/boolean.s7i        0.035627            403
+seed7/lib/browser.s7i        0.035893            280
+seed7/lib/bstring.s7i        0.036215            227
+seed7/lib/bytedata.s7i       0.036793            482
+seed7/lib/bzip2.s7i          0.035493            887
+seed7/lib/cards.s7i          0.035425           1342
+seed7/lib/category.s7i       0.037443            209
+seed7/lib/cc_conf.s7i        0.037080           1314
+seed7/lib/ccittfax.s7i       0.036521           1022
+seed7/lib/cgi.s7i            0.036073            109
+seed7/lib/cgidialog.s7i      0.036848           1118
+seed7/lib/char.s7i           0.036905            356
+seed7/lib/charsets.s7i       0.036903           2024
+seed7/lib/chartype.s7i       0.037469            121
+seed7/lib/cipher.s7i         0.037203            146
+seed7/lib/cli_cmds.s7i       0.040110           1360
+seed7/lib/clib_file.s7i      0.035552            301
+seed7/lib/color.s7i          0.035836            185
+seed7/lib/complex.s7i        0.036764            464
+seed7/lib/compress.s7i       0.035957            150
+seed7/lib/console.s7i        0.035643            188
+seed7/lib/cpio.s7i           0.036135           1708
+seed7/lib/crc32.s7i          0.035914            193
+seed7/lib/cronos16.s7i       0.037425           1173
+seed7/lib/cronos27.s7i       0.036352           1464
+seed7/lib/csv.s7i            0.035733            201
+seed7/lib/db_prop.s7i        0.035746            991
+seed7/lib/deflate.s7i        0.035288            740
+seed7/lib/des.s7i            0.035835            444
+seed7/lib/dialog.s7i         0.035153            311
+seed7/lib/dir.s7i            0.035147            163
+seed7/lib/draw.s7i           0.035446            854
+seed7/lib/duration.s7i       0.035423           1038
+seed7/lib/echo.s7i           0.035629            132
+seed7/lib/editline.s7i       0.035664            398
+seed7/lib/elf.s7i            0.036652           1560
+seed7/lib/elliptic.s7i       0.035544            649
+seed7/lib/enable_io.s7i      0.035351            312
+seed7/lib/encoding.s7i       0.035690            931
+seed7/lib/enumeration.s7i    0.035376            236
+seed7/lib/environment.s7i    0.037663            175
+seed7/lib/exif.s7i           0.037860            152
+seed7/lib/external_file.s7i  0.037727            340
+seed7/lib/field.s7i          0.035791            268
+seed7/lib/file.s7i           0.036006            372
+seed7/lib/filebits.s7i       0.038272             46
+seed7/lib/filesys.s7i        0.035751            601
+seed7/lib/fileutil.s7i       0.036457            144
+seed7/lib/fixarray.s7i       0.039769            307
+seed7/lib/float.s7i          0.037586            757
+seed7/lib/font.s7i           0.037277            196
+seed7/lib/font8x8.s7i        0.035864            998
+seed7/lib/forloop.s7i        0.035946            449
+seed7/lib/ftp.s7i            0.035666            969
+seed7/lib/ftpserv.s7i        0.035711            631
+seed7/lib/getf.s7i           0.035762            115
+seed7/lib/gethttp.s7i        0.036198             41
+seed7/lib/gethttps.s7i       0.035677             41
+seed7/lib/gif.s7i            0.035749            561
+seed7/lib/graph.s7i          0.035662            415
+seed7/lib/graph_file.s7i     0.036092            399
+seed7/lib/gtkserver.s7i      0.035921            161
+seed7/lib/gzip.s7i           0.036002            573
+seed7/lib/hash.s7i           0.035552            421
+seed7/lib/hashsetof.s7i      0.035393            499
+seed7/lib/hmac.s7i           0.035142            152
+seed7/lib/html.s7i           0.035536             83
+seed7/lib/html_ent.s7i       0.035958            476
+seed7/lib/htmldom.s7i        0.036176            286
+seed7/lib/http_request.s7i   0.035601            696
+seed7/lib/http_srv_resp.s7i  0.035657            380
+seed7/lib/https_request.s7i  0.035416            211
+seed7/lib/httpserv.s7i       0.035430            345
+seed7/lib/huffman.s7i        0.035340            644
+seed7/lib/ico.s7i            0.035543            221
+seed7/lib/idxarray.s7i       0.038135            232
+seed7/lib/image.s7i          0.035204            156
+seed7/lib/imagefile.s7i      0.035563            171
+seed7/lib/inflate.s7i        0.035814            411
+seed7/lib/inifile.s7i        0.035506            129
+seed7/lib/integer.s7i        0.035448            663
+seed7/lib/iobuffer.s7i       0.035896            289
+seed7/lib/jpeg.s7i           0.037571           1761
+seed7/lib/json.s7i           0.035496            891
+seed7/lib/json_serde.s7i     0.035641            783
+seed7/lib/keybd.s7i          0.036139            639
+seed7/lib/keydescr.s7i       0.035831            192
+seed7/lib/leb128.s7i         0.035587            218
+seed7/lib/line.s7i           0.036402            164
+seed7/lib/listener.s7i       0.035910            247
+seed7/lib/logfile.s7i        0.035962             73
+seed7/lib/lower.s7i          0.036275            142
+seed7/lib/lzma.s7i           0.035664            934
+seed7/lib/lzw.s7i            0.035757            861
+seed7/lib/magic.s7i          0.035778            403
+seed7/lib/mahjng32.s7i       0.035215           1500
+seed7/lib/make.s7i           0.034988            544
+seed7/lib/makedata.s7i       0.035254           1428
+seed7/lib/math.s7i           0.037285            201
+seed7/lib/mixarith.s7i       0.037893            249
+seed7/lib/modern27.s7i       0.038636           1099
+seed7/lib/more.s7i           0.036715            130
+seed7/lib/msgdigest.s7i      0.036945           1222
+seed7/lib/multiscr.s7i       0.035789             68
+seed7/lib/null_file.s7i      0.035936            345
+seed7/lib/osfiles.s7i        0.039235           1085
+seed7/lib/pbm.s7i            0.039897            230
+seed7/lib/pcx.s7i            0.037920            638
+seed7/lib/pem.s7i            0.037015            185
+seed7/lib/pgm.s7i            0.037123            238
+seed7/lib/pic16.s7i          0.036079           1037
+seed7/lib/pic32.s7i          0.035968           2060
+seed7/lib/pic_util.s7i       0.036327            144
+seed7/lib/pixelimage.s7i     0.035905            320
+seed7/lib/pixmap_file.s7i    0.035878            459
+seed7/lib/pixmapfont.s7i     0.037201            184
+seed7/lib/pkcs1.s7i          0.039783            543
+seed7/lib/png.s7i            0.036355           1064
+seed7/lib/poll.s7i           0.035588            313
+seed7/lib/ppm.s7i            0.034980            240
+seed7/lib/process.s7i        0.035203            541
+seed7/lib/progs.s7i          0.036530            789
+seed7/lib/propertyfile.s7i   0.036523            155
+seed7/lib/rational.s7i       0.035060            792
+seed7/lib/ref_list.s7i       0.035152            252
+seed7/lib/reference.s7i      0.035064            126
+seed7/lib/reverse.s7i        0.034842             94
+seed7/lib/rpm.s7i            0.035189           3487
+seed7/lib/rpmext.s7i         0.035424            318
+seed7/lib/scanfile.s7i       0.036550           1779
+seed7/lib/scanjson.s7i       0.036392            413
+seed7/lib/scanstri.s7i       0.036820           1814
+seed7/lib/scantoml.s7i       0.036669           1603
+seed7/lib/seed7_05.s7i       0.040249           1072
+seed7/lib/set.s7i            0.039580             57
+seed7/lib/shell.s7i          0.039032            615
+seed7/lib/showtls.s7i        0.037479            678
+seed7/lib/signature.s7i      0.036567            131
+seed7/lib/smtp.s7i           0.036383            261
+seed7/lib/sockbase.s7i       0.035454            217
+seed7/lib/socket.s7i         0.036428            326
+seed7/lib/sokoban1.s7i       0.036092           1519
+seed7/lib/sql_base.s7i       0.036217           1000
+seed7/lib/stars.s7i          0.036120           1705
+seed7/lib/stdfont10.s7i      0.036160           3347
+seed7/lib/stdfont12.s7i      0.036114           3928
+seed7/lib/stdfont14.s7i      0.035943           4510
+seed7/lib/stdfont16.s7i      0.036022           5092
+seed7/lib/stdfont18.s7i      0.036456           5868
+seed7/lib/stdfont20.s7i      0.035846           6449
+seed7/lib/stdfont24.s7i      0.036209           7421
+seed7/lib/stdfont8.s7i       0.036149           2960
+seed7/lib/stdfont9.s7i       0.035321           3152
+seed7/lib/stdio.s7i          0.035271            192
+seed7/lib/strifile.s7i       0.034956            345
+seed7/lib/string.s7i         0.035063            779
+seed7/lib/stritext.s7i       0.035674            352
+seed7/lib/struct.s7i         0.035318            266
+seed7/lib/struct_elem.s7i    0.035692            129
+seed7/lib/subfile.s7i        0.035769            174
+seed7/lib/subrange.s7i       0.035633             78
+seed7/lib/syntax.s7i         0.035433            294
+seed7/lib/tar.s7i            0.035694           1880
+seed7/lib/tar_cmds.s7i       0.036081            752
+seed7/lib/tdes.s7i           0.035157            143
+seed7/lib/tee.s7i            0.035306            143
+seed7/lib/text.s7i           0.035446            135
+seed7/lib/tga.s7i            0.035370            676
+seed7/lib/tiff.s7i           0.036628           2771
+seed7/lib/time.s7i           0.037589           1191
+seed7/lib/tls.s7i            0.037775           2230
+seed7/lib/unicode.s7i        0.036390            575
+seed7/lib/unionfnd.s7i       0.036111            130
+seed7/lib/upper.s7i          0.035707            142
+seed7/lib/utf16.s7i          0.035827            540
+seed7/lib/utf8.s7i           0.035978            234
+seed7/lib/vecfont10.s7i      0.036500           1056
+seed7/lib/vecfont18.s7i      0.035930           1119
+seed7/lib/vector3d.s7i       0.035870            293
+seed7/lib/vectorfont.s7i     0.035897            239
+seed7/lib/wildcard.s7i       0.035845            140
+seed7/lib/window.s7i         0.036225            455
+seed7/lib/wrinum.s7i         0.035189            248
+seed7/lib/x509cert.s7i       0.035056           1243
+seed7/lib/xml_ent.s7i        0.035079             94
+seed7/lib/xmldom.s7i         0.034926            303
+seed7/lib/xz.s7i             0.035630            442
+seed7/lib/zip.s7i            0.036707           2792
+seed7/lib/zstd.s7i           0.036665           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.036444        |
++-----------+-----------------+
+| Minimum   | 0.032541        |
++-----------+-----------------+
+| Maximum   | 0.043105        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.038394            190
+seed7/prg/bas7.sd7           0.038858          11459
+seed7/prg/bifurk.sd7         0.035943             73
+seed7/prg/bigfiles.sd7       0.037267            129
+seed7/prg/brainf7.sd7        0.036704             86
+seed7/prg/calc7.sd7          0.039838            128
+seed7/prg/carddemo.sd7       0.038538            190
+seed7/prg/castle.sd7         0.038664           3148
+seed7/prg/cat.sd7            0.036910             82
+seed7/prg/cellauto.sd7       0.037501             85
+seed7/prg/celsius.sd7        0.035849             42
+seed7/prg/chk_all.sd7        0.037987            843
+seed7/prg/chkarr.sd7         0.037726           8367
+seed7/prg/chkbig.sd7         0.042527          29026
+seed7/prg/chkbin.sd7         0.041072           6469
+seed7/prg/chkbitdata.sd7     0.039808           6624
+seed7/prg/chkbool.sd7        0.037567           3157
+seed7/prg/chkbst.sd7         0.037668            722
+seed7/prg/chkchr.sd7         0.038527           2809
+seed7/prg/chkcmd.sd7         0.036932           1205
+seed7/prg/chkdb.sd7          0.039722           7454
+seed7/prg/chkdecl.sd7        0.038431            448
+seed7/prg/chkenum.sd7        0.036446           1230
+seed7/prg/chkerr.sd7         0.039015           4663
+seed7/prg/chkexc.sd7         0.036492           2627
+seed7/prg/chkfil.sd7         0.037908           1615
+seed7/prg/chkflt.sd7         0.041925          20620
+seed7/prg/chkhent.sd7        0.036057             54
+seed7/prg/chkhsh.sd7         0.038527           4548
+seed7/prg/chkidx.sd7         0.040494          19567
+seed7/prg/chkint.sd7         0.043550          38129
+seed7/prg/chkjson.sd7        0.037838           1764
+seed7/prg/chkovf.sd7         0.037969           8216
+seed7/prg/chkprc.sd7         0.038020          10111
+seed7/prg/chkscan.sd7        0.037955            714
+seed7/prg/chkset.sd7         0.042209          11974
+seed7/prg/chkstr.sd7         0.045322          26952
+seed7/prg/chktime.sd7        0.043952           2025
+seed7/prg/chktoml.sd7        0.042023           1656
+seed7/prg/clock.sd7          0.035801             47
+seed7/prg/clock2.sd7         0.035980             43
+seed7/prg/clock3.sd7         0.038437             95
+seed7/prg/cmpfil.sd7         0.037448             84
+seed7/prg/comanche.sd7       0.038681            180
+seed7/prg/confval.sd7        0.039366            175
+seed7/prg/db7.sd7            0.041593            417
+seed7/prg/diff7.sd7          0.039179            263
+seed7/prg/dirtst.sd7         0.035639             42
+seed7/prg/dirx.sd7           0.038312            152
+seed7/prg/dnafight.sd7       0.039592           1381
+seed7/prg/dragon.sd7         0.036882             73
+seed7/prg/echo.sd7           0.035706             39
+seed7/prg/eliza.sd7          0.039023            302
+seed7/prg/err.sd7            0.042526             96
+seed7/prg/fannkuch.sd7       0.038194            131
+seed7/prg/fib.sd7            0.035894             47
+seed7/prg/find7.sd7          0.037526            133
+seed7/prg/findchar.sd7       0.038353            149
+seed7/prg/fractree.sd7       0.037320             55
+seed7/prg/ftp7.sd7           0.038275            296
+seed7/prg/ftpserv.sd7        0.037534             74
+seed7/prg/gcd.sd7            0.037274            109
+seed7/prg/gkbd.sd7           0.038713            358
+seed7/prg/gtksvtst.sd7       0.037291             94
+seed7/prg/hal.sd7            0.037116            250
+seed7/prg/hamu.sd7           0.036365            573
+seed7/prg/hanoi.sd7          0.035441             55
+seed7/prg/hd.sd7             0.036448             79
+seed7/prg/hello.sd7          0.035614             32
+seed7/prg/hilbert.sd7        0.037678            108
+seed7/prg/ide7.sd7           0.040691            196
+seed7/prg/kbd.sd7            0.040348             49
+seed7/prg/klondike.sd7       0.037397            883
+seed7/prg/lander.sd7         0.038151           1551
+seed7/prg/lst80bas.sd7       0.037726            344
+seed7/prg/lst99bas.sd7       0.037695            401
+seed7/prg/lstgwbas.sd7       0.037695            577
+seed7/prg/mahjong.sd7        0.038640           1943
+seed7/prg/make7.sd7          0.038629            121
+seed7/prg/mandelbr.sd7       0.038128            237
+seed7/prg/mind.sd7           0.036194            443
+seed7/prg/mirror.sd7         0.038313            131
+seed7/prg/ms.sd7             0.037844            641
+seed7/prg/nicoma.sd7         0.038460            135
+seed7/prg/pac.sd7            0.036934            726
+seed7/prg/pairs.sd7          0.039735           2025
+seed7/prg/panic.sd7          0.039497           2634
+seed7/prg/percolation.sd7    0.038549            330
+seed7/prg/planets.sd7        0.039177           1486
+seed7/prg/portfwd7.sd7       0.038375            139
+seed7/prg/prime.sd7          0.036633             74
+seed7/prg/printpi1.sd7       0.036342             56
+seed7/prg/printpi2.sd7       0.036551             54
+seed7/prg/printpi3.sd7       0.036880             60
+seed7/prg/pv7.sd7            0.038108            337
+seed7/prg/queen.sd7          0.037845            149
+seed7/prg/rand.sd7           0.038395            121
+seed7/prg/raytrace.sd7       0.039030            538
+seed7/prg/rever.sd7          0.038608            816
+seed7/prg/roman.sd7          0.036189             38
+seed7/prg/s7c.sd7            0.042230           9060
+seed7/prg/s7check.sd7        0.037611             68
+seed7/prg/savehd7.sd7        0.040484           1110
+seed7/prg/self.sd7           0.036561             49
+seed7/prg/shisen.sd7         0.038602           1423
+seed7/prg/sl.sd7             0.037331           1029
+seed7/prg/snake.sd7          0.037528            615
+seed7/prg/sokoban.sd7        0.037729            891
+seed7/prg/spigotpi.sd7       0.035992             64
+seed7/prg/sql7.sd7           0.037494            278
+seed7/prg/startrek.sd7       0.037587            979
+seed7/prg/sudoku7.sd7        0.041399           2657
+seed7/prg/sydir7.sd7         0.039199            384
+seed7/prg/syntaxhl.sd7       0.043273            177
+seed7/prg/tak.sd7            0.036217             59
+seed7/prg/tar7.sd7           0.040904            121
+seed7/prg/tch.sd7            0.040191             55
+seed7/prg/testfont.sd7       0.040620             95
+seed7/prg/tet.sd7            0.039420            479
+seed7/prg/tetg.sd7           0.038182            501
+seed7/prg/toutf8.sd7         0.038821            240
+seed7/prg/tst_cli.sd7        0.035252             40
+seed7/prg/tst_srv.sd7        0.036691             47
+seed7/prg/wator.sd7          0.038018            651
+seed7/prg/which.sd7          0.037129             65
+seed7/prg/wiz.sd7            0.039121           2833
+seed7/prg/wordcnt.sd7        0.038026             54
+seed7/prg/wrinum.sd7         0.038139             43
+seed7/prg/wumpus.sd7         0.039189            372
+seed7/lib/aes.s7i            0.043179           1144
+seed7/lib/aes_gcm.s7i        0.040275            392
+seed7/lib/ar.s7i             0.039869           1532
+seed7/lib/arc4.s7i           0.039632            144
+seed7/lib/archive.s7i        0.041084            143
+seed7/lib/archive_base.s7i   0.040992            135
+seed7/lib/array.s7i          0.038931            610
+seed7/lib/asn1.s7i           0.038350            544
+seed7/lib/asn1oid.s7i        0.041536            157
+seed7/lib/basearray.s7i      0.039030            450
+seed7/lib/bigfile.s7i        0.038453            136
+seed7/lib/bigint.s7i         0.040999            824
+seed7/lib/bigrat.s7i         0.039593            784
+seed7/lib/bin16.s7i          0.039873            592
+seed7/lib/bin32.s7i          0.038860            490
+seed7/lib/bin64.s7i          0.039269            539
+seed7/lib/bitdata.s7i        0.042206           1330
+seed7/lib/bitmapfont.s7i     0.038095            215
+seed7/lib/bitset.s7i         0.038470            593
+seed7/lib/bitsetof.s7i       0.038984            431
+seed7/lib/blowfish.s7i       0.040743            383
+seed7/lib/bmp.s7i            0.038050            924
+seed7/lib/boolean.s7i        0.036903            403
+seed7/lib/browser.s7i        0.037790            280
+seed7/lib/bstring.s7i        0.037603            227
+seed7/lib/bytedata.s7i       0.037991            482
+seed7/lib/bzip2.s7i          0.038740            887
+seed7/lib/cards.s7i          0.036037           1342
+seed7/lib/category.s7i       0.037508            209
+seed7/lib/cc_conf.s7i        0.037659           1314
+seed7/lib/ccittfax.s7i       0.038637           1022
+seed7/lib/cgi.s7i            0.038436            109
+seed7/lib/cgidialog.s7i      0.038851           1118
+seed7/lib/char.s7i           0.037780            356
+seed7/lib/charsets.s7i       0.039324           2024
+seed7/lib/chartype.s7i       0.040500            121
+seed7/lib/cipher.s7i         0.037396            146
+seed7/lib/cli_cmds.s7i       0.037722           1360
+seed7/lib/clib_file.s7i      0.039201            301
+seed7/lib/color.s7i          0.038603            185
+seed7/lib/complex.s7i        0.037229            464
+seed7/lib/compress.s7i       0.041894            150
+seed7/lib/console.s7i        0.044060            188
+seed7/lib/cpio.s7i           0.038503           1708
+seed7/lib/crc32.s7i          0.039809            193
+seed7/lib/cronos16.s7i       0.040205           1173
+seed7/lib/cronos27.s7i       0.040186           1464
+seed7/lib/csv.s7i            0.038546            201
+seed7/lib/db_prop.s7i        0.038540            991
+seed7/lib/deflate.s7i        0.039002            740
+seed7/lib/des.s7i            0.039178            444
+seed7/lib/dialog.s7i         0.038522            311
+seed7/lib/dir.s7i            0.038795            163
+seed7/lib/draw.s7i           0.039543            854
+seed7/lib/duration.s7i       0.039885           1038
+seed7/lib/echo.s7i           0.040332            132
+seed7/lib/editline.s7i       0.038370            398
+seed7/lib/elf.s7i            0.039408           1560
+seed7/lib/elliptic.s7i       0.036848            649
+seed7/lib/enable_io.s7i      0.037888            312
+seed7/lib/encoding.s7i       0.038181            931
+seed7/lib/enumeration.s7i    0.037689            236
+seed7/lib/environment.s7i    0.037699            175
+seed7/lib/exif.s7i           0.037755            152
+seed7/lib/external_file.s7i  0.037410            340
+seed7/lib/field.s7i          0.040000            268
+seed7/lib/file.s7i           0.037805            372
+seed7/lib/filebits.s7i       0.036069             46
+seed7/lib/filesys.s7i        0.038735            601
+seed7/lib/fileutil.s7i       0.038453            144
+seed7/lib/fixarray.s7i       0.037651            307
+seed7/lib/float.s7i          0.037530            757
+seed7/lib/font.s7i           0.038240            196
+seed7/lib/font8x8.s7i        0.036734            998
+seed7/lib/forloop.s7i        0.038319            449
+seed7/lib/ftp.s7i            0.038363            969
+seed7/lib/ftpserv.s7i        0.038477            631
+seed7/lib/getf.s7i           0.038276            115
+seed7/lib/gethttp.s7i        0.035855             41
+seed7/lib/gethttps.s7i       0.036009             41
+seed7/lib/gif.s7i            0.039113            561
+seed7/lib/graph.s7i          0.040662            415
+seed7/lib/graph_file.s7i     0.038287            399
+seed7/lib/gtkserver.s7i      0.038601            161
+seed7/lib/gzip.s7i           0.038573            573
+seed7/lib/hash.s7i           0.040089            421
+seed7/lib/hashsetof.s7i      0.039881            499
+seed7/lib/hmac.s7i           0.038453            152
+seed7/lib/html.s7i           0.042512             83
+seed7/lib/html_ent.s7i       0.038183            476
+seed7/lib/htmldom.s7i        0.037649            286
+seed7/lib/http_request.s7i   0.037898            696
+seed7/lib/http_srv_resp.s7i  0.037867            380
+seed7/lib/https_request.s7i  0.039886            211
+seed7/lib/httpserv.s7i       0.038277            345
+seed7/lib/huffman.s7i        0.038209            644
+seed7/lib/ico.s7i            0.038389            221
+seed7/lib/idxarray.s7i       0.038352            232
+seed7/lib/image.s7i          0.036771            156
+seed7/lib/imagefile.s7i      0.038153            171
+seed7/lib/inflate.s7i        0.039279            411
+seed7/lib/inifile.s7i        0.038190            129
+seed7/lib/integer.s7i        0.040411            663
+seed7/lib/iobuffer.s7i       0.038995            289
+seed7/lib/jpeg.s7i           0.040780           1761
+seed7/lib/json.s7i           0.038774            891
+seed7/lib/json_serde.s7i     0.038772            783
+seed7/lib/keybd.s7i          0.037902            639
+seed7/lib/keydescr.s7i       0.038669            192
+seed7/lib/leb128.s7i         0.039892            218
+seed7/lib/line.s7i           0.038541            164
+seed7/lib/listener.s7i       0.038294            247
+seed7/lib/logfile.s7i        0.036238             73
+seed7/lib/lower.s7i          0.036830            142
+seed7/lib/lzma.s7i           0.041196            934
+seed7/lib/lzw.s7i            0.040460            861
+seed7/lib/magic.s7i          0.038817            403
+seed7/lib/mahjng32.s7i       0.038811           1500
+seed7/lib/make.s7i           0.038793            544
+seed7/lib/makedata.s7i       0.040216           1428
+seed7/lib/math.s7i           0.044040            201
+seed7/lib/mixarith.s7i       0.040367            249
+seed7/lib/modern27.s7i       0.040855           1099
+seed7/lib/more.s7i           0.039160            130
+seed7/lib/msgdigest.s7i      0.040947           1222
+seed7/lib/multiscr.s7i       0.039332             68
+seed7/lib/null_file.s7i      0.039008            345
+seed7/lib/osfiles.s7i        0.040287           1085
+seed7/lib/pbm.s7i            0.039146            230
+seed7/lib/pcx.s7i            0.038701            638
+seed7/lib/pem.s7i            0.038247            185
+seed7/lib/pgm.s7i            0.038569            238
+seed7/lib/pic16.s7i          0.037321           1037
+seed7/lib/pic32.s7i          0.038443           2060
+seed7/lib/pic_util.s7i       0.040754            144
+seed7/lib/pixelimage.s7i     0.040882            320
+seed7/lib/pixmap_file.s7i    0.040210            459
+seed7/lib/pixmapfont.s7i     0.039949            184
+seed7/lib/pkcs1.s7i          0.044661            543
+seed7/lib/png.s7i            0.039738           1064
+seed7/lib/poll.s7i           0.039123            313
+seed7/lib/ppm.s7i            0.040986            240
+seed7/lib/process.s7i        0.041048            541
+seed7/lib/progs.s7i          0.041177            789
+seed7/lib/propertyfile.s7i   0.040322            155
+seed7/lib/rational.s7i       0.041596            792
+seed7/lib/ref_list.s7i       0.040661            252
+seed7/lib/reference.s7i      0.038272            126
+seed7/lib/reverse.s7i        0.037441             94
+seed7/lib/rpm.s7i            0.040129           3487
+seed7/lib/rpmext.s7i         0.039528            318
+seed7/lib/scanfile.s7i       0.041366           1779
+seed7/lib/scanjson.s7i       0.039244            413
+seed7/lib/scanstri.s7i       0.039871           1814
+seed7/lib/scantoml.s7i       0.041092           1603
+seed7/lib/seed7_05.s7i       0.041824           1072
+seed7/lib/set.s7i            0.037562             57
+seed7/lib/shell.s7i          0.038815            615
+seed7/lib/showtls.s7i        0.038839            678
+seed7/lib/signature.s7i      0.038323            131
+seed7/lib/smtp.s7i           0.038354            261
+seed7/lib/sockbase.s7i       0.038406            217
+seed7/lib/socket.s7i         0.038196            326
+seed7/lib/sokoban1.s7i       0.036791           1519
+seed7/lib/sql_base.s7i       0.038399           1000
+seed7/lib/stars.s7i          0.039475           1705
+seed7/lib/stdfont10.s7i      0.037401           3347
+seed7/lib/stdfont12.s7i      0.038459           3928
+seed7/lib/stdfont14.s7i      0.037722           4510
+seed7/lib/stdfont16.s7i      0.046121           5092
+seed7/lib/stdfont18.s7i      0.036614           5868
+seed7/lib/stdfont20.s7i      0.036596           6449
+seed7/lib/stdfont24.s7i      0.037484           7421
+seed7/lib/stdfont8.s7i       0.038175           2960
+seed7/lib/stdfont9.s7i       0.037047           3152
+seed7/lib/stdio.s7i          0.037958            192
+seed7/lib/strifile.s7i       0.038317            345
+seed7/lib/string.s7i         0.038459            779
+seed7/lib/stritext.s7i       0.038690            352
+seed7/lib/struct.s7i         0.038775            266
+seed7/lib/struct_elem.s7i    0.038839            129
+seed7/lib/subfile.s7i        0.038256            174
+seed7/lib/subrange.s7i       0.037374             78
+seed7/lib/syntax.s7i         0.038569            294
+seed7/lib/tar.s7i            0.038898           1880
+seed7/lib/tar_cmds.s7i       0.038724            752
+seed7/lib/tdes.s7i           0.038903            143
+seed7/lib/tee.s7i            0.038467            143
+seed7/lib/text.s7i           0.038581            135
+seed7/lib/tga.s7i            0.040556            676
+seed7/lib/tiff.s7i           0.039567           2771
+seed7/lib/time.s7i           0.038573           1191
+seed7/lib/tls.s7i            0.038484           2230
+seed7/lib/unicode.s7i        0.038780            575
+seed7/lib/unionfnd.s7i       0.037305            130
+seed7/lib/upper.s7i          0.037982            142
+seed7/lib/utf16.s7i          0.037597            540
+seed7/lib/utf8.s7i           0.037560            234
+seed7/lib/vecfont10.s7i      0.039272           1056
+seed7/lib/vecfont18.s7i      0.039802           1119
+seed7/lib/vector3d.s7i       0.037595            293
+seed7/lib/vectorfont.s7i     0.037882            239
+seed7/lib/wildcard.s7i       0.037352            140
+seed7/lib/window.s7i         0.037686            455
+seed7/lib/wrinum.s7i         0.038214            248
+seed7/lib/x509cert.s7i       0.038586           1243
+seed7/lib/xml_ent.s7i        0.037763             94
+seed7/lib/xmldom.s7i         0.036498            303
+seed7/lib/xz.s7i             0.037571            442
+seed7/lib/zip.s7i            0.038759           2792
+seed7/lib/zstd.s7i           0.038800           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.038717        |
++-----------+-----------------+
+| Minimum   | 0.035252        |
++-----------+-----------------+
+| Maximum   | 0.046121        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.037724            190
+seed7/prg/bas7.sd7           0.322031          11459
+seed7/prg/bifurk.sd7         0.036572             73
+seed7/prg/bigfiles.sd7       0.037061            129
+seed7/prg/brainf7.sd7        0.036262             86
+seed7/prg/calc7.sd7          0.037511            128
+seed7/prg/carddemo.sd7       0.039049            190
+seed7/prg/castle.sd7         0.110786           3148
+seed7/prg/cat.sd7            0.035457             82
+seed7/prg/cellauto.sd7       0.035705             85
+seed7/prg/celsius.sd7        0.034887             42
+seed7/prg/chk_all.sd7        0.057494            843
+seed7/prg/chkarr.sd7         0.350554           8367
+seed7/prg/chkbig.sd7         2.043048          29026
+seed7/prg/chkbin.sd7         0.513003           6469
+seed7/prg/chkbitdata.sd7     0.617016           6624
+seed7/prg/chkbool.sd7        0.116304           3157
+seed7/prg/chkbst.sd7         0.063191            722
+seed7/prg/chkchr.sd7         0.216953           2809
+seed7/prg/chkcmd.sd7         0.069236           1205
+seed7/prg/chkdb.sd7          0.353278           7454
+seed7/prg/chkdecl.sd7        0.058211            448
+seed7/prg/chkenum.sd7        0.067065           1230
+seed7/prg/chkerr.sd7         0.192605           4663
+seed7/prg/chkexc.sd7         0.084014           2627
+seed7/prg/chkfil.sd7         0.075686           1615
+seed7/prg/chkflt.sd7         1.343658          20620
+seed7/prg/chkhent.sd7        0.036390             54
+seed7/prg/chkhsh.sd7         0.258517           4548
+seed7/prg/chkidx.sd7         1.313739          19567
+seed7/prg/chkint.sd7         2.510868          38129
+seed7/prg/chkjson.sd7        0.109532           1764
+seed7/prg/chkovf.sd7         0.563700           8216
+seed7/prg/chkprc.sd7         0.321492          10111
+seed7/prg/chkscan.sd7        0.055579            714
+seed7/prg/chkset.sd7         0.667282          11974
+seed7/prg/chkstr.sd7         1.388681          26952
+seed7/prg/chktime.sd7        0.128233           2025
+seed7/prg/chktoml.sd7        0.106162           1656
+seed7/prg/clock.sd7          0.034457             47
+seed7/prg/clock2.sd7         0.034498             43
+seed7/prg/clock3.sd7         0.036602             95
+seed7/prg/cmpfil.sd7         0.035223             84
+seed7/prg/comanche.sd7       0.040101            180
+seed7/prg/confval.sd7        0.041893            175
+seed7/prg/db7.sd7            0.045936            417
+seed7/prg/diff7.sd7          0.041832            263
+seed7/prg/dirtst.sd7         0.034962             42
+seed7/prg/dirx.sd7           0.038012            152
+seed7/prg/dnafight.sd7       0.067758           1381
+seed7/prg/dragon.sd7         0.039021             73
+seed7/prg/echo.sd7           0.035386             39
+seed7/prg/eliza.sd7          0.042171            302
+seed7/prg/err.sd7            0.039318             96
+seed7/prg/fannkuch.sd7       0.036818            131
+seed7/prg/fib.sd7            0.035326             47
+seed7/prg/find7.sd7          0.037378            133
+seed7/prg/findchar.sd7       0.038686            149
+seed7/prg/fractree.sd7       0.035267             55
+seed7/prg/ftp7.sd7           0.041028            296
+seed7/prg/ftpserv.sd7        0.037841             74
+seed7/prg/gcd.sd7            0.035668            109
+seed7/prg/gkbd.sd7           0.044730            358
+seed7/prg/gtksvtst.sd7       0.042586             94
+seed7/prg/hal.sd7            0.048879            250
+seed7/prg/hamu.sd7           0.054321            573
+seed7/prg/hanoi.sd7          0.036786             55
+seed7/prg/hd.sd7             0.035800             79
+seed7/prg/hello.sd7          0.035206             32
+seed7/prg/hilbert.sd7        0.037554            108
+seed7/prg/ide7.sd7           0.039850            196
+seed7/prg/kbd.sd7            0.035160             49
+seed7/prg/klondike.sd7       0.054321            883
+seed7/prg/lander.sd7         0.084596           1551
+seed7/prg/lst80bas.sd7       0.047309            344
+seed7/prg/lst99bas.sd7       0.055351            401
+seed7/prg/lstgwbas.sd7       0.052707            577
+seed7/prg/mahjong.sd7        0.089274           1943
+seed7/prg/make7.sd7          0.039311            121
+seed7/prg/mandelbr.sd7       0.040401            237
+seed7/prg/mind.sd7           0.046744            443
+seed7/prg/mirror.sd7         0.041690            131
+seed7/prg/ms.sd7             0.049723            641
+seed7/prg/nicoma.sd7         0.044839            135
+seed7/prg/pac.sd7            0.048700            726
+seed7/prg/pairs.sd7          0.081298           2025
+seed7/prg/panic.sd7          0.105050           2634
+seed7/prg/percolation.sd7    0.047821            330
+seed7/prg/planets.sd7        0.080973           1486
+seed7/prg/portfwd7.sd7       0.037652            139
+seed7/prg/prime.sd7          0.035278             74
+seed7/prg/printpi1.sd7       0.035216             56
+seed7/prg/printpi2.sd7       0.034703             54
+seed7/prg/printpi3.sd7       0.035099             60
+seed7/prg/pv7.sd7            0.042535            337
+seed7/prg/queen.sd7          0.036997            149
+seed7/prg/rand.sd7           0.036362            121
+seed7/prg/raytrace.sd7       0.047546            538
+seed7/prg/rever.sd7          0.054213            816
+seed7/prg/roman.sd7          0.035919             38
+seed7/prg/s7c.sd7            0.283150           9060
+seed7/prg/s7check.sd7        0.036962             68
+seed7/prg/savehd7.sd7        0.066200           1110
+seed7/prg/self.sd7           0.036405             49
+seed7/prg/shisen.sd7         0.069368           1423
+seed7/prg/sl.sd7             0.057495           1029
+seed7/prg/snake.sd7          0.045457            615
+seed7/prg/sokoban.sd7        0.054707            891
+seed7/prg/spigotpi.sd7       0.035788             64
+seed7/prg/sql7.sd7           0.041258            278
+seed7/prg/startrek.sd7       0.058574            979
+seed7/prg/sudoku7.sd7        0.099521           2657
+seed7/prg/sydir7.sd7         0.044946            384
+seed7/prg/syntaxhl.sd7       0.040545            177
+seed7/prg/tak.sd7            0.035971             59
+seed7/prg/tar7.sd7           0.037371            121
+seed7/prg/tch.sd7            0.035786             55
+seed7/prg/testfont.sd7       0.037560             95
+seed7/prg/tet.sd7            0.054189            479
+seed7/prg/tetg.sd7           0.045763            501
+seed7/prg/toutf8.sd7         0.041444            240
+seed7/prg/tst_cli.sd7        0.034260             40
+seed7/prg/tst_srv.sd7        0.034564             47
+seed7/prg/wator.sd7          0.050269            651
+seed7/prg/which.sd7          0.035231             65
+seed7/prg/wiz.sd7            0.102972           2833
+seed7/prg/wordcnt.sd7        0.036040             54
+seed7/prg/wrinum.sd7         0.034610             43
+seed7/prg/wumpus.sd7         0.041223            372
+seed7/lib/aes.s7i            0.111555           1144
+seed7/lib/aes_gcm.s7i        0.046945            392
+seed7/lib/ar.s7i             0.075626           1532
+seed7/lib/arc4.s7i           0.038081            144
+seed7/lib/archive.s7i        0.037899            143
+seed7/lib/archive_base.s7i   0.038889            135
+seed7/lib/array.s7i          0.053648            610
+seed7/lib/asn1.s7i           0.046756            544
+seed7/lib/asn1oid.s7i        0.041686            157
+seed7/lib/basearray.s7i      0.048104            450
+seed7/lib/bigfile.s7i        0.038921            136
+seed7/lib/bigint.s7i         0.058337            824
+seed7/lib/bigrat.s7i         0.060482            784
+seed7/lib/bin16.s7i          0.056665            592
+seed7/lib/bin32.s7i          0.050182            490
+seed7/lib/bin64.s7i          0.054146            539
+seed7/lib/bitdata.s7i        0.080697           1330
+seed7/lib/bitmapfont.s7i     0.047035            215
+seed7/lib/bitset.s7i         0.050683            593
+seed7/lib/bitsetof.s7i       0.051041            431
+seed7/lib/blowfish.s7i       0.062818            383
+seed7/lib/bmp.s7i            0.062961            924
+seed7/lib/boolean.s7i        0.047381            403
+seed7/lib/browser.s7i        0.046956            280
+seed7/lib/bstring.s7i        0.044400            227
+seed7/lib/bytedata.s7i       0.052765            482
+seed7/lib/bzip2.s7i          0.062341            887
+seed7/lib/cards.s7i          0.073718           1342
+seed7/lib/category.s7i       0.045257            209
+seed7/lib/cc_conf.s7i        0.080993           1314
+seed7/lib/ccittfax.s7i       0.072088           1022
+seed7/lib/cgi.s7i            0.040121            109
+seed7/lib/cgidialog.s7i      0.066405           1118
+seed7/lib/char.s7i           0.050230            356
+seed7/lib/charsets.s7i       0.082052           2024
+seed7/lib/chartype.s7i       0.038690            121
+seed7/lib/cipher.s7i         0.038244            146
+seed7/lib/cli_cmds.s7i       0.066954           1360
+seed7/lib/clib_file.s7i      0.042988            301
+seed7/lib/color.s7i          0.041033            185
+seed7/lib/complex.s7i        0.044874            464
+seed7/lib/compress.s7i       0.038079            150
+seed7/lib/console.s7i        0.039343            188
+seed7/lib/cpio.s7i           0.084935           1708
+seed7/lib/crc32.s7i          0.043968            193
+seed7/lib/cronos16.s7i       0.097485           1173
+seed7/lib/cronos27.s7i       0.115856           1464
+seed7/lib/csv.s7i            0.039352            201
+seed7/lib/db_prop.s7i        0.061308            991
+seed7/lib/deflate.s7i        0.053966            740
+seed7/lib/des.s7i            0.054188            444
+seed7/lib/dialog.s7i         0.042416            311
+seed7/lib/dir.s7i            0.037679            163
+seed7/lib/draw.s7i           0.055211            854
+seed7/lib/duration.s7i       0.059320           1038
+seed7/lib/echo.s7i           0.037297            132
+seed7/lib/editline.s7i       0.043937            398
+seed7/lib/elf.s7i            0.083117           1560
+seed7/lib/elliptic.s7i       0.053129            649
+seed7/lib/enable_io.s7i      0.043255            312
+seed7/lib/encoding.s7i       0.060736            931
+seed7/lib/enumeration.s7i    0.041529            236
+seed7/lib/environment.s7i    0.039137            175
+seed7/lib/exif.s7i           0.039505            152
+seed7/lib/external_file.s7i  0.043193            340
+seed7/lib/field.s7i          0.041324            268
+seed7/lib/file.s7i           0.044057            372
+seed7/lib/filebits.s7i       0.035745             46
+seed7/lib/filesys.s7i        0.048213            601
+seed7/lib/fileutil.s7i       0.039510            144
+seed7/lib/fixarray.s7i       0.045707            307
+seed7/lib/float.s7i          0.055001            757
+seed7/lib/font.s7i           0.039156            196
+seed7/lib/font8x8.s7i        0.048527            998
+seed7/lib/forloop.s7i        0.044960            449
+seed7/lib/ftp.s7i            0.057714            969
+seed7/lib/ftpserv.s7i        0.050394            631
+seed7/lib/getf.s7i           0.036232            115
+seed7/lib/gethttp.s7i        0.034729             41
+seed7/lib/gethttps.s7i       0.034807             41
+seed7/lib/gif.s7i            0.049811            561
+seed7/lib/graph.s7i          0.048123            415
+seed7/lib/graph_file.s7i     0.043523            399
+seed7/lib/gtkserver.s7i      0.037441            161
+seed7/lib/gzip.s7i           0.047300            573
+seed7/lib/hash.s7i           0.047937            421
+seed7/lib/hashsetof.s7i      0.048370            499
+seed7/lib/hmac.s7i           0.037438            152
+seed7/lib/html.s7i           0.035747             83
+seed7/lib/html_ent.s7i       0.046477            476
+seed7/lib/htmldom.s7i        0.042499            286
+seed7/lib/http_request.s7i   0.051503            696
+seed7/lib/http_srv_resp.s7i  0.045268            380
+seed7/lib/https_request.s7i  0.039929            211
+seed7/lib/httpserv.s7i       0.043515            345
+seed7/lib/huffman.s7i        0.052484            644
+seed7/lib/ico.s7i            0.040526            221
+seed7/lib/idxarray.s7i       0.041598            232
+seed7/lib/image.s7i          0.036670            156
+seed7/lib/imagefile.s7i      0.038130            171
+seed7/lib/inflate.s7i        0.045691            411
+seed7/lib/inifile.s7i        0.036493            129
+seed7/lib/integer.s7i        0.051436            663
+seed7/lib/iobuffer.s7i       0.041915            289
+seed7/lib/jpeg.s7i           0.083326           1761
+seed7/lib/json.s7i           0.055587            891
+seed7/lib/json_serde.s7i     0.052394            783
+seed7/lib/keybd.s7i          0.055150            639
+seed7/lib/keydescr.s7i       0.040790            192
+seed7/lib/leb128.s7i         0.039456            218
+seed7/lib/line.s7i           0.037915            164
+seed7/lib/listener.s7i       0.040898            247
+seed7/lib/logfile.s7i        0.036006             73
+seed7/lib/lower.s7i          0.038122            142
+seed7/lib/lzma.s7i           0.058969            934
+seed7/lib/lzw.s7i            0.058047            861
+seed7/lib/magic.s7i          0.046714            403
+seed7/lib/mahjng32.s7i       0.063107           1500
+seed7/lib/make.s7i           0.047685            544
+seed7/lib/makedata.s7i       0.068020           1428
+seed7/lib/math.s7i           0.038750            201
+seed7/lib/mixarith.s7i       0.044709            249
+seed7/lib/modern27.s7i       0.085834           1099
+seed7/lib/more.s7i           0.038270            130
+seed7/lib/msgdigest.s7i      0.078410           1222
+seed7/lib/multiscr.s7i       0.040602             68
+seed7/lib/null_file.s7i      0.042825            345
+seed7/lib/osfiles.s7i        0.064773           1085
+seed7/lib/pbm.s7i            0.039578            230
+seed7/lib/pcx.s7i            0.051776            638
+seed7/lib/pem.s7i            0.039294            185
+seed7/lib/pgm.s7i            0.039941            238
+seed7/lib/pic16.s7i          0.048546           1037
+seed7/lib/pic32.s7i          0.079104           2060
+seed7/lib/pic_util.s7i       0.038036            144
+seed7/lib/pixelimage.s7i     0.041768            320
+seed7/lib/pixmap_file.s7i    0.045170            459
+seed7/lib/pixmapfont.s7i     0.039594            184
+seed7/lib/pkcs1.s7i          0.058807            543
+seed7/lib/png.s7i            0.063283           1064
+seed7/lib/poll.s7i           0.042739            313
+seed7/lib/ppm.s7i            0.039558            240
+seed7/lib/process.s7i        0.047677            541
+seed7/lib/progs.s7i          0.056174            789
+seed7/lib/propertyfile.s7i   0.038534            155
+seed7/lib/rational.s7i       0.053514            792
+seed7/lib/ref_list.s7i       0.041066            252
+seed7/lib/reference.s7i      0.037696            126
+seed7/lib/reverse.s7i        0.036728             94
+seed7/lib/rpm.s7i            0.140293           3487
+seed7/lib/rpmext.s7i         0.041755            318
+seed7/lib/scanfile.s7i       0.079963           1779
+seed7/lib/scanjson.s7i       0.046001            413
+seed7/lib/scanstri.s7i       0.079077           1814
+seed7/lib/scantoml.s7i       0.070967           1603
+seed7/lib/seed7_05.s7i       0.066190           1072
+seed7/lib/set.s7i            0.036175             57
+seed7/lib/shell.s7i          0.052920            615
+seed7/lib/showtls.s7i        0.053569            678
+seed7/lib/signature.s7i      0.037162            131
+seed7/lib/smtp.s7i           0.039846            261
+seed7/lib/sockbase.s7i       0.041217            217
+seed7/lib/socket.s7i         0.046197            326
+seed7/lib/sokoban1.s7i       0.059677           1519
+seed7/lib/sql_base.s7i       0.067532           1000
+seed7/lib/stars.s7i          0.139587           1705
+seed7/lib/stdfont10.s7i      0.086914           3347
+seed7/lib/stdfont12.s7i      0.095629           3928
+seed7/lib/stdfont14.s7i      0.110036           4510
+seed7/lib/stdfont16.s7i      0.122630           5092
+seed7/lib/stdfont18.s7i      0.137523           5868
+seed7/lib/stdfont20.s7i      0.148575           6449
+seed7/lib/stdfont24.s7i      0.176702           7421
+seed7/lib/stdfont8.s7i       0.072197           2960
+seed7/lib/stdfont9.s7i       0.074477           3152
+seed7/lib/stdio.s7i          0.038148            192
+seed7/lib/strifile.s7i       0.042215            345
+seed7/lib/string.s7i         0.054031            779
+seed7/lib/stritext.s7i       0.042772            352
+seed7/lib/struct.s7i         0.042350            266
+seed7/lib/struct_elem.s7i    0.036740            129
+seed7/lib/subfile.s7i        0.038108            174
+seed7/lib/subrange.s7i       0.036609             78
+seed7/lib/syntax.s7i         0.045052            294
+seed7/lib/tar.s7i            0.081687           1880
+seed7/lib/tar_cmds.s7i       0.055764            752
+seed7/lib/tdes.s7i           0.038177            143
+seed7/lib/tee.s7i            0.037293            143
+seed7/lib/text.s7i           0.036546            135
+seed7/lib/tga.s7i            0.052221            676
+seed7/lib/tiff.s7i           0.123769           2771
+seed7/lib/time.s7i           0.061959           1191
+seed7/lib/tls.s7i            0.103457           2230
+seed7/lib/unicode.s7i        0.052165            575
+seed7/lib/unionfnd.s7i       0.036840            130
+seed7/lib/upper.s7i          0.037409            142
+seed7/lib/utf16.s7i          0.049385            540
+seed7/lib/utf8.s7i           0.040746            234
+seed7/lib/vecfont10.s7i      0.078378           1056
+seed7/lib/vecfont18.s7i      0.086754           1119
+seed7/lib/vector3d.s7i       0.040931            293
+seed7/lib/vectorfont.s7i     0.040457            239
+seed7/lib/wildcard.s7i       0.037993            140
+seed7/lib/window.s7i         0.045088            455
+seed7/lib/wrinum.s7i         0.039874            248
+seed7/lib/x509cert.s7i       0.070032           1243
+seed7/lib/xml_ent.s7i        0.036168             94
+seed7/lib/xmldom.s7i         0.040041            303
+seed7/lib/xz.s7i             0.044976            442
+seed7/lib/zip.s7i            0.118034           2792
+seed7/lib/zstd.s7i           0.081392           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.089399        |
++-----------+-----------------+
+| Minimum   | 0.034260        |
++-----------+-----------------+
+| Maximum   | 2.510868        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.050192            190
+seed7/prg/bas7.sd7           0.792509          11459
+seed7/prg/bifurk.sd7         0.044658             73
+seed7/prg/bigfiles.sd7       0.048537            129
+seed7/prg/brainf7.sd7        0.044687             86
+seed7/prg/calc7.sd7          0.048385            128
+seed7/prg/carddemo.sd7       0.052854            190
+seed7/prg/castle.sd7         0.222013           3148
+seed7/prg/cat.sd7            0.040558             82
+seed7/prg/cellauto.sd7       0.039885             85
+seed7/prg/celsius.sd7        0.039989             42
+seed7/prg/chk_all.sd7        0.086621            843
+seed7/prg/chkarr.sd7         0.881348           8367
+seed7/prg/chkbig.sd7         4.170704          29026
+seed7/prg/chkbin.sd7         1.028347           6469
+seed7/prg/chkbitdata.sd7     1.269761           6624
+seed7/prg/chkbool.sd7        0.232274           3157
+seed7/prg/chkbst.sd7         0.105386            722
+seed7/prg/chkchr.sd7         0.482467           2809
+seed7/prg/chkcmd.sd7         0.109907           1205
+seed7/prg/chkdb.sd7          0.768569           7454
+seed7/prg/chkdecl.sd7        0.093845            448
+seed7/prg/chkenum.sd7        0.121771           1230
+seed7/prg/chkerr.sd7         0.339230           4663
+seed7/prg/chkexc.sd7         0.148882           2627
+seed7/prg/chkfil.sd7         0.127918           1615
+seed7/prg/chkflt.sd7         2.823792          20620
+seed7/prg/chkhent.sd7        0.037182             54
+seed7/prg/chkhsh.sd7         0.504200           4548
+seed7/prg/chkidx.sd7         3.163368          19567
+seed7/prg/chkint.sd7         5.635506          38129
+seed7/prg/chkjson.sd7        0.185724           1764
+seed7/prg/chkovf.sd7         1.207329           8216
+seed7/prg/chkprc.sd7         0.704401          10111
+seed7/prg/chkscan.sd7        0.089687            714
+seed7/prg/chkset.sd7         1.752859          11974
+seed7/prg/chkstr.sd7         3.415173          26952
+seed7/prg/chktime.sd7        0.250800           2025
+seed7/prg/chktoml.sd7        0.201630           1656
+seed7/prg/clock.sd7          0.038773             47
+seed7/prg/clock2.sd7         0.038149             43
+seed7/prg/clock3.sd7         0.042360             95
+seed7/prg/cmpfil.sd7         0.040440             84
+seed7/prg/comanche.sd7       0.048575            180
+seed7/prg/confval.sd7        0.053711            175
+seed7/prg/db7.sd7            0.065883            417
+seed7/prg/diff7.sd7          0.058202            263
+seed7/prg/dirtst.sd7         0.040606             42
+seed7/prg/dirx.sd7           0.042970            152
+seed7/prg/dnafight.sd7       0.115146           1381
+seed7/prg/dragon.sd7         0.038189             73
+seed7/prg/echo.sd7           0.035269             39
+seed7/prg/eliza.sd7          0.050248            302
+seed7/prg/err.sd7            0.045555             96
+seed7/prg/fannkuch.sd7       0.041141            131
+seed7/prg/fib.sd7            0.036668             47
+seed7/prg/find7.sd7          0.042228            133
+seed7/prg/findchar.sd7       0.044843            149
+seed7/prg/fractree.sd7       0.037708             55
+seed7/prg/ftp7.sd7           0.051819            296
+seed7/prg/ftpserv.sd7        0.038352             74
+seed7/prg/gcd.sd7            0.038812            109
+seed7/prg/gkbd.sd7           0.062985            358
+seed7/prg/gtksvtst.sd7       0.039969             94
+seed7/prg/hal.sd7            0.046438            250
+seed7/prg/hamu.sd7           0.068791            573
+seed7/prg/hanoi.sd7          0.036158             55
+seed7/prg/hd.sd7             0.037869             79
+seed7/prg/hello.sd7          0.035982             32
+seed7/prg/hilbert.sd7        0.040477            108
+seed7/prg/ide7.sd7           0.046698            196
+seed7/prg/kbd.sd7            0.036340             49
+seed7/prg/klondike.sd7       0.087287            883
+seed7/prg/lander.sd7         0.129443           1551
+seed7/prg/lst80bas.sd7       0.054862            344
+seed7/prg/lst99bas.sd7       0.060256            401
+seed7/prg/lstgwbas.sd7       0.077119            577
+seed7/prg/mahjong.sd7        0.150748           1943
+seed7/prg/make7.sd7          0.042660            121
+seed7/prg/mandelbr.sd7       0.049308            237
+seed7/prg/mind.sd7           0.060838            443
+seed7/prg/mirror.sd7         0.044872            131
+seed7/prg/ms.sd7             0.068544            641
+seed7/prg/nicoma.sd7         0.041576            135
+seed7/prg/pac.sd7            0.072216            726
+seed7/prg/pairs.sd7          0.140374           2025
+seed7/prg/panic.sd7          0.194940           2634
+seed7/prg/percolation.sd7    0.060765            330
+seed7/prg/planets.sd7        0.138966           1486
+seed7/prg/portfwd7.sd7       0.043349            139
+seed7/prg/prime.sd7          0.036934             74
+seed7/prg/printpi1.sd7       0.036772             56
+seed7/prg/printpi2.sd7       0.037000             54
+seed7/prg/printpi3.sd7       0.037608             60
+seed7/prg/pv7.sd7            0.057783            337
+seed7/prg/queen.sd7          0.042300            149
+seed7/prg/rand.sd7           0.040524            121
+seed7/prg/raytrace.sd7       0.068341            538
+seed7/prg/rever.sd7          0.082512            816
+seed7/prg/roman.sd7          0.035762             38
+seed7/prg/s7c.sd7            0.629999           9060
+seed7/prg/s7check.sd7        0.040017             68
+seed7/prg/savehd7.sd7        0.115914           1110
+seed7/prg/self.sd7           0.037881             49
+seed7/prg/shisen.sd7         0.122049           1423
+seed7/prg/sl.sd7             0.096102           1029
+seed7/prg/snake.sd7          0.066031            615
+seed7/prg/sokoban.sd7        0.084362            891
+seed7/prg/spigotpi.sd7       0.038855             64
+seed7/prg/sql7.sd7           0.050220            278
+seed7/prg/startrek.sd7       0.093750            979
+seed7/prg/sudoku7.sd7        0.202489           2657
+seed7/prg/sydir7.sd7         0.063900            384
+seed7/prg/syntaxhl.sd7       0.048730            177
+seed7/prg/tak.sd7            0.037927             59
+seed7/prg/tar7.sd7           0.041705            121
+seed7/prg/tch.sd7            0.036845             55
+seed7/prg/testfont.sd7       0.040695             95
+seed7/prg/tet.sd7            0.059967            479
+seed7/prg/tetg.sd7           0.061420            501
+seed7/prg/toutf8.sd7         0.050201            240
+seed7/prg/tst_cli.sd7        0.036258             40
+seed7/prg/tst_srv.sd7        0.039181             47
+seed7/prg/wator.sd7          0.078321            651
+seed7/prg/which.sd7          0.037166             65
+seed7/prg/wiz.sd7            0.206552           2833
+seed7/prg/wordcnt.sd7        0.037848             54
+seed7/prg/wrinum.sd7         0.042431             43
+seed7/prg/wumpus.sd7         0.056856            372
+seed7/lib/aes.s7i            0.201927           1144
+seed7/lib/aes_gcm.s7i        0.062172            392
+seed7/lib/ar.s7i             0.123543           1532
+seed7/lib/arc4.s7i           0.042641            144
+seed7/lib/archive.s7i        0.043529            143
+seed7/lib/archive_base.s7i   0.043717            135
+seed7/lib/array.s7i          0.073828            610
+seed7/lib/asn1.s7i           0.062768            544
+seed7/lib/asn1oid.s7i        0.048543            157
+seed7/lib/basearray.s7i      0.064287            450
+seed7/lib/bigfile.s7i        0.040616            136
+seed7/lib/bigint.s7i         0.077533            824
+seed7/lib/bigrat.s7i         0.081056            784
+seed7/lib/bin16.s7i          0.073432            592
+seed7/lib/bin32.s7i          0.068787            490
+seed7/lib/bin64.s7i          0.067608            539
+seed7/lib/bitdata.s7i        0.127017           1330
+seed7/lib/bitmapfont.s7i     0.048767            215
+seed7/lib/bitset.s7i         0.066296            593
+seed7/lib/bitsetof.s7i       0.063420            431
+seed7/lib/blowfish.s7i       0.079335            383
+seed7/lib/bmp.s7i            0.102486            924
+seed7/lib/boolean.s7i        0.057666            403
+seed7/lib/browser.s7i        0.054377            280
+seed7/lib/bstring.s7i        0.047613            227
+seed7/lib/bytedata.s7i       0.064021            482
+seed7/lib/bzip2.s7i          0.089526            887
+seed7/lib/cards.s7i          0.102359           1342
+seed7/lib/category.s7i       0.051137            209
+seed7/lib/cc_conf.s7i        0.123161           1314
+seed7/lib/ccittfax.s7i       0.105233           1022
+seed7/lib/cgi.s7i            0.040615            109
+seed7/lib/cgidialog.s7i      0.096412           1118
+seed7/lib/char.s7i           0.053639            356
+seed7/lib/charsets.s7i       0.123446           2024
+seed7/lib/chartype.s7i       0.046436            121
+seed7/lib/cipher.s7i         0.041425            146
+seed7/lib/cli_cmds.s7i       0.114424           1360
+seed7/lib/clib_file.s7i      0.051959            301
+seed7/lib/color.s7i          0.049866            185
+seed7/lib/complex.s7i        0.058204            464
+seed7/lib/compress.s7i       0.041902            150
+seed7/lib/console.s7i        0.043735            188
+seed7/lib/cpio.s7i           0.149780           1708
+seed7/lib/crc32.s7i          0.054059            193
+seed7/lib/cronos16.s7i       0.195162           1173
+seed7/lib/cronos27.s7i       0.256364           1464
+seed7/lib/csv.s7i            0.048150            201
+seed7/lib/db_prop.s7i        0.104531            991
+seed7/lib/deflate.s7i        0.085679            740
+seed7/lib/des.s7i            0.078989            444
+seed7/lib/dialog.s7i         0.055007            311
+seed7/lib/dir.s7i            0.042832            163
+seed7/lib/draw.s7i           0.085176            854
+seed7/lib/duration.s7i       0.097846           1038
+seed7/lib/echo.s7i           0.041695            132
+seed7/lib/editline.s7i       0.058356            398
+seed7/lib/elf.s7i            0.156028           1560
+seed7/lib/elliptic.s7i       0.075546            649
+seed7/lib/enable_io.s7i      0.051665            312
+seed7/lib/encoding.s7i       0.096050            931
+seed7/lib/enumeration.s7i    0.048694            236
+seed7/lib/environment.s7i    0.043546            175
+seed7/lib/exif.s7i           0.044328            152
+seed7/lib/external_file.s7i  0.050723            340
+seed7/lib/field.s7i          0.051110            268
+seed7/lib/file.s7i           0.052265            372
+seed7/lib/filebits.s7i       0.037044             46
+seed7/lib/filesys.s7i        0.067932            601
+seed7/lib/fileutil.s7i       0.043849            144
+seed7/lib/fixarray.s7i       0.054222            307
+seed7/lib/float.s7i          0.074575            757
+seed7/lib/font.s7i           0.043069            196
+seed7/lib/font8x8.s7i        0.071331            998
+seed7/lib/forloop.s7i        0.065048            449
+seed7/lib/ftp.s7i            0.087005            969
+seed7/lib/ftpserv.s7i        0.073960            631
+seed7/lib/getf.s7i           0.040952            115
+seed7/lib/gethttp.s7i        0.037607             41
+seed7/lib/gethttps.s7i       0.036502             41
+seed7/lib/gif.s7i            0.070284            561
+seed7/lib/graph.s7i          0.063777            415
+seed7/lib/graph_file.s7i     0.055509            399
+seed7/lib/gtkserver.s7i      0.040414            161
+seed7/lib/gzip.s7i           0.066108            573
+seed7/lib/hash.s7i           0.064023            421
+seed7/lib/hashsetof.s7i      0.065370            499
+seed7/lib/hmac.s7i           0.043380            152
+seed7/lib/html.s7i           0.038699             83
+seed7/lib/html_ent.s7i       0.062343            476
+seed7/lib/htmldom.s7i        0.053422            286
+seed7/lib/http_request.s7i   0.077178            696
+seed7/lib/http_srv_resp.s7i  0.057759            380
+seed7/lib/https_request.s7i  0.046694            211
+seed7/lib/httpserv.s7i       0.055005            345
+seed7/lib/huffman.s7i        0.074083            644
+seed7/lib/ico.s7i            0.055341            221
+seed7/lib/idxarray.s7i       0.055128            232
+seed7/lib/image.s7i          0.041142            156
+seed7/lib/imagefile.s7i      0.045005            171
+seed7/lib/inflate.s7i        0.062823            411
+seed7/lib/inifile.s7i        0.040973            129
+seed7/lib/integer.s7i        0.069622            663
+seed7/lib/iobuffer.s7i       0.051912            289
+seed7/lib/jpeg.s7i           0.158740           1761
+seed7/lib/json.s7i           0.080528            891
+seed7/lib/json_serde.s7i     0.081372            783
+seed7/lib/keybd.s7i          0.082112            639
+seed7/lib/keydescr.s7i       0.051088            192
+seed7/lib/leb128.s7i         0.047336            218
+seed7/lib/line.s7i           0.043356            164
+seed7/lib/listener.s7i       0.050010            247
+seed7/lib/logfile.s7i        0.039553             73
+seed7/lib/lower.s7i          0.042187            142
+seed7/lib/lzma.s7i           0.096844            934
+seed7/lib/lzw.s7i            0.091438            861
+seed7/lib/magic.s7i          0.062540            403
+seed7/lib/mahjng32.s7i       0.090356           1500
+seed7/lib/make.s7i           0.070799            544
+seed7/lib/makedata.s7i       0.122015           1428
+seed7/lib/math.s7i           0.044170            201
+seed7/lib/mixarith.s7i       0.047026            249
+seed7/lib/modern27.s7i       0.166965           1099
+seed7/lib/more.s7i           0.040848            130
+seed7/lib/msgdigest.s7i      0.134994           1222
+seed7/lib/multiscr.s7i       0.037681             68
+seed7/lib/null_file.s7i      0.050241            345
+seed7/lib/osfiles.s7i        0.096529           1085
+seed7/lib/pbm.s7i            0.047471            230
+seed7/lib/pcx.s7i            0.076428            638
+seed7/lib/pem.s7i            0.044374            185
+seed7/lib/pgm.s7i            0.047467            238
+seed7/lib/pic16.s7i          0.064744           1037
+seed7/lib/pic32.s7i          0.126549           2060
+seed7/lib/pic_util.s7i       0.043642            144
+seed7/lib/pixelimage.s7i     0.051974            320
+seed7/lib/pixmap_file.s7i    0.061552            459
+seed7/lib/pixmapfont.s7i     0.056089            184
+seed7/lib/pkcs1.s7i          0.077656            543
+seed7/lib/png.s7i            0.108485           1064
+seed7/lib/poll.s7i           0.051472            313
+seed7/lib/ppm.s7i            0.048199            240
+seed7/lib/process.s7i        0.063521            541
+seed7/lib/progs.s7i          0.078907            789
+seed7/lib/propertyfile.s7i   0.043273            155
+seed7/lib/rational.s7i       0.078529            792
+seed7/lib/ref_list.s7i       0.048182            252
+seed7/lib/reference.s7i      0.040936            126
+seed7/lib/reverse.s7i        0.039411             94
+seed7/lib/rpm.s7i            0.282949           3487
+seed7/lib/rpmext.s7i         0.051243            318
+seed7/lib/scanfile.s7i       0.134147           1779
+seed7/lib/scanjson.s7i       0.060449            413
+seed7/lib/scanstri.s7i       0.136529           1814
+seed7/lib/scantoml.s7i       0.136413           1603
+seed7/lib/seed7_05.s7i       0.110932           1072
+seed7/lib/set.s7i            0.037070             57
+seed7/lib/shell.s7i          0.067423            615
+seed7/lib/showtls.s7i        0.083257            678
+seed7/lib/signature.s7i      0.042092            131
+seed7/lib/smtp.s7i           0.051722            261
+seed7/lib/sockbase.s7i       0.050062            217
+seed7/lib/socket.s7i         0.051977            326
+seed7/lib/sokoban1.s7i       0.080358           1519
+seed7/lib/sql_base.s7i       0.093985           1000
+seed7/lib/stars.s7i          0.236932           1705
+seed7/lib/stdfont10.s7i      0.141472           3347
+seed7/lib/stdfont12.s7i      0.168521           3928
+seed7/lib/stdfont14.s7i      0.186269           4510
+seed7/lib/stdfont16.s7i      0.211324           5092
+seed7/lib/stdfont18.s7i      0.245015           5868
+seed7/lib/stdfont20.s7i      0.274614           6449
+seed7/lib/stdfont24.s7i      0.326728           7421
+seed7/lib/stdfont8.s7i       0.124571           2960
+seed7/lib/stdfont9.s7i       0.131817           3152
+seed7/lib/stdio.s7i          0.042560            192
+seed7/lib/strifile.s7i       0.052985            345
+seed7/lib/string.s7i         0.074823            779
+seed7/lib/stritext.s7i       0.054293            352
+seed7/lib/struct.s7i         0.055096            266
+seed7/lib/struct_elem.s7i    0.041503            129
+seed7/lib/subfile.s7i        0.051193            174
+seed7/lib/subrange.s7i       0.039475             78
+seed7/lib/syntax.s7i         0.059705            294
+seed7/lib/tar.s7i            0.150091           1880
+seed7/lib/tar_cmds.s7i       0.082743            752
+seed7/lib/tdes.s7i           0.042340            143
+seed7/lib/tee.s7i            0.040354            143
+seed7/lib/text.s7i           0.040211            135
+seed7/lib/tga.s7i            0.079057            676
+seed7/lib/tiff.s7i           0.242867           2771
+seed7/lib/time.s7i           0.101474           1191
+seed7/lib/tls.s7i            0.193854           2230
+seed7/lib/unicode.s7i        0.072445            575
+seed7/lib/unionfnd.s7i       0.041192            130
+seed7/lib/upper.s7i          0.041270            142
+seed7/lib/utf16.s7i          0.064347            540
+seed7/lib/utf8.s7i           0.046026            234
+seed7/lib/vecfont10.s7i      0.160469           1056
+seed7/lib/vecfont18.s7i      0.181491           1119
+seed7/lib/vector3d.s7i       0.048865            293
+seed7/lib/vectorfont.s7i     0.047251            239
+seed7/lib/wildcard.s7i       0.041976            140
+seed7/lib/window.s7i         0.060370            455
+seed7/lib/wrinum.s7i         0.049251            248
+seed7/lib/x509cert.s7i       0.117956           1243
+seed7/lib/xml_ent.s7i        0.040517             94
+seed7/lib/xmldom.s7i         0.049654            303
+seed7/lib/xz.s7i             0.060368            442
+seed7/lib/zip.s7i            0.232999           2792
+seed7/lib/zstd.s7i           0.115612           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.159538        |
++-----------+-----------------+
+| Minimum   | 0.035269        |
++-----------+-----------------+
+| Maximum   | 5.635506        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.036444        | 0.032541        | 0.043105        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.038717        | 0.035252        | 0.046121        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.089399        | 0.034260        | 2.510868        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.159538        | 0.035269        | 5.635506        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:14.034 | 00:01:02.084 | 00:01:16.118 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.878 | 00:01:06.012 | 00:01:20.891 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:35.879 | 00:02:33.286 | 00:03:09.165 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:02.905 | 00:04:32.838 | 00:05:35.744 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:21.926 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-09.1.rst
+++ b/reports/seed7mode-perf-09.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-24T21:10:39+0000 W26-3
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 17:13:00 local time
+:Generated on: 2026-06-24 21:24:16 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 230x84 chars
+:Window body: 230x82 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.034890            190
+seed7/prg/bas7.sd7           0.036055          11459
+seed7/prg/bifurk.sd7         0.034495             73
+seed7/prg/bigfiles.sd7       0.034931            129
+seed7/prg/brainf7.sd7        0.035688             86
+seed7/prg/calc7.sd7          0.035036            128
+seed7/prg/carddemo.sd7       0.034925            190
+seed7/prg/castle.sd7         0.034387           3148
+seed7/prg/cat.sd7            0.034881             82
+seed7/prg/cellauto.sd7       0.034280             85
+seed7/prg/celsius.sd7        0.033614             42
+seed7/prg/chk_all.sd7        0.032607            843
+seed7/prg/chkarr.sd7         0.033538           8367
+seed7/prg/chkbig.sd7         0.037108          29026
+seed7/prg/chkbin.sd7         0.033040           6469
+seed7/prg/chkbitdata.sd7     0.035844           6624
+seed7/prg/chkbool.sd7        0.033206           3157
+seed7/prg/chkbst.sd7         0.033658            722
+seed7/prg/chkchr.sd7         0.034632           2809
+seed7/prg/chkcmd.sd7         0.034621           1205
+seed7/prg/chkdb.sd7          0.035905           7454
+seed7/prg/chkdecl.sd7        0.036326            448
+seed7/prg/chkenum.sd7        0.034826           1230
+seed7/prg/chkerr.sd7         0.033616           4663
+seed7/prg/chkexc.sd7         0.033870           2627
+seed7/prg/chkfil.sd7         0.033102           1615
+seed7/prg/chkflt.sd7         0.036092          20620
+seed7/prg/chkhent.sd7        0.033062             54
+seed7/prg/chkhsh.sd7         0.033131           4548
+seed7/prg/chkidx.sd7         0.034879          19567
+seed7/prg/chkint.sd7         0.039045          38129
+seed7/prg/chkjson.sd7        0.032553           1764
+seed7/prg/chkovf.sd7         0.033150           8216
+seed7/prg/chkprc.sd7         0.033084          10111
+seed7/prg/chkscan.sd7        0.032950            714
+seed7/prg/chkset.sd7         0.033663          11974
+seed7/prg/chkstr.sd7         0.037370          26952
+seed7/prg/chktime.sd7        0.033789           2025
+seed7/prg/chktoml.sd7        0.037108           1656
+seed7/prg/clock.sd7          0.034956             47
+seed7/prg/clock2.sd7         0.035450             43
+seed7/prg/clock3.sd7         0.033696             95
+seed7/prg/cmpfil.sd7         0.036496             84
+seed7/prg/comanche.sd7       0.037349            180
+seed7/prg/confval.sd7        0.035560            175
+seed7/prg/db7.sd7            0.036327            417
+seed7/prg/diff7.sd7          0.035071            263
+seed7/prg/dirtst.sd7         0.036487             42
+seed7/prg/dirx.sd7           0.036913            152
+seed7/prg/dnafight.sd7       0.034820           1381
+seed7/prg/dragon.sd7         0.035648             73
+seed7/prg/echo.sd7           0.035507             39
+seed7/prg/eliza.sd7          0.033615            302
+seed7/prg/err.sd7            0.033122             96
+seed7/prg/fannkuch.sd7       0.033106            131
+seed7/prg/fib.sd7            0.032831             47
+seed7/prg/find7.sd7          0.032915            133
+seed7/prg/findchar.sd7       0.032885            149
+seed7/prg/fractree.sd7       0.033027             55
+seed7/prg/ftp7.sd7           0.033394            296
+seed7/prg/ftpserv.sd7        0.032969             74
+seed7/prg/gcd.sd7            0.032824            109
+seed7/prg/gkbd.sd7           0.033094            358
+seed7/prg/gtksvtst.sd7       0.032892             94
+seed7/prg/hal.sd7            0.034567            250
+seed7/prg/hamu.sd7           0.033584            573
+seed7/prg/hanoi.sd7          0.033191             55
+seed7/prg/hd.sd7             0.033205             79
+seed7/prg/hello.sd7          0.032897             32
+seed7/prg/hilbert.sd7        0.033051            108
+seed7/prg/ide7.sd7           0.032909            196
+seed7/prg/kbd.sd7            0.032870             49
+seed7/prg/klondike.sd7       0.032828            883
+seed7/prg/lander.sd7         0.032476           1551
+seed7/prg/lst80bas.sd7       0.032407            344
+seed7/prg/lst99bas.sd7       0.032318            401
+seed7/prg/lstgwbas.sd7       0.032648            577
+seed7/prg/mahjong.sd7        0.033897           1943
+seed7/prg/make7.sd7          0.033091            121
+seed7/prg/mandelbr.sd7       0.032703            237
+seed7/prg/mind.sd7           0.032489            443
+seed7/prg/mirror.sd7         0.033034            131
+seed7/prg/ms.sd7             0.032507            641
+seed7/prg/nicoma.sd7         0.032723            135
+seed7/prg/pac.sd7            0.033027            726
+seed7/prg/pairs.sd7          0.032365           2025
+seed7/prg/panic.sd7          0.032700           2634
+seed7/prg/percolation.sd7    0.033042            330
+seed7/prg/planets.sd7        0.033222           1486
+seed7/prg/portfwd7.sd7       0.033800            139
+seed7/prg/prime.sd7          0.035489             74
+seed7/prg/printpi1.sd7       0.033400             56
+seed7/prg/printpi2.sd7       0.033003             54
+seed7/prg/printpi3.sd7       0.032940             60
+seed7/prg/pv7.sd7            0.033138            337
+seed7/prg/queen.sd7          0.033531            149
+seed7/prg/rand.sd7           0.033940            121
+seed7/prg/raytrace.sd7       0.038909            538
+seed7/prg/rever.sd7          0.035547            816
+seed7/prg/roman.sd7          0.033238             38
+seed7/prg/s7c.sd7            0.033525           9060
+seed7/prg/s7check.sd7        0.033080             68
+seed7/prg/savehd7.sd7        0.032909           1110
+seed7/prg/self.sd7           0.032816             49
+seed7/prg/shisen.sd7         0.032615           1423
+seed7/prg/sl.sd7             0.032608           1029
+seed7/prg/snake.sd7          0.032677            615
+seed7/prg/sokoban.sd7        0.032380            891
+seed7/prg/spigotpi.sd7       0.032679             64
+seed7/prg/sql7.sd7           0.034048            278
+seed7/prg/startrek.sd7       0.033448            979
+seed7/prg/sudoku7.sd7        0.033543           2657
+seed7/prg/sydir7.sd7         0.033180            384
+seed7/prg/syntaxhl.sd7       0.032936            177
+seed7/prg/tak.sd7            0.033044             59
+seed7/prg/tar7.sd7           0.032973            121
+seed7/prg/tch.sd7            0.032973             55
+seed7/prg/testfont.sd7       0.033011             95
+seed7/prg/tet.sd7            0.033226            479
+seed7/prg/tetg.sd7           0.032750            501
+seed7/prg/toutf8.sd7         0.033239            240
+seed7/prg/tst_cli.sd7        0.033064             40
+seed7/prg/tst_srv.sd7        0.033148             47
+seed7/prg/wator.sd7          0.033017            651
+seed7/prg/which.sd7          0.033066             65
+seed7/prg/wiz.sd7            0.033604           2833
+seed7/prg/wordcnt.sd7        0.032838             54
+seed7/prg/wrinum.sd7         0.033701             43
+seed7/prg/wumpus.sd7         0.033069            372
+seed7/lib/aes.s7i            0.033238           1144
+seed7/lib/aes_gcm.s7i        0.033105            392
+seed7/lib/ar.s7i             0.032929           1532
+seed7/lib/arc4.s7i           0.033223            144
+seed7/lib/archive.s7i        0.032948            143
+seed7/lib/archive_base.s7i   0.034125            135
+seed7/lib/array.s7i          0.038799            610
+seed7/lib/asn1.s7i           0.035421            544
+seed7/lib/asn1oid.s7i        0.032634            157
+seed7/lib/basearray.s7i      0.033827            450
+seed7/lib/bigfile.s7i        0.033402            136
+seed7/lib/bigint.s7i         0.032437            824
+seed7/lib/bigrat.s7i         0.034422            784
+seed7/lib/bin16.s7i          0.032708            592
+seed7/lib/bin32.s7i          0.032410            490
+seed7/lib/bin64.s7i          0.033128            539
+seed7/lib/bitdata.s7i        0.032927           1330
+seed7/lib/bitmapfont.s7i     0.032239            215
+seed7/lib/bitset.s7i         0.032172            593
+seed7/lib/bitsetof.s7i       0.032843            431
+seed7/lib/blowfish.s7i       0.033238            383
+seed7/lib/bmp.s7i            0.033372            924
+seed7/lib/boolean.s7i        0.034359            403
+seed7/lib/browser.s7i        0.036048            280
+seed7/lib/bstring.s7i        0.033067            227
+seed7/lib/bytedata.s7i       0.033096            482
+seed7/lib/bzip2.s7i          0.033718            887
+seed7/lib/cards.s7i          0.033900           1342
+seed7/lib/category.s7i       0.033148            209
+seed7/lib/cc_conf.s7i        0.033216           1314
+seed7/lib/ccittfax.s7i       0.033247           1022
+seed7/lib/cgi.s7i            0.032978            109
+seed7/lib/cgidialog.s7i      0.033375           1118
+seed7/lib/char.s7i           0.033342            356
+seed7/lib/charsets.s7i       0.033039           2024
+seed7/lib/chartype.s7i       0.032782            121
+seed7/lib/cipher.s7i         0.033144            146
+seed7/lib/cli_cmds.s7i       0.033344           1360
+seed7/lib/clib_file.s7i      0.032715            301
+seed7/lib/color.s7i          0.032718            185
+seed7/lib/complex.s7i        0.032719            464
+seed7/lib/compress.s7i       0.032664            150
+seed7/lib/console.s7i        0.032536            188
+seed7/lib/cpio.s7i           0.033407           1708
+seed7/lib/crc32.s7i          0.033674            193
+seed7/lib/cronos16.s7i       0.033321           1173
+seed7/lib/cronos27.s7i       0.034589           1464
+seed7/lib/csv.s7i            0.033098            201
+seed7/lib/db_prop.s7i        0.034290            991
+seed7/lib/deflate.s7i        0.036723            740
+seed7/lib/des.s7i            0.036012            444
+seed7/lib/dialog.s7i         0.033037            311
+seed7/lib/dir.s7i            0.033173            163
+seed7/lib/draw.s7i           0.034510            854
+seed7/lib/duration.s7i       0.033270           1038
+seed7/lib/echo.s7i           0.033140            132
+seed7/lib/editline.s7i       0.033761            398
+seed7/lib/elf.s7i            0.033192           1560
+seed7/lib/elliptic.s7i       0.033528            649
+seed7/lib/enable_io.s7i      0.033159            312
+seed7/lib/encoding.s7i       0.033066            931
+seed7/lib/enumeration.s7i    0.033059            236
+seed7/lib/environment.s7i    0.033272            175
+seed7/lib/exif.s7i           0.033084            152
+seed7/lib/external_file.s7i  0.033146            340
+seed7/lib/field.s7i          0.032987            268
+seed7/lib/file.s7i           0.033128            372
+seed7/lib/filebits.s7i       0.035123             46
+seed7/lib/filesys.s7i        0.034971            601
+seed7/lib/fileutil.s7i       0.033097            144
+seed7/lib/fixarray.s7i       0.032710            307
+seed7/lib/float.s7i          0.032616            757
+seed7/lib/font.s7i           0.032762            196
+seed7/lib/font8x8.s7i        0.032417            998
+seed7/lib/forloop.s7i        0.033812            449
+seed7/lib/ftp.s7i            0.036452            969
+seed7/lib/ftpserv.s7i        0.033187            631
+seed7/lib/getf.s7i           0.033152            115
+seed7/lib/gethttp.s7i        0.033236             41
+seed7/lib/gethttps.s7i       0.033400             41
+seed7/lib/gif.s7i            0.033325            561
+seed7/lib/graph.s7i          0.033333            415
+seed7/lib/graph_file.s7i     0.032945            399
+seed7/lib/gtkserver.s7i      0.032957            161
+seed7/lib/gzip.s7i           0.033162            573
+seed7/lib/hash.s7i           0.032956            421
+seed7/lib/hashsetof.s7i      0.033300            499
+seed7/lib/hmac.s7i           0.033036            152
+seed7/lib/html.s7i           0.032914             83
+seed7/lib/html_ent.s7i       0.033231            476
+seed7/lib/htmldom.s7i        0.033070            286
+seed7/lib/http_request.s7i   0.033335            696
+seed7/lib/http_srv_resp.s7i  0.033506            380
+seed7/lib/https_request.s7i  0.033271            211
+seed7/lib/httpserv.s7i       0.033644            345
+seed7/lib/huffman.s7i        0.033301            644
+seed7/lib/ico.s7i            0.033262            221
+seed7/lib/idxarray.s7i       0.033000            232
+seed7/lib/image.s7i          0.032996            156
+seed7/lib/imagefile.s7i      0.032957            171
+seed7/lib/inflate.s7i        0.032534            411
+seed7/lib/inifile.s7i        0.032622            129
+seed7/lib/integer.s7i        0.032542            663
+seed7/lib/iobuffer.s7i       0.032392            289
+seed7/lib/jpeg.s7i           0.033127           1761
+seed7/lib/json.s7i           0.033762            891
+seed7/lib/json_serde.s7i     0.033363            783
+seed7/lib/keybd.s7i          0.033288            639
+seed7/lib/keydescr.s7i       0.033117            192
+seed7/lib/leb128.s7i         0.033115            218
+seed7/lib/line.s7i           0.033535            164
+seed7/lib/listener.s7i       0.033854            247
+seed7/lib/logfile.s7i        0.034392             73
+seed7/lib/lower.s7i          0.034992            142
+seed7/lib/lzma.s7i           0.033331            934
+seed7/lib/lzw.s7i            0.033274            861
+seed7/lib/magic.s7i          0.035015            403
+seed7/lib/mahjng32.s7i       0.039522           1500
+seed7/lib/make.s7i           0.034490            544
+seed7/lib/makedata.s7i       0.033223           1428
+seed7/lib/math.s7i           0.033108            201
+seed7/lib/mixarith.s7i       0.033848            249
+seed7/lib/modern27.s7i       0.034181           1099
+seed7/lib/more.s7i           0.033179            130
+seed7/lib/msgdigest.s7i      0.035829           1222
+seed7/lib/multiscr.s7i       0.040069             68
+seed7/lib/null_file.s7i      0.035433            345
+seed7/lib/osfiles.s7i        0.033054           1085
+seed7/lib/pbm.s7i            0.033092            230
+seed7/lib/pcx.s7i            0.033218            638
+seed7/lib/pem.s7i            0.032471            185
+seed7/lib/pgm.s7i            0.036792            238
+seed7/lib/pic16.s7i          0.035491           1037
+seed7/lib/pic32.s7i          0.033436           2060
+seed7/lib/pic_util.s7i       0.033253            144
+seed7/lib/pixelimage.s7i     0.033830            320
+seed7/lib/pixmap_file.s7i    0.033058            459
+seed7/lib/pixmapfont.s7i     0.033367            184
+seed7/lib/pkcs1.s7i          0.033080            543
+seed7/lib/png.s7i            0.033497           1064
+seed7/lib/poll.s7i           0.033002            313
+seed7/lib/ppm.s7i            0.033078            240
+seed7/lib/process.s7i        0.033193            541
+seed7/lib/progs.s7i          0.033224            789
+seed7/lib/propertyfile.s7i   0.033242            155
+seed7/lib/rational.s7i       0.033464            792
+seed7/lib/ref_list.s7i       0.032982            252
+seed7/lib/reference.s7i      0.033945            126
+seed7/lib/reverse.s7i        0.033770             94
+seed7/lib/rpm.s7i            0.036479           3487
+seed7/lib/rpmext.s7i         0.035835            318
+seed7/lib/scanfile.s7i       0.033620           1779
+seed7/lib/scanjson.s7i       0.033448            413
+seed7/lib/scanstri.s7i       0.033926           1814
+seed7/lib/scantoml.s7i       0.039024           1603
+seed7/lib/seed7_05.s7i       0.035372           1072
+seed7/lib/set.s7i            0.033191             57
+seed7/lib/shell.s7i          0.033025            615
+seed7/lib/showtls.s7i        0.032835            678
+seed7/lib/signature.s7i      0.033236            131
+seed7/lib/smtp.s7i           0.032549            261
+seed7/lib/sockbase.s7i       0.032932            217
+seed7/lib/socket.s7i         0.032414            326
+seed7/lib/sokoban1.s7i       0.032618           1519
+seed7/lib/sql_base.s7i       0.034086           1000
+seed7/lib/stars.s7i          0.033648           1705
+seed7/lib/stdfont10.s7i      0.033338           3347
+seed7/lib/stdfont12.s7i      0.033264           3928
+seed7/lib/stdfont14.s7i      0.033295           4510
+seed7/lib/stdfont16.s7i      0.033604           5092
+seed7/lib/stdfont18.s7i      0.033557           5868
+seed7/lib/stdfont20.s7i      0.033392           6449
+seed7/lib/stdfont24.s7i      0.033127           7421
+seed7/lib/stdfont8.s7i       0.034155           2960
+seed7/lib/stdfont9.s7i       0.033577           3152
+seed7/lib/stdio.s7i          0.033210            192
+seed7/lib/strifile.s7i       0.034102            345
+seed7/lib/string.s7i         0.033164            779
+seed7/lib/stritext.s7i       0.033386            352
+seed7/lib/struct.s7i         0.033259            266
+seed7/lib/struct_elem.s7i    0.033248            129
+seed7/lib/subfile.s7i        0.033170            174
+seed7/lib/subrange.s7i       0.033269             78
+seed7/lib/syntax.s7i         0.033843            294
+seed7/lib/tar.s7i            0.032921           1880
+seed7/lib/tar_cmds.s7i       0.033222            752
+seed7/lib/tdes.s7i           0.033075            143
+seed7/lib/tee.s7i            0.033093            143
+seed7/lib/text.s7i           0.033149            135
+seed7/lib/tga.s7i            0.033109            676
+seed7/lib/tiff.s7i           0.033399           2771
+seed7/lib/time.s7i           0.033935           1191
+seed7/lib/tls.s7i            0.038834           2230
+seed7/lib/unicode.s7i        0.034409            575
+seed7/lib/unionfnd.s7i       0.032529            130
+seed7/lib/upper.s7i          0.032140            142
+seed7/lib/utf16.s7i          0.034826            540
+seed7/lib/utf8.s7i           0.033238            234
+seed7/lib/vecfont10.s7i      0.033277           1056
+seed7/lib/vecfont18.s7i      0.033608           1119
+seed7/lib/vector3d.s7i       0.033377            293
+seed7/lib/vectorfont.s7i     0.033046            239
+seed7/lib/wildcard.s7i       0.033051            140
+seed7/lib/window.s7i         0.033131            455
+seed7/lib/wrinum.s7i         0.033335            248
+seed7/lib/x509cert.s7i       0.033281           1243
+seed7/lib/xml_ent.s7i        0.032928             94
+seed7/lib/xmldom.s7i         0.033099            303
+seed7/lib/xz.s7i             0.033528            442
+seed7/lib/zip.s7i            0.033343           2792
+seed7/lib/zstd.s7i           0.033031           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033692        |
++-----------+-----------------+
+| Minimum   | 0.032140        |
++-----------+-----------------+
+| Maximum   | 0.040069        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.038483            190
+seed7/prg/bas7.sd7           0.040703          11459
+seed7/prg/bifurk.sd7         0.040563             73
+seed7/prg/bigfiles.sd7       0.043376            129
+seed7/prg/brainf7.sd7        0.038364             86
+seed7/prg/calc7.sd7          0.037819            128
+seed7/prg/carddemo.sd7       0.038317            190
+seed7/prg/castle.sd7         0.047615           3148
+seed7/prg/cat.sd7            0.039309             82
+seed7/prg/cellauto.sd7       0.037651             85
+seed7/prg/celsius.sd7        0.035759             42
+seed7/prg/chk_all.sd7        0.038342            843
+seed7/prg/chkarr.sd7         0.037426           8367
+seed7/prg/chkbig.sd7         0.040800          29026
+seed7/prg/chkbin.sd7         0.037941           6469
+seed7/prg/chkbitdata.sd7     0.038821           6624
+seed7/prg/chkbool.sd7        0.036807           3157
+seed7/prg/chkbst.sd7         0.037851            722
+seed7/prg/chkchr.sd7         0.038307           2809
+seed7/prg/chkcmd.sd7         0.037325           1205
+seed7/prg/chkdb.sd7          0.039730           7454
+seed7/prg/chkdecl.sd7        0.038819            448
+seed7/prg/chkenum.sd7        0.036775           1230
+seed7/prg/chkerr.sd7         0.039086           4663
+seed7/prg/chkexc.sd7         0.037259           2627
+seed7/prg/chkfil.sd7         0.039765           1615
+seed7/prg/chkflt.sd7         0.040586          20620
+seed7/prg/chkhent.sd7        0.037116             54
+seed7/prg/chkhsh.sd7         0.039030           4548
+seed7/prg/chkidx.sd7         0.040727          19567
+seed7/prg/chkint.sd7         0.047167          38129
+seed7/prg/chkjson.sd7        0.037708           1764
+seed7/prg/chkovf.sd7         0.037255           8216
+seed7/prg/chkprc.sd7         0.037708          10111
+seed7/prg/chkscan.sd7        0.038890            714
+seed7/prg/chkset.sd7         0.040188          11974
+seed7/prg/chkstr.sd7         0.041520          26952
+seed7/prg/chktime.sd7        0.039639           2025
+seed7/prg/chktoml.sd7        0.038445           1656
+seed7/prg/clock.sd7          0.035457             47
+seed7/prg/clock2.sd7         0.035367             43
+seed7/prg/clock3.sd7         0.037683             95
+seed7/prg/cmpfil.sd7         0.036539             84
+seed7/prg/comanche.sd7       0.038484            180
+seed7/prg/confval.sd7        0.040263            175
+seed7/prg/db7.sd7            0.038356            417
+seed7/prg/diff7.sd7          0.038961            263
+seed7/prg/dirtst.sd7         0.035580             42
+seed7/prg/dirx.sd7           0.038212            152
+seed7/prg/dnafight.sd7       0.038532           1381
+seed7/prg/dragon.sd7         0.036659             73
+seed7/prg/echo.sd7           0.035388             39
+seed7/prg/eliza.sd7          0.038115            302
+seed7/prg/err.sd7            0.040572             96
+seed7/prg/fannkuch.sd7       0.037550            131
+seed7/prg/fib.sd7            0.035826             47
+seed7/prg/find7.sd7          0.037967            133
+seed7/prg/findchar.sd7       0.038286            149
+seed7/prg/fractree.sd7       0.036065             55
+seed7/prg/ftp7.sd7           0.038150            296
+seed7/prg/ftpserv.sd7        0.037204             74
+seed7/prg/gcd.sd7            0.037097            109
+seed7/prg/gkbd.sd7           0.038737            358
+seed7/prg/gtksvtst.sd7       0.037563             94
+seed7/prg/hal.sd7            0.038004            250
+seed7/prg/hamu.sd7           0.037323            573
+seed7/prg/hanoi.sd7          0.035797             55
+seed7/prg/hd.sd7             0.038643             79
+seed7/prg/hello.sd7          0.041495             32
+seed7/prg/hilbert.sd7        0.039361            108
+seed7/prg/ide7.sd7           0.039497            196
+seed7/prg/kbd.sd7            0.035546             49
+seed7/prg/klondike.sd7       0.039692            883
+seed7/prg/lander.sd7         0.038859           1551
+seed7/prg/lst80bas.sd7       0.037767            344
+seed7/prg/lst99bas.sd7       0.037661            401
+seed7/prg/lstgwbas.sd7       0.037363            577
+seed7/prg/mahjong.sd7        0.038525           1943
+seed7/prg/make7.sd7          0.038274            121
+seed7/prg/mandelbr.sd7       0.038324            237
+seed7/prg/mind.sd7           0.037202            443
+seed7/prg/mirror.sd7         0.037883            131
+seed7/prg/ms.sd7             0.038224            641
+seed7/prg/nicoma.sd7         0.038327            135
+seed7/prg/pac.sd7            0.036626            726
+seed7/prg/pairs.sd7          0.037541           2025
+seed7/prg/panic.sd7          0.044296           2634
+seed7/prg/percolation.sd7    0.040062            330
+seed7/prg/planets.sd7        0.039086           1486
+seed7/prg/portfwd7.sd7       0.038228            139
+seed7/prg/prime.sd7          0.036223             74
+seed7/prg/printpi1.sd7       0.037678             56
+seed7/prg/printpi2.sd7       0.036116             54
+seed7/prg/printpi3.sd7       0.036333             60
+seed7/prg/pv7.sd7            0.037951            337
+seed7/prg/queen.sd7          0.036186            149
+seed7/prg/rand.sd7           0.036448            121
+seed7/prg/raytrace.sd7       0.038036            538
+seed7/prg/rever.sd7          0.037697            816
+seed7/prg/roman.sd7          0.035254             38
+seed7/prg/s7c.sd7            0.040993           9060
+seed7/prg/s7check.sd7        0.044044             68
+seed7/prg/savehd7.sd7        0.041032           1110
+seed7/prg/self.sd7           0.035373             49
+seed7/prg/shisen.sd7         0.037884           1423
+seed7/prg/sl.sd7             0.036347           1029
+seed7/prg/snake.sd7          0.036678            615
+seed7/prg/sokoban.sd7        0.038400            891
+seed7/prg/spigotpi.sd7       0.036682             64
+seed7/prg/sql7.sd7           0.038625            278
+seed7/prg/startrek.sd7       0.038848            979
+seed7/prg/sudoku7.sd7        0.039016           2657
+seed7/prg/sydir7.sd7         0.038569            384
+seed7/prg/syntaxhl.sd7       0.039096            177
+seed7/prg/tak.sd7            0.036195             59
+seed7/prg/tar7.sd7           0.038386            121
+seed7/prg/tch.sd7            0.038571             55
+seed7/prg/testfont.sd7       0.041238             95
+seed7/prg/tet.sd7            0.038299            479
+seed7/prg/tetg.sd7           0.038671            501
+seed7/prg/toutf8.sd7         0.038870            240
+seed7/prg/tst_cli.sd7        0.035400             40
+seed7/prg/tst_srv.sd7        0.035054             47
+seed7/prg/wator.sd7          0.036587            651
+seed7/prg/which.sd7          0.036033             65
+seed7/prg/wiz.sd7            0.038132           2833
+seed7/prg/wordcnt.sd7        0.035784             54
+seed7/prg/wrinum.sd7         0.036299             43
+seed7/prg/wumpus.sd7         0.038005            372
+seed7/lib/aes.s7i            0.041709           1144
+seed7/lib/aes_gcm.s7i        0.039264            392
+seed7/lib/ar.s7i             0.038836           1532
+seed7/lib/arc4.s7i           0.038659            144
+seed7/lib/archive.s7i        0.038606            143
+seed7/lib/archive_base.s7i   0.038597            135
+seed7/lib/array.s7i          0.038923            610
+seed7/lib/asn1.s7i           0.036736            544
+seed7/lib/asn1oid.s7i        0.040929            157
+seed7/lib/basearray.s7i      0.038731            450
+seed7/lib/bigfile.s7i        0.038307            136
+seed7/lib/bigint.s7i         0.038468            824
+seed7/lib/bigrat.s7i         0.038308            784
+seed7/lib/bin16.s7i          0.038344            592
+seed7/lib/bin32.s7i          0.038502            490
+seed7/lib/bin64.s7i          0.038548            539
+seed7/lib/bitdata.s7i        0.042432           1330
+seed7/lib/bitmapfont.s7i     0.038433            215
+seed7/lib/bitset.s7i         0.038617            593
+seed7/lib/bitsetof.s7i       0.038759            431
+seed7/lib/blowfish.s7i       0.040688            383
+seed7/lib/bmp.s7i            0.038451            924
+seed7/lib/boolean.s7i        0.037474            403
+seed7/lib/browser.s7i        0.038026            280
+seed7/lib/bstring.s7i        0.037520            227
+seed7/lib/bytedata.s7i       0.038381            482
+seed7/lib/bzip2.s7i          0.040241            887
+seed7/lib/cards.s7i          0.036759           1342
+seed7/lib/category.s7i       0.038672            209
+seed7/lib/cc_conf.s7i        0.038201           1314
+seed7/lib/ccittfax.s7i       0.039019           1022
+seed7/lib/cgi.s7i            0.038759            109
+seed7/lib/cgidialog.s7i      0.038514           1118
+seed7/lib/char.s7i           0.038936            356
+seed7/lib/charsets.s7i       0.040122           2024
+seed7/lib/chartype.s7i       0.042322            121
+seed7/lib/cipher.s7i         0.038373            146
+seed7/lib/cli_cmds.s7i       0.038180           1360
+seed7/lib/clib_file.s7i      0.037827            301
+seed7/lib/color.s7i          0.037702            185
+seed7/lib/complex.s7i        0.036185            464
+seed7/lib/compress.s7i       0.038057            150
+seed7/lib/console.s7i        0.037318            188
+seed7/lib/cpio.s7i           0.039066           1708
+seed7/lib/crc32.s7i          0.038746            193
+seed7/lib/cronos16.s7i       0.039502           1173
+seed7/lib/cronos27.s7i       0.040685           1464
+seed7/lib/csv.s7i            0.039443            201
+seed7/lib/db_prop.s7i        0.039066            991
+seed7/lib/deflate.s7i        0.038665            740
+seed7/lib/des.s7i            0.040202            444
+seed7/lib/dialog.s7i         0.038661            311
+seed7/lib/dir.s7i            0.041484            163
+seed7/lib/draw.s7i           0.039449            854
+seed7/lib/duration.s7i       0.038747           1038
+seed7/lib/echo.s7i           0.038478            132
+seed7/lib/editline.s7i       0.038749            398
+seed7/lib/elf.s7i            0.040148           1560
+seed7/lib/elliptic.s7i       0.036760            649
+seed7/lib/enable_io.s7i      0.038402            312
+seed7/lib/encoding.s7i       0.038985            931
+seed7/lib/enumeration.s7i    0.038631            236
+seed7/lib/environment.s7i    0.038319            175
+seed7/lib/exif.s7i           0.038452            152
+seed7/lib/external_file.s7i  0.038249            340
+seed7/lib/field.s7i          0.038783            268
+seed7/lib/file.s7i           0.038170            372
+seed7/lib/filebits.s7i       0.036499             46
+seed7/lib/filesys.s7i        0.038323            601
+seed7/lib/fileutil.s7i       0.039005            144
+seed7/lib/fixarray.s7i       0.038291            307
+seed7/lib/float.s7i          0.038664            757
+seed7/lib/font.s7i           0.038172            196
+seed7/lib/font8x8.s7i        0.037214            998
+seed7/lib/forloop.s7i        0.038514            449
+seed7/lib/ftp.s7i            0.038795            969
+seed7/lib/ftpserv.s7i        0.038038            631
+seed7/lib/getf.s7i           0.037702            115
+seed7/lib/gethttp.s7i        0.035575             41
+seed7/lib/gethttps.s7i       0.035762             41
+seed7/lib/gif.s7i            0.037813            561
+seed7/lib/graph.s7i          0.041442            415
+seed7/lib/graph_file.s7i     0.038380            399
+seed7/lib/gtkserver.s7i      0.038669            161
+seed7/lib/gzip.s7i           0.038381            573
+seed7/lib/hash.s7i           0.041907            421
+seed7/lib/hashsetof.s7i      0.040499            499
+seed7/lib/hmac.s7i           0.038109            152
+seed7/lib/html.s7i           0.037475             83
+seed7/lib/html_ent.s7i       0.038136            476
+seed7/lib/htmldom.s7i        0.038387            286
+seed7/lib/http_request.s7i   0.038466            696
+seed7/lib/http_srv_resp.s7i  0.038332            380
+seed7/lib/https_request.s7i  0.038348            211
+seed7/lib/httpserv.s7i       0.038486            345
+seed7/lib/huffman.s7i        0.039775            644
+seed7/lib/ico.s7i            0.039016            221
+seed7/lib/idxarray.s7i       0.038586            232
+seed7/lib/image.s7i          0.036796            156
+seed7/lib/imagefile.s7i      0.038571            171
+seed7/lib/inflate.s7i        0.039067            411
+seed7/lib/inifile.s7i        0.038867            129
+seed7/lib/integer.s7i        0.038388            663
+seed7/lib/iobuffer.s7i       0.038261            289
+seed7/lib/jpeg.s7i           0.037955           1761
+seed7/lib/json.s7i           0.037451            891
+seed7/lib/json_serde.s7i     0.037802            783
+seed7/lib/keybd.s7i          0.037571            639
+seed7/lib/keydescr.s7i       0.039354            192
+seed7/lib/leb128.s7i         0.039557            218
+seed7/lib/line.s7i           0.037390            164
+seed7/lib/listener.s7i       0.038951            247
+seed7/lib/logfile.s7i        0.040916             73
+seed7/lib/lower.s7i          0.042834            142
+seed7/lib/lzma.s7i           0.039461            934
+seed7/lib/lzw.s7i            0.038489            861
+seed7/lib/magic.s7i          0.038950            403
+seed7/lib/mahjng32.s7i       0.037894           1500
+seed7/lib/make.s7i           0.038632            544
+seed7/lib/makedata.s7i       0.038525           1428
+seed7/lib/math.s7i           0.038260            201
+seed7/lib/mixarith.s7i       0.038218            249
+seed7/lib/modern27.s7i       0.039967           1099
+seed7/lib/more.s7i           0.038322            130
+seed7/lib/msgdigest.s7i      0.039320           1222
+seed7/lib/multiscr.s7i       0.037012             68
+seed7/lib/null_file.s7i      0.038107            345
+seed7/lib/osfiles.s7i        0.040158           1085
+seed7/lib/pbm.s7i            0.038884            230
+seed7/lib/pcx.s7i            0.038711            638
+seed7/lib/pem.s7i            0.038456            185
+seed7/lib/pgm.s7i            0.037924            238
+seed7/lib/pic16.s7i          0.036404           1037
+seed7/lib/pic32.s7i          0.037247           2060
+seed7/lib/pic_util.s7i       0.037475            144
+seed7/lib/pixelimage.s7i     0.037534            320
+seed7/lib/pixmap_file.s7i    0.038987            459
+seed7/lib/pixmapfont.s7i     0.039697            184
+seed7/lib/pkcs1.s7i          0.043644            543
+seed7/lib/png.s7i            0.038650           1064
+seed7/lib/poll.s7i           0.038345            313
+seed7/lib/ppm.s7i            0.038512            240
+seed7/lib/process.s7i        0.038537            541
+seed7/lib/progs.s7i          0.038385            789
+seed7/lib/propertyfile.s7i   0.038202            155
+seed7/lib/rational.s7i       0.038793            792
+seed7/lib/ref_list.s7i       0.038676            252
+seed7/lib/reference.s7i      0.038351            126
+seed7/lib/reverse.s7i        0.037652             94
+seed7/lib/rpm.s7i            0.039102           3487
+seed7/lib/rpmext.s7i         0.039097            318
+seed7/lib/scanfile.s7i       0.038775           1779
+seed7/lib/scanjson.s7i       0.039086            413
+seed7/lib/scanstri.s7i       0.038613           1814
+seed7/lib/scantoml.s7i       0.038482           1603
+seed7/lib/seed7_05.s7i       0.040765           1072
+seed7/lib/set.s7i            0.039576             57
+seed7/lib/shell.s7i          0.038200            615
+seed7/lib/showtls.s7i        0.038123            678
+seed7/lib/signature.s7i      0.037617            131
+seed7/lib/smtp.s7i           0.037796            261
+seed7/lib/sockbase.s7i       0.040625            217
+seed7/lib/socket.s7i         0.038050            326
+seed7/lib/sokoban1.s7i       0.038519           1519
+seed7/lib/sql_base.s7i       0.041171           1000
+seed7/lib/stars.s7i          0.039159           1705
+seed7/lib/stdfont10.s7i      0.037354           3347
+seed7/lib/stdfont12.s7i      0.037295           3928
+seed7/lib/stdfont14.s7i      0.037204           4510
+seed7/lib/stdfont16.s7i      0.037346           5092
+seed7/lib/stdfont18.s7i      0.037614           5868
+seed7/lib/stdfont20.s7i      0.037406           6449
+seed7/lib/stdfont24.s7i      0.038934           7421
+seed7/lib/stdfont8.s7i       0.036794           2960
+seed7/lib/stdfont9.s7i       0.036996           3152
+seed7/lib/stdio.s7i          0.038224            192
+seed7/lib/strifile.s7i       0.038417            345
+seed7/lib/string.s7i         0.039100            779
+seed7/lib/stritext.s7i       0.038769            352
+seed7/lib/struct.s7i         0.038322            266
+seed7/lib/struct_elem.s7i    0.037482            129
+seed7/lib/subfile.s7i        0.037773            174
+seed7/lib/subrange.s7i       0.036471             78
+seed7/lib/syntax.s7i         0.037672            294
+seed7/lib/tar.s7i            0.038377           1880
+seed7/lib/tar_cmds.s7i       0.037885            752
+seed7/lib/tdes.s7i           0.037851            143
+seed7/lib/tee.s7i            0.037562            143
+seed7/lib/text.s7i           0.037532            135
+seed7/lib/tga.s7i            0.040083            676
+seed7/lib/tiff.s7i           0.038680           2771
+seed7/lib/time.s7i           0.038700           1191
+seed7/lib/tls.s7i            0.039081           2230
+seed7/lib/unicode.s7i        0.039283            575
+seed7/lib/unionfnd.s7i       0.037289            130
+seed7/lib/upper.s7i          0.038146            142
+seed7/lib/utf16.s7i          0.038309            540
+seed7/lib/utf8.s7i           0.038671            234
+seed7/lib/vecfont10.s7i      0.039706           1056
+seed7/lib/vecfont18.s7i      0.040162           1119
+seed7/lib/vector3d.s7i       0.037272            293
+seed7/lib/vectorfont.s7i     0.038242            239
+seed7/lib/wildcard.s7i       0.038972            140
+seed7/lib/window.s7i         0.038727            455
+seed7/lib/wrinum.s7i         0.038481            248
+seed7/lib/x509cert.s7i       0.038512           1243
+seed7/lib/xml_ent.s7i        0.038123             94
+seed7/lib/xmldom.s7i         0.036823            303
+seed7/lib/xz.s7i             0.038246            442
+seed7/lib/zip.s7i            0.043432           2792
+seed7/lib/zstd.s7i           0.043289           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.038499        |
++-----------+-----------------+
+| Minimum   | 0.035054        |
++-----------+-----------------+
+| Maximum   | 0.047615        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.038679            190
+seed7/prg/bas7.sd7           0.323249          11459
+seed7/prg/bifurk.sd7         0.035399             73
+seed7/prg/bigfiles.sd7       0.036931            129
+seed7/prg/brainf7.sd7        0.037032             86
+seed7/prg/calc7.sd7          0.039975            128
+seed7/prg/carddemo.sd7       0.039653            190
+seed7/prg/castle.sd7         0.106436           3148
+seed7/prg/cat.sd7            0.036122             82
+seed7/prg/cellauto.sd7       0.035983             85
+seed7/prg/celsius.sd7        0.035109             42
+seed7/prg/chk_all.sd7        0.057966            843
+seed7/prg/chkarr.sd7         0.402317           8367
+seed7/prg/chkbig.sd7         2.079120          29026
+seed7/prg/chkbin.sd7         0.517027           6469
+seed7/prg/chkbitdata.sd7     0.617034           6624
+seed7/prg/chkbool.sd7        0.121816           3157
+seed7/prg/chkbst.sd7         0.071584            722
+seed7/prg/chkchr.sd7         0.230757           2809
+seed7/prg/chkcmd.sd7         0.078001           1205
+seed7/prg/chkdb.sd7          0.352970           7454
+seed7/prg/chkdecl.sd7        0.061227            448
+seed7/prg/chkenum.sd7        0.068606           1230
+seed7/prg/chkerr.sd7         0.197240           4663
+seed7/prg/chkexc.sd7         0.090039           2627
+seed7/prg/chkfil.sd7         0.085229           1615
+seed7/prg/chkflt.sd7         1.359779          20620
+seed7/prg/chkhent.sd7        0.041325             54
+seed7/prg/chkhsh.sd7         0.249479           4548
+seed7/prg/chkidx.sd7         1.330276          19567
+seed7/prg/chkint.sd7         2.514514          38129
+seed7/prg/chkjson.sd7        0.106982           1764
+seed7/prg/chkovf.sd7         0.590183           8216
+seed7/prg/chkprc.sd7         0.338350          10111
+seed7/prg/chkscan.sd7        0.059884            714
+seed7/prg/chkset.sd7         0.692561          11974
+seed7/prg/chkstr.sd7         1.460050          26952
+seed7/prg/chktime.sd7        0.131121           2025
+seed7/prg/chktoml.sd7        0.106419           1656
+seed7/prg/clock.sd7          0.035200             47
+seed7/prg/clock2.sd7         0.034958             43
+seed7/prg/clock3.sd7         0.037158             95
+seed7/prg/cmpfil.sd7         0.035798             84
+seed7/prg/comanche.sd7       0.039804            180
+seed7/prg/confval.sd7        0.041424            175
+seed7/prg/db7.sd7            0.045118            417
+seed7/prg/diff7.sd7          0.041382            263
+seed7/prg/dirtst.sd7         0.034238             42
+seed7/prg/dirx.sd7           0.037105            152
+seed7/prg/dnafight.sd7       0.068417           1381
+seed7/prg/dragon.sd7         0.035312             73
+seed7/prg/echo.sd7           0.034872             39
+seed7/prg/eliza.sd7          0.042033            302
+seed7/prg/err.sd7            0.039310             96
+seed7/prg/fannkuch.sd7       0.036650            131
+seed7/prg/fib.sd7            0.034861             47
+seed7/prg/find7.sd7          0.037388            133
+seed7/prg/findchar.sd7       0.038556            149
+seed7/prg/fractree.sd7       0.035327             55
+seed7/prg/ftp7.sd7           0.041896            296
+seed7/prg/ftpserv.sd7        0.036532             74
+seed7/prg/gcd.sd7            0.037826            109
+seed7/prg/gkbd.sd7           0.047187            358
+seed7/prg/gtksvtst.sd7       0.037468             94
+seed7/prg/hal.sd7            0.044514            250
+seed7/prg/hamu.sd7           0.053397            573
+seed7/prg/hanoi.sd7          0.035735             55
+seed7/prg/hd.sd7             0.036273             79
+seed7/prg/hello.sd7          0.035212             32
+seed7/prg/hilbert.sd7        0.036385            108
+seed7/prg/ide7.sd7           0.038998            196
+seed7/prg/kbd.sd7            0.034850             49
+seed7/prg/klondike.sd7       0.053140            883
+seed7/prg/lander.sd7         0.070283           1551
+seed7/prg/lst80bas.sd7       0.043367            344
+seed7/prg/lst99bas.sd7       0.044504            401
+seed7/prg/lstgwbas.sd7       0.050031            577
+seed7/prg/mahjong.sd7        0.079105           1943
+seed7/prg/make7.sd7          0.037290            121
+seed7/prg/mandelbr.sd7       0.039498            237
+seed7/prg/mind.sd7           0.044065            443
+seed7/prg/mirror.sd7         0.038030            131
+seed7/prg/ms.sd7             0.051957            641
+seed7/prg/nicoma.sd7         0.038496            135
+seed7/prg/pac.sd7            0.049654            726
+seed7/prg/pairs.sd7          0.082214           2025
+seed7/prg/panic.sd7          0.094968           2634
+seed7/prg/percolation.sd7    0.041613            330
+seed7/prg/planets.sd7        0.074658           1486
+seed7/prg/portfwd7.sd7       0.037469            139
+seed7/prg/prime.sd7          0.039866             74
+seed7/prg/printpi1.sd7       0.039960             56
+seed7/prg/printpi2.sd7       0.035141             54
+seed7/prg/printpi3.sd7       0.037369             60
+seed7/prg/pv7.sd7            0.043882            337
+seed7/prg/queen.sd7          0.037503            149
+seed7/prg/rand.sd7           0.037332            121
+seed7/prg/raytrace.sd7       0.048107            538
+seed7/prg/rever.sd7          0.053056            816
+seed7/prg/roman.sd7          0.034804             38
+seed7/prg/s7c.sd7            0.279922           9060
+seed7/prg/s7check.sd7        0.036672             68
+seed7/prg/savehd7.sd7        0.071415           1110
+seed7/prg/self.sd7           0.036352             49
+seed7/prg/shisen.sd7         0.071259           1423
+seed7/prg/sl.sd7             0.057836           1029
+seed7/prg/snake.sd7          0.045451            615
+seed7/prg/sokoban.sd7        0.053004            891
+seed7/prg/spigotpi.sd7       0.035087             64
+seed7/prg/sql7.sd7           0.040295            278
+seed7/prg/startrek.sd7       0.058842            979
+seed7/prg/sudoku7.sd7        0.099638           2657
+seed7/prg/sydir7.sd7         0.044911            384
+seed7/prg/syntaxhl.sd7       0.040682            177
+seed7/prg/tak.sd7            0.038869             59
+seed7/prg/tar7.sd7           0.039315            121
+seed7/prg/tch.sd7            0.038739             55
+seed7/prg/testfont.sd7       0.038972             95
+seed7/prg/tet.sd7            0.043905            479
+seed7/prg/tetg.sd7           0.044742            501
+seed7/prg/toutf8.sd7         0.042029            240
+seed7/prg/tst_cli.sd7        0.036526             40
+seed7/prg/tst_srv.sd7        0.041656             47
+seed7/prg/wator.sd7          0.053929            651
+seed7/prg/which.sd7          0.035628             65
+seed7/prg/wiz.sd7            0.104261           2833
+seed7/prg/wordcnt.sd7        0.035684             54
+seed7/prg/wrinum.sd7         0.034648             43
+seed7/prg/wumpus.sd7         0.041707            372
+seed7/lib/aes.s7i            0.107437           1144
+seed7/lib/aes_gcm.s7i        0.045390            392
+seed7/lib/ar.s7i             0.073969           1532
+seed7/lib/arc4.s7i           0.037684            144
+seed7/lib/archive.s7i        0.039426            143
+seed7/lib/archive_base.s7i   0.038085            135
+seed7/lib/array.s7i          0.053103            610
+seed7/lib/asn1.s7i           0.047640            544
+seed7/lib/asn1oid.s7i        0.041995            157
+seed7/lib/basearray.s7i      0.048683            450
+seed7/lib/bigfile.s7i        0.037674            136
+seed7/lib/bigint.s7i         0.055460            824
+seed7/lib/bigrat.s7i         0.054284            784
+seed7/lib/bin16.s7i          0.052702            592
+seed7/lib/bin32.s7i          0.049182            490
+seed7/lib/bin64.s7i          0.051100            539
+seed7/lib/bitdata.s7i        0.077884           1330
+seed7/lib/bitmapfont.s7i     0.040062            215
+seed7/lib/bitset.s7i         0.050862            593
+seed7/lib/bitsetof.s7i       0.047526            431
+seed7/lib/blowfish.s7i       0.054743            383
+seed7/lib/bmp.s7i            0.058837            924
+seed7/lib/boolean.s7i        0.043297            403
+seed7/lib/browser.s7i        0.042537            280
+seed7/lib/bstring.s7i        0.040683            227
+seed7/lib/bytedata.s7i       0.050097            482
+seed7/lib/bzip2.s7i          0.058696            887
+seed7/lib/cards.s7i          0.066650           1342
+seed7/lib/category.s7i       0.040684            209
+seed7/lib/cc_conf.s7i        0.077810           1314
+seed7/lib/ccittfax.s7i       0.065294           1022
+seed7/lib/cgi.s7i            0.037325            109
+seed7/lib/cgidialog.s7i      0.059666           1118
+seed7/lib/char.s7i           0.042703            356
+seed7/lib/charsets.s7i       0.087002           2024
+seed7/lib/chartype.s7i       0.041509            121
+seed7/lib/cipher.s7i         0.040464            146
+seed7/lib/cli_cmds.s7i       0.069253           1360
+seed7/lib/clib_file.s7i      0.046927            301
+seed7/lib/color.s7i          0.041795            185
+seed7/lib/complex.s7i        0.046427            464
+seed7/lib/compress.s7i       0.040036            150
+seed7/lib/console.s7i        0.039129            188
+seed7/lib/cpio.s7i           0.086006           1708
+seed7/lib/crc32.s7i          0.043920            193
+seed7/lib/cronos16.s7i       0.094862           1173
+seed7/lib/cronos27.s7i       0.119206           1464
+seed7/lib/csv.s7i            0.040374            201
+seed7/lib/db_prop.s7i        0.062331            991
+seed7/lib/deflate.s7i        0.061534            740
+seed7/lib/des.s7i            0.058571            444
+seed7/lib/dialog.s7i         0.052172            311
+seed7/lib/dir.s7i            0.042787            163
+seed7/lib/draw.s7i           0.055750            854
+seed7/lib/duration.s7i       0.060423           1038
+seed7/lib/echo.s7i           0.037388            132
+seed7/lib/editline.s7i       0.044837            398
+seed7/lib/elf.s7i            0.083960           1560
+seed7/lib/elliptic.s7i       0.057032            649
+seed7/lib/enable_io.s7i      0.045556            312
+seed7/lib/encoding.s7i       0.071283            931
+seed7/lib/enumeration.s7i    0.051457            236
+seed7/lib/environment.s7i    0.046019            175
+seed7/lib/exif.s7i           0.047487            152
+seed7/lib/external_file.s7i  0.049043            340
+seed7/lib/field.s7i          0.057827            268
+seed7/lib/file.s7i           0.043699            372
+seed7/lib/filebits.s7i       0.037069             46
+seed7/lib/filesys.s7i        0.050004            601
+seed7/lib/fileutil.s7i       0.037349            144
+seed7/lib/fixarray.s7i       0.043182            307
+seed7/lib/float.s7i          0.055497            757
+seed7/lib/font.s7i           0.038869            196
+seed7/lib/font8x8.s7i        0.048636            998
+seed7/lib/forloop.s7i        0.045226            449
+seed7/lib/ftp.s7i            0.057092            969
+seed7/lib/ftpserv.s7i        0.053085            631
+seed7/lib/getf.s7i           0.039316            115
+seed7/lib/gethttp.s7i        0.035287             41
+seed7/lib/gethttps.s7i       0.034676             41
+seed7/lib/gif.s7i            0.048831            561
+seed7/lib/graph.s7i          0.047577            415
+seed7/lib/graph_file.s7i     0.043474            399
+seed7/lib/gtkserver.s7i      0.041439            161
+seed7/lib/gzip.s7i           0.047912            573
+seed7/lib/hash.s7i           0.049223            421
+seed7/lib/hashsetof.s7i      0.048158            499
+seed7/lib/hmac.s7i           0.038735            152
+seed7/lib/html.s7i           0.042316             83
+seed7/lib/html_ent.s7i       0.046326            476
+seed7/lib/htmldom.s7i        0.042671            286
+seed7/lib/http_request.s7i   0.051735            696
+seed7/lib/http_srv_resp.s7i  0.044629            380
+seed7/lib/https_request.s7i  0.039640            211
+seed7/lib/httpserv.s7i       0.043396            345
+seed7/lib/huffman.s7i        0.052283            644
+seed7/lib/ico.s7i            0.040741            221
+seed7/lib/idxarray.s7i       0.041694            232
+seed7/lib/image.s7i          0.041514            156
+seed7/lib/imagefile.s7i      0.042777            171
+seed7/lib/inflate.s7i        0.045356            411
+seed7/lib/inifile.s7i        0.036732            129
+seed7/lib/integer.s7i        0.050695            663
+seed7/lib/iobuffer.s7i       0.040671            289
+seed7/lib/jpeg.s7i           0.081803           1761
+seed7/lib/json.s7i           0.054605            891
+seed7/lib/json_serde.s7i     0.052554            783
+seed7/lib/keybd.s7i          0.054781            639
+seed7/lib/keydescr.s7i       0.040686            192
+seed7/lib/leb128.s7i         0.039629            218
+seed7/lib/line.s7i           0.037722            164
+seed7/lib/listener.s7i       0.040885            247
+seed7/lib/logfile.s7i        0.037426             73
+seed7/lib/lower.s7i          0.037232            142
+seed7/lib/lzma.s7i           0.059591            934
+seed7/lib/lzw.s7i            0.058705            861
+seed7/lib/magic.s7i          0.047679            403
+seed7/lib/mahjng32.s7i       0.063451           1500
+seed7/lib/make.s7i           0.049133            544
+seed7/lib/makedata.s7i       0.069659           1428
+seed7/lib/math.s7i           0.039470            201
+seed7/lib/mixarith.s7i       0.039675            249
+seed7/lib/modern27.s7i       0.083561           1099
+seed7/lib/more.s7i           0.037848            130
+seed7/lib/msgdigest.s7i      0.083372           1222
+seed7/lib/multiscr.s7i       0.036496             68
+seed7/lib/null_file.s7i      0.041209            345
+seed7/lib/osfiles.s7i        0.065997           1085
+seed7/lib/pbm.s7i            0.039882            230
+seed7/lib/pcx.s7i            0.051903            638
+seed7/lib/pem.s7i            0.039026            185
+seed7/lib/pgm.s7i            0.040304            238
+seed7/lib/pic16.s7i          0.048144           1037
+seed7/lib/pic32.s7i          0.079375           2060
+seed7/lib/pic_util.s7i       0.038315            144
+seed7/lib/pixelimage.s7i     0.042099            320
+seed7/lib/pixmap_file.s7i    0.045471            459
+seed7/lib/pixmapfont.s7i     0.039509            184
+seed7/lib/pkcs1.s7i          0.060331            543
+seed7/lib/png.s7i            0.067358           1064
+seed7/lib/poll.s7i           0.045150            313
+seed7/lib/ppm.s7i            0.040856            240
+seed7/lib/process.s7i        0.048548            541
+seed7/lib/progs.s7i          0.055670            789
+seed7/lib/propertyfile.s7i   0.037766            155
+seed7/lib/rational.s7i       0.052943            792
+seed7/lib/ref_list.s7i       0.040680            252
+seed7/lib/reference.s7i      0.037029            126
+seed7/lib/reverse.s7i        0.038851             94
+seed7/lib/rpm.s7i            0.150448           3487
+seed7/lib/rpmext.s7i         0.043241            318
+seed7/lib/scanfile.s7i       0.080868           1779
+seed7/lib/scanjson.s7i       0.047829            413
+seed7/lib/scanstri.s7i       0.080906           1814
+seed7/lib/scantoml.s7i       0.070844           1603
+seed7/lib/seed7_05.s7i       0.066010           1072
+seed7/lib/set.s7i            0.036359             57
+seed7/lib/shell.s7i          0.052068            615
+seed7/lib/showtls.s7i        0.053924            678
+seed7/lib/signature.s7i      0.037160            131
+seed7/lib/smtp.s7i           0.040416            261
+seed7/lib/sockbase.s7i       0.041594            217
+seed7/lib/socket.s7i         0.042337            326
+seed7/lib/sokoban1.s7i       0.053058           1519
+seed7/lib/sql_base.s7i       0.062442           1000
+seed7/lib/stars.s7i          0.136023           1705
+seed7/lib/stdfont10.s7i      0.081230           3347
+seed7/lib/stdfont12.s7i      0.091682           3928
+seed7/lib/stdfont14.s7i      0.107723           4510
+seed7/lib/stdfont16.s7i      0.118830           5092
+seed7/lib/stdfont18.s7i      0.134915           5868
+seed7/lib/stdfont20.s7i      0.150106           6449
+seed7/lib/stdfont24.s7i      0.178904           7421
+seed7/lib/stdfont8.s7i       0.071210           2960
+seed7/lib/stdfont9.s7i       0.076429           3152
+seed7/lib/stdio.s7i          0.038665            192
+seed7/lib/strifile.s7i       0.043730            345
+seed7/lib/string.s7i         0.055346            779
+seed7/lib/stritext.s7i       0.048865            352
+seed7/lib/struct.s7i         0.043897            266
+seed7/lib/struct_elem.s7i    0.037804            129
+seed7/lib/subfile.s7i        0.038491            174
+seed7/lib/subrange.s7i       0.037443             78
+seed7/lib/syntax.s7i         0.045572            294
+seed7/lib/tar.s7i            0.082073           1880
+seed7/lib/tar_cmds.s7i       0.062126            752
+seed7/lib/tdes.s7i           0.039049            143
+seed7/lib/tee.s7i            0.037313            143
+seed7/lib/text.s7i           0.040104            135
+seed7/lib/tga.s7i            0.053768            676
+seed7/lib/tiff.s7i           0.121224           2771
+seed7/lib/time.s7i           0.061560           1191
+seed7/lib/tls.s7i            0.102010           2230
+seed7/lib/unicode.s7i        0.050769            575
+seed7/lib/unionfnd.s7i       0.038739            130
+seed7/lib/upper.s7i          0.037857            142
+seed7/lib/utf16.s7i          0.049504            540
+seed7/lib/utf8.s7i           0.041152            234
+seed7/lib/vecfont10.s7i      0.078749           1056
+seed7/lib/vecfont18.s7i      0.087122           1119
+seed7/lib/vector3d.s7i       0.039982            293
+seed7/lib/vectorfont.s7i     0.040061            239
+seed7/lib/wildcard.s7i       0.037953            140
+seed7/lib/window.s7i         0.045388            455
+seed7/lib/wrinum.s7i         0.049291            248
+seed7/lib/x509cert.s7i       0.071728           1243
+seed7/lib/xml_ent.s7i        0.037810             94
+seed7/lib/xmldom.s7i         0.043920            303
+seed7/lib/xz.s7i             0.053765            442
+seed7/lib/zip.s7i            0.120334           2792
+seed7/lib/zstd.s7i           0.072091           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.090383        |
++-----------+-----------------+
+| Minimum   | 0.034238        |
++-----------+-----------------+
+| Maximum   | 2.514514        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.043945            190
+seed7/prg/bas7.sd7           0.772484          11459
+seed7/prg/bifurk.sd7         0.037808             73
+seed7/prg/bigfiles.sd7       0.041745            129
+seed7/prg/brainf7.sd7        0.039752             86
+seed7/prg/calc7.sd7          0.040628            128
+seed7/prg/carddemo.sd7       0.045379            190
+seed7/prg/castle.sd7         0.214009           3148
+seed7/prg/cat.sd7            0.039111             82
+seed7/prg/cellauto.sd7       0.039617             85
+seed7/prg/celsius.sd7        0.045326             42
+seed7/prg/chk_all.sd7        0.084144            843
+seed7/prg/chkarr.sd7         0.864372           8367
+seed7/prg/chkbig.sd7         4.139529          29026
+seed7/prg/chkbin.sd7         1.027855           6469
+seed7/prg/chkbitdata.sd7     1.241921           6624
+seed7/prg/chkbool.sd7        0.232510           3157
+seed7/prg/chkbst.sd7         0.101803            722
+seed7/prg/chkchr.sd7         0.484919           2809
+seed7/prg/chkcmd.sd7         0.109883           1205
+seed7/prg/chkdb.sd7          0.763593           7454
+seed7/prg/chkdecl.sd7        0.097708            448
+seed7/prg/chkenum.sd7        0.128289           1230
+seed7/prg/chkerr.sd7         0.338839           4663
+seed7/prg/chkexc.sd7         0.149150           2627
+seed7/prg/chkfil.sd7         0.128392           1615
+seed7/prg/chkflt.sd7         2.837895          20620
+seed7/prg/chkhent.sd7        0.037578             54
+seed7/prg/chkhsh.sd7         0.497973           4548
+seed7/prg/chkidx.sd7         3.184359          19567
+seed7/prg/chkint.sd7         5.555027          38129
+seed7/prg/chkjson.sd7        0.192109           1764
+seed7/prg/chkovf.sd7         1.215336           8216
+seed7/prg/chkprc.sd7         0.700530          10111
+seed7/prg/chkscan.sd7        0.090983            714
+seed7/prg/chkset.sd7         1.753957          11974
+seed7/prg/chkstr.sd7         3.427283          26952
+seed7/prg/chktime.sd7        0.260510           2025
+seed7/prg/chktoml.sd7        0.209597           1656
+seed7/prg/clock.sd7          0.043057             47
+seed7/prg/clock2.sd7         0.042938             43
+seed7/prg/clock3.sd7         0.047648             95
+seed7/prg/cmpfil.sd7         0.043114             84
+seed7/prg/comanche.sd7       0.048668            180
+seed7/prg/confval.sd7        0.056591            175
+seed7/prg/db7.sd7            0.066719            417
+seed7/prg/diff7.sd7          0.052630            263
+seed7/prg/dirtst.sd7         0.035601             42
+seed7/prg/dirx.sd7           0.041446            152
+seed7/prg/dnafight.sd7       0.123662           1381
+seed7/prg/dragon.sd7         0.038378             73
+seed7/prg/echo.sd7           0.036829             39
+seed7/prg/eliza.sd7          0.051308            302
+seed7/prg/err.sd7            0.045218             96
+seed7/prg/fannkuch.sd7       0.042251            131
+seed7/prg/fib.sd7            0.037725             47
+seed7/prg/find7.sd7          0.043414            133
+seed7/prg/findchar.sd7       0.043711            149
+seed7/prg/fractree.sd7       0.037335             55
+seed7/prg/ftp7.sd7           0.053004            296
+seed7/prg/ftpserv.sd7        0.038635             74
+seed7/prg/gcd.sd7            0.040804            109
+seed7/prg/gkbd.sd7           0.061671            358
+seed7/prg/gtksvtst.sd7       0.039836             94
+seed7/prg/hal.sd7            0.047361            250
+seed7/prg/hamu.sd7           0.067230            573
+seed7/prg/hanoi.sd7          0.037029             55
+seed7/prg/hd.sd7             0.038227             79
+seed7/prg/hello.sd7          0.036005             32
+seed7/prg/hilbert.sd7        0.039976            108
+seed7/prg/ide7.sd7           0.047510            196
+seed7/prg/kbd.sd7            0.037673             49
+seed7/prg/klondike.sd7       0.087104            883
+seed7/prg/lander.sd7         0.134416           1551
+seed7/prg/lst80bas.sd7       0.057470            344
+seed7/prg/lst99bas.sd7       0.059817            401
+seed7/prg/lstgwbas.sd7       0.074002            577
+seed7/prg/mahjong.sd7        0.152393           1943
+seed7/prg/make7.sd7          0.043384            121
+seed7/prg/mandelbr.sd7       0.049133            237
+seed7/prg/mind.sd7           0.059807            443
+seed7/prg/mirror.sd7         0.043487            131
+seed7/prg/ms.sd7             0.069676            641
+seed7/prg/nicoma.sd7         0.043917            135
+seed7/prg/pac.sd7            0.071323            726
+seed7/prg/pairs.sd7          0.138916           2025
+seed7/prg/panic.sd7          0.194736           2634
+seed7/prg/percolation.sd7    0.055788            330
+seed7/prg/planets.sd7        0.138248           1486
+seed7/prg/portfwd7.sd7       0.043252            139
+seed7/prg/prime.sd7          0.041755             74
+seed7/prg/printpi1.sd7       0.042789             56
+seed7/prg/printpi2.sd7       0.038273             54
+seed7/prg/printpi3.sd7       0.038842             60
+seed7/prg/pv7.sd7            0.058982            337
+seed7/prg/queen.sd7          0.042054            149
+seed7/prg/rand.sd7           0.042618            121
+seed7/prg/raytrace.sd7       0.076321            538
+seed7/prg/rever.sd7          0.084522            816
+seed7/prg/roman.sd7          0.035555             38
+seed7/prg/s7c.sd7            0.627658           9060
+seed7/prg/s7check.sd7        0.038462             68
+seed7/prg/savehd7.sd7        0.117006           1110
+seed7/prg/self.sd7           0.037664             49
+seed7/prg/shisen.sd7         0.121144           1423
+seed7/prg/sl.sd7             0.096128           1029
+seed7/prg/snake.sd7          0.065182            615
+seed7/prg/sokoban.sd7        0.084208            891
+seed7/prg/spigotpi.sd7       0.037647             64
+seed7/prg/sql7.sd7           0.053510            278
+seed7/prg/startrek.sd7       0.096789            979
+seed7/prg/sudoku7.sd7        0.200664           2657
+seed7/prg/sydir7.sd7         0.063487            384
+seed7/prg/syntaxhl.sd7       0.050873            177
+seed7/prg/tak.sd7            0.036973             59
+seed7/prg/tar7.sd7           0.044075            121
+seed7/prg/tch.sd7            0.037378             55
+seed7/prg/testfont.sd7       0.041867             95
+seed7/prg/tet.sd7            0.059825            479
+seed7/prg/tetg.sd7           0.064612            501
+seed7/prg/toutf8.sd7         0.053782            240
+seed7/prg/tst_cli.sd7        0.038168             40
+seed7/prg/tst_srv.sd7        0.038220             47
+seed7/prg/wator.sd7          0.076787            651
+seed7/prg/which.sd7          0.037085             65
+seed7/prg/wiz.sd7            0.218477           2833
+seed7/prg/wordcnt.sd7        0.038421             54
+seed7/prg/wrinum.sd7         0.039186             43
+seed7/prg/wumpus.sd7         0.054314            372
+seed7/lib/aes.s7i            0.199847           1144
+seed7/lib/aes_gcm.s7i        0.061061            392
+seed7/lib/ar.s7i             0.126055           1532
+seed7/lib/arc4.s7i           0.043156            144
+seed7/lib/archive.s7i        0.042717            143
+seed7/lib/archive_base.s7i   0.042816            135
+seed7/lib/array.s7i          0.074575            610
+seed7/lib/asn1.s7i           0.064008            544
+seed7/lib/asn1oid.s7i        0.049110            157
+seed7/lib/basearray.s7i      0.067707            450
+seed7/lib/bigfile.s7i        0.041583            136
+seed7/lib/bigint.s7i         0.078037            824
+seed7/lib/bigrat.s7i         0.081323            784
+seed7/lib/bin16.s7i          0.071257            592
+seed7/lib/bin32.s7i          0.063840            490
+seed7/lib/bin64.s7i          0.063912            539
+seed7/lib/bitdata.s7i        0.123375           1330
+seed7/lib/bitmapfont.s7i     0.047270            215
+seed7/lib/bitset.s7i         0.065863            593
+seed7/lib/bitsetof.s7i       0.062012            431
+seed7/lib/blowfish.s7i       0.077623            383
+seed7/lib/bmp.s7i            0.098637            924
+seed7/lib/boolean.s7i        0.053685            403
+seed7/lib/browser.s7i        0.051728            280
+seed7/lib/bstring.s7i        0.047729            227
+seed7/lib/bytedata.s7i       0.066277            482
+seed7/lib/bzip2.s7i          0.089630            887
+seed7/lib/cards.s7i          0.106350           1342
+seed7/lib/category.s7i       0.061708            209
+seed7/lib/cc_conf.s7i        0.122589           1314
+seed7/lib/ccittfax.s7i       0.102406           1022
+seed7/lib/cgi.s7i            0.043194            109
+seed7/lib/cgidialog.s7i      0.097701           1118
+seed7/lib/char.s7i           0.052013            356
+seed7/lib/charsets.s7i       0.124321           2024
+seed7/lib/chartype.s7i       0.046808            121
+seed7/lib/cipher.s7i         0.042465            146
+seed7/lib/cli_cmds.s7i       0.113938           1360
+seed7/lib/clib_file.s7i      0.050602            301
+seed7/lib/color.s7i          0.048084            185
+seed7/lib/complex.s7i        0.061886            464
+seed7/lib/compress.s7i       0.047001            150
+seed7/lib/console.s7i        0.049508            188
+seed7/lib/cpio.s7i           0.151979           1708
+seed7/lib/crc32.s7i          0.052902            193
+seed7/lib/cronos16.s7i       0.203136           1173
+seed7/lib/cronos27.s7i       0.262156           1464
+seed7/lib/csv.s7i            0.049714            201
+seed7/lib/db_prop.s7i        0.103579            991
+seed7/lib/deflate.s7i        0.092143            740
+seed7/lib/des.s7i            0.086524            444
+seed7/lib/dialog.s7i         0.061665            311
+seed7/lib/dir.s7i            0.046379            163
+seed7/lib/draw.s7i           0.086540            854
+seed7/lib/duration.s7i       0.098111           1038
+seed7/lib/echo.s7i           0.045019            132
+seed7/lib/editline.s7i       0.061314            398
+seed7/lib/elf.s7i            0.159543           1560
+seed7/lib/elliptic.s7i       0.077945            649
+seed7/lib/enable_io.s7i      0.058860            312
+seed7/lib/encoding.s7i       0.106438            931
+seed7/lib/enumeration.s7i    0.054634            236
+seed7/lib/environment.s7i    0.045699            175
+seed7/lib/exif.s7i           0.046188            152
+seed7/lib/external_file.s7i  0.052734            340
+seed7/lib/field.s7i          0.058208            268
+seed7/lib/file.s7i           0.056290            372
+seed7/lib/filebits.s7i       0.042278             46
+seed7/lib/filesys.s7i        0.073374            601
+seed7/lib/fileutil.s7i       0.045870            144
+seed7/lib/fixarray.s7i       0.054795            307
+seed7/lib/float.s7i          0.074880            757
+seed7/lib/font.s7i           0.045859            196
+seed7/lib/font8x8.s7i        0.069697            998
+seed7/lib/forloop.s7i        0.062006            449
+seed7/lib/ftp.s7i            0.089493            969
+seed7/lib/ftpserv.s7i        0.082832            631
+seed7/lib/getf.s7i           0.044042            115
+seed7/lib/gethttp.s7i        0.037822             41
+seed7/lib/gethttps.s7i       0.036643             41
+seed7/lib/gif.s7i            0.071308            561
+seed7/lib/graph.s7i          0.064156            415
+seed7/lib/graph_file.s7i     0.060126            399
+seed7/lib/gtkserver.s7i      0.042625            161
+seed7/lib/gzip.s7i           0.071618            573
+seed7/lib/hash.s7i           0.067204            421
+seed7/lib/hashsetof.s7i      0.067352            499
+seed7/lib/hmac.s7i           0.046895            152
+seed7/lib/html.s7i           0.039958             83
+seed7/lib/html_ent.s7i       0.067073            476
+seed7/lib/htmldom.s7i        0.053384            286
+seed7/lib/http_request.s7i   0.076922            696
+seed7/lib/http_srv_resp.s7i  0.061149            380
+seed7/lib/https_request.s7i  0.048718            211
+seed7/lib/httpserv.s7i       0.059188            345
+seed7/lib/huffman.s7i        0.080465            644
+seed7/lib/ico.s7i            0.048034            221
+seed7/lib/idxarray.s7i       0.049721            232
+seed7/lib/image.s7i          0.041909            156
+seed7/lib/imagefile.s7i      0.045967            171
+seed7/lib/inflate.s7i        0.063426            411
+seed7/lib/inifile.s7i        0.041688            129
+seed7/lib/integer.s7i        0.069712            663
+seed7/lib/iobuffer.s7i       0.050533            289
+seed7/lib/jpeg.s7i           0.155922           1761
+seed7/lib/json.s7i           0.083981            891
+seed7/lib/json_serde.s7i     0.081495            783
+seed7/lib/keybd.s7i          0.083316            639
+seed7/lib/keydescr.s7i       0.049141            192
+seed7/lib/leb128.s7i         0.045575            218
+seed7/lib/line.s7i           0.043049            164
+seed7/lib/listener.s7i       0.054339            247
+seed7/lib/logfile.s7i        0.045830             73
+seed7/lib/lower.s7i          0.043784            142
+seed7/lib/lzma.s7i           0.099227            934
+seed7/lib/lzw.s7i            0.096193            861
+seed7/lib/magic.s7i          0.064505            403
+seed7/lib/mahjng32.s7i       0.094422           1500
+seed7/lib/make.s7i           0.071290            544
+seed7/lib/makedata.s7i       0.132327           1428
+seed7/lib/math.s7i           0.046959            201
+seed7/lib/mixarith.s7i       0.046760            249
+seed7/lib/modern27.s7i       0.169355           1099
+seed7/lib/more.s7i           0.041338            130
+seed7/lib/msgdigest.s7i      0.139546           1222
+seed7/lib/multiscr.s7i       0.037662             68
+seed7/lib/null_file.s7i      0.050947            345
+seed7/lib/osfiles.s7i        0.097685           1085
+seed7/lib/pbm.s7i            0.048863            230
+seed7/lib/pcx.s7i            0.075716            638
+seed7/lib/pem.s7i            0.044393            185
+seed7/lib/pgm.s7i            0.048982            238
+seed7/lib/pic16.s7i          0.065568           1037
+seed7/lib/pic32.s7i          0.118682           2060
+seed7/lib/pic_util.s7i       0.044436            144
+seed7/lib/pixelimage.s7i     0.051663            320
+seed7/lib/pixmap_file.s7i    0.061484            459
+seed7/lib/pixmapfont.s7i     0.047368            184
+seed7/lib/pkcs1.s7i          0.078225            543
+seed7/lib/png.s7i            0.106234           1064
+seed7/lib/poll.s7i           0.052001            313
+seed7/lib/ppm.s7i            0.052596            240
+seed7/lib/process.s7i        0.064948            541
+seed7/lib/progs.s7i          0.079917            789
+seed7/lib/propertyfile.s7i   0.045417            155
+seed7/lib/rational.s7i       0.079239            792
+seed7/lib/ref_list.s7i       0.048978            252
+seed7/lib/reference.s7i      0.041726            126
+seed7/lib/reverse.s7i        0.040464             94
+seed7/lib/rpm.s7i            0.290002           3487
+seed7/lib/rpmext.s7i         0.055489            318
+seed7/lib/scanfile.s7i       0.136773           1779
+seed7/lib/scanjson.s7i       0.062427            413
+seed7/lib/scanstri.s7i       0.138703           1814
+seed7/lib/scantoml.s7i       0.131006           1603
+seed7/lib/seed7_05.s7i       0.113310           1072
+seed7/lib/set.s7i            0.039203             57
+seed7/lib/shell.s7i          0.069481            615
+seed7/lib/showtls.s7i        0.090227            678
+seed7/lib/signature.s7i      0.043691            131
+seed7/lib/smtp.s7i           0.049642            261
+seed7/lib/sockbase.s7i       0.049452            217
+seed7/lib/socket.s7i         0.056025            326
+seed7/lib/sokoban1.s7i       0.085126           1519
+seed7/lib/sql_base.s7i       0.094584           1000
+seed7/lib/stars.s7i          0.237696           1705
+seed7/lib/stdfont10.s7i      0.146153           3347
+seed7/lib/stdfont12.s7i      0.168985           3928
+seed7/lib/stdfont14.s7i      0.192955           4510
+seed7/lib/stdfont16.s7i      0.214532           5092
+seed7/lib/stdfont18.s7i      0.246958           5868
+seed7/lib/stdfont20.s7i      0.281384           6449
+seed7/lib/stdfont24.s7i      0.332883           7421
+seed7/lib/stdfont8.s7i       0.132560           2960
+seed7/lib/stdfont9.s7i       0.146464           3152
+seed7/lib/stdio.s7i          0.044019            192
+seed7/lib/strifile.s7i       0.054733            345
+seed7/lib/string.s7i         0.074500            779
+seed7/lib/stritext.s7i       0.057013            352
+seed7/lib/struct.s7i         0.062786            266
+seed7/lib/struct_elem.s7i    0.042095            129
+seed7/lib/subfile.s7i        0.043668            174
+seed7/lib/subrange.s7i       0.038197             78
+seed7/lib/syntax.s7i         0.060282            294
+seed7/lib/tar.s7i            0.150866           1880
+seed7/lib/tar_cmds.s7i       0.091163            752
+seed7/lib/tdes.s7i           0.044376            143
+seed7/lib/tee.s7i            0.041050            143
+seed7/lib/text.s7i           0.041076            135
+seed7/lib/tga.s7i            0.080024            676
+seed7/lib/tiff.s7i           0.243751           2771
+seed7/lib/time.s7i           0.099541           1191
+seed7/lib/tls.s7i            0.196623           2230
+seed7/lib/unicode.s7i        0.077147            575
+seed7/lib/unionfnd.s7i       0.042842            130
+seed7/lib/upper.s7i          0.043655            142
+seed7/lib/utf16.s7i          0.066005            540
+seed7/lib/utf8.s7i           0.046598            234
+seed7/lib/vecfont10.s7i      0.162304           1056
+seed7/lib/vecfont18.s7i      0.177109           1119
+seed7/lib/vector3d.s7i       0.048187            293
+seed7/lib/vectorfont.s7i     0.046466            239
+seed7/lib/wildcard.s7i       0.041540            140
+seed7/lib/window.s7i         0.059700            455
+seed7/lib/wrinum.s7i         0.049538            248
+seed7/lib/x509cert.s7i       0.119168           1243
+seed7/lib/xml_ent.s7i        0.043115             94
+seed7/lib/xmldom.s7i         0.050103            303
+seed7/lib/xz.s7i             0.059692            442
+seed7/lib/zip.s7i            0.234999           2792
+seed7/lib/zstd.s7i           0.122285           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.160272        |
++-----------+-----------------+
+| Minimum   | 0.035555        |
++-----------+-----------------+
+| Maximum   | 5.555027        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033692        | 0.032140        | 0.040069        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.038499        | 0.035054        | 0.047615        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.090383        | 0.034238        | 2.514514        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.160272        | 0.035555        | 5.555027        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.865 | 00:00:57.398 | 00:01:10.264 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.814 | 00:01:05.641 | 00:01:20.455 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:35.834 | 00:02:34.880 | 00:03:10.715 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:01.245 | 00:04:33.985 | 00:05:35.230 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:16.671 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-10.1.rst
+++ b/reports/seed7mode-perf-10.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-25T03:05:30+0000 W26-4
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 23:12:51 local time
+:Generated on: 2026-06-25 03:24:28 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 230x95 chars
+:Window body: 230x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.034597            190
+seed7/prg/bas7.sd7           0.034502          11459
+seed7/prg/bifurk.sd7         0.034266             73
+seed7/prg/bigfiles.sd7       0.033522            129
+seed7/prg/brainf7.sd7        0.033608             86
+seed7/prg/calc7.sd7          0.034264            128
+seed7/prg/carddemo.sd7       0.035143            190
+seed7/prg/castle.sd7         0.033730           3148
+seed7/prg/cat.sd7            0.033302             82
+seed7/prg/cellauto.sd7       0.032820             85
+seed7/prg/celsius.sd7        0.032124             42
+seed7/prg/chk_all.sd7        0.033063            843
+seed7/prg/chkarr.sd7         0.033376           8367
+seed7/prg/chkbig.sd7         0.037450          29026
+seed7/prg/chkbin.sd7         0.033857           6469
+seed7/prg/chkbitdata.sd7     0.034962           6624
+seed7/prg/chkbool.sd7        0.033247           3157
+seed7/prg/chkbst.sd7         0.032746            722
+seed7/prg/chkchr.sd7         0.033464           2809
+seed7/prg/chkcmd.sd7         0.032531           1205
+seed7/prg/chkdb.sd7          0.033845           7454
+seed7/prg/chkdecl.sd7        0.032223            448
+seed7/prg/chkenum.sd7        0.033429           1230
+seed7/prg/chkerr.sd7         0.036375           4663
+seed7/prg/chkexc.sd7         0.038691           2627
+seed7/prg/chkfil.sd7         0.033912           1615
+seed7/prg/chkflt.sd7         0.038583          20620
+seed7/prg/chkhent.sd7        0.033335             54
+seed7/prg/chkhsh.sd7         0.033774           4548
+seed7/prg/chkidx.sd7         0.035922          19567
+seed7/prg/chkint.sd7         0.040152          38129
+seed7/prg/chkjson.sd7        0.033247           1764
+seed7/prg/chkovf.sd7         0.035443           8216
+seed7/prg/chkprc.sd7         0.034165          10111
+seed7/prg/chkscan.sd7        0.033392            714
+seed7/prg/chkset.sd7         0.034531          11974
+seed7/prg/chkstr.sd7         0.037595          26952
+seed7/prg/chktime.sd7        0.033474           2025
+seed7/prg/chktoml.sd7        0.033651           1656
+seed7/prg/clock.sd7          0.032197             47
+seed7/prg/clock2.sd7         0.032649             43
+seed7/prg/clock3.sd7         0.033038             95
+seed7/prg/cmpfil.sd7         0.032370             84
+seed7/prg/comanche.sd7       0.032716            180
+seed7/prg/confval.sd7        0.032732            175
+seed7/prg/db7.sd7            0.032682            417
+seed7/prg/diff7.sd7          0.036055            263
+seed7/prg/dirtst.sd7         0.033555             42
+seed7/prg/dirx.sd7           0.035349            152
+seed7/prg/dnafight.sd7       0.036721           1381
+seed7/prg/dragon.sd7         0.033503             73
+seed7/prg/echo.sd7           0.033283             39
+seed7/prg/eliza.sd7          0.037261            302
+seed7/prg/err.sd7            0.037923             96
+seed7/prg/fannkuch.sd7       0.036309            131
+seed7/prg/fib.sd7            0.033390             47
+seed7/prg/find7.sd7          0.032285            133
+seed7/prg/findchar.sd7       0.032264            149
+seed7/prg/fractree.sd7       0.036239             55
+seed7/prg/ftp7.sd7           0.040213            296
+seed7/prg/ftpserv.sd7        0.033002             74
+seed7/prg/gcd.sd7            0.032644            109
+seed7/prg/gkbd.sd7           0.032658            358
+seed7/prg/gtksvtst.sd7       0.032371             94
+seed7/prg/hal.sd7            0.033092            250
+seed7/prg/hamu.sd7           0.032449            573
+seed7/prg/hanoi.sd7          0.032082             55
+seed7/prg/hd.sd7             0.032311             79
+seed7/prg/hello.sd7          0.033853             32
+seed7/prg/hilbert.sd7        0.033076            108
+seed7/prg/ide7.sd7           0.033097            196
+seed7/prg/kbd.sd7            0.033146             49
+seed7/prg/klondike.sd7       0.033184            883
+seed7/prg/lander.sd7         0.032600           1551
+seed7/prg/lst80bas.sd7       0.032347            344
+seed7/prg/lst99bas.sd7       0.032144            401
+seed7/prg/lstgwbas.sd7       0.032416            577
+seed7/prg/mahjong.sd7        0.032378           1943
+seed7/prg/make7.sd7          0.035478            121
+seed7/prg/mandelbr.sd7       0.034601            237
+seed7/prg/mind.sd7           0.033709            443
+seed7/prg/mirror.sd7         0.033490            131
+seed7/prg/ms.sd7             0.033986            641
+seed7/prg/nicoma.sd7         0.033725            135
+seed7/prg/pac.sd7            0.033280            726
+seed7/prg/pairs.sd7          0.033245           2025
+seed7/prg/panic.sd7          0.033447           2634
+seed7/prg/percolation.sd7    0.033198            330
+seed7/prg/planets.sd7        0.033598           1486
+seed7/prg/portfwd7.sd7       0.033597            139
+seed7/prg/prime.sd7          0.033117             74
+seed7/prg/printpi1.sd7       0.036226             56
+seed7/prg/printpi2.sd7       0.034496             54
+seed7/prg/printpi3.sd7       0.037173             60
+seed7/prg/pv7.sd7            0.033633            337
+seed7/prg/queen.sd7          0.033452            149
+seed7/prg/rand.sd7           0.033224            121
+seed7/prg/raytrace.sd7       0.033495            538
+seed7/prg/rever.sd7          0.033157            816
+seed7/prg/roman.sd7          0.038527             38
+seed7/prg/s7c.sd7            0.037521           9060
+seed7/prg/s7check.sd7        0.034552             68
+seed7/prg/savehd7.sd7        0.034168           1110
+seed7/prg/self.sd7           0.033322             49
+seed7/prg/shisen.sd7         0.033214           1423
+seed7/prg/sl.sd7             0.032750           1029
+seed7/prg/snake.sd7          0.033334            615
+seed7/prg/sokoban.sd7        0.033034            891
+seed7/prg/spigotpi.sd7       0.033996             64
+seed7/prg/sql7.sd7           0.037355            278
+seed7/prg/startrek.sd7       0.039451            979
+seed7/prg/sudoku7.sd7        0.034731           2657
+seed7/prg/sydir7.sd7         0.033113            384
+seed7/prg/syntaxhl.sd7       0.032674            177
+seed7/prg/tak.sd7            0.033550             59
+seed7/prg/tar7.sd7           0.033528            121
+seed7/prg/tch.sd7            0.034723             55
+seed7/prg/testfont.sd7       0.033903             95
+seed7/prg/tet.sd7            0.033571            479
+seed7/prg/tetg.sd7           0.033412            501
+seed7/prg/toutf8.sd7         0.033694            240
+seed7/prg/tst_cli.sd7        0.033435             40
+seed7/prg/tst_srv.sd7        0.033176             47
+seed7/prg/wator.sd7          0.033220            651
+seed7/prg/which.sd7          0.033534             65
+seed7/prg/wiz.sd7            0.033625           2833
+seed7/prg/wordcnt.sd7        0.033022             54
+seed7/prg/wrinum.sd7         0.033466             43
+seed7/prg/wumpus.sd7         0.033477            372
+seed7/lib/aes.s7i            0.033410           1144
+seed7/lib/aes_gcm.s7i        0.033513            392
+seed7/lib/ar.s7i             0.033397           1532
+seed7/lib/arc4.s7i           0.032559            144
+seed7/lib/archive.s7i        0.032813            143
+seed7/lib/archive_base.s7i   0.032745            135
+seed7/lib/array.s7i          0.032327            610
+seed7/lib/asn1.s7i           0.033418            544
+seed7/lib/asn1oid.s7i        0.032917            157
+seed7/lib/basearray.s7i      0.034192            450
+seed7/lib/bigfile.s7i        0.033460            136
+seed7/lib/bigint.s7i         0.033311            824
+seed7/lib/bigrat.s7i         0.033494            784
+seed7/lib/bin16.s7i          0.033471            592
+seed7/lib/bin32.s7i          0.033362            490
+seed7/lib/bin64.s7i          0.033435            539
+seed7/lib/bitdata.s7i        0.034111           1330
+seed7/lib/bitmapfont.s7i     0.034095            215
+seed7/lib/bitset.s7i         0.033532            593
+seed7/lib/bitsetof.s7i       0.033957            431
+seed7/lib/blowfish.s7i       0.033457            383
+seed7/lib/bmp.s7i            0.033482            924
+seed7/lib/boolean.s7i        0.033758            403
+seed7/lib/browser.s7i        0.033635            280
+seed7/lib/bstring.s7i        0.032951            227
+seed7/lib/bytedata.s7i       0.033277            482
+seed7/lib/bzip2.s7i          0.032705            887
+seed7/lib/cards.s7i          0.032407           1342
+seed7/lib/category.s7i       0.032688            209
+seed7/lib/cc_conf.s7i        0.032360           1314
+seed7/lib/ccittfax.s7i       0.032721           1022
+seed7/lib/cgi.s7i            0.032609            109
+seed7/lib/cgidialog.s7i      0.032991           1118
+seed7/lib/char.s7i           0.032694            356
+seed7/lib/charsets.s7i       0.032716           2024
+seed7/lib/chartype.s7i       0.032654            121
+seed7/lib/cipher.s7i         0.033039            146
+seed7/lib/cli_cmds.s7i       0.032658           1360
+seed7/lib/clib_file.s7i      0.033105            301
+seed7/lib/color.s7i          0.035317            185
+seed7/lib/complex.s7i        0.033722            464
+seed7/lib/compress.s7i       0.033342            150
+seed7/lib/console.s7i        0.033192            188
+seed7/lib/cpio.s7i           0.033432           1708
+seed7/lib/crc32.s7i          0.033091            193
+seed7/lib/cronos16.s7i       0.033480           1173
+seed7/lib/cronos27.s7i       0.033676           1464
+seed7/lib/csv.s7i            0.033404            201
+seed7/lib/db_prop.s7i        0.033336            991
+seed7/lib/deflate.s7i        0.034156            740
+seed7/lib/des.s7i            0.033284            444
+seed7/lib/dialog.s7i         0.034070            311
+seed7/lib/dir.s7i            0.033397            163
+seed7/lib/draw.s7i           0.033500            854
+seed7/lib/duration.s7i       0.033312           1038
+seed7/lib/echo.s7i           0.033337            132
+seed7/lib/editline.s7i       0.033429            398
+seed7/lib/elf.s7i            0.033666           1560
+seed7/lib/elliptic.s7i       0.033571            649
+seed7/lib/enable_io.s7i      0.033023            312
+seed7/lib/encoding.s7i       0.033162            931
+seed7/lib/enumeration.s7i    0.033595            236
+seed7/lib/environment.s7i    0.033231            175
+seed7/lib/exif.s7i           0.035435            152
+seed7/lib/external_file.s7i  0.036292            340
+seed7/lib/field.s7i          0.032883            268
+seed7/lib/file.s7i           0.032440            372
+seed7/lib/filebits.s7i       0.033066             46
+seed7/lib/filesys.s7i        0.037120            601
+seed7/lib/fileutil.s7i       0.032765            144
+seed7/lib/fixarray.s7i       0.033931            307
+seed7/lib/float.s7i          0.033995            757
+seed7/lib/font.s7i           0.032375            196
+seed7/lib/font8x8.s7i        0.032717            998
+seed7/lib/forloop.s7i        0.032480            449
+seed7/lib/ftp.s7i            0.032651            969
+seed7/lib/ftpserv.s7i        0.032623            631
+seed7/lib/getf.s7i           0.032644            115
+seed7/lib/gethttp.s7i        0.033375             41
+seed7/lib/gethttps.s7i       0.032820             41
+seed7/lib/gif.s7i            0.032412            561
+seed7/lib/graph.s7i          0.033156            415
+seed7/lib/graph_file.s7i     0.033412            399
+seed7/lib/gtkserver.s7i      0.033148            161
+seed7/lib/gzip.s7i           0.033631            573
+seed7/lib/hash.s7i           0.033685            421
+seed7/lib/hashsetof.s7i      0.033639            499
+seed7/lib/hmac.s7i           0.033345            152
+seed7/lib/html.s7i           0.032879             83
+seed7/lib/html_ent.s7i       0.033033            476
+seed7/lib/htmldom.s7i        0.033777            286
+seed7/lib/http_request.s7i   0.033383            696
+seed7/lib/http_srv_resp.s7i  0.033792            380
+seed7/lib/https_request.s7i  0.033419            211
+seed7/lib/httpserv.s7i       0.033786            345
+seed7/lib/huffman.s7i        0.036458            644
+seed7/lib/ico.s7i            0.033468            221
+seed7/lib/idxarray.s7i       0.032366            232
+seed7/lib/image.s7i          0.032528            156
+seed7/lib/imagefile.s7i      0.032634            171
+seed7/lib/inflate.s7i        0.032614            411
+seed7/lib/inifile.s7i        0.032983            129
+seed7/lib/integer.s7i        0.034544            663
+seed7/lib/iobuffer.s7i       0.035662            289
+seed7/lib/jpeg.s7i           0.033942           1761
+seed7/lib/json.s7i           0.033666            891
+seed7/lib/json_serde.s7i     0.033357            783
+seed7/lib/keybd.s7i          0.033448            639
+seed7/lib/keydescr.s7i       0.040685            192
+seed7/lib/leb128.s7i         0.037196            218
+seed7/lib/line.s7i           0.034770            164
+seed7/lib/listener.s7i       0.033999            247
+seed7/lib/logfile.s7i        0.033438             73
+seed7/lib/lower.s7i          0.033618            142
+seed7/lib/lzma.s7i           0.033598            934
+seed7/lib/lzw.s7i            0.033698            861
+seed7/lib/magic.s7i          0.033784            403
+seed7/lib/mahjng32.s7i       0.033170           1500
+seed7/lib/make.s7i           0.033168            544
+seed7/lib/makedata.s7i       0.033504           1428
+seed7/lib/math.s7i           0.033684            201
+seed7/lib/mixarith.s7i       0.033326            249
+seed7/lib/modern27.s7i       0.037915           1099
+seed7/lib/more.s7i           0.038715            130
+seed7/lib/msgdigest.s7i      0.033206           1222
+seed7/lib/multiscr.s7i       0.032627             68
+seed7/lib/null_file.s7i      0.032648            345
+seed7/lib/osfiles.s7i        0.033290           1085
+seed7/lib/pbm.s7i            0.033768            230
+seed7/lib/pcx.s7i            0.032872            638
+seed7/lib/pem.s7i            0.033035            185
+seed7/lib/pgm.s7i            0.032628            238
+seed7/lib/pic16.s7i          0.032671           1037
+seed7/lib/pic32.s7i          0.034441           2060
+seed7/lib/pic_util.s7i       0.035046            144
+seed7/lib/pixelimage.s7i     0.033593            320
+seed7/lib/pixmap_file.s7i    0.033237            459
+seed7/lib/pixmapfont.s7i     0.033891            184
+seed7/lib/pkcs1.s7i          0.033727            543
+seed7/lib/png.s7i            0.033748           1064
+seed7/lib/poll.s7i           0.033421            313
+seed7/lib/ppm.s7i            0.033642            240
+seed7/lib/process.s7i        0.033667            541
+seed7/lib/progs.s7i          0.034251            789
+seed7/lib/propertyfile.s7i   0.033528            155
+seed7/lib/rational.s7i       0.033851            792
+seed7/lib/ref_list.s7i       0.033449            252
+seed7/lib/reference.s7i      0.033872            126
+seed7/lib/reverse.s7i        0.033428             94
+seed7/lib/rpm.s7i            0.033527           3487
+seed7/lib/rpmext.s7i         0.033520            318
+seed7/lib/scanfile.s7i       0.033820           1779
+seed7/lib/scanjson.s7i       0.033427            413
+seed7/lib/scanstri.s7i       0.033806           1814
+seed7/lib/scantoml.s7i       0.033338           1603
+seed7/lib/seed7_05.s7i       0.033416           1072
+seed7/lib/set.s7i            0.033280             57
+seed7/lib/shell.s7i          0.033522            615
+seed7/lib/showtls.s7i        0.032556            678
+seed7/lib/signature.s7i      0.032250            131
+seed7/lib/smtp.s7i           0.032933            261
+seed7/lib/sockbase.s7i       0.032845            217
+seed7/lib/socket.s7i         0.032384            326
+seed7/lib/sokoban1.s7i       0.032290           1519
+seed7/lib/sql_base.s7i       0.034445           1000
+seed7/lib/stars.s7i          0.033522           1705
+seed7/lib/stdfont10.s7i      0.033330           3347
+seed7/lib/stdfont12.s7i      0.033755           3928
+seed7/lib/stdfont14.s7i      0.034111           4510
+seed7/lib/stdfont16.s7i      0.032520           5092
+seed7/lib/stdfont18.s7i      0.032751           5868
+seed7/lib/stdfont20.s7i      0.032976           6449
+seed7/lib/stdfont24.s7i      0.032991           7421
+seed7/lib/stdfont8.s7i       0.032445           2960
+seed7/lib/stdfont9.s7i       0.032332           3152
+seed7/lib/stdio.s7i          0.032939            192
+seed7/lib/strifile.s7i       0.032723            345
+seed7/lib/string.s7i         0.032637            779
+seed7/lib/stritext.s7i       0.032795            352
+seed7/lib/struct.s7i         0.033327            266
+seed7/lib/struct_elem.s7i    0.033247            129
+seed7/lib/subfile.s7i        0.033564            174
+seed7/lib/subrange.s7i       0.033489             78
+seed7/lib/syntax.s7i         0.033601            294
+seed7/lib/tar.s7i            0.033619           1880
+seed7/lib/tar_cmds.s7i       0.033372            752
+seed7/lib/tdes.s7i           0.033116            143
+seed7/lib/tee.s7i            0.033560            143
+seed7/lib/text.s7i           0.033648            135
+seed7/lib/tga.s7i            0.033199            676
+seed7/lib/tiff.s7i           0.032888           2771
+seed7/lib/time.s7i           0.034340           1191
+seed7/lib/tls.s7i            0.033007           2230
+seed7/lib/unicode.s7i        0.034432            575
+seed7/lib/unionfnd.s7i       0.034792            130
+seed7/lib/upper.s7i          0.037061            142
+seed7/lib/utf16.s7i          0.034271            540
+seed7/lib/utf8.s7i           0.033541            234
+seed7/lib/vecfont10.s7i      0.033846           1056
+seed7/lib/vecfont18.s7i      0.034123           1119
+seed7/lib/vector3d.s7i       0.034358            293
+seed7/lib/vectorfont.s7i     0.033497            239
+seed7/lib/wildcard.s7i       0.037190            140
+seed7/lib/window.s7i         0.041644            455
+seed7/lib/wrinum.s7i         0.033529            248
+seed7/lib/x509cert.s7i       0.033572           1243
+seed7/lib/xml_ent.s7i        0.033446             94
+seed7/lib/xmldom.s7i         0.033797            303
+seed7/lib/xz.s7i             0.033816            442
+seed7/lib/zip.s7i            0.033836           2792
+seed7/lib/zstd.s7i           0.033881           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033764        |
++-----------+-----------------+
+| Minimum   | 0.032082        |
++-----------+-----------------+
+| Maximum   | 0.041644        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.040882            190
+seed7/prg/bas7.sd7           0.041404          11459
+seed7/prg/bifurk.sd7         0.036913             73
+seed7/prg/bigfiles.sd7       0.038948            129
+seed7/prg/brainf7.sd7        0.037568             86
+seed7/prg/calc7.sd7          0.039097            128
+seed7/prg/carddemo.sd7       0.038330            190
+seed7/prg/castle.sd7         0.039384           3148
+seed7/prg/cat.sd7            0.035857             82
+seed7/prg/cellauto.sd7       0.036360             85
+seed7/prg/celsius.sd7        0.035447             42
+seed7/prg/chk_all.sd7        0.038137            843
+seed7/prg/chkarr.sd7         0.039353           8367
+seed7/prg/chkbig.sd7         0.042586          29026
+seed7/prg/chkbin.sd7         0.039203           6469
+seed7/prg/chkbitdata.sd7     0.039025           6624
+seed7/prg/chkbool.sd7        0.037372           3157
+seed7/prg/chkbst.sd7         0.037874            722
+seed7/prg/chkchr.sd7         0.041629           2809
+seed7/prg/chkcmd.sd7         0.039162           1205
+seed7/prg/chkdb.sd7          0.040080           7454
+seed7/prg/chkdecl.sd7        0.039088            448
+seed7/prg/chkenum.sd7        0.038762           1230
+seed7/prg/chkerr.sd7         0.040138           4663
+seed7/prg/chkexc.sd7         0.038816           2627
+seed7/prg/chkfil.sd7         0.038662           1615
+seed7/prg/chkflt.sd7         0.043141          20620
+seed7/prg/chkhent.sd7        0.036365             54
+seed7/prg/chkhsh.sd7         0.040524           4548
+seed7/prg/chkidx.sd7         0.041683          19567
+seed7/prg/chkint.sd7         0.046236          38129
+seed7/prg/chkjson.sd7        0.040993           1764
+seed7/prg/chkovf.sd7         0.045406           8216
+seed7/prg/chkprc.sd7         0.040613          10111
+seed7/prg/chkscan.sd7        0.046473            714
+seed7/prg/chkset.sd7         0.041607          11974
+seed7/prg/chkstr.sd7         0.044282          26952
+seed7/prg/chktime.sd7        0.041046           2025
+seed7/prg/chktoml.sd7        0.039644           1656
+seed7/prg/clock.sd7          0.034834             47
+seed7/prg/clock2.sd7         0.034666             43
+seed7/prg/clock3.sd7         0.037544             95
+seed7/prg/cmpfil.sd7         0.036105             84
+seed7/prg/comanche.sd7       0.037540            180
+seed7/prg/confval.sd7        0.040524            175
+seed7/prg/db7.sd7            0.039800            417
+seed7/prg/diff7.sd7          0.039865            263
+seed7/prg/dirtst.sd7         0.035120             42
+seed7/prg/dirx.sd7           0.038125            152
+seed7/prg/dnafight.sd7       0.039106           1381
+seed7/prg/dragon.sd7         0.036017             73
+seed7/prg/echo.sd7           0.034326             39
+seed7/prg/eliza.sd7          0.037736            302
+seed7/prg/err.sd7            0.040153             96
+seed7/prg/fannkuch.sd7       0.037449            131
+seed7/prg/fib.sd7            0.035969             47
+seed7/prg/find7.sd7          0.038843            133
+seed7/prg/findchar.sd7       0.039191            149
+seed7/prg/fractree.sd7       0.036578             55
+seed7/prg/ftp7.sd7           0.038889            296
+seed7/prg/ftpserv.sd7        0.037773             74
+seed7/prg/gcd.sd7            0.038038            109
+seed7/prg/gkbd.sd7           0.042282            358
+seed7/prg/gtksvtst.sd7       0.038043             94
+seed7/prg/hal.sd7            0.038494            250
+seed7/prg/hamu.sd7           0.039408            573
+seed7/prg/hanoi.sd7          0.036947             55
+seed7/prg/hd.sd7             0.036797             79
+seed7/prg/hello.sd7          0.034505             32
+seed7/prg/hilbert.sd7        0.037281            108
+seed7/prg/ide7.sd7           0.038183            196
+seed7/prg/kbd.sd7            0.035192             49
+seed7/prg/klondike.sd7       0.040018            883
+seed7/prg/lander.sd7         0.039709           1551
+seed7/prg/lst80bas.sd7       0.037966            344
+seed7/prg/lst99bas.sd7       0.039309            401
+seed7/prg/lstgwbas.sd7       0.040207            577
+seed7/prg/mahjong.sd7        0.038970           1943
+seed7/prg/make7.sd7          0.038906            121
+seed7/prg/mandelbr.sd7       0.039144            237
+seed7/prg/mind.sd7           0.038891            443
+seed7/prg/mirror.sd7         0.039962            131
+seed7/prg/ms.sd7             0.039575            641
+seed7/prg/nicoma.sd7         0.038693            135
+seed7/prg/pac.sd7            0.039049            726
+seed7/prg/pairs.sd7          0.038778           2025
+seed7/prg/panic.sd7          0.039497           2634
+seed7/prg/percolation.sd7    0.039072            330
+seed7/prg/planets.sd7        0.039850           1486
+seed7/prg/portfwd7.sd7       0.039598            139
+seed7/prg/prime.sd7          0.036794             74
+seed7/prg/printpi1.sd7       0.037029             56
+seed7/prg/printpi2.sd7       0.036339             54
+seed7/prg/printpi3.sd7       0.036336             60
+seed7/prg/pv7.sd7            0.037998            337
+seed7/prg/queen.sd7          0.038076            149
+seed7/prg/rand.sd7           0.036978            121
+seed7/prg/raytrace.sd7       0.038241            538
+seed7/prg/rever.sd7          0.037627            816
+seed7/prg/roman.sd7          0.034425             38
+seed7/prg/s7c.sd7            0.040186           9060
+seed7/prg/s7check.sd7        0.036031             68
+seed7/prg/savehd7.sd7        0.037717           1110
+seed7/prg/self.sd7           0.035653             49
+seed7/prg/shisen.sd7         0.038558           1423
+seed7/prg/sl.sd7             0.037520           1029
+seed7/prg/snake.sd7          0.038316            615
+seed7/prg/sokoban.sd7        0.037268            891
+seed7/prg/spigotpi.sd7       0.035821             64
+seed7/prg/sql7.sd7           0.038062            278
+seed7/prg/startrek.sd7       0.038671            979
+seed7/prg/sudoku7.sd7        0.039066           2657
+seed7/prg/sydir7.sd7         0.038995            384
+seed7/prg/syntaxhl.sd7       0.041666            177
+seed7/prg/tak.sd7            0.036660             59
+seed7/prg/tar7.sd7           0.038719            121
+seed7/prg/tch.sd7            0.036413             55
+seed7/prg/testfont.sd7       0.038927             95
+seed7/prg/tet.sd7            0.038596            479
+seed7/prg/tetg.sd7           0.038986            501
+seed7/prg/toutf8.sd7         0.040848            240
+seed7/prg/tst_cli.sd7        0.036599             40
+seed7/prg/tst_srv.sd7        0.035842             47
+seed7/prg/wator.sd7          0.037699            651
+seed7/prg/which.sd7          0.037646             65
+seed7/prg/wiz.sd7            0.042034           2833
+seed7/prg/wordcnt.sd7        0.036217             54
+seed7/prg/wrinum.sd7         0.035483             43
+seed7/prg/wumpus.sd7         0.039047            372
+seed7/lib/aes.s7i            0.042074           1144
+seed7/lib/aes_gcm.s7i        0.039740            392
+seed7/lib/ar.s7i             0.039510           1532
+seed7/lib/arc4.s7i           0.039504            144
+seed7/lib/archive.s7i        0.038586            143
+seed7/lib/archive_base.s7i   0.038923            135
+seed7/lib/array.s7i          0.039060            610
+seed7/lib/asn1.s7i           0.037927            544
+seed7/lib/asn1oid.s7i        0.042898            157
+seed7/lib/basearray.s7i      0.039970            450
+seed7/lib/bigfile.s7i        0.038939            136
+seed7/lib/bigint.s7i         0.038537            824
+seed7/lib/bigrat.s7i         0.038461            784
+seed7/lib/bin16.s7i          0.038687            592
+seed7/lib/bin32.s7i          0.046037            490
+seed7/lib/bin64.s7i          0.039742            539
+seed7/lib/bitdata.s7i        0.043546           1330
+seed7/lib/bitmapfont.s7i     0.037527            215
+seed7/lib/bitset.s7i         0.037884            593
+seed7/lib/bitsetof.s7i       0.039573            431
+seed7/lib/blowfish.s7i       0.049414            383
+seed7/lib/bmp.s7i            0.040876            924
+seed7/lib/boolean.s7i        0.039574            403
+seed7/lib/browser.s7i        0.039311            280
+seed7/lib/bstring.s7i        0.038499            227
+seed7/lib/bytedata.s7i       0.038383            482
+seed7/lib/bzip2.s7i          0.040580            887
+seed7/lib/cards.s7i          0.035805           1342
+seed7/lib/category.s7i       0.037439            209
+seed7/lib/cc_conf.s7i        0.038035           1314
+seed7/lib/ccittfax.s7i       0.039504           1022
+seed7/lib/cgi.s7i            0.041772            109
+seed7/lib/cgidialog.s7i      0.040044           1118
+seed7/lib/char.s7i           0.039492            356
+seed7/lib/charsets.s7i       0.039786           2024
+seed7/lib/chartype.s7i       0.041963            121
+seed7/lib/cipher.s7i         0.038867            146
+seed7/lib/cli_cmds.s7i       0.039272           1360
+seed7/lib/clib_file.s7i      0.039601            301
+seed7/lib/color.s7i          0.039516            185
+seed7/lib/complex.s7i        0.042592            464
+seed7/lib/compress.s7i       0.038522            150
+seed7/lib/console.s7i        0.037945            188
+seed7/lib/cpio.s7i           0.038691           1708
+seed7/lib/crc32.s7i          0.039008            193
+seed7/lib/cronos16.s7i       0.042132           1173
+seed7/lib/cronos27.s7i       0.042255           1464
+seed7/lib/csv.s7i            0.038199            201
+seed7/lib/db_prop.s7i        0.038208            991
+seed7/lib/deflate.s7i        0.045011            740
+seed7/lib/des.s7i            0.040435            444
+seed7/lib/dialog.s7i         0.039302            311
+seed7/lib/dir.s7i            0.039316            163
+seed7/lib/draw.s7i           0.039988            854
+seed7/lib/duration.s7i       0.037878           1038
+seed7/lib/echo.s7i           0.037747            132
+seed7/lib/editline.s7i       0.037726            398
+seed7/lib/elf.s7i            0.039181           1560
+seed7/lib/elliptic.s7i       0.037395            649
+seed7/lib/enable_io.s7i      0.037833            312
+seed7/lib/encoding.s7i       0.037713            931
+seed7/lib/enumeration.s7i    0.037950            236
+seed7/lib/environment.s7i    0.037862            175
+seed7/lib/exif.s7i           0.040182            152
+seed7/lib/external_file.s7i  0.038674            340
+seed7/lib/field.s7i          0.044679            268
+seed7/lib/file.s7i           0.042860            372
+seed7/lib/filebits.s7i       0.036344             46
+seed7/lib/filesys.s7i        0.038890            601
+seed7/lib/fileutil.s7i       0.038907            144
+seed7/lib/fixarray.s7i       0.040324            307
+seed7/lib/float.s7i          0.038690            757
+seed7/lib/font.s7i           0.038296            196
+seed7/lib/font8x8.s7i        0.038407            998
+seed7/lib/forloop.s7i        0.039579            449
+seed7/lib/ftp.s7i            0.038350            969
+seed7/lib/ftpserv.s7i        0.040203            631
+seed7/lib/getf.s7i           0.038038            115
+seed7/lib/gethttp.s7i        0.035040             41
+seed7/lib/gethttps.s7i       0.034847             41
+seed7/lib/gif.s7i            0.039380            561
+seed7/lib/graph.s7i          0.040927            415
+seed7/lib/graph_file.s7i     0.038940            399
+seed7/lib/gtkserver.s7i      0.038169            161
+seed7/lib/gzip.s7i           0.038682            573
+seed7/lib/hash.s7i           0.040402            421
+seed7/lib/hashsetof.s7i      0.040993            499
+seed7/lib/hmac.s7i           0.039233            152
+seed7/lib/html.s7i           0.037815             83
+seed7/lib/html_ent.s7i       0.038875            476
+seed7/lib/htmldom.s7i        0.039066            286
+seed7/lib/http_request.s7i   0.038631            696
+seed7/lib/http_srv_resp.s7i  0.039772            380
+seed7/lib/https_request.s7i  0.039439            211
+seed7/lib/httpserv.s7i       0.045359            345
+seed7/lib/huffman.s7i        0.038476            644
+seed7/lib/ico.s7i            0.037760            221
+seed7/lib/idxarray.s7i       0.038766            232
+seed7/lib/image.s7i          0.037241            156
+seed7/lib/imagefile.s7i      0.037881            171
+seed7/lib/inflate.s7i        0.038752            411
+seed7/lib/inifile.s7i        0.038087            129
+seed7/lib/integer.s7i        0.037925            663
+seed7/lib/iobuffer.s7i       0.038314            289
+seed7/lib/jpeg.s7i           0.038238           1761
+seed7/lib/json.s7i           0.037400            891
+seed7/lib/json_serde.s7i     0.038142            783
+seed7/lib/keybd.s7i          0.039839            639
+seed7/lib/keydescr.s7i       0.040820            192
+seed7/lib/leb128.s7i         0.039428            218
+seed7/lib/line.s7i           0.039142            164
+seed7/lib/listener.s7i       0.040847            247
+seed7/lib/logfile.s7i        0.042637             73
+seed7/lib/lower.s7i          0.039816            142
+seed7/lib/lzma.s7i           0.039831            934
+seed7/lib/lzw.s7i            0.039476            861
+seed7/lib/magic.s7i          0.041015            403
+seed7/lib/mahjng32.s7i       0.039111           1500
+seed7/lib/make.s7i           0.038586            544
+seed7/lib/makedata.s7i       0.039503           1428
+seed7/lib/math.s7i           0.039341            201
+seed7/lib/mixarith.s7i       0.039033            249
+seed7/lib/modern27.s7i       0.042433           1099
+seed7/lib/more.s7i           0.038932            130
+seed7/lib/msgdigest.s7i      0.040871           1222
+seed7/lib/multiscr.s7i       0.037478             68
+seed7/lib/null_file.s7i      0.038480            345
+seed7/lib/osfiles.s7i        0.041094           1085
+seed7/lib/pbm.s7i            0.038448            230
+seed7/lib/pcx.s7i            0.038272            638
+seed7/lib/pem.s7i            0.037443            185
+seed7/lib/pgm.s7i            0.038071            238
+seed7/lib/pic16.s7i          0.036928           1037
+seed7/lib/pic32.s7i          0.038082           2060
+seed7/lib/pic_util.s7i       0.038371            144
+seed7/lib/pixelimage.s7i     0.037816            320
+seed7/lib/pixmap_file.s7i    0.038612            459
+seed7/lib/pixmapfont.s7i     0.039044            184
+seed7/lib/pkcs1.s7i          0.043121            543
+seed7/lib/png.s7i            0.037853           1064
+seed7/lib/poll.s7i           0.038282            313
+seed7/lib/ppm.s7i            0.038372            240
+seed7/lib/process.s7i        0.037972            541
+seed7/lib/progs.s7i          0.040300            789
+seed7/lib/propertyfile.s7i   0.040985            155
+seed7/lib/rational.s7i       0.039489            792
+seed7/lib/ref_list.s7i       0.038769            252
+seed7/lib/reference.s7i      0.039142            126
+seed7/lib/reverse.s7i        0.038679             94
+seed7/lib/rpm.s7i            0.039076           3487
+seed7/lib/rpmext.s7i         0.039415            318
+seed7/lib/scanfile.s7i       0.039154           1779
+seed7/lib/scanjson.s7i       0.039519            413
+seed7/lib/scanstri.s7i       0.039141           1814
+seed7/lib/scantoml.s7i       0.039349           1603
+seed7/lib/seed7_05.s7i       0.041011           1072
+seed7/lib/set.s7i            0.035747             57
+seed7/lib/shell.s7i          0.038593            615
+seed7/lib/showtls.s7i        0.038120            678
+seed7/lib/signature.s7i      0.038054            131
+seed7/lib/smtp.s7i           0.037543            261
+seed7/lib/sockbase.s7i       0.041108            217
+seed7/lib/socket.s7i         0.039119            326
+seed7/lib/sokoban1.s7i       0.037941           1519
+seed7/lib/sql_base.s7i       0.039357           1000
+seed7/lib/stars.s7i          0.041406           1705
+seed7/lib/stdfont10.s7i      0.039993           3347
+seed7/lib/stdfont12.s7i      0.042173           3928
+seed7/lib/stdfont14.s7i      0.041415           4510
+seed7/lib/stdfont16.s7i      0.041270           5092
+seed7/lib/stdfont18.s7i      0.041424           5868
+seed7/lib/stdfont20.s7i      0.041328           6449
+seed7/lib/stdfont24.s7i      0.041202           7421
+seed7/lib/stdfont8.s7i       0.040650           2960
+seed7/lib/stdfont9.s7i       0.040756           3152
+seed7/lib/stdio.s7i          0.041753            192
+seed7/lib/strifile.s7i       0.040434            345
+seed7/lib/string.s7i         0.041244            779
+seed7/lib/stritext.s7i       0.040560            352
+seed7/lib/struct.s7i         0.041291            266
+seed7/lib/struct_elem.s7i    0.039852            129
+seed7/lib/subfile.s7i        0.040324            174
+seed7/lib/subrange.s7i       0.038912             78
+seed7/lib/syntax.s7i         0.040724            294
+seed7/lib/tar.s7i            0.041207           1880
+seed7/lib/tar_cmds.s7i       0.040579            752
+seed7/lib/tdes.s7i           0.040057            143
+seed7/lib/tee.s7i            0.040515            143
+seed7/lib/text.s7i           0.040564            135
+seed7/lib/tga.s7i            0.043037            676
+seed7/lib/tiff.s7i           0.043157           2771
+seed7/lib/time.s7i           0.042112           1191
+seed7/lib/tls.s7i            0.041711           2230
+seed7/lib/unicode.s7i        0.043102            575
+seed7/lib/unionfnd.s7i       0.040953            130
+seed7/lib/upper.s7i          0.040583            142
+seed7/lib/utf16.s7i          0.040918            540
+seed7/lib/utf8.s7i           0.042132            234
+seed7/lib/vecfont10.s7i      0.044148           1056
+seed7/lib/vecfont18.s7i      0.044284           1119
+seed7/lib/vector3d.s7i       0.046615            293
+seed7/lib/vectorfont.s7i     0.043546            239
+seed7/lib/wildcard.s7i       0.040847            140
+seed7/lib/window.s7i         0.040817            455
+seed7/lib/wrinum.s7i         0.042137            248
+seed7/lib/x509cert.s7i       0.041474           1243
+seed7/lib/xml_ent.s7i        0.040671             94
+seed7/lib/xmldom.s7i         0.040083            303
+seed7/lib/xz.s7i             0.040008            442
+seed7/lib/zip.s7i            0.041136           2792
+seed7/lib/zstd.s7i           0.043073           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039331        |
++-----------+-----------------+
+| Minimum   | 0.034326        |
++-----------+-----------------+
+| Maximum   | 0.049414        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.044318            190
+seed7/prg/bas7.sd7           0.335147          11459
+seed7/prg/bifurk.sd7         0.040897             73
+seed7/prg/bigfiles.sd7       0.040719            129
+seed7/prg/brainf7.sd7        0.038646             86
+seed7/prg/calc7.sd7          0.039257            128
+seed7/prg/carddemo.sd7       0.040734            190
+seed7/prg/castle.sd7         0.110211           3148
+seed7/prg/cat.sd7            0.037811             82
+seed7/prg/cellauto.sd7       0.036874             85
+seed7/prg/celsius.sd7        0.036415             42
+seed7/prg/chk_all.sd7        0.062023            843
+seed7/prg/chkarr.sd7         0.370677           8367
+seed7/prg/chkbig.sd7         2.115264          29026
+seed7/prg/chkbin.sd7         0.528716           6469
+seed7/prg/chkbitdata.sd7     0.631042           6624
+seed7/prg/chkbool.sd7        0.120793           3157
+seed7/prg/chkbst.sd7         0.066698            722
+seed7/prg/chkchr.sd7         0.225455           2809
+seed7/prg/chkcmd.sd7         0.069035           1205
+seed7/prg/chkdb.sd7          0.363667           7454
+seed7/prg/chkdecl.sd7        0.059836            448
+seed7/prg/chkenum.sd7        0.070360           1230
+seed7/prg/chkerr.sd7         0.198532           4663
+seed7/prg/chkexc.sd7         0.084151           2627
+seed7/prg/chkfil.sd7         0.077237           1615
+seed7/prg/chkflt.sd7         1.377946          20620
+seed7/prg/chkhent.sd7        0.037275             54
+seed7/prg/chkhsh.sd7         0.252228           4548
+seed7/prg/chkidx.sd7         1.349728          19567
+seed7/prg/chkint.sd7         2.597008          38129
+seed7/prg/chkjson.sd7        0.107299           1764
+seed7/prg/chkovf.sd7         0.583550           8216
+seed7/prg/chkprc.sd7         0.332219          10111
+seed7/prg/chkscan.sd7        0.067686            714
+seed7/prg/chkset.sd7         0.675382          11974
+seed7/prg/chkstr.sd7         1.501723          26952
+seed7/prg/chktime.sd7        0.134832           2025
+seed7/prg/chktoml.sd7        0.111153           1656
+seed7/prg/clock.sd7          0.044844             47
+seed7/prg/clock2.sd7         0.043223             43
+seed7/prg/clock3.sd7         0.044575             95
+seed7/prg/cmpfil.sd7         0.042841             84
+seed7/prg/comanche.sd7       0.045407            180
+seed7/prg/confval.sd7        0.043065            175
+seed7/prg/db7.sd7            0.049163            417
+seed7/prg/diff7.sd7          0.046584            263
+seed7/prg/dirtst.sd7         0.038665             42
+seed7/prg/dirx.sd7           0.041952            152
+seed7/prg/dnafight.sd7       0.071185           1381
+seed7/prg/dragon.sd7         0.041744             73
+seed7/prg/echo.sd7           0.041588             39
+seed7/prg/eliza.sd7          0.050181            302
+seed7/prg/err.sd7            0.045107             96
+seed7/prg/fannkuch.sd7       0.042923            131
+seed7/prg/fib.sd7            0.039760             47
+seed7/prg/find7.sd7          0.041617            133
+seed7/prg/findchar.sd7       0.044671            149
+seed7/prg/fractree.sd7       0.039952             55
+seed7/prg/ftp7.sd7           0.047958            296
+seed7/prg/ftpserv.sd7        0.041455             74
+seed7/prg/gcd.sd7            0.040458            109
+seed7/prg/gkbd.sd7           0.051565            358
+seed7/prg/gtksvtst.sd7       0.042721             94
+seed7/prg/hal.sd7            0.042962            250
+seed7/prg/hamu.sd7           0.053036            573
+seed7/prg/hanoi.sd7          0.041252             55
+seed7/prg/hd.sd7             0.042915             79
+seed7/prg/hello.sd7          0.044921             32
+seed7/prg/hilbert.sd7        0.043565            108
+seed7/prg/ide7.sd7           0.046767            196
+seed7/prg/kbd.sd7            0.042344             49
+seed7/prg/klondike.sd7       0.062319            883
+seed7/prg/lander.sd7         0.080794           1551
+seed7/prg/lst80bas.sd7       0.049328            344
+seed7/prg/lst99bas.sd7       0.051391            401
+seed7/prg/lstgwbas.sd7       0.056203            577
+seed7/prg/mahjong.sd7        0.088806           1943
+seed7/prg/make7.sd7          0.043597            121
+seed7/prg/mandelbr.sd7       0.045242            237
+seed7/prg/mind.sd7           0.049754            443
+seed7/prg/mirror.sd7         0.045340            131
+seed7/prg/ms.sd7             0.052491            641
+seed7/prg/nicoma.sd7         0.043865            135
+seed7/prg/pac.sd7            0.056148            726
+seed7/prg/pairs.sd7          0.090268           2025
+seed7/prg/panic.sd7          0.104075           2634
+seed7/prg/percolation.sd7    0.047397            330
+seed7/prg/planets.sd7        0.080871           1486
+seed7/prg/portfwd7.sd7       0.043899            139
+seed7/prg/prime.sd7          0.041595             74
+seed7/prg/printpi1.sd7       0.039291             56
+seed7/prg/printpi2.sd7       0.038088             54
+seed7/prg/printpi3.sd7       0.039690             60
+seed7/prg/pv7.sd7            0.048157            337
+seed7/prg/queen.sd7          0.041158            149
+seed7/prg/rand.sd7           0.045638            121
+seed7/prg/raytrace.sd7       0.053043            538
+seed7/prg/rever.sd7          0.057602            816
+seed7/prg/roman.sd7          0.041828             38
+seed7/prg/s7c.sd7            0.294857           9060
+seed7/prg/s7check.sd7        0.040055             68
+seed7/prg/savehd7.sd7        0.074062           1110
+seed7/prg/self.sd7           0.041221             49
+seed7/prg/shisen.sd7         0.077371           1423
+seed7/prg/sl.sd7             0.063331           1029
+seed7/prg/snake.sd7          0.054389            615
+seed7/prg/sokoban.sd7        0.060195            891
+seed7/prg/spigotpi.sd7       0.041414             64
+seed7/prg/sql7.sd7           0.045123            278
+seed7/prg/startrek.sd7       0.067722            979
+seed7/prg/sudoku7.sd7        0.106848           2657
+seed7/prg/sydir7.sd7         0.054169            384
+seed7/prg/syntaxhl.sd7       0.048635            177
+seed7/prg/tak.sd7            0.042379             59
+seed7/prg/tar7.sd7           0.046271            121
+seed7/prg/tch.sd7            0.043619             55
+seed7/prg/testfont.sd7       0.048987             95
+seed7/prg/tet.sd7            0.066867            479
+seed7/prg/tetg.sd7           0.052688            501
+seed7/prg/toutf8.sd7         0.050372            240
+seed7/prg/tst_cli.sd7        0.044780             40
+seed7/prg/tst_srv.sd7        0.042429             47
+seed7/prg/wator.sd7          0.060323            651
+seed7/prg/which.sd7          0.043591             65
+seed7/prg/wiz.sd7            0.119052           2833
+seed7/prg/wordcnt.sd7        0.044341             54
+seed7/prg/wrinum.sd7         0.040764             43
+seed7/prg/wumpus.sd7         0.049618            372
+seed7/lib/aes.s7i            0.118333           1144
+seed7/lib/aes_gcm.s7i        0.052470            392
+seed7/lib/ar.s7i             0.079701           1532
+seed7/lib/arc4.s7i           0.043005            144
+seed7/lib/archive.s7i        0.044683            143
+seed7/lib/archive_base.s7i   0.042153            135
+seed7/lib/array.s7i          0.059267            610
+seed7/lib/asn1.s7i           0.050858            544
+seed7/lib/asn1oid.s7i        0.044792            157
+seed7/lib/basearray.s7i      0.050358            450
+seed7/lib/bigfile.s7i        0.038567            136
+seed7/lib/bigint.s7i         0.058678            824
+seed7/lib/bigrat.s7i         0.055674            784
+seed7/lib/bin16.s7i          0.053781            592
+seed7/lib/bin32.s7i          0.052339            490
+seed7/lib/bin64.s7i          0.060556            539
+seed7/lib/bitdata.s7i        0.084559           1330
+seed7/lib/bitmapfont.s7i     0.043958            215
+seed7/lib/bitset.s7i         0.050794            593
+seed7/lib/bitsetof.s7i       0.049724            431
+seed7/lib/blowfish.s7i       0.060909            383
+seed7/lib/bmp.s7i            0.063915            924
+seed7/lib/boolean.s7i        0.046698            403
+seed7/lib/browser.s7i        0.045750            280
+seed7/lib/bstring.s7i        0.044349            227
+seed7/lib/bytedata.s7i       0.053705            482
+seed7/lib/bzip2.s7i          0.064113            887
+seed7/lib/cards.s7i          0.071084           1342
+seed7/lib/category.s7i       0.043769            209
+seed7/lib/cc_conf.s7i        0.082889           1314
+seed7/lib/ccittfax.s7i       0.072083           1022
+seed7/lib/cgi.s7i            0.041014            109
+seed7/lib/cgidialog.s7i      0.065138           1118
+seed7/lib/char.s7i           0.048305            356
+seed7/lib/charsets.s7i       0.088816           2024
+seed7/lib/chartype.s7i       0.043134            121
+seed7/lib/cipher.s7i         0.041152            146
+seed7/lib/cli_cmds.s7i       0.073579           1360
+seed7/lib/clib_file.s7i      0.046114            301
+seed7/lib/color.s7i          0.042724            185
+seed7/lib/complex.s7i        0.048846            464
+seed7/lib/compress.s7i       0.042392            150
+seed7/lib/console.s7i        0.042425            188
+seed7/lib/cpio.s7i           0.086584           1708
+seed7/lib/crc32.s7i          0.046378            193
+seed7/lib/cronos16.s7i       0.098119           1173
+seed7/lib/cronos27.s7i       0.124241           1464
+seed7/lib/csv.s7i            0.043899            201
+seed7/lib/db_prop.s7i        0.067728            991
+seed7/lib/deflate.s7i        0.059649            740
+seed7/lib/des.s7i            0.060591            444
+seed7/lib/dialog.s7i         0.048331            311
+seed7/lib/dir.s7i            0.041828            163
+seed7/lib/draw.s7i           0.060405            854
+seed7/lib/duration.s7i       0.065080           1038
+seed7/lib/echo.s7i           0.040834            132
+seed7/lib/editline.s7i       0.049460            398
+seed7/lib/elf.s7i            0.090845           1560
+seed7/lib/elliptic.s7i       0.056107            649
+seed7/lib/enable_io.s7i      0.047327            312
+seed7/lib/encoding.s7i       0.065772            931
+seed7/lib/enumeration.s7i    0.045014            236
+seed7/lib/environment.s7i    0.043006            175
+seed7/lib/exif.s7i           0.043494            152
+seed7/lib/external_file.s7i  0.055223            340
+seed7/lib/field.s7i          0.051688            268
+seed7/lib/file.s7i           0.048471            372
+seed7/lib/filebits.s7i       0.038731             46
+seed7/lib/filesys.s7i        0.050755            601
+seed7/lib/fileutil.s7i       0.041283            144
+seed7/lib/fixarray.s7i       0.050586            307
+seed7/lib/float.s7i          0.063396            757
+seed7/lib/font.s7i           0.042291            196
+seed7/lib/font8x8.s7i        0.051473            998
+seed7/lib/forloop.s7i        0.049292            449
+seed7/lib/ftp.s7i            0.061527            969
+seed7/lib/ftpserv.s7i        0.055647            631
+seed7/lib/getf.s7i           0.040891            115
+seed7/lib/gethttp.s7i        0.039303             41
+seed7/lib/gethttps.s7i       0.042442             41
+seed7/lib/gif.s7i            0.055469            561
+seed7/lib/graph.s7i          0.052750            415
+seed7/lib/graph_file.s7i     0.048477            399
+seed7/lib/gtkserver.s7i      0.041590            161
+seed7/lib/gzip.s7i           0.051176            573
+seed7/lib/hash.s7i           0.051596            421
+seed7/lib/hashsetof.s7i      0.051323            499
+seed7/lib/hmac.s7i           0.040169            152
+seed7/lib/html.s7i           0.038313             83
+seed7/lib/html_ent.s7i       0.047995            476
+seed7/lib/htmldom.s7i        0.044696            286
+seed7/lib/http_request.s7i   0.055694            696
+seed7/lib/http_srv_resp.s7i  0.049866            380
+seed7/lib/https_request.s7i  0.043474            211
+seed7/lib/httpserv.s7i       0.045507            345
+seed7/lib/huffman.s7i        0.054718            644
+seed7/lib/ico.s7i            0.046110            221
+seed7/lib/idxarray.s7i       0.049358            232
+seed7/lib/image.s7i          0.040271            156
+seed7/lib/imagefile.s7i      0.041076            171
+seed7/lib/inflate.s7i        0.048503            411
+seed7/lib/inifile.s7i        0.039932            129
+seed7/lib/integer.s7i        0.053928            663
+seed7/lib/iobuffer.s7i       0.043309            289
+seed7/lib/jpeg.s7i           0.085225           1761
+seed7/lib/json.s7i           0.057677            891
+seed7/lib/json_serde.s7i     0.055242            783
+seed7/lib/keybd.s7i          0.056595            639
+seed7/lib/keydescr.s7i       0.045039            192
+seed7/lib/leb128.s7i         0.041224            218
+seed7/lib/line.s7i           0.039812            164
+seed7/lib/listener.s7i       0.044011            247
+seed7/lib/logfile.s7i        0.039848             73
+seed7/lib/lower.s7i          0.041939            142
+seed7/lib/lzma.s7i           0.062838            934
+seed7/lib/lzw.s7i            0.066445            861
+seed7/lib/magic.s7i          0.050882            403
+seed7/lib/mahjng32.s7i       0.068025           1500
+seed7/lib/make.s7i           0.056332            544
+seed7/lib/makedata.s7i       0.078680           1428
+seed7/lib/math.s7i           0.041377            201
+seed7/lib/mixarith.s7i       0.043786            249
+seed7/lib/modern27.s7i       0.086908           1099
+seed7/lib/more.s7i           0.039309            130
+seed7/lib/msgdigest.s7i      0.080843           1222
+seed7/lib/multiscr.s7i       0.038141             68
+seed7/lib/null_file.s7i      0.044400            345
+seed7/lib/osfiles.s7i        0.067219           1085
+seed7/lib/pbm.s7i            0.041818            230
+seed7/lib/pcx.s7i            0.056067            638
+seed7/lib/pem.s7i            0.042302            185
+seed7/lib/pgm.s7i            0.044181            238
+seed7/lib/pic16.s7i          0.051301           1037
+seed7/lib/pic32.s7i          0.081539           2060
+seed7/lib/pic_util.s7i       0.038977            144
+seed7/lib/pixelimage.s7i     0.042656            320
+seed7/lib/pixmap_file.s7i    0.046848            459
+seed7/lib/pixmapfont.s7i     0.041873            184
+seed7/lib/pkcs1.s7i          0.062125            543
+seed7/lib/png.s7i            0.065812           1064
+seed7/lib/poll.s7i           0.045849            313
+seed7/lib/ppm.s7i            0.043011            240
+seed7/lib/process.s7i        0.050429            541
+seed7/lib/progs.s7i          0.057776            789
+seed7/lib/propertyfile.s7i   0.040483            155
+seed7/lib/rational.s7i       0.055445            792
+seed7/lib/ref_list.s7i       0.043210            252
+seed7/lib/reference.s7i      0.039679            126
+seed7/lib/reverse.s7i        0.038140             94
+seed7/lib/rpm.s7i            0.152451           3487
+seed7/lib/rpmext.s7i         0.045356            318
+seed7/lib/scanfile.s7i       0.083191           1779
+seed7/lib/scanjson.s7i       0.048864            413
+seed7/lib/scanstri.s7i       0.082299           1814
+seed7/lib/scantoml.s7i       0.074055           1603
+seed7/lib/seed7_05.s7i       0.068662           1072
+seed7/lib/set.s7i            0.038277             57
+seed7/lib/shell.s7i          0.055673            615
+seed7/lib/showtls.s7i        0.056995            678
+seed7/lib/signature.s7i      0.039764            131
+seed7/lib/smtp.s7i           0.042839            261
+seed7/lib/sockbase.s7i       0.043602            217
+seed7/lib/socket.s7i         0.044885            326
+seed7/lib/sokoban1.s7i       0.057412           1519
+seed7/lib/sql_base.s7i       0.066262           1000
+seed7/lib/stars.s7i          0.141531           1705
+seed7/lib/stdfont10.s7i      0.086549           3347
+seed7/lib/stdfont12.s7i      0.094613           3928
+seed7/lib/stdfont14.s7i      0.105710           4510
+seed7/lib/stdfont16.s7i      0.118117           5092
+seed7/lib/stdfont18.s7i      0.136242           5868
+seed7/lib/stdfont20.s7i      0.151562           6449
+seed7/lib/stdfont24.s7i      0.184486           7421
+seed7/lib/stdfont8.s7i       0.073515           2960
+seed7/lib/stdfont9.s7i       0.077950           3152
+seed7/lib/stdio.s7i          0.042283            192
+seed7/lib/strifile.s7i       0.047299            345
+seed7/lib/string.s7i         0.057048            779
+seed7/lib/stritext.s7i       0.043751            352
+seed7/lib/struct.s7i         0.046140            266
+seed7/lib/struct_elem.s7i    0.039849            129
+seed7/lib/subfile.s7i        0.041099            174
+seed7/lib/subrange.s7i       0.038211             78
+seed7/lib/syntax.s7i         0.047197            294
+seed7/lib/tar.s7i            0.084250           1880
+seed7/lib/tar_cmds.s7i       0.058504            752
+seed7/lib/tdes.s7i           0.039686            143
+seed7/lib/tee.s7i            0.038970            143
+seed7/lib/text.s7i           0.039245            135
+seed7/lib/tga.s7i            0.055385            676
+seed7/lib/tiff.s7i           0.125569           2771
+seed7/lib/time.s7i           0.065194           1191
+seed7/lib/tls.s7i            0.106485           2230
+seed7/lib/unicode.s7i        0.054975            575
+seed7/lib/unionfnd.s7i       0.042572            130
+seed7/lib/upper.s7i          0.043287            142
+seed7/lib/utf16.s7i          0.053174            540
+seed7/lib/utf8.s7i           0.042866            234
+seed7/lib/vecfont10.s7i      0.080836           1056
+seed7/lib/vecfont18.s7i      0.089734           1119
+seed7/lib/vector3d.s7i       0.042764            293
+seed7/lib/vectorfont.s7i     0.046204            239
+seed7/lib/wildcard.s7i       0.039295            140
+seed7/lib/window.s7i         0.045508            455
+seed7/lib/wrinum.s7i         0.041102            248
+seed7/lib/x509cert.s7i       0.072753           1243
+seed7/lib/xml_ent.s7i        0.038428             94
+seed7/lib/xmldom.s7i         0.041744            303
+seed7/lib/xz.s7i             0.046196            442
+seed7/lib/zip.s7i            0.123267           2792
+seed7/lib/zstd.s7i           0.070863           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.094209        |
++-----------+-----------------+
+| Minimum   | 0.036415        |
++-----------+-----------------+
+| Maximum   | 2.597008        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.047193            190
+seed7/prg/bas7.sd7           0.787898          11459
+seed7/prg/bifurk.sd7         0.039441             73
+seed7/prg/bigfiles.sd7       0.044809            129
+seed7/prg/brainf7.sd7        0.041974             86
+seed7/prg/calc7.sd7          0.045075            128
+seed7/prg/carddemo.sd7       0.048842            190
+seed7/prg/castle.sd7         0.221276           3148
+seed7/prg/cat.sd7            0.040174             82
+seed7/prg/cellauto.sd7       0.040245             85
+seed7/prg/celsius.sd7        0.039080             42
+seed7/prg/chk_all.sd7        0.084582            843
+seed7/prg/chkarr.sd7         0.889562           8367
+seed7/prg/chkbig.sd7         4.257712          29026
+seed7/prg/chkbin.sd7         1.058765           6469
+seed7/prg/chkbitdata.sd7     1.283392           6624
+seed7/prg/chkbool.sd7        0.240251           3157
+seed7/prg/chkbst.sd7         0.108627            722
+seed7/prg/chkchr.sd7         0.496045           2809
+seed7/prg/chkcmd.sd7         0.114794           1205
+seed7/prg/chkdb.sd7          0.777904           7454
+seed7/prg/chkdecl.sd7        0.097295            448
+seed7/prg/chkenum.sd7        0.124129           1230
+seed7/prg/chkerr.sd7         0.348452           4663
+seed7/prg/chkexc.sd7         0.157716           2627
+seed7/prg/chkfil.sd7         0.132294           1615
+seed7/prg/chkflt.sd7         2.908201          20620
+seed7/prg/chkhent.sd7        0.041767             54
+seed7/prg/chkhsh.sd7         0.519959           4548
+seed7/prg/chkidx.sd7         3.279382          19567
+seed7/prg/chkint.sd7         5.724086          38129
+seed7/prg/chkjson.sd7        0.192756           1764
+seed7/prg/chkovf.sd7         1.246020           8216
+seed7/prg/chkprc.sd7         0.724023          10111
+seed7/prg/chkscan.sd7        0.094194            714
+seed7/prg/chkset.sd7         1.807403          11974
+seed7/prg/chkstr.sd7         3.532060          26952
+seed7/prg/chktime.sd7        0.254845           2025
+seed7/prg/chktoml.sd7        0.203086           1656
+seed7/prg/clock.sd7          0.038577             47
+seed7/prg/clock2.sd7         0.038085             43
+seed7/prg/clock3.sd7         0.043353             95
+seed7/prg/cmpfil.sd7         0.039672             84
+seed7/prg/comanche.sd7       0.048285            180
+seed7/prg/confval.sd7        0.052691            175
+seed7/prg/db7.sd7            0.065276            417
+seed7/prg/diff7.sd7          0.056117            263
+seed7/prg/dirtst.sd7         0.040362             42
+seed7/prg/dirx.sd7           0.046068            152
+seed7/prg/dnafight.sd7       0.125420           1381
+seed7/prg/dragon.sd7         0.040538             73
+seed7/prg/echo.sd7           0.038009             39
+seed7/prg/eliza.sd7          0.053398            302
+seed7/prg/err.sd7            0.045853             96
+seed7/prg/fannkuch.sd7       0.043239            131
+seed7/prg/fib.sd7            0.038303             47
+seed7/prg/find7.sd7          0.043461            133
+seed7/prg/findchar.sd7       0.045000            149
+seed7/prg/fractree.sd7       0.038916             55
+seed7/prg/ftp7.sd7           0.054906            296
+seed7/prg/ftpserv.sd7        0.039017             74
+seed7/prg/gcd.sd7            0.040310            109
+seed7/prg/gkbd.sd7           0.063384            358
+seed7/prg/gtksvtst.sd7       0.040973             94
+seed7/prg/hal.sd7            0.049600            250
+seed7/prg/hamu.sd7           0.068911            573
+seed7/prg/hanoi.sd7          0.038029             55
+seed7/prg/hd.sd7             0.041823             79
+seed7/prg/hello.sd7          0.039579             32
+seed7/prg/hilbert.sd7        0.045072            108
+seed7/prg/ide7.sd7           0.050328            196
+seed7/prg/kbd.sd7            0.038458             49
+seed7/prg/klondike.sd7       0.089719            883
+seed7/prg/lander.sd7         0.135708           1551
+seed7/prg/lst80bas.sd7       0.057110            344
+seed7/prg/lst99bas.sd7       0.061274            401
+seed7/prg/lstgwbas.sd7       0.074347            577
+seed7/prg/mahjong.sd7        0.151155           1943
+seed7/prg/make7.sd7          0.044901            121
+seed7/prg/mandelbr.sd7       0.087832            237
+seed7/prg/mind.sd7           0.072176            443
+seed7/prg/mirror.sd7         0.048404            131
+seed7/prg/ms.sd7             0.075455            641
+seed7/prg/nicoma.sd7         0.047575            135
+seed7/prg/pac.sd7            0.074805            726
+seed7/prg/pairs.sd7          0.145267           2025
+seed7/prg/panic.sd7          0.198152           2634
+seed7/prg/percolation.sd7    0.057287            330
+seed7/prg/planets.sd7        0.141050           1486
+seed7/prg/portfwd7.sd7       0.045310            139
+seed7/prg/prime.sd7          0.040638             74
+seed7/prg/printpi1.sd7       0.039502             56
+seed7/prg/printpi2.sd7       0.039275             54
+seed7/prg/printpi3.sd7       0.040136             60
+seed7/prg/pv7.sd7            0.060657            337
+seed7/prg/queen.sd7          0.044621            149
+seed7/prg/rand.sd7           0.043236            121
+seed7/prg/raytrace.sd7       0.075189            538
+seed7/prg/rever.sd7          0.087296            816
+seed7/prg/roman.sd7          0.038630             38
+seed7/prg/s7c.sd7            0.642631           9060
+seed7/prg/s7check.sd7        0.040735             68
+seed7/prg/savehd7.sd7        0.114453           1110
+seed7/prg/self.sd7           0.038909             49
+seed7/prg/shisen.sd7         0.127802           1423
+seed7/prg/sl.sd7             0.099586           1029
+seed7/prg/snake.sd7          0.068195            615
+seed7/prg/sokoban.sd7        0.085054            891
+seed7/prg/spigotpi.sd7       0.039821             64
+seed7/prg/sql7.sd7           0.053822            278
+seed7/prg/startrek.sd7       0.096797            979
+seed7/prg/sudoku7.sd7        0.203652           2657
+seed7/prg/sydir7.sd7         0.062984            384
+seed7/prg/syntaxhl.sd7       0.050805            177
+seed7/prg/tak.sd7            0.042432             59
+seed7/prg/tar7.sd7           0.046270            121
+seed7/prg/tch.sd7            0.039464             55
+seed7/prg/testfont.sd7       0.043366             95
+seed7/prg/tet.sd7            0.064099            479
+seed7/prg/tetg.sd7           0.067421            501
+seed7/prg/toutf8.sd7         0.053962            240
+seed7/prg/tst_cli.sd7        0.039017             40
+seed7/prg/tst_srv.sd7        0.038721             47
+seed7/prg/wator.sd7          0.081133            651
+seed7/prg/which.sd7          0.040196             65
+seed7/prg/wiz.sd7            0.216715           2833
+seed7/prg/wordcnt.sd7        0.039011             54
+seed7/prg/wrinum.sd7         0.037411             43
+seed7/prg/wumpus.sd7         0.055244            372
+seed7/lib/aes.s7i            0.204260           1144
+seed7/lib/aes_gcm.s7i        0.070772            392
+seed7/lib/ar.s7i             0.131414           1532
+seed7/lib/arc4.s7i           0.047937            144
+seed7/lib/archive.s7i        0.046331            143
+seed7/lib/archive_base.s7i   0.045320            135
+seed7/lib/array.s7i          0.078173            610
+seed7/lib/asn1.s7i           0.066517            544
+seed7/lib/asn1oid.s7i        0.051507            157
+seed7/lib/basearray.s7i      0.066711            450
+seed7/lib/bigfile.s7i        0.043508            136
+seed7/lib/bigint.s7i         0.080139            824
+seed7/lib/bigrat.s7i         0.085716            784
+seed7/lib/bin16.s7i          0.072520            592
+seed7/lib/bin32.s7i          0.064249            490
+seed7/lib/bin64.s7i          0.066543            539
+seed7/lib/bitdata.s7i        0.127899           1330
+seed7/lib/bitmapfont.s7i     0.050739            215
+seed7/lib/bitset.s7i         0.073357            593
+seed7/lib/bitsetof.s7i       0.069647            431
+seed7/lib/blowfish.s7i       0.080642            383
+seed7/lib/bmp.s7i            0.103669            924
+seed7/lib/boolean.s7i        0.058837            403
+seed7/lib/browser.s7i        0.059494            280
+seed7/lib/bstring.s7i        0.049183            227
+seed7/lib/bytedata.s7i       0.068117            482
+seed7/lib/bzip2.s7i          0.091255            887
+seed7/lib/cards.s7i          0.105133           1342
+seed7/lib/category.s7i       0.053813            209
+seed7/lib/cc_conf.s7i        0.123010           1314
+seed7/lib/ccittfax.s7i       0.103546           1022
+seed7/lib/cgi.s7i            0.045295            109
+seed7/lib/cgidialog.s7i      0.104730           1118
+seed7/lib/char.s7i           0.054092            356
+seed7/lib/charsets.s7i       0.132559           2024
+seed7/lib/chartype.s7i       0.050132            121
+seed7/lib/cipher.s7i         0.044066            146
+seed7/lib/cli_cmds.s7i       0.117215           1360
+seed7/lib/clib_file.s7i      0.054341            301
+seed7/lib/color.s7i          0.048939            185
+seed7/lib/complex.s7i        0.061663            464
+seed7/lib/compress.s7i       0.045477            150
+seed7/lib/console.s7i        0.049927            188
+seed7/lib/cpio.s7i           0.149538           1708
+seed7/lib/crc32.s7i          0.056405            193
+seed7/lib/cronos16.s7i       0.203629           1173
+seed7/lib/cronos27.s7i       0.262788           1464
+seed7/lib/csv.s7i            0.052613            201
+seed7/lib/db_prop.s7i        0.105392            991
+seed7/lib/deflate.s7i        0.089467            740
+seed7/lib/des.s7i            0.083576            444
+seed7/lib/dialog.s7i         0.058923            311
+seed7/lib/dir.s7i            0.045230            163
+seed7/lib/draw.s7i           0.088614            854
+seed7/lib/duration.s7i       0.104176           1038
+seed7/lib/echo.s7i           0.046945            132
+seed7/lib/editline.s7i       0.061908            398
+seed7/lib/elf.s7i            0.159925           1560
+seed7/lib/elliptic.s7i       0.078656            649
+seed7/lib/enable_io.s7i      0.054322            312
+seed7/lib/encoding.s7i       0.100466            931
+seed7/lib/enumeration.s7i    0.051431            236
+seed7/lib/environment.s7i    0.045734            175
+seed7/lib/exif.s7i           0.047873            152
+seed7/lib/external_file.s7i  0.053736            340
+seed7/lib/field.s7i          0.053877            268
+seed7/lib/file.s7i           0.056245            372
+seed7/lib/filebits.s7i       0.039862             46
+seed7/lib/filesys.s7i        0.066897            601
+seed7/lib/fileutil.s7i       0.045071            144
+seed7/lib/fixarray.s7i       0.054888            307
+seed7/lib/float.s7i          0.076427            757
+seed7/lib/font.s7i           0.045797            196
+seed7/lib/font8x8.s7i        0.069196            998
+seed7/lib/forloop.s7i        0.061556            449
+seed7/lib/ftp.s7i            0.089081            969
+seed7/lib/ftpserv.s7i        0.078292            631
+seed7/lib/getf.s7i           0.042970            115
+seed7/lib/gethttp.s7i        0.038715             41
+seed7/lib/gethttps.s7i       0.039594             41
+seed7/lib/gif.s7i            0.073283            561
+seed7/lib/graph.s7i          0.066370            415
+seed7/lib/graph_file.s7i     0.059528            399
+seed7/lib/gtkserver.s7i      0.043615            161
+seed7/lib/gzip.s7i           0.070200            573
+seed7/lib/hash.s7i           0.068449            421
+seed7/lib/hashsetof.s7i      0.067971            499
+seed7/lib/hmac.s7i           0.046052            152
+seed7/lib/html.s7i           0.041980             83
+seed7/lib/html_ent.s7i       0.065503            476
+seed7/lib/htmldom.s7i        0.056103            286
+seed7/lib/http_request.s7i   0.082945            696
+seed7/lib/http_srv_resp.s7i  0.062644            380
+seed7/lib/https_request.s7i  0.050773            211
+seed7/lib/httpserv.s7i       0.059920            345
+seed7/lib/huffman.s7i        0.078791            644
+seed7/lib/ico.s7i            0.051664            221
+seed7/lib/idxarray.s7i       0.052733            232
+seed7/lib/image.s7i          0.042641            156
+seed7/lib/imagefile.s7i      0.046229            171
+seed7/lib/inflate.s7i        0.066572            411
+seed7/lib/inifile.s7i        0.043919            129
+seed7/lib/integer.s7i        0.069756            663
+seed7/lib/iobuffer.s7i       0.052977            289
+seed7/lib/jpeg.s7i           0.159923           1761
+seed7/lib/json.s7i           0.083478            891
+seed7/lib/json_serde.s7i     0.081195            783
+seed7/lib/keybd.s7i          0.081803            639
+seed7/lib/keydescr.s7i       0.051821            192
+seed7/lib/leb128.s7i         0.047811            218
+seed7/lib/line.s7i           0.045113            164
+seed7/lib/listener.s7i       0.050191            247
+seed7/lib/logfile.s7i        0.041420             73
+seed7/lib/lower.s7i          0.043664            142
+seed7/lib/lzma.s7i           0.101917            934
+seed7/lib/lzw.s7i            0.091627            861
+seed7/lib/magic.s7i          0.065127            403
+seed7/lib/mahjng32.s7i       0.094421           1500
+seed7/lib/make.s7i           0.070513            544
+seed7/lib/makedata.s7i       0.124303           1428
+seed7/lib/math.s7i           0.047064            201
+seed7/lib/mixarith.s7i       0.048573            249
+seed7/lib/modern27.s7i       0.176122           1099
+seed7/lib/more.s7i           0.044338            130
+seed7/lib/msgdigest.s7i      0.142170           1222
+seed7/lib/multiscr.s7i       0.039919             68
+seed7/lib/null_file.s7i      0.052895            345
+seed7/lib/osfiles.s7i        0.097374           1085
+seed7/lib/pbm.s7i            0.049918            230
+seed7/lib/pcx.s7i            0.080072            638
+seed7/lib/pem.s7i            0.045796            185
+seed7/lib/pgm.s7i            0.050576            238
+seed7/lib/pic16.s7i          0.069715           1037
+seed7/lib/pic32.s7i          0.124984           2060
+seed7/lib/pic_util.s7i       0.045311            144
+seed7/lib/pixelimage.s7i     0.054871            320
+seed7/lib/pixmap_file.s7i    0.065499            459
+seed7/lib/pixmapfont.s7i     0.049164            184
+seed7/lib/pkcs1.s7i          0.079134            543
+seed7/lib/png.s7i            0.111013           1064
+seed7/lib/poll.s7i           0.054490            313
+seed7/lib/ppm.s7i            0.049956            240
+seed7/lib/process.s7i        0.065620            541
+seed7/lib/progs.s7i          0.082045            789
+seed7/lib/propertyfile.s7i   0.045022            155
+seed7/lib/rational.s7i       0.080127            792
+seed7/lib/ref_list.s7i       0.049788            252
+seed7/lib/reference.s7i      0.043651            126
+seed7/lib/reverse.s7i        0.041934             94
+seed7/lib/rpm.s7i            0.294845           3487
+seed7/lib/rpmext.s7i         0.054959            318
+seed7/lib/scanfile.s7i       0.136142           1779
+seed7/lib/scanjson.s7i       0.063127            413
+seed7/lib/scanstri.s7i       0.140384           1814
+seed7/lib/scantoml.s7i       0.135382           1603
+seed7/lib/seed7_05.s7i       0.113406           1072
+seed7/lib/set.s7i            0.039595             57
+seed7/lib/shell.s7i          0.070982            615
+seed7/lib/showtls.s7i        0.087747            678
+seed7/lib/signature.s7i      0.044405            131
+seed7/lib/smtp.s7i           0.051137            261
+seed7/lib/sockbase.s7i       0.052228            217
+seed7/lib/socket.s7i         0.056213            326
+seed7/lib/sokoban1.s7i       0.084412           1519
+seed7/lib/sql_base.s7i       0.102495           1000
+seed7/lib/stars.s7i          0.243425           1705
+seed7/lib/stdfont10.s7i      0.148347           3347
+seed7/lib/stdfont12.s7i      0.170354           3928
+seed7/lib/stdfont14.s7i      0.196206           4510
+seed7/lib/stdfont16.s7i      0.222559           5092
+seed7/lib/stdfont18.s7i      0.255333           5868
+seed7/lib/stdfont20.s7i      0.281887           6449
+seed7/lib/stdfont24.s7i      0.338947           7421
+seed7/lib/stdfont8.s7i       0.132782           2960
+seed7/lib/stdfont9.s7i       0.143055           3152
+seed7/lib/stdio.s7i          0.045835            192
+seed7/lib/strifile.s7i       0.055393            345
+seed7/lib/string.s7i         0.077217            779
+seed7/lib/stritext.s7i       0.056298            352
+seed7/lib/struct.s7i         0.057729            266
+seed7/lib/struct_elem.s7i    0.047468            129
+seed7/lib/subfile.s7i        0.047405            174
+seed7/lib/subrange.s7i       0.040659             78
+seed7/lib/syntax.s7i         0.063142            294
+seed7/lib/tar.s7i            0.150501           1880
+seed7/lib/tar_cmds.s7i       0.087308            752
+seed7/lib/tdes.s7i           0.045998            143
+seed7/lib/tee.s7i            0.044361            143
+seed7/lib/text.s7i           0.044665            135
+seed7/lib/tga.s7i            0.082708            676
+seed7/lib/tiff.s7i           0.250859           2771
+seed7/lib/time.s7i           0.105024           1191
+seed7/lib/tls.s7i            0.202900           2230
+seed7/lib/unicode.s7i        0.077754            575
+seed7/lib/unionfnd.s7i       0.045860            130
+seed7/lib/upper.s7i          0.044187            142
+seed7/lib/utf16.s7i          0.068398            540
+seed7/lib/utf8.s7i           0.050525            234
+seed7/lib/vecfont10.s7i      0.165607           1056
+seed7/lib/vecfont18.s7i      0.184383           1119
+seed7/lib/vector3d.s7i       0.052171            293
+seed7/lib/vectorfont.s7i     0.049805            239
+seed7/lib/wildcard.s7i       0.044412            140
+seed7/lib/window.s7i         0.063764            455
+seed7/lib/wrinum.s7i         0.053151            248
+seed7/lib/x509cert.s7i       0.122771           1243
+seed7/lib/xml_ent.s7i        0.041728             94
+seed7/lib/xmldom.s7i         0.054790            303
+seed7/lib/xz.s7i             0.062829            442
+seed7/lib/zip.s7i            0.241086           2792
+seed7/lib/zstd.s7i           0.121809           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.164394        |
++-----------+-----------------+
+| Minimum   | 0.037411        |
++-----------+-----------------+
+| Maximum   | 5.724086        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033764        | 0.032082        | 0.041644        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039331        | 0.034326        | 0.049414        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.094209        | 0.036415        | 2.597008        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.164394        | 0.037411        | 5.724086        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.464 | 00:00:57.528 | 00:01:09.992 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.965 | 00:01:07.078 | 00:01:22.044 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:38.492 | 00:02:41.483 | 00:03:19.976 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:03.282 | 00:04:41.239 | 00:05:44.521 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:36.542 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-11.1.rst
+++ b/reports/seed7mode-perf-11.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-25T13:29:52+0000 W26-4
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 09:36:48 local time
+:Generated on: 2026-06-25 13:48:20 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 248x95 chars
+:Window body: 248x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039502            190
+seed7/prg/bas7.sd7           0.034090          11459
+seed7/prg/bifurk.sd7         0.033128             73
+seed7/prg/bigfiles.sd7       0.033384            129
+seed7/prg/brainf7.sd7        0.033941             86
+seed7/prg/calc7.sd7          0.034271            128
+seed7/prg/carddemo.sd7       0.033795            190
+seed7/prg/castle.sd7         0.033282           3148
+seed7/prg/cat.sd7            0.032910             82
+seed7/prg/cellauto.sd7       0.033164             85
+seed7/prg/celsius.sd7        0.033267             42
+seed7/prg/chk_all.sd7        0.035560            843
+seed7/prg/chkarr.sd7         0.038474           8367
+seed7/prg/chkbig.sd7         0.038647          29026
+seed7/prg/chkbin.sd7         0.034350           6469
+seed7/prg/chkbitdata.sd7     0.034336           6624
+seed7/prg/chkbool.sd7        0.034029           3157
+seed7/prg/chkbst.sd7         0.034801            722
+seed7/prg/chkchr.sd7         0.037157           2809
+seed7/prg/chkcmd.sd7         0.038700           1205
+seed7/prg/chkdb.sd7          0.036729           7454
+seed7/prg/chkdecl.sd7        0.033276            448
+seed7/prg/chkenum.sd7        0.036382           1230
+seed7/prg/chkerr.sd7         0.036687           4663
+seed7/prg/chkexc.sd7         0.033909           2627
+seed7/prg/chkfil.sd7         0.034727           1615
+seed7/prg/chkflt.sd7         0.037391          20620
+seed7/prg/chkhent.sd7        0.033572             54
+seed7/prg/chkhsh.sd7         0.034863           4548
+seed7/prg/chkidx.sd7         0.036403          19567
+seed7/prg/chkint.sd7         0.040727          38129
+seed7/prg/chkjson.sd7        0.035342           1764
+seed7/prg/chkovf.sd7         0.034794           8216
+seed7/prg/chkprc.sd7         0.034039          10111
+seed7/prg/chkscan.sd7        0.034359            714
+seed7/prg/chkset.sd7         0.034342          11974
+seed7/prg/chkstr.sd7         0.037822          26952
+seed7/prg/chktime.sd7        0.033121           2025
+seed7/prg/chktoml.sd7        0.034768           1656
+seed7/prg/clock.sd7          0.032549             47
+seed7/prg/clock2.sd7         0.033752             43
+seed7/prg/clock3.sd7         0.038107             95
+seed7/prg/cmpfil.sd7         0.034683             84
+seed7/prg/comanche.sd7       0.037380            180
+seed7/prg/confval.sd7        0.035715            175
+seed7/prg/db7.sd7            0.034162            417
+seed7/prg/diff7.sd7          0.034531            263
+seed7/prg/dirtst.sd7         0.035322             42
+seed7/prg/dirx.sd7           0.034771            152
+seed7/prg/dnafight.sd7       0.034023           1381
+seed7/prg/dragon.sd7         0.033367             73
+seed7/prg/echo.sd7           0.032948             39
+seed7/prg/eliza.sd7          0.034543            302
+seed7/prg/err.sd7            0.036719             96
+seed7/prg/fannkuch.sd7       0.034083            131
+seed7/prg/fib.sd7            0.035199             47
+seed7/prg/find7.sd7          0.033440            133
+seed7/prg/findchar.sd7       0.033276            149
+seed7/prg/fractree.sd7       0.034043             55
+seed7/prg/ftp7.sd7           0.035355            296
+seed7/prg/ftpserv.sd7        0.037214             74
+seed7/prg/gcd.sd7            0.034683            109
+seed7/prg/gkbd.sd7           0.033494            358
+seed7/prg/gtksvtst.sd7       0.033532             94
+seed7/prg/hal.sd7            0.034577            250
+seed7/prg/hamu.sd7           0.035478            573
+seed7/prg/hanoi.sd7          0.035953             55
+seed7/prg/hd.sd7             0.036545             79
+seed7/prg/hello.sd7          0.037143             32
+seed7/prg/hilbert.sd7        0.033262            108
+seed7/prg/ide7.sd7           0.033550            196
+seed7/prg/kbd.sd7            0.034432             49
+seed7/prg/klondike.sd7       0.034791            883
+seed7/prg/lander.sd7         0.035691           1551
+seed7/prg/lst80bas.sd7       0.033486            344
+seed7/prg/lst99bas.sd7       0.033254            401
+seed7/prg/lstgwbas.sd7       0.033983            577
+seed7/prg/mahjong.sd7        0.033417           1943
+seed7/prg/make7.sd7          0.034978            121
+seed7/prg/mandelbr.sd7       0.034847            237
+seed7/prg/mind.sd7           0.033831            443
+seed7/prg/mirror.sd7         0.032452            131
+seed7/prg/ms.sd7             0.033372            641
+seed7/prg/nicoma.sd7         0.033136            135
+seed7/prg/pac.sd7            0.035726            726
+seed7/prg/pairs.sd7          0.038198           2025
+seed7/prg/panic.sd7          0.037392           2634
+seed7/prg/percolation.sd7    0.035965            330
+seed7/prg/planets.sd7        0.034714           1486
+seed7/prg/portfwd7.sd7       0.036310            139
+seed7/prg/prime.sd7          0.039715             74
+seed7/prg/printpi1.sd7       0.037656             56
+seed7/prg/printpi2.sd7       0.039316             54
+seed7/prg/printpi3.sd7       0.036005             60
+seed7/prg/pv7.sd7            0.036185            337
+seed7/prg/queen.sd7          0.036881            149
+seed7/prg/rand.sd7           0.033219            121
+seed7/prg/raytrace.sd7       0.032782            538
+seed7/prg/rever.sd7          0.033707            816
+seed7/prg/roman.sd7          0.032473             38
+seed7/prg/s7c.sd7            0.035781           9060
+seed7/prg/s7check.sd7        0.036863             68
+seed7/prg/savehd7.sd7        0.040604           1110
+seed7/prg/self.sd7           0.040501             49
+seed7/prg/shisen.sd7         0.038389           1423
+seed7/prg/sl.sd7             0.033490           1029
+seed7/prg/snake.sd7          0.034678            615
+seed7/prg/sokoban.sd7        0.035058            891
+seed7/prg/spigotpi.sd7       0.033515             64
+seed7/prg/sql7.sd7           0.034473            278
+seed7/prg/startrek.sd7       0.038141            979
+seed7/prg/sudoku7.sd7        0.034722           2657
+seed7/prg/sydir7.sd7         0.035073            384
+seed7/prg/syntaxhl.sd7       0.038785            177
+seed7/prg/tak.sd7            0.040598             59
+seed7/prg/tar7.sd7           0.037187            121
+seed7/prg/tch.sd7            0.034245             55
+seed7/prg/testfont.sd7       0.034203             95
+seed7/prg/tet.sd7            0.039590            479
+seed7/prg/tetg.sd7           0.036673            501
+seed7/prg/toutf8.sd7         0.034873            240
+seed7/prg/tst_cli.sd7        0.036335             40
+seed7/prg/tst_srv.sd7        0.037851             47
+seed7/prg/wator.sd7          0.035158            651
+seed7/prg/which.sd7          0.033995             65
+seed7/prg/wiz.sd7            0.035315           2833
+seed7/prg/wordcnt.sd7        0.033876             54
+seed7/prg/wrinum.sd7         0.034606             43
+seed7/prg/wumpus.sd7         0.033575            372
+seed7/lib/aes.s7i            0.036657           1144
+seed7/lib/aes_gcm.s7i        0.039171            392
+seed7/lib/ar.s7i             0.036225           1532
+seed7/lib/arc4.s7i           0.035712            144
+seed7/lib/archive.s7i        0.035360            143
+seed7/lib/archive_base.s7i   0.038611            135
+seed7/lib/array.s7i          0.041604            610
+seed7/lib/asn1.s7i           0.038961            544
+seed7/lib/asn1oid.s7i        0.038026            157
+seed7/lib/basearray.s7i      0.036056            450
+seed7/lib/bigfile.s7i        0.035059            136
+seed7/lib/bigint.s7i         0.033365            824
+seed7/lib/bigrat.s7i         0.034644            784
+seed7/lib/bin16.s7i          0.034899            592
+seed7/lib/bin32.s7i          0.034871            490
+seed7/lib/bin64.s7i          0.034757            539
+seed7/lib/bitdata.s7i        0.035411           1330
+seed7/lib/bitmapfont.s7i     0.034286            215
+seed7/lib/bitset.s7i         0.035558            593
+seed7/lib/bitsetof.s7i       0.036602            431
+seed7/lib/blowfish.s7i       0.040823            383
+seed7/lib/bmp.s7i            0.039482            924
+seed7/lib/boolean.s7i        0.040652            403
+seed7/lib/browser.s7i        0.039837            280
+seed7/lib/bstring.s7i        0.035824            227
+seed7/lib/bytedata.s7i       0.036747            482
+seed7/lib/bzip2.s7i          0.035497            887
+seed7/lib/cards.s7i          0.035853           1342
+seed7/lib/category.s7i       0.037299            209
+seed7/lib/cc_conf.s7i        0.039620           1314
+seed7/lib/ccittfax.s7i       0.035186           1022
+seed7/lib/cgi.s7i            0.033075            109
+seed7/lib/cgidialog.s7i      0.034339           1118
+seed7/lib/char.s7i           0.034591            356
+seed7/lib/charsets.s7i       0.034398           2024
+seed7/lib/chartype.s7i       0.034143            121
+seed7/lib/cipher.s7i         0.033873            146
+seed7/lib/cli_cmds.s7i       0.033747           1360
+seed7/lib/clib_file.s7i      0.034415            301
+seed7/lib/color.s7i          0.033542            185
+seed7/lib/complex.s7i        0.033358            464
+seed7/lib/compress.s7i       0.032948            150
+seed7/lib/console.s7i        0.032825            188
+seed7/lib/cpio.s7i           0.033788           1708
+seed7/lib/crc32.s7i          0.033409            193
+seed7/lib/cronos16.s7i       0.037402           1173
+seed7/lib/cronos27.s7i       0.037499           1464
+seed7/lib/csv.s7i            0.032783            201
+seed7/lib/db_prop.s7i        0.034204            991
+seed7/lib/deflate.s7i        0.036371            740
+seed7/lib/des.s7i            0.035742            444
+seed7/lib/dialog.s7i         0.035220            311
+seed7/lib/dir.s7i            0.033857            163
+seed7/lib/draw.s7i           0.033563            854
+seed7/lib/duration.s7i       0.037681           1038
+seed7/lib/echo.s7i           0.034555            132
+seed7/lib/editline.s7i       0.033267            398
+seed7/lib/elf.s7i            0.033337           1560
+seed7/lib/elliptic.s7i       0.035633            649
+seed7/lib/enable_io.s7i      0.035766            312
+seed7/lib/encoding.s7i       0.036113            931
+seed7/lib/enumeration.s7i    0.036656            236
+seed7/lib/environment.s7i    0.037527            175
+seed7/lib/exif.s7i           0.039526            152
+seed7/lib/external_file.s7i  0.036855            340
+seed7/lib/field.s7i          0.034872            268
+seed7/lib/file.s7i           0.035089            372
+seed7/lib/filebits.s7i       0.037677             46
+seed7/lib/filesys.s7i        0.035720            601
+seed7/lib/fileutil.s7i       0.038927            144
+seed7/lib/fixarray.s7i       0.037986            307
+seed7/lib/float.s7i          0.034288            757
+seed7/lib/font.s7i           0.034981            196
+seed7/lib/font8x8.s7i        0.034550            998
+seed7/lib/forloop.s7i        0.033878            449
+seed7/lib/ftp.s7i            0.035317            969
+seed7/lib/ftpserv.s7i        0.034188            631
+seed7/lib/getf.s7i           0.033605            115
+seed7/lib/gethttp.s7i        0.034530             41
+seed7/lib/gethttps.s7i       0.033440             41
+seed7/lib/gif.s7i            0.033693            561
+seed7/lib/graph.s7i          0.035063            415
+seed7/lib/graph_file.s7i     0.034433            399
+seed7/lib/gtkserver.s7i      0.033786            161
+seed7/lib/gzip.s7i           0.034092            573
+seed7/lib/hash.s7i           0.036406            421
+seed7/lib/hashsetof.s7i      0.033626            499
+seed7/lib/hmac.s7i           0.032834            152
+seed7/lib/html.s7i           0.036663             83
+seed7/lib/html_ent.s7i       0.032796            476
+seed7/lib/htmldom.s7i        0.034075            286
+seed7/lib/http_request.s7i   0.033536            696
+seed7/lib/http_srv_resp.s7i  0.035446            380
+seed7/lib/https_request.s7i  0.034571            211
+seed7/lib/httpserv.s7i       0.036323            345
+seed7/lib/huffman.s7i        0.038358            644
+seed7/lib/ico.s7i            0.033992            221
+seed7/lib/idxarray.s7i       0.034218            232
+seed7/lib/image.s7i          0.033107            156
+seed7/lib/imagefile.s7i      0.033302            171
+seed7/lib/inflate.s7i        0.034615            411
+seed7/lib/inifile.s7i        0.033449            129
+seed7/lib/integer.s7i        0.033423            663
+seed7/lib/iobuffer.s7i       0.034655            289
+seed7/lib/jpeg.s7i           0.033376           1761
+seed7/lib/json.s7i           0.033421            891
+seed7/lib/json_serde.s7i     0.032908            783
+seed7/lib/keybd.s7i          0.037708            639
+seed7/lib/keydescr.s7i       0.034497            192
+seed7/lib/leb128.s7i         0.035022            218
+seed7/lib/line.s7i           0.033586            164
+seed7/lib/listener.s7i       0.033160            247
+seed7/lib/logfile.s7i        0.033793             73
+seed7/lib/lower.s7i          0.033424            142
+seed7/lib/lzma.s7i           0.033425            934
+seed7/lib/lzw.s7i            0.033292            861
+seed7/lib/magic.s7i          0.033798            403
+seed7/lib/mahjng32.s7i       0.033579           1500
+seed7/lib/make.s7i           0.032247            544
+seed7/lib/makedata.s7i       0.032634           1428
+seed7/lib/math.s7i           0.032347            201
+seed7/lib/mixarith.s7i       0.035065            249
+seed7/lib/modern27.s7i       0.036316           1099
+seed7/lib/more.s7i           0.034593            130
+seed7/lib/msgdigest.s7i      0.033134           1222
+seed7/lib/multiscr.s7i       0.033017             68
+seed7/lib/null_file.s7i      0.032479            345
+seed7/lib/osfiles.s7i        0.032889           1085
+seed7/lib/pbm.s7i            0.032237            230
+seed7/lib/pcx.s7i            0.032246            638
+seed7/lib/pem.s7i            0.032720            185
+seed7/lib/pgm.s7i            0.032642            238
+seed7/lib/pic16.s7i          0.032097           1037
+seed7/lib/pic32.s7i          0.032847           2060
+seed7/lib/pic_util.s7i       0.033395            144
+seed7/lib/pixelimage.s7i     0.033528            320
+seed7/lib/pixmap_file.s7i    0.033414            459
+seed7/lib/pixmapfont.s7i     0.033211            184
+seed7/lib/pkcs1.s7i          0.036427            543
+seed7/lib/png.s7i            0.035957           1064
+seed7/lib/poll.s7i           0.033643            313
+seed7/lib/ppm.s7i            0.033825            240
+seed7/lib/process.s7i        0.034221            541
+seed7/lib/progs.s7i          0.033782            789
+seed7/lib/propertyfile.s7i   0.033337            155
+seed7/lib/rational.s7i       0.040035            792
+seed7/lib/ref_list.s7i       0.034818            252
+seed7/lib/reference.s7i      0.034080            126
+seed7/lib/reverse.s7i        0.034710             94
+seed7/lib/rpm.s7i            0.033406           3487
+seed7/lib/rpmext.s7i         0.032931            318
+seed7/lib/scanfile.s7i       0.037141           1779
+seed7/lib/scanjson.s7i       0.036825            413
+seed7/lib/scanstri.s7i       0.032733           1814
+seed7/lib/scantoml.s7i       0.032659           1603
+seed7/lib/seed7_05.s7i       0.035990           1072
+seed7/lib/set.s7i            0.033875             57
+seed7/lib/shell.s7i          0.034857            615
+seed7/lib/showtls.s7i        0.034695            678
+seed7/lib/signature.s7i      0.033230            131
+seed7/lib/smtp.s7i           0.033442            261
+seed7/lib/sockbase.s7i       0.033790            217
+seed7/lib/socket.s7i         0.038929            326
+seed7/lib/sokoban1.s7i       0.035586           1519
+seed7/lib/sql_base.s7i       0.034009           1000
+seed7/lib/stars.s7i          0.033422           1705
+seed7/lib/stdfont10.s7i      0.033555           3347
+seed7/lib/stdfont12.s7i      0.033520           3928
+seed7/lib/stdfont14.s7i      0.033367           4510
+seed7/lib/stdfont16.s7i      0.033520           5092
+seed7/lib/stdfont18.s7i      0.034454           5868
+seed7/lib/stdfont20.s7i      0.033690           6449
+seed7/lib/stdfont24.s7i      0.033536           7421
+seed7/lib/stdfont8.s7i       0.033469           2960
+seed7/lib/stdfont9.s7i       0.035309           3152
+seed7/lib/stdio.s7i          0.033943            192
+seed7/lib/strifile.s7i       0.032628            345
+seed7/lib/string.s7i         0.032609            779
+seed7/lib/stritext.s7i       0.032859            352
+seed7/lib/struct.s7i         0.032378            266
+seed7/lib/struct_elem.s7i    0.032512            129
+seed7/lib/subfile.s7i        0.032578            174
+seed7/lib/subrange.s7i       0.032708             78
+seed7/lib/syntax.s7i         0.036036            294
+seed7/lib/tar.s7i            0.035596           1880
+seed7/lib/tar_cmds.s7i       0.041448            752
+seed7/lib/tdes.s7i           0.034242            143
+seed7/lib/tee.s7i            0.034232            143
+seed7/lib/text.s7i           0.033173            135
+seed7/lib/tga.s7i            0.033282            676
+seed7/lib/tiff.s7i           0.034150           2771
+seed7/lib/time.s7i           0.034586           1191
+seed7/lib/tls.s7i            0.036196           2230
+seed7/lib/unicode.s7i        0.037269            575
+seed7/lib/unionfnd.s7i       0.033829            130
+seed7/lib/upper.s7i          0.033295            142
+seed7/lib/utf16.s7i          0.033482            540
+seed7/lib/utf8.s7i           0.033279            234
+seed7/lib/vecfont10.s7i      0.033741           1056
+seed7/lib/vecfont18.s7i      0.035318           1119
+seed7/lib/vector3d.s7i       0.036811            293
+seed7/lib/vectorfont.s7i     0.033774            239
+seed7/lib/wildcard.s7i       0.033334            140
+seed7/lib/window.s7i         0.035023            455
+seed7/lib/wrinum.s7i         0.042321            248
+seed7/lib/x509cert.s7i       0.038682           1243
+seed7/lib/xml_ent.s7i        0.036565             94
+seed7/lib/xmldom.s7i         0.037456            303
+seed7/lib/xz.s7i             0.039454            442
+seed7/lib/zip.s7i            0.034503           2792
+seed7/lib/zstd.s7i           0.033913           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.035029        |
++-----------+-----------------+
+| Minimum   | 0.032097        |
++-----------+-----------------+
+| Maximum   | 0.042321        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039238            190
+seed7/prg/bas7.sd7           0.041240          11459
+seed7/prg/bifurk.sd7         0.035841             73
+seed7/prg/bigfiles.sd7       0.037881            129
+seed7/prg/brainf7.sd7        0.036853             86
+seed7/prg/calc7.sd7          0.037161            128
+seed7/prg/carddemo.sd7       0.037498            190
+seed7/prg/castle.sd7         0.039290           3148
+seed7/prg/cat.sd7            0.037702             82
+seed7/prg/cellauto.sd7       0.037279             85
+seed7/prg/celsius.sd7        0.035445             42
+seed7/prg/chk_all.sd7        0.038343            843
+seed7/prg/chkarr.sd7         0.038336           8367
+seed7/prg/chkbig.sd7         0.042697          29026
+seed7/prg/chkbin.sd7         0.042612           6469
+seed7/prg/chkbitdata.sd7     0.041606           6624
+seed7/prg/chkbool.sd7        0.038871           3157
+seed7/prg/chkbst.sd7         0.038304            722
+seed7/prg/chkchr.sd7         0.039726           2809
+seed7/prg/chkcmd.sd7         0.040140           1205
+seed7/prg/chkdb.sd7          0.040316           7454
+seed7/prg/chkdecl.sd7        0.038235            448
+seed7/prg/chkenum.sd7        0.038112           1230
+seed7/prg/chkerr.sd7         0.038454           4663
+seed7/prg/chkexc.sd7         0.037385           2627
+seed7/prg/chkfil.sd7         0.037336           1615
+seed7/prg/chkflt.sd7         0.042182          20620
+seed7/prg/chkhent.sd7        0.035266             54
+seed7/prg/chkhsh.sd7         0.039211           4548
+seed7/prg/chkidx.sd7         0.041546          19567
+seed7/prg/chkint.sd7         0.044669          38129
+seed7/prg/chkjson.sd7        0.037966           1764
+seed7/prg/chkovf.sd7         0.038991           8216
+seed7/prg/chkprc.sd7         0.039176          10111
+seed7/prg/chkscan.sd7        0.039096            714
+seed7/prg/chkset.sd7         0.041103          11974
+seed7/prg/chkstr.sd7         0.044079          26952
+seed7/prg/chktime.sd7        0.039622           2025
+seed7/prg/chktoml.sd7        0.039119           1656
+seed7/prg/clock.sd7          0.036079             47
+seed7/prg/clock2.sd7         0.036438             43
+seed7/prg/clock3.sd7         0.040506             95
+seed7/prg/cmpfil.sd7         0.037439             84
+seed7/prg/comanche.sd7       0.038907            180
+seed7/prg/confval.sd7        0.040090            175
+seed7/prg/db7.sd7            0.039143            417
+seed7/prg/diff7.sd7          0.039365            263
+seed7/prg/dirtst.sd7         0.036302             42
+seed7/prg/dirx.sd7           0.038863            152
+seed7/prg/dnafight.sd7       0.039322           1381
+seed7/prg/dragon.sd7         0.036691             73
+seed7/prg/echo.sd7           0.035909             39
+seed7/prg/eliza.sd7          0.037485            302
+seed7/prg/err.sd7            0.040592             96
+seed7/prg/fannkuch.sd7       0.037354            131
+seed7/prg/fib.sd7            0.035110             47
+seed7/prg/find7.sd7          0.037352            133
+seed7/prg/findchar.sd7       0.037820            149
+seed7/prg/fractree.sd7       0.036188             55
+seed7/prg/ftp7.sd7           0.041586            296
+seed7/prg/ftpserv.sd7        0.040233             74
+seed7/prg/gcd.sd7            0.037981            109
+seed7/prg/gkbd.sd7           0.040660            358
+seed7/prg/gtksvtst.sd7       0.037926             94
+seed7/prg/hal.sd7            0.038428            250
+seed7/prg/hamu.sd7           0.038407            573
+seed7/prg/hanoi.sd7          0.036616             55
+seed7/prg/hd.sd7             0.038328             79
+seed7/prg/hello.sd7          0.035991             32
+seed7/prg/hilbert.sd7        0.039860            108
+seed7/prg/ide7.sd7           0.041545            196
+seed7/prg/kbd.sd7            0.036547             49
+seed7/prg/klondike.sd7       0.038978            883
+seed7/prg/lander.sd7         0.039298           1551
+seed7/prg/lst80bas.sd7       0.038176            344
+seed7/prg/lst99bas.sd7       0.039722            401
+seed7/prg/lstgwbas.sd7       0.040098            577
+seed7/prg/mahjong.sd7        0.039092           1943
+seed7/prg/make7.sd7          0.038989            121
+seed7/prg/mandelbr.sd7       0.038867            237
+seed7/prg/mind.sd7           0.039114            443
+seed7/prg/mirror.sd7         0.039066            131
+seed7/prg/ms.sd7             0.037457            641
+seed7/prg/nicoma.sd7         0.038009            135
+seed7/prg/pac.sd7            0.039766            726
+seed7/prg/pairs.sd7          0.037280           2025
+seed7/prg/panic.sd7          0.041854           2634
+seed7/prg/percolation.sd7    0.041415            330
+seed7/prg/planets.sd7        0.039579           1486
+seed7/prg/portfwd7.sd7       0.038909            139
+seed7/prg/prime.sd7          0.037240             74
+seed7/prg/printpi1.sd7       0.036717             56
+seed7/prg/printpi2.sd7       0.036524             54
+seed7/prg/printpi3.sd7       0.037003             60
+seed7/prg/pv7.sd7            0.037821            337
+seed7/prg/queen.sd7          0.037928            149
+seed7/prg/rand.sd7           0.036881            121
+seed7/prg/raytrace.sd7       0.037965            538
+seed7/prg/rever.sd7          0.037528            816
+seed7/prg/roman.sd7          0.035639             38
+seed7/prg/s7c.sd7            0.039583           9060
+seed7/prg/s7check.sd7        0.035732             68
+seed7/prg/savehd7.sd7        0.038924           1110
+seed7/prg/self.sd7           0.036490             49
+seed7/prg/shisen.sd7         0.038773           1423
+seed7/prg/sl.sd7             0.045018           1029
+seed7/prg/snake.sd7          0.041331            615
+seed7/prg/sokoban.sd7        0.039373            891
+seed7/prg/spigotpi.sd7       0.040064             64
+seed7/prg/sql7.sd7           0.037754            278
+seed7/prg/startrek.sd7       0.037867            979
+seed7/prg/sudoku7.sd7        0.037965           2657
+seed7/prg/sydir7.sd7         0.038073            384
+seed7/prg/syntaxhl.sd7       0.040418            177
+seed7/prg/tak.sd7            0.037666             59
+seed7/prg/tar7.sd7           0.039511            121
+seed7/prg/tch.sd7            0.036633             55
+seed7/prg/testfont.sd7       0.038765             95
+seed7/prg/tet.sd7            0.039978            479
+seed7/prg/tetg.sd7           0.039565            501
+seed7/prg/toutf8.sd7         0.044931            240
+seed7/prg/tst_cli.sd7        0.038351             40
+seed7/prg/tst_srv.sd7        0.036208             47
+seed7/prg/wator.sd7          0.039020            651
+seed7/prg/which.sd7          0.036864             65
+seed7/prg/wiz.sd7            0.039310           2833
+seed7/prg/wordcnt.sd7        0.036920             54
+seed7/prg/wrinum.sd7         0.035413             43
+seed7/prg/wumpus.sd7         0.039291            372
+seed7/lib/aes.s7i            0.043335           1144
+seed7/lib/aes_gcm.s7i        0.039476            392
+seed7/lib/ar.s7i             0.039522           1532
+seed7/lib/arc4.s7i           0.039066            144
+seed7/lib/archive.s7i        0.038380            143
+seed7/lib/archive_base.s7i   0.037840            135
+seed7/lib/array.s7i          0.038460            610
+seed7/lib/asn1.s7i           0.036506            544
+seed7/lib/asn1oid.s7i        0.041249            157
+seed7/lib/basearray.s7i      0.038562            450
+seed7/lib/bigfile.s7i        0.038140            136
+seed7/lib/bigint.s7i         0.038001            824
+seed7/lib/bigrat.s7i         0.040258            784
+seed7/lib/bin16.s7i          0.038722            592
+seed7/lib/bin32.s7i          0.043846            490
+seed7/lib/bin64.s7i          0.040413            539
+seed7/lib/bitdata.s7i        0.045253           1330
+seed7/lib/bitmapfont.s7i     0.039206            215
+seed7/lib/bitset.s7i         0.040480            593
+seed7/lib/bitsetof.s7i       0.041331            431
+seed7/lib/blowfish.s7i       0.042452            383
+seed7/lib/bmp.s7i            0.039557            924
+seed7/lib/boolean.s7i        0.038971            403
+seed7/lib/browser.s7i        0.044330            280
+seed7/lib/bstring.s7i        0.044044            227
+seed7/lib/bytedata.s7i       0.039564            482
+seed7/lib/bzip2.s7i          0.039122            887
+seed7/lib/cards.s7i          0.037853           1342
+seed7/lib/category.s7i       0.039249            209
+seed7/lib/cc_conf.s7i        0.038642           1314
+seed7/lib/ccittfax.s7i       0.039688           1022
+seed7/lib/cgi.s7i            0.038577            109
+seed7/lib/cgidialog.s7i      0.038189           1118
+seed7/lib/char.s7i           0.037708            356
+seed7/lib/charsets.s7i       0.038585           2024
+seed7/lib/chartype.s7i       0.040690            121
+seed7/lib/cipher.s7i         0.037189            146
+seed7/lib/cli_cmds.s7i       0.038024           1360
+seed7/lib/clib_file.s7i      0.040651            301
+seed7/lib/color.s7i          0.039146            185
+seed7/lib/complex.s7i        0.038927            464
+seed7/lib/compress.s7i       0.039488            150
+seed7/lib/console.s7i        0.038803            188
+seed7/lib/cpio.s7i           0.040275           1708
+seed7/lib/crc32.s7i          0.041150            193
+seed7/lib/cronos16.s7i       0.042230           1173
+seed7/lib/cronos27.s7i       0.043992           1464
+seed7/lib/csv.s7i            0.037917            201
+seed7/lib/db_prop.s7i        0.037682            991
+seed7/lib/deflate.s7i        0.037748            740
+seed7/lib/des.s7i            0.038537            444
+seed7/lib/dialog.s7i         0.038479            311
+seed7/lib/dir.s7i            0.037774            163
+seed7/lib/draw.s7i           0.038337            854
+seed7/lib/duration.s7i       0.039506           1038
+seed7/lib/echo.s7i           0.039104            132
+seed7/lib/editline.s7i       0.039022            398
+seed7/lib/elf.s7i            0.040886           1560
+seed7/lib/elliptic.s7i       0.037537            649
+seed7/lib/enable_io.s7i      0.037550            312
+seed7/lib/encoding.s7i       0.038267            931
+seed7/lib/enumeration.s7i    0.037720            236
+seed7/lib/environment.s7i    0.037441            175
+seed7/lib/exif.s7i           0.040806            152
+seed7/lib/external_file.s7i  0.038459            340
+seed7/lib/field.s7i          0.039260            268
+seed7/lib/file.s7i           0.039112            372
+seed7/lib/filebits.s7i       0.036822             46
+seed7/lib/filesys.s7i        0.038616            601
+seed7/lib/fileutil.s7i       0.038944            144
+seed7/lib/fixarray.s7i       0.040699            307
+seed7/lib/float.s7i          0.039084            757
+seed7/lib/font.s7i           0.039116            196
+seed7/lib/font8x8.s7i        0.038562            998
+seed7/lib/forloop.s7i        0.040823            449
+seed7/lib/ftp.s7i            0.039221            969
+seed7/lib/ftpserv.s7i        0.039257            631
+seed7/lib/getf.s7i           0.038794            115
+seed7/lib/gethttp.s7i        0.036077             41
+seed7/lib/gethttps.s7i       0.036341             41
+seed7/lib/gif.s7i            0.038798            561
+seed7/lib/graph.s7i          0.040819            415
+seed7/lib/graph_file.s7i     0.038990            399
+seed7/lib/gtkserver.s7i      0.039788            161
+seed7/lib/gzip.s7i           0.038540            573
+seed7/lib/hash.s7i           0.039198            421
+seed7/lib/hashsetof.s7i      0.039349            499
+seed7/lib/hmac.s7i           0.037728            152
+seed7/lib/html.s7i           0.036738             83
+seed7/lib/html_ent.s7i       0.037715            476
+seed7/lib/htmldom.s7i        0.038219            286
+seed7/lib/http_request.s7i   0.039273            696
+seed7/lib/http_srv_resp.s7i  0.038628            380
+seed7/lib/https_request.s7i  0.038700            211
+seed7/lib/httpserv.s7i       0.038800            345
+seed7/lib/huffman.s7i        0.039563            644
+seed7/lib/ico.s7i            0.042899            221
+seed7/lib/idxarray.s7i       0.040206            232
+seed7/lib/image.s7i          0.038998            156
+seed7/lib/imagefile.s7i      0.038903            171
+seed7/lib/inflate.s7i        0.039552            411
+seed7/lib/inifile.s7i        0.038977            129
+seed7/lib/integer.s7i        0.038955            663
+seed7/lib/iobuffer.s7i       0.038785            289
+seed7/lib/jpeg.s7i           0.040820           1761
+seed7/lib/json.s7i           0.038640            891
+seed7/lib/json_serde.s7i     0.038950            783
+seed7/lib/keybd.s7i          0.038591            639
+seed7/lib/keydescr.s7i       0.040435            192
+seed7/lib/leb128.s7i         0.039462            218
+seed7/lib/line.s7i           0.039042            164
+seed7/lib/listener.s7i       0.039667            247
+seed7/lib/logfile.s7i        0.037316             73
+seed7/lib/lower.s7i          0.037557            142
+seed7/lib/lzma.s7i           0.039232            934
+seed7/lib/lzw.s7i            0.043782            861
+seed7/lib/magic.s7i          0.040864            403
+seed7/lib/mahjng32.s7i       0.038578           1500
+seed7/lib/make.s7i           0.040338            544
+seed7/lib/makedata.s7i       0.039894           1428
+seed7/lib/math.s7i           0.039035            201
+seed7/lib/mixarith.s7i       0.039106            249
+seed7/lib/modern27.s7i       0.042561           1099
+seed7/lib/more.s7i           0.039162            130
+seed7/lib/msgdigest.s7i      0.039701           1222
+seed7/lib/multiscr.s7i       0.037156             68
+seed7/lib/null_file.s7i      0.037518            345
+seed7/lib/osfiles.s7i        0.039489           1085
+seed7/lib/pbm.s7i            0.037959            230
+seed7/lib/pcx.s7i            0.038525            638
+seed7/lib/pem.s7i            0.037437            185
+seed7/lib/pgm.s7i            0.037898            238
+seed7/lib/pic16.s7i          0.038322           1037
+seed7/lib/pic32.s7i          0.036914           2060
+seed7/lib/pic_util.s7i       0.037502            144
+seed7/lib/pixelimage.s7i     0.039050            320
+seed7/lib/pixmap_file.s7i    0.039109            459
+seed7/lib/pixmapfont.s7i     0.040620            184
+seed7/lib/pkcs1.s7i          0.044470            543
+seed7/lib/png.s7i            0.039237           1064
+seed7/lib/poll.s7i           0.037415            313
+seed7/lib/ppm.s7i            0.037716            240
+seed7/lib/process.s7i        0.037536            541
+seed7/lib/progs.s7i          0.037957            789
+seed7/lib/propertyfile.s7i   0.037663            155
+seed7/lib/rational.s7i       0.039120            792
+seed7/lib/ref_list.s7i       0.039017            252
+seed7/lib/reference.s7i      0.038751            126
+seed7/lib/reverse.s7i        0.038734             94
+seed7/lib/rpm.s7i            0.039911           3487
+seed7/lib/rpmext.s7i         0.038875            318
+seed7/lib/scanfile.s7i       0.038238           1779
+seed7/lib/scanjson.s7i       0.039557            413
+seed7/lib/scanstri.s7i       0.039589           1814
+seed7/lib/scantoml.s7i       0.039243           1603
+seed7/lib/seed7_05.s7i       0.041010           1072
+seed7/lib/set.s7i            0.037116             57
+seed7/lib/shell.s7i          0.039637            615
+seed7/lib/showtls.s7i        0.039157            678
+seed7/lib/signature.s7i      0.039221            131
+seed7/lib/smtp.s7i           0.038988            261
+seed7/lib/sockbase.s7i       0.039987            217
+seed7/lib/socket.s7i         0.038892            326
+seed7/lib/sokoban1.s7i       0.038546           1519
+seed7/lib/sql_base.s7i       0.039077           1000
+seed7/lib/stars.s7i          0.041054           1705
+seed7/lib/stdfont10.s7i      0.037733           3347
+seed7/lib/stdfont12.s7i      0.037898           3928
+seed7/lib/stdfont14.s7i      0.038268           4510
+seed7/lib/stdfont16.s7i      0.038063           5092
+seed7/lib/stdfont18.s7i      0.038007           5868
+seed7/lib/stdfont20.s7i      0.037693           6449
+seed7/lib/stdfont24.s7i      0.040017           7421
+seed7/lib/stdfont8.s7i       0.038587           2960
+seed7/lib/stdfont9.s7i       0.036355           3152
+seed7/lib/stdio.s7i          0.044751            192
+seed7/lib/strifile.s7i       0.050422            345
+seed7/lib/string.s7i         0.044135            779
+seed7/lib/stritext.s7i       0.039758            352
+seed7/lib/struct.s7i         0.040026            266
+seed7/lib/struct_elem.s7i    0.037275            129
+seed7/lib/subfile.s7i        0.038228            174
+seed7/lib/subrange.s7i       0.043224             78
+seed7/lib/syntax.s7i         0.039235            294
+seed7/lib/tar.s7i            0.040010           1880
+seed7/lib/tar_cmds.s7i       0.039387            752
+seed7/lib/tdes.s7i           0.038739            143
+seed7/lib/tee.s7i            0.039046            143
+seed7/lib/text.s7i           0.038563            135
+seed7/lib/tga.s7i            0.040930            676
+seed7/lib/tiff.s7i           0.040928           2771
+seed7/lib/time.s7i           0.039167           1191
+seed7/lib/tls.s7i            0.039080           2230
+seed7/lib/unicode.s7i        0.041117            575
+seed7/lib/unionfnd.s7i       0.037658            130
+seed7/lib/upper.s7i          0.037310            142
+seed7/lib/utf16.s7i          0.037289            540
+seed7/lib/utf8.s7i           0.038772            234
+seed7/lib/vecfont10.s7i      0.040413           1056
+seed7/lib/vecfont18.s7i      0.042463           1119
+seed7/lib/vector3d.s7i       0.039163            293
+seed7/lib/vectorfont.s7i     0.040062            239
+seed7/lib/wildcard.s7i       0.038903            140
+seed7/lib/window.s7i         0.039048            455
+seed7/lib/wrinum.s7i         0.039167            248
+seed7/lib/x509cert.s7i       0.039242           1243
+seed7/lib/xml_ent.s7i        0.038984             94
+seed7/lib/xmldom.s7i         0.040145            303
+seed7/lib/xz.s7i             0.037974            442
+seed7/lib/zip.s7i            0.038127           2792
+seed7/lib/zstd.s7i           0.037445           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039068        |
++-----------+-----------------+
+| Minimum   | 0.035110        |
++-----------+-----------------+
+| Maximum   | 0.050422        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.043563            190
+seed7/prg/bas7.sd7           0.335241          11459
+seed7/prg/bifurk.sd7         0.039558             73
+seed7/prg/bigfiles.sd7       0.042088            129
+seed7/prg/brainf7.sd7        0.039859             86
+seed7/prg/calc7.sd7          0.041075            128
+seed7/prg/carddemo.sd7       0.042287            190
+seed7/prg/castle.sd7         0.113570           3148
+seed7/prg/cat.sd7            0.039654             82
+seed7/prg/cellauto.sd7       0.039709             85
+seed7/prg/celsius.sd7        0.039292             42
+seed7/prg/chk_all.sd7        0.064299            843
+seed7/prg/chkarr.sd7         0.371218           8367
+seed7/prg/chkbig.sd7         2.132564          29026
+seed7/prg/chkbin.sd7         0.528717           6469
+seed7/prg/chkbitdata.sd7     0.631322           6624
+seed7/prg/chkbool.sd7        0.121650           3157
+seed7/prg/chkbst.sd7         0.071568            722
+seed7/prg/chkchr.sd7         0.227591           2809
+seed7/prg/chkcmd.sd7         0.073145           1205
+seed7/prg/chkdb.sd7          0.365639           7454
+seed7/prg/chkdecl.sd7        0.062424            448
+seed7/prg/chkenum.sd7        0.071994           1230
+seed7/prg/chkerr.sd7         0.203665           4663
+seed7/prg/chkexc.sd7         0.087023           2627
+seed7/prg/chkfil.sd7         0.080717           1615
+seed7/prg/chkflt.sd7         1.388200          20620
+seed7/prg/chkhent.sd7        0.040388             54
+seed7/prg/chkhsh.sd7         0.255544           4548
+seed7/prg/chkidx.sd7         1.369854          19567
+seed7/prg/chkint.sd7         2.613087          38129
+seed7/prg/chkjson.sd7        0.106217           1764
+seed7/prg/chkovf.sd7         0.578796           8216
+seed7/prg/chkprc.sd7         0.332285          10111
+seed7/prg/chkscan.sd7        0.061556            714
+seed7/prg/chkset.sd7         0.688914          11974
+seed7/prg/chkstr.sd7         1.427030          26952
+seed7/prg/chktime.sd7        0.134833           2025
+seed7/prg/chktoml.sd7        0.116077           1656
+seed7/prg/clock.sd7          0.041554             47
+seed7/prg/clock2.sd7         0.039293             43
+seed7/prg/clock3.sd7         0.042752             95
+seed7/prg/cmpfil.sd7         0.041430             84
+seed7/prg/comanche.sd7       0.045112            180
+seed7/prg/confval.sd7        0.047058            175
+seed7/prg/db7.sd7            0.051663            417
+seed7/prg/diff7.sd7          0.047363            263
+seed7/prg/dirtst.sd7         0.040081             42
+seed7/prg/dirx.sd7           0.042768            152
+seed7/prg/dnafight.sd7       0.073469           1381
+seed7/prg/dragon.sd7         0.041475             73
+seed7/prg/echo.sd7           0.040161             39
+seed7/prg/eliza.sd7          0.047677            302
+seed7/prg/err.sd7            0.044679             96
+seed7/prg/fannkuch.sd7       0.041702            131
+seed7/prg/fib.sd7            0.038629             47
+seed7/prg/find7.sd7          0.041414            133
+seed7/prg/findchar.sd7       0.041737            149
+seed7/prg/fractree.sd7       0.039385             55
+seed7/prg/ftp7.sd7           0.046536            296
+seed7/prg/ftpserv.sd7        0.041403             74
+seed7/prg/gcd.sd7            0.041379            109
+seed7/prg/gkbd.sd7           0.050858            358
+seed7/prg/gtksvtst.sd7       0.041432             94
+seed7/prg/hal.sd7            0.044126            250
+seed7/prg/hamu.sd7           0.052426            573
+seed7/prg/hanoi.sd7          0.039809             55
+seed7/prg/hd.sd7             0.041418             79
+seed7/prg/hello.sd7          0.039861             32
+seed7/prg/hilbert.sd7        0.041429            108
+seed7/prg/ide7.sd7           0.044869            196
+seed7/prg/kbd.sd7            0.040327             49
+seed7/prg/klondike.sd7       0.060438            883
+seed7/prg/lander.sd7         0.077705           1551
+seed7/prg/lst80bas.sd7       0.048445            344
+seed7/prg/lst99bas.sd7       0.048807            401
+seed7/prg/lstgwbas.sd7       0.054557            577
+seed7/prg/mahjong.sd7        0.085665           1943
+seed7/prg/make7.sd7          0.042106            121
+seed7/prg/mandelbr.sd7       0.045071            237
+seed7/prg/mind.sd7           0.048895            443
+seed7/prg/mirror.sd7         0.042180            131
+seed7/prg/ms.sd7             0.054376            641
+seed7/prg/nicoma.sd7         0.042796            135
+seed7/prg/pac.sd7            0.054521            726
+seed7/prg/pairs.sd7          0.089274           2025
+seed7/prg/panic.sd7          0.105252           2634
+seed7/prg/percolation.sd7    0.048673            330
+seed7/prg/planets.sd7        0.082700           1486
+seed7/prg/portfwd7.sd7       0.043407            139
+seed7/prg/prime.sd7          0.041167             74
+seed7/prg/printpi1.sd7       0.040115             56
+seed7/prg/printpi2.sd7       0.040142             54
+seed7/prg/printpi3.sd7       0.039456             60
+seed7/prg/pv7.sd7            0.048214            337
+seed7/prg/queen.sd7          0.041003            149
+seed7/prg/rand.sd7           0.040763            121
+seed7/prg/raytrace.sd7       0.052579            538
+seed7/prg/rever.sd7          0.057841            816
+seed7/prg/roman.sd7          0.038919             38
+seed7/prg/s7c.sd7            0.291422           9060
+seed7/prg/s7check.sd7        0.040876             68
+seed7/prg/savehd7.sd7        0.072934           1110
+seed7/prg/self.sd7           0.040794             49
+seed7/prg/shisen.sd7         0.077223           1423
+seed7/prg/sl.sd7             0.065827           1029
+seed7/prg/snake.sd7          0.052289            615
+seed7/prg/sokoban.sd7        0.060824            891
+seed7/prg/spigotpi.sd7       0.040979             64
+seed7/prg/sql7.sd7           0.047854            278
+seed7/prg/startrek.sd7       0.065676            979
+seed7/prg/sudoku7.sd7        0.107006           2657
+seed7/prg/sydir7.sd7         0.049333            384
+seed7/prg/syntaxhl.sd7       0.044744            177
+seed7/prg/tak.sd7            0.039826             59
+seed7/prg/tar7.sd7           0.040927            121
+seed7/prg/tch.sd7            0.040811             55
+seed7/prg/testfont.sd7       0.042228             95
+seed7/prg/tet.sd7            0.049368            479
+seed7/prg/tetg.sd7           0.050612            501
+seed7/prg/toutf8.sd7         0.047350            240
+seed7/prg/tst_cli.sd7        0.040370             40
+seed7/prg/tst_srv.sd7        0.040512             47
+seed7/prg/wator.sd7          0.057798            651
+seed7/prg/which.sd7          0.041007             65
+seed7/prg/wiz.sd7            0.111937           2833
+seed7/prg/wordcnt.sd7        0.040789             54
+seed7/prg/wrinum.sd7         0.038852             43
+seed7/prg/wumpus.sd7         0.046367            372
+seed7/lib/aes.s7i            0.116099           1144
+seed7/lib/aes_gcm.s7i        0.050324            392
+seed7/lib/ar.s7i             0.078339           1532
+seed7/lib/arc4.s7i           0.042003            144
+seed7/lib/archive.s7i        0.042586            143
+seed7/lib/archive_base.s7i   0.042591            135
+seed7/lib/array.s7i          0.057497            610
+seed7/lib/asn1.s7i           0.052409            544
+seed7/lib/asn1oid.s7i        0.046616            157
+seed7/lib/basearray.s7i      0.053915            450
+seed7/lib/bigfile.s7i        0.041882            136
+seed7/lib/bigint.s7i         0.060850            824
+seed7/lib/bigrat.s7i         0.059781            784
+seed7/lib/bin16.s7i          0.057533            592
+seed7/lib/bin32.s7i          0.060289            490
+seed7/lib/bin64.s7i          0.061388            539
+seed7/lib/bitdata.s7i        0.086596           1330
+seed7/lib/bitmapfont.s7i     0.044713            215
+seed7/lib/bitset.s7i         0.053704            593
+seed7/lib/bitsetof.s7i       0.052562            431
+seed7/lib/blowfish.s7i       0.062228            383
+seed7/lib/bmp.s7i            0.066446            924
+seed7/lib/boolean.s7i        0.048581            403
+seed7/lib/browser.s7i        0.046645            280
+seed7/lib/bstring.s7i        0.044239            227
+seed7/lib/bytedata.s7i       0.053518            482
+seed7/lib/bzip2.s7i          0.063687            887
+seed7/lib/cards.s7i          0.072014           1342
+seed7/lib/category.s7i       0.045854            209
+seed7/lib/cc_conf.s7i        0.083714           1314
+seed7/lib/ccittfax.s7i       0.072805           1022
+seed7/lib/cgi.s7i            0.041457            109
+seed7/lib/cgidialog.s7i      0.064913           1118
+seed7/lib/char.s7i           0.047480            356
+seed7/lib/charsets.s7i       0.088254           2024
+seed7/lib/chartype.s7i       0.044524            121
+seed7/lib/cipher.s7i         0.042985            146
+seed7/lib/cli_cmds.s7i       0.075824           1360
+seed7/lib/clib_file.s7i      0.048730            301
+seed7/lib/color.s7i          0.045682            185
+seed7/lib/complex.s7i        0.049610            464
+seed7/lib/compress.s7i       0.042033            150
+seed7/lib/console.s7i        0.042926            188
+seed7/lib/cpio.s7i           0.086591           1708
+seed7/lib/crc32.s7i          0.048997            193
+seed7/lib/cronos16.s7i       0.099828           1173
+seed7/lib/cronos27.s7i       0.125232           1464
+seed7/lib/csv.s7i            0.045203            201
+seed7/lib/db_prop.s7i        0.069175            991
+seed7/lib/deflate.s7i        0.061384            740
+seed7/lib/des.s7i            0.061076            444
+seed7/lib/dialog.s7i         0.048766            311
+seed7/lib/dir.s7i            0.043057            163
+seed7/lib/draw.s7i           0.061620            854
+seed7/lib/duration.s7i       0.066834           1038
+seed7/lib/echo.s7i           0.043143            132
+seed7/lib/editline.s7i       0.049624            398
+seed7/lib/elf.s7i            0.090809           1560
+seed7/lib/elliptic.s7i       0.056767            649
+seed7/lib/enable_io.s7i      0.048019            312
+seed7/lib/encoding.s7i       0.067447            931
+seed7/lib/enumeration.s7i    0.047074            236
+seed7/lib/environment.s7i    0.044024            175
+seed7/lib/exif.s7i           0.044843            152
+seed7/lib/external_file.s7i  0.047849            340
+seed7/lib/field.s7i          0.047262            268
+seed7/lib/file.s7i           0.049666            372
+seed7/lib/filebits.s7i       0.040969             46
+seed7/lib/filesys.s7i        0.055828            601
+seed7/lib/fileutil.s7i       0.045383            144
+seed7/lib/fixarray.s7i       0.053324            307
+seed7/lib/float.s7i          0.061250            757
+seed7/lib/font.s7i           0.043941            196
+seed7/lib/font8x8.s7i        0.053747            998
+seed7/lib/forloop.s7i        0.050515            449
+seed7/lib/ftp.s7i            0.062416            969
+seed7/lib/ftpserv.s7i        0.057357            631
+seed7/lib/getf.s7i           0.041519            115
+seed7/lib/gethttp.s7i        0.039525             41
+seed7/lib/gethttps.s7i       0.040030             41
+seed7/lib/gif.s7i            0.056093            561
+seed7/lib/graph.s7i          0.055857            415
+seed7/lib/graph_file.s7i     0.051666            399
+seed7/lib/gtkserver.s7i      0.043406            161
+seed7/lib/gzip.s7i           0.055912            573
+seed7/lib/hash.s7i           0.055911            421
+seed7/lib/hashsetof.s7i      0.054826            499
+seed7/lib/hmac.s7i           0.044208            152
+seed7/lib/html.s7i           0.041329             83
+seed7/lib/html_ent.s7i       0.052447            476
+seed7/lib/htmldom.s7i        0.047957            286
+seed7/lib/http_request.s7i   0.057103            696
+seed7/lib/http_srv_resp.s7i  0.051191            380
+seed7/lib/https_request.s7i  0.045016            211
+seed7/lib/httpserv.s7i       0.048995            345
+seed7/lib/huffman.s7i        0.058903            644
+seed7/lib/ico.s7i            0.045317            221
+seed7/lib/idxarray.s7i       0.046118            232
+seed7/lib/image.s7i          0.041501            156
+seed7/lib/imagefile.s7i      0.044369            171
+seed7/lib/inflate.s7i        0.055496            411
+seed7/lib/inifile.s7i        0.044422            129
+seed7/lib/integer.s7i        0.058209            663
+seed7/lib/iobuffer.s7i       0.047199            289
+seed7/lib/jpeg.s7i           0.090623           1761
+seed7/lib/json.s7i           0.061251            891
+seed7/lib/json_serde.s7i     0.058472            783
+seed7/lib/keybd.s7i          0.061015            639
+seed7/lib/keydescr.s7i       0.045484            192
+seed7/lib/leb128.s7i         0.044943            218
+seed7/lib/line.s7i           0.041921            164
+seed7/lib/listener.s7i       0.045136            247
+seed7/lib/logfile.s7i        0.039422             73
+seed7/lib/lower.s7i          0.040459            142
+seed7/lib/lzma.s7i           0.064259            934
+seed7/lib/lzw.s7i            0.064463            861
+seed7/lib/magic.s7i          0.052221            403
+seed7/lib/mahjng32.s7i       0.069631           1500
+seed7/lib/make.s7i           0.053653            544
+seed7/lib/makedata.s7i       0.074834           1428
+seed7/lib/math.s7i           0.043795            201
+seed7/lib/mixarith.s7i       0.044573            249
+seed7/lib/modern27.s7i       0.090174           1099
+seed7/lib/more.s7i           0.042898            130
+seed7/lib/msgdigest.s7i      0.085067           1222
+seed7/lib/multiscr.s7i       0.041415             68
+seed7/lib/null_file.s7i      0.046433            345
+seed7/lib/osfiles.s7i        0.071386           1085
+seed7/lib/pbm.s7i            0.044848            230
+seed7/lib/pcx.s7i            0.057685            638
+seed7/lib/pem.s7i            0.044177            185
+seed7/lib/pgm.s7i            0.045258            238
+seed7/lib/pic16.s7i          0.053548           1037
+seed7/lib/pic32.s7i          0.086336           2060
+seed7/lib/pic_util.s7i       0.044067            144
+seed7/lib/pixelimage.s7i     0.046045            320
+seed7/lib/pixmap_file.s7i    0.049246            459
+seed7/lib/pixmapfont.s7i     0.043265            184
+seed7/lib/pkcs1.s7i          0.063014            543
+seed7/lib/png.s7i            0.069093           1064
+seed7/lib/poll.s7i           0.049491            313
+seed7/lib/ppm.s7i            0.047515            240
+seed7/lib/process.s7i        0.054312            541
+seed7/lib/progs.s7i          0.060815            789
+seed7/lib/propertyfile.s7i   0.042143            155
+seed7/lib/rational.s7i       0.059740            792
+seed7/lib/ref_list.s7i       0.045417            252
+seed7/lib/reference.s7i      0.041367            126
+seed7/lib/reverse.s7i        0.042098             94
+seed7/lib/rpm.s7i            0.154600           3487
+seed7/lib/rpmext.s7i         0.048017            318
+seed7/lib/scanfile.s7i       0.088127           1779
+seed7/lib/scanjson.s7i       0.051910            413
+seed7/lib/scanstri.s7i       0.085490           1814
+seed7/lib/scantoml.s7i       0.076483           1603
+seed7/lib/seed7_05.s7i       0.071892           1072
+seed7/lib/set.s7i            0.040573             57
+seed7/lib/shell.s7i          0.058697            615
+seed7/lib/showtls.s7i        0.060484            678
+seed7/lib/signature.s7i      0.042625            131
+seed7/lib/smtp.s7i           0.045169            261
+seed7/lib/sockbase.s7i       0.046884            217
+seed7/lib/socket.s7i         0.047120            326
+seed7/lib/sokoban1.s7i       0.059360           1519
+seed7/lib/sql_base.s7i       0.070157           1000
+seed7/lib/stars.s7i          0.146279           1705
+seed7/lib/stdfont10.s7i      0.087707           3347
+seed7/lib/stdfont12.s7i      0.097692           3928
+seed7/lib/stdfont14.s7i      0.109135           4510
+seed7/lib/stdfont16.s7i      0.121682           5092
+seed7/lib/stdfont18.s7i      0.141504           5868
+seed7/lib/stdfont20.s7i      0.157736           6449
+seed7/lib/stdfont24.s7i      0.191614           7421
+seed7/lib/stdfont8.s7i       0.078443           2960
+seed7/lib/stdfont9.s7i       0.083107           3152
+seed7/lib/stdio.s7i          0.043964            192
+seed7/lib/strifile.s7i       0.048013            345
+seed7/lib/string.s7i         0.060575            779
+seed7/lib/stritext.s7i       0.047023            352
+seed7/lib/struct.s7i         0.047853            266
+seed7/lib/struct_elem.s7i    0.045434            129
+seed7/lib/subfile.s7i        0.044070            174
+seed7/lib/subrange.s7i       0.040485             78
+seed7/lib/syntax.s7i         0.050168            294
+seed7/lib/tar.s7i            0.089300           1880
+seed7/lib/tar_cmds.s7i       0.061624            752
+seed7/lib/tdes.s7i           0.043114            143
+seed7/lib/tee.s7i            0.041921            143
+seed7/lib/text.s7i           0.041637            135
+seed7/lib/tga.s7i            0.058060            676
+seed7/lib/tiff.s7i           0.128945           2771
+seed7/lib/time.s7i           0.069123           1191
+seed7/lib/tls.s7i            0.110116           2230
+seed7/lib/unicode.s7i        0.056990            575
+seed7/lib/unionfnd.s7i       0.042105            130
+seed7/lib/upper.s7i          0.042495            142
+seed7/lib/utf16.s7i          0.054112            540
+seed7/lib/utf8.s7i           0.047088            234
+seed7/lib/vecfont10.s7i      0.085250           1056
+seed7/lib/vecfont18.s7i      0.093905           1119
+seed7/lib/vector3d.s7i       0.049631            293
+seed7/lib/vectorfont.s7i     0.044727            239
+seed7/lib/wildcard.s7i       0.042873            140
+seed7/lib/window.s7i         0.049906            455
+seed7/lib/wrinum.s7i         0.044969            248
+seed7/lib/x509cert.s7i       0.077584           1243
+seed7/lib/xml_ent.s7i        0.041551             94
+seed7/lib/xmldom.s7i         0.045361            303
+seed7/lib/xz.s7i             0.050654            442
+seed7/lib/zip.s7i            0.127054           2792
+seed7/lib/zstd.s7i           0.074948           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.095313        |
++-----------+-----------------+
+| Minimum   | 0.038629        |
++-----------+-----------------+
+| Maximum   | 2.613087        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.045775            190
+seed7/prg/bas7.sd7           0.773695          11459
+seed7/prg/bifurk.sd7         0.039797             73
+seed7/prg/bigfiles.sd7       0.042910            129
+seed7/prg/brainf7.sd7        0.038717             86
+seed7/prg/calc7.sd7          0.040954            128
+seed7/prg/carddemo.sd7       0.045639            190
+seed7/prg/castle.sd7         0.212839           3148
+seed7/prg/cat.sd7            0.040003             82
+seed7/prg/cellauto.sd7       0.040288             85
+seed7/prg/celsius.sd7        0.036659             42
+seed7/prg/chk_all.sd7        0.082019            843
+seed7/prg/chkarr.sd7         0.854813           8367
+seed7/prg/chkbig.sd7         4.116968          29026
+seed7/prg/chkbin.sd7         1.026193           6469
+seed7/prg/chkbitdata.sd7     1.247098           6624
+seed7/prg/chkbool.sd7        0.229763           3157
+seed7/prg/chkbst.sd7         0.103988            722
+seed7/prg/chkchr.sd7         0.475445           2809
+seed7/prg/chkcmd.sd7         0.112390           1205
+seed7/prg/chkdb.sd7          0.757860           7454
+seed7/prg/chkdecl.sd7        0.094618            448
+seed7/prg/chkenum.sd7        0.122874           1230
+seed7/prg/chkerr.sd7         0.338405           4663
+seed7/prg/chkexc.sd7         0.149445           2627
+seed7/prg/chkfil.sd7         0.127239           1615
+seed7/prg/chkflt.sd7         2.823731          20620
+seed7/prg/chkhent.sd7        0.038856             54
+seed7/prg/chkhsh.sd7         0.505644           4548
+seed7/prg/chkidx.sd7         3.162527          19567
+seed7/prg/chkint.sd7         5.570794          38129
+seed7/prg/chkjson.sd7        0.194530           1764
+seed7/prg/chkovf.sd7         1.201189           8216
+seed7/prg/chkprc.sd7         0.698575          10111
+seed7/prg/chkscan.sd7        0.089580            714
+seed7/prg/chkset.sd7         1.740321          11974
+seed7/prg/chkstr.sd7         3.430423          26952
+seed7/prg/chktime.sd7        0.247386           2025
+seed7/prg/chktoml.sd7        0.197638           1656
+seed7/prg/clock.sd7          0.038618             47
+seed7/prg/clock2.sd7         0.036213             43
+seed7/prg/clock3.sd7         0.040420             95
+seed7/prg/cmpfil.sd7         0.038480             84
+seed7/prg/comanche.sd7       0.046985            180
+seed7/prg/confval.sd7        0.049877            175
+seed7/prg/db7.sd7            0.063782            417
+seed7/prg/diff7.sd7          0.053570            263
+seed7/prg/dirtst.sd7         0.037301             42
+seed7/prg/dirx.sd7           0.043734            152
+seed7/prg/dnafight.sd7       0.120455           1381
+seed7/prg/dragon.sd7         0.038337             73
+seed7/prg/echo.sd7           0.036153             39
+seed7/prg/eliza.sd7          0.052072            302
+seed7/prg/err.sd7            0.044632             96
+seed7/prg/fannkuch.sd7       0.042926            131
+seed7/prg/fib.sd7            0.038698             47
+seed7/prg/find7.sd7          0.042656            133
+seed7/prg/findchar.sd7       0.043567            149
+seed7/prg/fractree.sd7       0.036936             55
+seed7/prg/ftp7.sd7           0.053566            296
+seed7/prg/ftpserv.sd7        0.038895             74
+seed7/prg/gcd.sd7            0.040400            109
+seed7/prg/gkbd.sd7           0.062444            358
+seed7/prg/gtksvtst.sd7       0.038846             94
+seed7/prg/hal.sd7            0.047287            250
+seed7/prg/hamu.sd7           0.070222            573
+seed7/prg/hanoi.sd7          0.036655             55
+seed7/prg/hd.sd7             0.037353             79
+seed7/prg/hello.sd7          0.044636             32
+seed7/prg/hilbert.sd7        0.045026            108
+seed7/prg/ide7.sd7           0.050749            196
+seed7/prg/kbd.sd7            0.037072             49
+seed7/prg/klondike.sd7       0.088498            883
+seed7/prg/lander.sd7         0.134835           1551
+seed7/prg/lst80bas.sd7       0.055287            344
+seed7/prg/lst99bas.sd7       0.066035            401
+seed7/prg/lstgwbas.sd7       0.073924            577
+seed7/prg/mahjong.sd7        0.147080           1943
+seed7/prg/make7.sd7          0.042598            121
+seed7/prg/mandelbr.sd7       0.049076            237
+seed7/prg/mind.sd7           0.059239            443
+seed7/prg/mirror.sd7         0.042804            131
+seed7/prg/ms.sd7             0.068285            641
+seed7/prg/nicoma.sd7         0.041274            135
+seed7/prg/pac.sd7            0.071453            726
+seed7/prg/pairs.sd7          0.138626           2025
+seed7/prg/panic.sd7          0.192680           2634
+seed7/prg/percolation.sd7    0.055252            330
+seed7/prg/planets.sd7        0.135902           1486
+seed7/prg/portfwd7.sd7       0.042877            139
+seed7/prg/prime.sd7          0.037400             74
+seed7/prg/printpi1.sd7       0.037019             56
+seed7/prg/printpi2.sd7       0.036666             54
+seed7/prg/printpi3.sd7       0.037218             60
+seed7/prg/pv7.sd7            0.057226            337
+seed7/prg/queen.sd7          0.042625            149
+seed7/prg/rand.sd7           0.040629            121
+seed7/prg/raytrace.sd7       0.065950            538
+seed7/prg/rever.sd7          0.078766            816
+seed7/prg/roman.sd7          0.038460             38
+seed7/prg/s7c.sd7            0.622716           9060
+seed7/prg/s7check.sd7        0.039297             68
+seed7/prg/savehd7.sd7        0.116403           1110
+seed7/prg/self.sd7           0.041508             49
+seed7/prg/shisen.sd7         0.122610           1423
+seed7/prg/sl.sd7             0.097551           1029
+seed7/prg/snake.sd7          0.065440            615
+seed7/prg/sokoban.sd7        0.083986            891
+seed7/prg/spigotpi.sd7       0.037837             64
+seed7/prg/sql7.sd7           0.053300            278
+seed7/prg/startrek.sd7       0.094479            979
+seed7/prg/sudoku7.sd7        0.201871           2657
+seed7/prg/sydir7.sd7         0.061979            384
+seed7/prg/syntaxhl.sd7       0.048615            177
+seed7/prg/tak.sd7            0.037794             59
+seed7/prg/tar7.sd7           0.043007            121
+seed7/prg/tch.sd7            0.037088             55
+seed7/prg/testfont.sd7       0.046242             95
+seed7/prg/tet.sd7            0.062596            479
+seed7/prg/tetg.sd7           0.065427            501
+seed7/prg/toutf8.sd7         0.052604            240
+seed7/prg/tst_cli.sd7        0.037686             40
+seed7/prg/tst_srv.sd7        0.036760             47
+seed7/prg/wator.sd7          0.078862            651
+seed7/prg/which.sd7          0.038506             65
+seed7/prg/wiz.sd7            0.207782           2833
+seed7/prg/wordcnt.sd7        0.038046             54
+seed7/prg/wrinum.sd7         0.036249             43
+seed7/prg/wumpus.sd7         0.053489            372
+seed7/lib/aes.s7i            0.197659           1144
+seed7/lib/aes_gcm.s7i        0.062634            392
+seed7/lib/ar.s7i             0.124887           1532
+seed7/lib/arc4.s7i           0.042755            144
+seed7/lib/archive.s7i        0.042675            143
+seed7/lib/archive_base.s7i   0.041682            135
+seed7/lib/array.s7i          0.078298            610
+seed7/lib/asn1.s7i           0.062934            544
+seed7/lib/asn1oid.s7i        0.053326            157
+seed7/lib/basearray.s7i      0.063003            450
+seed7/lib/bigfile.s7i        0.041586            136
+seed7/lib/bigint.s7i         0.078350            824
+seed7/lib/bigrat.s7i         0.084955            784
+seed7/lib/bin16.s7i          0.072941            592
+seed7/lib/bin32.s7i          0.064054            490
+seed7/lib/bin64.s7i          0.062428            539
+seed7/lib/bitdata.s7i        0.131996           1330
+seed7/lib/bitmapfont.s7i     0.048505            215
+seed7/lib/bitset.s7i         0.061935            593
+seed7/lib/bitsetof.s7i       0.062076            431
+seed7/lib/blowfish.s7i       0.078192            383
+seed7/lib/bmp.s7i            0.097399            924
+seed7/lib/boolean.s7i        0.054904            403
+seed7/lib/browser.s7i        0.054187            280
+seed7/lib/bstring.s7i        0.052458            227
+seed7/lib/bytedata.s7i       0.068195            482
+seed7/lib/bzip2.s7i          0.093274            887
+seed7/lib/cards.s7i          0.107719           1342
+seed7/lib/category.s7i       0.049308            209
+seed7/lib/cc_conf.s7i        0.124567           1314
+seed7/lib/ccittfax.s7i       0.102509           1022
+seed7/lib/cgi.s7i            0.041830            109
+seed7/lib/cgidialog.s7i      0.102349           1118
+seed7/lib/char.s7i           0.050730            356
+seed7/lib/charsets.s7i       0.121967           2024
+seed7/lib/chartype.s7i       0.046126            121
+seed7/lib/cipher.s7i         0.041168            146
+seed7/lib/cli_cmds.s7i       0.111865           1360
+seed7/lib/clib_file.s7i      0.053243            301
+seed7/lib/color.s7i          0.046615            185
+seed7/lib/complex.s7i        0.058754            464
+seed7/lib/compress.s7i       0.045864            150
+seed7/lib/console.s7i        0.046196            188
+seed7/lib/cpio.s7i           0.147425           1708
+seed7/lib/crc32.s7i          0.054960            193
+seed7/lib/cronos16.s7i       0.195033           1173
+seed7/lib/cronos27.s7i       0.252250           1464
+seed7/lib/csv.s7i            0.046158            201
+seed7/lib/db_prop.s7i        0.101327            991
+seed7/lib/deflate.s7i        0.087195            740
+seed7/lib/des.s7i            0.081545            444
+seed7/lib/dialog.s7i         0.057923            311
+seed7/lib/dir.s7i            0.042803            163
+seed7/lib/draw.s7i           0.086973            854
+seed7/lib/duration.s7i       0.102256           1038
+seed7/lib/echo.s7i           0.042602            132
+seed7/lib/editline.s7i       0.061361            398
+seed7/lib/elf.s7i            0.156627           1560
+seed7/lib/elliptic.s7i       0.075879            649
+seed7/lib/enable_io.s7i      0.051497            312
+seed7/lib/encoding.s7i       0.096877            931
+seed7/lib/enumeration.s7i    0.051321            236
+seed7/lib/environment.s7i    0.046394            175
+seed7/lib/exif.s7i           0.047272            152
+seed7/lib/external_file.s7i  0.052311            340
+seed7/lib/field.s7i          0.055349            268
+seed7/lib/file.s7i           0.057417            372
+seed7/lib/filebits.s7i       0.038455             46
+seed7/lib/filesys.s7i        0.065526            601
+seed7/lib/fileutil.s7i       0.043620            144
+seed7/lib/fixarray.s7i       0.054127            307
+seed7/lib/float.s7i          0.074457            757
+seed7/lib/font.s7i           0.045412            196
+seed7/lib/font8x8.s7i        0.069384            998
+seed7/lib/forloop.s7i        0.059734            449
+seed7/lib/ftp.s7i            0.086300            969
+seed7/lib/ftpserv.s7i        0.074980            631
+seed7/lib/getf.s7i           0.040439            115
+seed7/lib/gethttp.s7i        0.038635             41
+seed7/lib/gethttps.s7i       0.036914             41
+seed7/lib/gif.s7i            0.072811            561
+seed7/lib/graph.s7i          0.065600            415
+seed7/lib/graph_file.s7i     0.059513            399
+seed7/lib/gtkserver.s7i      0.042454            161
+seed7/lib/gzip.s7i           0.069319            573
+seed7/lib/hash.s7i           0.066413            421
+seed7/lib/hashsetof.s7i      0.068293            499
+seed7/lib/hmac.s7i           0.044531            152
+seed7/lib/html.s7i           0.039738             83
+seed7/lib/html_ent.s7i       0.065338            476
+seed7/lib/htmldom.s7i        0.053709            286
+seed7/lib/http_request.s7i   0.078447            696
+seed7/lib/http_srv_resp.s7i  0.060194            380
+seed7/lib/https_request.s7i  0.048603            211
+seed7/lib/httpserv.s7i       0.058447            345
+seed7/lib/huffman.s7i        0.074098            644
+seed7/lib/ico.s7i            0.049041            221
+seed7/lib/idxarray.s7i       0.049368            232
+seed7/lib/image.s7i          0.043943            156
+seed7/lib/imagefile.s7i      0.044390            171
+seed7/lib/inflate.s7i        0.063633            411
+seed7/lib/inifile.s7i        0.040856            129
+seed7/lib/integer.s7i        0.066818            663
+seed7/lib/iobuffer.s7i       0.050064            289
+seed7/lib/jpeg.s7i           0.153176           1761
+seed7/lib/json.s7i           0.081315            891
+seed7/lib/json_serde.s7i     0.078382            783
+seed7/lib/keybd.s7i          0.079180            639
+seed7/lib/keydescr.s7i       0.051042            192
+seed7/lib/leb128.s7i         0.048141            218
+seed7/lib/line.s7i           0.042270            164
+seed7/lib/listener.s7i       0.046977            247
+seed7/lib/logfile.s7i        0.039458             73
+seed7/lib/lower.s7i          0.041945            142
+seed7/lib/lzma.s7i           0.101601            934
+seed7/lib/lzw.s7i            0.090021            861
+seed7/lib/magic.s7i          0.064517            403
+seed7/lib/mahjng32.s7i       0.095089           1500
+seed7/lib/make.s7i           0.070460            544
+seed7/lib/makedata.s7i       0.122506           1428
+seed7/lib/math.s7i           0.044465            201
+seed7/lib/mixarith.s7i       0.046950            249
+seed7/lib/modern27.s7i       0.174733           1099
+seed7/lib/more.s7i           0.043330            130
+seed7/lib/msgdigest.s7i      0.134810           1222
+seed7/lib/multiscr.s7i       0.039987             68
+seed7/lib/null_file.s7i      0.050437            345
+seed7/lib/osfiles.s7i        0.097394           1085
+seed7/lib/pbm.s7i            0.048153            230
+seed7/lib/pcx.s7i            0.078813            638
+seed7/lib/pem.s7i            0.049189            185
+seed7/lib/pgm.s7i            0.048913            238
+seed7/lib/pic16.s7i          0.067044           1037
+seed7/lib/pic32.s7i          0.124644           2060
+seed7/lib/pic_util.s7i       0.045199            144
+seed7/lib/pixelimage.s7i     0.053656            320
+seed7/lib/pixmap_file.s7i    0.063377            459
+seed7/lib/pixmapfont.s7i     0.047755            184
+seed7/lib/pkcs1.s7i          0.078922            543
+seed7/lib/png.s7i            0.107687           1064
+seed7/lib/poll.s7i           0.050794            313
+seed7/lib/ppm.s7i            0.048270            240
+seed7/lib/process.s7i        0.070467            541
+seed7/lib/progs.s7i          0.087507            789
+seed7/lib/propertyfile.s7i   0.047103            155
+seed7/lib/rational.s7i       0.083769            792
+seed7/lib/ref_list.s7i       0.047468            252
+seed7/lib/reference.s7i      0.040630            126
+seed7/lib/reverse.s7i        0.039005             94
+seed7/lib/rpm.s7i            0.285252           3487
+seed7/lib/rpmext.s7i         0.054487            318
+seed7/lib/scanfile.s7i       0.139395           1779
+seed7/lib/scanjson.s7i       0.065311            413
+seed7/lib/scanstri.s7i       0.134804           1814
+seed7/lib/scantoml.s7i       0.134086           1603
+seed7/lib/seed7_05.s7i       0.112066           1072
+seed7/lib/set.s7i            0.043097             57
+seed7/lib/shell.s7i          0.069802            615
+seed7/lib/showtls.s7i        0.088850            678
+seed7/lib/signature.s7i      0.045115            131
+seed7/lib/smtp.s7i           0.049725            261
+seed7/lib/sockbase.s7i       0.054548            217
+seed7/lib/socket.s7i         0.052399            326
+seed7/lib/sokoban1.s7i       0.084937           1519
+seed7/lib/sql_base.s7i       0.094503           1000
+seed7/lib/stars.s7i          0.238439           1705
+seed7/lib/stdfont10.s7i      0.152002           3347
+seed7/lib/stdfont12.s7i      0.168136           3928
+seed7/lib/stdfont14.s7i      0.198650           4510
+seed7/lib/stdfont16.s7i      0.215745           5092
+seed7/lib/stdfont18.s7i      0.251831           5868
+seed7/lib/stdfont20.s7i      0.284966           6449
+seed7/lib/stdfont24.s7i      0.338735           7421
+seed7/lib/stdfont8.s7i       0.136484           2960
+seed7/lib/stdfont9.s7i       0.139787           3152
+seed7/lib/stdio.s7i          0.044900            192
+seed7/lib/strifile.s7i       0.055195            345
+seed7/lib/string.s7i         0.076768            779
+seed7/lib/stritext.s7i       0.053665            352
+seed7/lib/struct.s7i         0.054388            266
+seed7/lib/struct_elem.s7i    0.043562            129
+seed7/lib/subfile.s7i        0.046572            174
+seed7/lib/subrange.s7i       0.039102             78
+seed7/lib/syntax.s7i         0.061445            294
+seed7/lib/tar.s7i            0.155187           1880
+seed7/lib/tar_cmds.s7i       0.087248            752
+seed7/lib/tdes.s7i           0.048346            143
+seed7/lib/tee.s7i            0.043578            143
+seed7/lib/text.s7i           0.043947            135
+seed7/lib/tga.s7i            0.082081            676
+seed7/lib/tiff.s7i           0.247217           2771
+seed7/lib/time.s7i           0.103795           1191
+seed7/lib/tls.s7i            0.204144           2230
+seed7/lib/unicode.s7i        0.075665            575
+seed7/lib/unionfnd.s7i       0.044288            130
+seed7/lib/upper.s7i          0.042630            142
+seed7/lib/utf16.s7i          0.065863            540
+seed7/lib/utf8.s7i           0.049394            234
+seed7/lib/vecfont10.s7i      0.164033           1056
+seed7/lib/vecfont18.s7i      0.186523           1119
+seed7/lib/vector3d.s7i       0.053554            293
+seed7/lib/vectorfont.s7i     0.049671            239
+seed7/lib/wildcard.s7i       0.044430            140
+seed7/lib/window.s7i         0.064293            455
+seed7/lib/wrinum.s7i         0.052560            248
+seed7/lib/x509cert.s7i       0.125881           1243
+seed7/lib/xml_ent.s7i        0.041183             94
+seed7/lib/xmldom.s7i         0.052029            303
+seed7/lib/xz.s7i             0.065139            442
+seed7/lib/zip.s7i            0.240010           2792
+seed7/lib/zstd.s7i           0.124689           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.159702        |
++-----------+-----------------+
+| Minimum   | 0.036153        |
++-----------+-----------------+
+| Maximum   | 5.570794        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.035029        | 0.032097        | 0.042321        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039068        | 0.035110        | 0.050422        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.095313        | 0.038629        | 2.613087        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.159702        | 0.036153        | 5.570794        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:13.062 | 00:00:59.681 | 00:01:12.744 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.779 | 00:01:06.628 | 00:01:21.407 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:38.182 | 00:02:43.328 | 00:03:21.511 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:03.507 | 00:04:33.036 | 00:05:36.544 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:32.214 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-11.2.rst
+++ b/reports/seed7mode-perf-11.2.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-25T14:41:17+0000 W26-4
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 10:52:57 local time
+:Generated on: 2026-06-25 15:04:30 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 253x95 chars
+:Window body: 253x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.034187            190
+seed7/prg/bas7.sd7           0.034177          11459
+seed7/prg/bifurk.sd7         0.034839             73
+seed7/prg/bigfiles.sd7       0.034666            129
+seed7/prg/brainf7.sd7        0.035568             86
+seed7/prg/calc7.sd7          0.034224            128
+seed7/prg/carddemo.sd7       0.033602            190
+seed7/prg/castle.sd7         0.033618           3148
+seed7/prg/cat.sd7            0.032914             82
+seed7/prg/cellauto.sd7       0.034849             85
+seed7/prg/celsius.sd7        0.032859             42
+seed7/prg/chk_all.sd7        0.032745            843
+seed7/prg/chkarr.sd7         0.032824           8367
+seed7/prg/chkbig.sd7         0.037690          29026
+seed7/prg/chkbin.sd7         0.034230           6469
+seed7/prg/chkbitdata.sd7     0.036221           6624
+seed7/prg/chkbool.sd7        0.037582           3157
+seed7/prg/chkbst.sd7         0.034393            722
+seed7/prg/chkchr.sd7         0.034039           2809
+seed7/prg/chkcmd.sd7         0.033619           1205
+seed7/prg/chkdb.sd7          0.034398           7454
+seed7/prg/chkdecl.sd7        0.034638            448
+seed7/prg/chkenum.sd7        0.036616           1230
+seed7/prg/chkerr.sd7         0.034975           4663
+seed7/prg/chkexc.sd7         0.033712           2627
+seed7/prg/chkfil.sd7         0.034959           1615
+seed7/prg/chkflt.sd7         0.044017          20620
+seed7/prg/chkhent.sd7        0.037049             54
+seed7/prg/chkhsh.sd7         0.040378           4548
+seed7/prg/chkidx.sd7         0.035549          19567
+seed7/prg/chkint.sd7         0.039219          38129
+seed7/prg/chkjson.sd7        0.032710           1764
+seed7/prg/chkovf.sd7         0.033443           8216
+seed7/prg/chkprc.sd7         0.034465          10111
+seed7/prg/chkscan.sd7        0.037278            714
+seed7/prg/chkset.sd7         0.035192          11974
+seed7/prg/chkstr.sd7         0.037366          26952
+seed7/prg/chktime.sd7        0.032907           2025
+seed7/prg/chktoml.sd7        0.033024           1656
+seed7/prg/clock.sd7          0.032784             47
+seed7/prg/clock2.sd7         0.032890             43
+seed7/prg/clock3.sd7         0.034194             95
+seed7/prg/cmpfil.sd7         0.034619             84
+seed7/prg/comanche.sd7       0.033578            180
+seed7/prg/confval.sd7        0.033391            175
+seed7/prg/db7.sd7            0.033514            417
+seed7/prg/diff7.sd7          0.033785            263
+seed7/prg/dirtst.sd7         0.033680             42
+seed7/prg/dirx.sd7           0.033493            152
+seed7/prg/dnafight.sd7       0.034157           1381
+seed7/prg/dragon.sd7         0.034738             73
+seed7/prg/echo.sd7           0.033749             39
+seed7/prg/eliza.sd7          0.033704            302
+seed7/prg/err.sd7            0.033703             96
+seed7/prg/fannkuch.sd7       0.033317            131
+seed7/prg/fib.sd7            0.033352             47
+seed7/prg/find7.sd7          0.033600            133
+seed7/prg/findchar.sd7       0.033300            149
+seed7/prg/fractree.sd7       0.033300             55
+seed7/prg/ftp7.sd7           0.033535            296
+seed7/prg/ftpserv.sd7        0.033398             74
+seed7/prg/gcd.sd7            0.033443            109
+seed7/prg/gkbd.sd7           0.033257            358
+seed7/prg/gtksvtst.sd7       0.033687             94
+seed7/prg/hal.sd7            0.033782            250
+seed7/prg/hamu.sd7           0.033367            573
+seed7/prg/hanoi.sd7          0.033143             55
+seed7/prg/hd.sd7             0.034693             79
+seed7/prg/hello.sd7          0.032539             32
+seed7/prg/hilbert.sd7        0.032510            108
+seed7/prg/ide7.sd7           0.038715            196
+seed7/prg/kbd.sd7            0.037108             49
+seed7/prg/klondike.sd7       0.035405            883
+seed7/prg/lander.sd7         0.034185           1551
+seed7/prg/lst80bas.sd7       0.036760            344
+seed7/prg/lst99bas.sd7       0.035547            401
+seed7/prg/lstgwbas.sd7       0.033789            577
+seed7/prg/mahjong.sd7        0.033041           1943
+seed7/prg/make7.sd7          0.032669            121
+seed7/prg/mandelbr.sd7       0.033417            237
+seed7/prg/mind.sd7           0.032960            443
+seed7/prg/mirror.sd7         0.033621            131
+seed7/prg/ms.sd7             0.032361            641
+seed7/prg/nicoma.sd7         0.032308            135
+seed7/prg/pac.sd7            0.033790            726
+seed7/prg/pairs.sd7          0.033571           2025
+seed7/prg/panic.sd7          0.033130           2634
+seed7/prg/percolation.sd7    0.033521            330
+seed7/prg/planets.sd7        0.033514           1486
+seed7/prg/portfwd7.sd7       0.033293            139
+seed7/prg/prime.sd7          0.033376             74
+seed7/prg/printpi1.sd7       0.033404             56
+seed7/prg/printpi2.sd7       0.033420             54
+seed7/prg/printpi3.sd7       0.033434             60
+seed7/prg/pv7.sd7            0.033989            337
+seed7/prg/queen.sd7          0.032476            149
+seed7/prg/rand.sd7           0.032698            121
+seed7/prg/raytrace.sd7       0.033039            538
+seed7/prg/rever.sd7          0.032378            816
+seed7/prg/roman.sd7          0.032171             38
+seed7/prg/s7c.sd7            0.033064           9060
+seed7/prg/s7check.sd7        0.034377             68
+seed7/prg/savehd7.sd7        0.034329           1110
+seed7/prg/self.sd7           0.034092             49
+seed7/prg/shisen.sd7         0.033192           1423
+seed7/prg/sl.sd7             0.033996           1029
+seed7/prg/snake.sd7          0.033403            615
+seed7/prg/sokoban.sd7        0.033348            891
+seed7/prg/spigotpi.sd7       0.033277             64
+seed7/prg/sql7.sd7           0.033955            278
+seed7/prg/startrek.sd7       0.033265            979
+seed7/prg/sudoku7.sd7        0.033836           2657
+seed7/prg/sydir7.sd7         0.038971            384
+seed7/prg/syntaxhl.sd7       0.036541            177
+seed7/prg/tak.sd7            0.033731             59
+seed7/prg/tar7.sd7           0.033880            121
+seed7/prg/tch.sd7            0.033897             55
+seed7/prg/testfont.sd7       0.033516             95
+seed7/prg/tet.sd7            0.033465            479
+seed7/prg/tetg.sd7           0.033772            501
+seed7/prg/toutf8.sd7         0.032731            240
+seed7/prg/tst_cli.sd7        0.032677             40
+seed7/prg/tst_srv.sd7        0.034826             47
+seed7/prg/wator.sd7          0.036413            651
+seed7/prg/which.sd7          0.033989             65
+seed7/prg/wiz.sd7            0.035087           2833
+seed7/prg/wordcnt.sd7        0.036671             54
+seed7/prg/wrinum.sd7         0.034306             43
+seed7/prg/wumpus.sd7         0.032667            372
+seed7/lib/aes.s7i            0.033208           1144
+seed7/lib/aes_gcm.s7i        0.034050            392
+seed7/lib/ar.s7i             0.033764           1532
+seed7/lib/arc4.s7i           0.033263            144
+seed7/lib/archive.s7i        0.033589            143
+seed7/lib/archive_base.s7i   0.034209            135
+seed7/lib/array.s7i          0.034044            610
+seed7/lib/asn1.s7i           0.033734            544
+seed7/lib/asn1oid.s7i        0.033735            157
+seed7/lib/basearray.s7i      0.033386            450
+seed7/lib/bigfile.s7i        0.033361            136
+seed7/lib/bigint.s7i         0.033779            824
+seed7/lib/bigrat.s7i         0.033725            784
+seed7/lib/bin16.s7i          0.035818            592
+seed7/lib/bin32.s7i          0.036521            490
+seed7/lib/bin64.s7i          0.033709            539
+seed7/lib/bitdata.s7i        0.033780           1330
+seed7/lib/bitmapfont.s7i     0.033281            215
+seed7/lib/bitset.s7i         0.034881            593
+seed7/lib/bitsetof.s7i       0.035703            431
+seed7/lib/blowfish.s7i       0.033958            383
+seed7/lib/bmp.s7i            0.033212            924
+seed7/lib/boolean.s7i        0.034211            403
+seed7/lib/browser.s7i        0.033986            280
+seed7/lib/bstring.s7i        0.033345            227
+seed7/lib/bytedata.s7i       0.033661            482
+seed7/lib/bzip2.s7i          0.032329            887
+seed7/lib/cards.s7i          0.034399           1342
+seed7/lib/category.s7i       0.035361            209
+seed7/lib/cc_conf.s7i        0.032758           1314
+seed7/lib/ccittfax.s7i       0.032632           1022
+seed7/lib/cgi.s7i            0.033492            109
+seed7/lib/cgidialog.s7i      0.033985           1118
+seed7/lib/char.s7i           0.033493            356
+seed7/lib/charsets.s7i       0.034356           2024
+seed7/lib/chartype.s7i       0.034754            121
+seed7/lib/cipher.s7i         0.037376            146
+seed7/lib/cli_cmds.s7i       0.032827           1360
+seed7/lib/clib_file.s7i      0.032784            301
+seed7/lib/color.s7i          0.032629            185
+seed7/lib/complex.s7i        0.032602            464
+seed7/lib/compress.s7i       0.032823            150
+seed7/lib/console.s7i        0.032482            188
+seed7/lib/cpio.s7i           0.032866           1708
+seed7/lib/crc32.s7i          0.032579            193
+seed7/lib/cronos16.s7i       0.033002           1173
+seed7/lib/cronos27.s7i       0.033107           1464
+seed7/lib/csv.s7i            0.034580            201
+seed7/lib/db_prop.s7i        0.034025            991
+seed7/lib/deflate.s7i        0.033761            740
+seed7/lib/des.s7i            0.033861            444
+seed7/lib/dialog.s7i         0.033689            311
+seed7/lib/dir.s7i            0.033714            163
+seed7/lib/draw.s7i           0.033961            854
+seed7/lib/duration.s7i       0.034199           1038
+seed7/lib/echo.s7i           0.035487            132
+seed7/lib/editline.s7i       0.033764            398
+seed7/lib/elf.s7i            0.035492           1560
+seed7/lib/elliptic.s7i       0.035291            649
+seed7/lib/enable_io.s7i      0.036586            312
+seed7/lib/encoding.s7i       0.033527            931
+seed7/lib/enumeration.s7i    0.032395            236
+seed7/lib/environment.s7i    0.032424            175
+seed7/lib/exif.s7i           0.034110            152
+seed7/lib/external_file.s7i  0.033526            340
+seed7/lib/field.s7i          0.033650            268
+seed7/lib/file.s7i           0.033497            372
+seed7/lib/filebits.s7i       0.033414             46
+seed7/lib/filesys.s7i        0.033465            601
+seed7/lib/fileutil.s7i       0.033437            144
+seed7/lib/fixarray.s7i       0.033689            307
+seed7/lib/float.s7i          0.033386            757
+seed7/lib/font.s7i           0.033989            196
+seed7/lib/font8x8.s7i        0.033736            998
+seed7/lib/forloop.s7i        0.033367            449
+seed7/lib/ftp.s7i            0.033632            969
+seed7/lib/ftpserv.s7i        0.033493            631
+seed7/lib/getf.s7i           0.033547            115
+seed7/lib/gethttp.s7i        0.033664             41
+seed7/lib/gethttps.s7i       0.033293             41
+seed7/lib/gif.s7i            0.038822            561
+seed7/lib/graph.s7i          0.038065            415
+seed7/lib/graph_file.s7i     0.033538            399
+seed7/lib/gtkserver.s7i      0.032916            161
+seed7/lib/gzip.s7i           0.032653            573
+seed7/lib/hash.s7i           0.032303            421
+seed7/lib/hashsetof.s7i      0.032676            499
+seed7/lib/hmac.s7i           0.033310            152
+seed7/lib/html.s7i           0.032938             83
+seed7/lib/html_ent.s7i       0.032716            476
+seed7/lib/htmldom.s7i        0.033064            286
+seed7/lib/http_request.s7i   0.032890            696
+seed7/lib/http_srv_resp.s7i  0.032664            380
+seed7/lib/https_request.s7i  0.032603            211
+seed7/lib/httpserv.s7i       0.033187            345
+seed7/lib/huffman.s7i        0.035333            644
+seed7/lib/ico.s7i            0.035677            221
+seed7/lib/idxarray.s7i       0.034110            232
+seed7/lib/image.s7i          0.033528            156
+seed7/lib/imagefile.s7i      0.033476            171
+seed7/lib/inflate.s7i        0.033650            411
+seed7/lib/inifile.s7i        0.033485            129
+seed7/lib/integer.s7i        0.034026            663
+seed7/lib/iobuffer.s7i       0.033934            289
+seed7/lib/jpeg.s7i           0.033597           1761
+seed7/lib/json.s7i           0.033602            891
+seed7/lib/json_serde.s7i     0.033396            783
+seed7/lib/keybd.s7i          0.034372            639
+seed7/lib/keydescr.s7i       0.033957            192
+seed7/lib/leb128.s7i         0.033686            218
+seed7/lib/line.s7i           0.033800            164
+seed7/lib/listener.s7i       0.033641            247
+seed7/lib/logfile.s7i        0.034006             73
+seed7/lib/lower.s7i          0.033586            142
+seed7/lib/lzma.s7i           0.033691            934
+seed7/lib/lzw.s7i            0.033707            861
+seed7/lib/magic.s7i          0.033880            403
+seed7/lib/mahjng32.s7i       0.034083           1500
+seed7/lib/make.s7i           0.033600            544
+seed7/lib/makedata.s7i       0.033540           1428
+seed7/lib/math.s7i           0.033231            201
+seed7/lib/mixarith.s7i       0.032461            249
+seed7/lib/modern27.s7i       0.033771           1099
+seed7/lib/more.s7i           0.032702            130
+seed7/lib/msgdigest.s7i      0.032757           1222
+seed7/lib/multiscr.s7i       0.032762             68
+seed7/lib/null_file.s7i      0.034700            345
+seed7/lib/osfiles.s7i        0.033196           1085
+seed7/lib/pbm.s7i            0.033095            230
+seed7/lib/pcx.s7i            0.032517            638
+seed7/lib/pem.s7i            0.032964            185
+seed7/lib/pgm.s7i            0.033124            238
+seed7/lib/pic16.s7i          0.032412           1037
+seed7/lib/pic32.s7i          0.032670           2060
+seed7/lib/pic_util.s7i       0.033149            144
+seed7/lib/pixelimage.s7i     0.032401            320
+seed7/lib/pixmap_file.s7i    0.032834            459
+seed7/lib/pixmapfont.s7i     0.033522            184
+seed7/lib/pkcs1.s7i          0.033447            543
+seed7/lib/png.s7i            0.033542           1064
+seed7/lib/poll.s7i           0.033321            313
+seed7/lib/ppm.s7i            0.033517            240
+seed7/lib/process.s7i        0.033754            541
+seed7/lib/progs.s7i          0.033590            789
+seed7/lib/propertyfile.s7i   0.033362            155
+seed7/lib/rational.s7i       0.033535            792
+seed7/lib/ref_list.s7i       0.034032            252
+seed7/lib/reference.s7i      0.033751            126
+seed7/lib/reverse.s7i        0.033568             94
+seed7/lib/rpm.s7i            0.034370           3487
+seed7/lib/rpmext.s7i         0.033136            318
+seed7/lib/scanfile.s7i       0.032530           1779
+seed7/lib/scanjson.s7i       0.032899            413
+seed7/lib/scanstri.s7i       0.032923           1814
+seed7/lib/scantoml.s7i       0.032336           1603
+seed7/lib/seed7_05.s7i       0.032405           1072
+seed7/lib/set.s7i            0.034519             57
+seed7/lib/shell.s7i          0.033611            615
+seed7/lib/showtls.s7i        0.034261            678
+seed7/lib/signature.s7i      0.033602            131
+seed7/lib/smtp.s7i           0.034417            261
+seed7/lib/sockbase.s7i       0.033372            217
+seed7/lib/socket.s7i         0.037697            326
+seed7/lib/sokoban1.s7i       0.037680           1519
+seed7/lib/sql_base.s7i       0.037844           1000
+seed7/lib/stars.s7i          0.034014           1705
+seed7/lib/stdfont10.s7i      0.033806           3347
+seed7/lib/stdfont12.s7i      0.033799           3928
+seed7/lib/stdfont14.s7i      0.033777           4510
+seed7/lib/stdfont16.s7i      0.033759           5092
+seed7/lib/stdfont18.s7i      0.034373           5868
+seed7/lib/stdfont20.s7i      0.033790           6449
+seed7/lib/stdfont24.s7i      0.037282           7421
+seed7/lib/stdfont8.s7i       0.040517           2960
+seed7/lib/stdfont9.s7i       0.033979           3152
+seed7/lib/stdio.s7i          0.032751            192
+seed7/lib/strifile.s7i       0.032775            345
+seed7/lib/string.s7i         0.032454            779
+seed7/lib/stritext.s7i       0.032443            352
+seed7/lib/struct.s7i         0.032973            266
+seed7/lib/struct_elem.s7i    0.032663            129
+seed7/lib/subfile.s7i        0.032505            174
+seed7/lib/subrange.s7i       0.032837             78
+seed7/lib/syntax.s7i         0.033134            294
+seed7/lib/tar.s7i            0.033101           1880
+seed7/lib/tar_cmds.s7i       0.032435            752
+seed7/lib/tdes.s7i           0.032423            143
+seed7/lib/tee.s7i            0.034283            143
+seed7/lib/text.s7i           0.033914            135
+seed7/lib/tga.s7i            0.034011            676
+seed7/lib/tiff.s7i           0.033526           2771
+seed7/lib/time.s7i           0.035596           1191
+seed7/lib/tls.s7i            0.036232           2230
+seed7/lib/unicode.s7i        0.033811            575
+seed7/lib/unionfnd.s7i       0.033874            130
+seed7/lib/upper.s7i          0.033464            142
+seed7/lib/utf16.s7i          0.033830            540
+seed7/lib/utf8.s7i           0.033848            234
+seed7/lib/vecfont10.s7i      0.033813           1056
+seed7/lib/vecfont18.s7i      0.033197           1119
+seed7/lib/vector3d.s7i       0.033456            293
+seed7/lib/vectorfont.s7i     0.033689            239
+seed7/lib/wildcard.s7i       0.033793            140
+seed7/lib/window.s7i         0.033683            455
+seed7/lib/wrinum.s7i         0.033478            248
+seed7/lib/x509cert.s7i       0.039437           1243
+seed7/lib/xml_ent.s7i        0.037176             94
+seed7/lib/xmldom.s7i         0.033471            303
+seed7/lib/xz.s7i             0.033295            442
+seed7/lib/zip.s7i            0.033668           2792
+seed7/lib/zstd.s7i           0.033508           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033959        |
++-----------+-----------------+
+| Minimum   | 0.032171        |
++-----------+-----------------+
+| Maximum   | 0.044017        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.038871            190
+seed7/prg/bas7.sd7           0.040081          11459
+seed7/prg/bifurk.sd7         0.035555             73
+seed7/prg/bigfiles.sd7       0.037347            129
+seed7/prg/brainf7.sd7        0.036419             86
+seed7/prg/calc7.sd7          0.037085            128
+seed7/prg/carddemo.sd7       0.038067            190
+seed7/prg/castle.sd7         0.038209           3148
+seed7/prg/cat.sd7            0.036091             82
+seed7/prg/cellauto.sd7       0.037108             85
+seed7/prg/celsius.sd7        0.034928             42
+seed7/prg/chk_all.sd7        0.040000            843
+seed7/prg/chkarr.sd7         0.040272           8367
+seed7/prg/chkbig.sd7         0.044016          29026
+seed7/prg/chkbin.sd7         0.040211           6469
+seed7/prg/chkbitdata.sd7     0.040281           6624
+seed7/prg/chkbool.sd7        0.037784           3157
+seed7/prg/chkbst.sd7         0.038411            722
+seed7/prg/chkchr.sd7         0.039844           2809
+seed7/prg/chkcmd.sd7         0.037698           1205
+seed7/prg/chkdb.sd7          0.038734           7454
+seed7/prg/chkdecl.sd7        0.037977            448
+seed7/prg/chkenum.sd7        0.037771           1230
+seed7/prg/chkerr.sd7         0.038489           4663
+seed7/prg/chkexc.sd7         0.039054           2627
+seed7/prg/chkfil.sd7         0.039056           1615
+seed7/prg/chkflt.sd7         0.043095          20620
+seed7/prg/chkhent.sd7        0.036861             54
+seed7/prg/chkhsh.sd7         0.047065           4548
+seed7/prg/chkidx.sd7         0.042864          19567
+seed7/prg/chkint.sd7         0.047221          38129
+seed7/prg/chkjson.sd7        0.038955           1764
+seed7/prg/chkovf.sd7         0.041656           8216
+seed7/prg/chkprc.sd7         0.041640          10111
+seed7/prg/chkscan.sd7        0.038801            714
+seed7/prg/chkset.sd7         0.039256          11974
+seed7/prg/chkstr.sd7         0.042699          26952
+seed7/prg/chktime.sd7        0.040888           2025
+seed7/prg/chktoml.sd7        0.039218           1656
+seed7/prg/clock.sd7          0.036263             47
+seed7/prg/clock2.sd7         0.036022             43
+seed7/prg/clock3.sd7         0.039755             95
+seed7/prg/cmpfil.sd7         0.037884             84
+seed7/prg/comanche.sd7       0.039056            180
+seed7/prg/confval.sd7        0.039663            175
+seed7/prg/db7.sd7            0.039197            417
+seed7/prg/diff7.sd7          0.039661            263
+seed7/prg/dirtst.sd7         0.035971             42
+seed7/prg/dirx.sd7           0.038426            152
+seed7/prg/dnafight.sd7       0.040298           1381
+seed7/prg/dragon.sd7         0.037161             73
+seed7/prg/echo.sd7           0.035508             39
+seed7/prg/eliza.sd7          0.038528            302
+seed7/prg/err.sd7            0.041394             96
+seed7/prg/fannkuch.sd7       0.038254            131
+seed7/prg/fib.sd7            0.034891             47
+seed7/prg/find7.sd7          0.037682            133
+seed7/prg/findchar.sd7       0.037863            149
+seed7/prg/fractree.sd7       0.036568             55
+seed7/prg/ftp7.sd7           0.038011            296
+seed7/prg/ftpserv.sd7        0.036685             74
+seed7/prg/gcd.sd7            0.036635            109
+seed7/prg/gkbd.sd7           0.039702            358
+seed7/prg/gtksvtst.sd7       0.036900             94
+seed7/prg/hal.sd7            0.037400            250
+seed7/prg/hamu.sd7           0.043061            573
+seed7/prg/hanoi.sd7          0.040742             55
+seed7/prg/hd.sd7             0.041748             79
+seed7/prg/hello.sd7          0.035637             32
+seed7/prg/hilbert.sd7        0.038426            108
+seed7/prg/ide7.sd7           0.038872            196
+seed7/prg/kbd.sd7            0.036040             49
+seed7/prg/klondike.sd7       0.038503            883
+seed7/prg/lander.sd7         0.039124           1551
+seed7/prg/lst80bas.sd7       0.038093            344
+seed7/prg/lst99bas.sd7       0.039960            401
+seed7/prg/lstgwbas.sd7       0.039635            577
+seed7/prg/mahjong.sd7        0.039307           1943
+seed7/prg/make7.sd7          0.038738            121
+seed7/prg/mandelbr.sd7       0.039123            237
+seed7/prg/mind.sd7           0.042099            443
+seed7/prg/mirror.sd7         0.046929            131
+seed7/prg/ms.sd7             0.039551            641
+seed7/prg/nicoma.sd7         0.039150            135
+seed7/prg/pac.sd7            0.038712            726
+seed7/prg/pairs.sd7          0.038826           2025
+seed7/prg/panic.sd7          0.039790           2634
+seed7/prg/percolation.sd7    0.038502            330
+seed7/prg/planets.sd7        0.038518           1486
+seed7/prg/portfwd7.sd7       0.038560            139
+seed7/prg/prime.sd7          0.036292             74
+seed7/prg/printpi1.sd7       0.035634             56
+seed7/prg/printpi2.sd7       0.043093             54
+seed7/prg/printpi3.sd7       0.043557             60
+seed7/prg/pv7.sd7            0.042860            337
+seed7/prg/queen.sd7          0.039699            149
+seed7/prg/rand.sd7           0.037337            121
+seed7/prg/raytrace.sd7       0.038389            538
+seed7/prg/rever.sd7          0.037742            816
+seed7/prg/roman.sd7          0.035017             38
+seed7/prg/s7c.sd7            0.038334           9060
+seed7/prg/s7check.sd7        0.036795             68
+seed7/prg/savehd7.sd7        0.037940           1110
+seed7/prg/self.sd7           0.035912             49
+seed7/prg/shisen.sd7         0.038653           1423
+seed7/prg/sl.sd7             0.038636           1029
+seed7/prg/snake.sd7          0.040885            615
+seed7/prg/sokoban.sd7        0.040843            891
+seed7/prg/spigotpi.sd7       0.036465             64
+seed7/prg/sql7.sd7           0.038789            278
+seed7/prg/startrek.sd7       0.039048            979
+seed7/prg/sudoku7.sd7        0.041071           2657
+seed7/prg/sydir7.sd7         0.040699            384
+seed7/prg/syntaxhl.sd7       0.041307            177
+seed7/prg/tak.sd7            0.041336             59
+seed7/prg/tar7.sd7           0.042709            121
+seed7/prg/tch.sd7            0.037112             55
+seed7/prg/testfont.sd7       0.040588             95
+seed7/prg/tet.sd7            0.039884            479
+seed7/prg/tetg.sd7           0.037789            501
+seed7/prg/toutf8.sd7         0.041904            240
+seed7/prg/tst_cli.sd7        0.035685             40
+seed7/prg/tst_srv.sd7        0.036139             47
+seed7/prg/wator.sd7          0.038927            651
+seed7/prg/which.sd7          0.039754             65
+seed7/prg/wiz.sd7            0.041526           2833
+seed7/prg/wordcnt.sd7        0.036585             54
+seed7/prg/wrinum.sd7         0.035921             43
+seed7/prg/wumpus.sd7         0.038555            372
+seed7/lib/aes.s7i            0.042719           1144
+seed7/lib/aes_gcm.s7i        0.039952            392
+seed7/lib/ar.s7i             0.039265           1532
+seed7/lib/arc4.s7i           0.039530            144
+seed7/lib/archive.s7i        0.039558            143
+seed7/lib/archive_base.s7i   0.038893            135
+seed7/lib/array.s7i          0.039082            610
+seed7/lib/asn1.s7i           0.035985            544
+seed7/lib/asn1oid.s7i        0.042136            157
+seed7/lib/basearray.s7i      0.039454            450
+seed7/lib/bigfile.s7i        0.037384            136
+seed7/lib/bigint.s7i         0.038036            824
+seed7/lib/bigrat.s7i         0.037829            784
+seed7/lib/bin16.s7i          0.038024            592
+seed7/lib/bin32.s7i          0.038213            490
+seed7/lib/bin64.s7i          0.037827            539
+seed7/lib/bitdata.s7i        0.043234           1330
+seed7/lib/bitmapfont.s7i     0.037816            215
+seed7/lib/bitset.s7i         0.040115            593
+seed7/lib/bitsetof.s7i       0.040447            431
+seed7/lib/blowfish.s7i       0.042148            383
+seed7/lib/bmp.s7i            0.039348            924
+seed7/lib/boolean.s7i        0.038869            403
+seed7/lib/browser.s7i        0.039192            280
+seed7/lib/bstring.s7i        0.041148            227
+seed7/lib/bytedata.s7i       0.039553            482
+seed7/lib/bzip2.s7i          0.039116            887
+seed7/lib/cards.s7i          0.036964           1342
+seed7/lib/category.s7i       0.039235            209
+seed7/lib/cc_conf.s7i        0.038881           1314
+seed7/lib/ccittfax.s7i       0.039417           1022
+seed7/lib/cgi.s7i            0.039042            109
+seed7/lib/cgidialog.s7i      0.039035           1118
+seed7/lib/char.s7i           0.039173            356
+seed7/lib/charsets.s7i       0.039646           2024
+seed7/lib/chartype.s7i       0.042038            121
+seed7/lib/cipher.s7i         0.038406            146
+seed7/lib/cli_cmds.s7i       0.039271           1360
+seed7/lib/clib_file.s7i      0.039122            301
+seed7/lib/color.s7i          0.038817            185
+seed7/lib/complex.s7i        0.038006            464
+seed7/lib/compress.s7i       0.038191            150
+seed7/lib/console.s7i        0.038012            188
+seed7/lib/cpio.s7i           0.038088           1708
+seed7/lib/crc32.s7i          0.038068            193
+seed7/lib/cronos16.s7i       0.043468           1173
+seed7/lib/cronos27.s7i       0.041969           1464
+seed7/lib/csv.s7i            0.038406            201
+seed7/lib/db_prop.s7i        0.038147            991
+seed7/lib/deflate.s7i        0.038108            740
+seed7/lib/des.s7i            0.038470            444
+seed7/lib/dialog.s7i         0.037834            311
+seed7/lib/dir.s7i            0.037791            163
+seed7/lib/draw.s7i           0.037589            854
+seed7/lib/duration.s7i       0.037498           1038
+seed7/lib/echo.s7i           0.039189            132
+seed7/lib/editline.s7i       0.038658            398
+seed7/lib/elf.s7i            0.040996           1560
+seed7/lib/elliptic.s7i       0.039081            649
+seed7/lib/enable_io.s7i      0.039949            312
+seed7/lib/encoding.s7i       0.039617            931
+seed7/lib/enumeration.s7i    0.041881            236
+seed7/lib/environment.s7i    0.038752            175
+seed7/lib/exif.s7i           0.040621            152
+seed7/lib/external_file.s7i  0.039095            340
+seed7/lib/field.s7i          0.038850            268
+seed7/lib/file.s7i           0.038686            372
+seed7/lib/filebits.s7i       0.036159             46
+seed7/lib/filesys.s7i        0.037639            601
+seed7/lib/fileutil.s7i       0.039204            144
+seed7/lib/fixarray.s7i       0.038621            307
+seed7/lib/float.s7i          0.041224            757
+seed7/lib/font.s7i           0.042000            196
+seed7/lib/font8x8.s7i        0.040732            998
+seed7/lib/forloop.s7i        0.042932            449
+seed7/lib/ftp.s7i            0.041068            969
+seed7/lib/ftpserv.s7i        0.041466            631
+seed7/lib/getf.s7i           0.042367            115
+seed7/lib/gethttp.s7i        0.036811             41
+seed7/lib/gethttps.s7i       0.036529             41
+seed7/lib/gif.s7i            0.039106            561
+seed7/lib/graph.s7i          0.040358            415
+seed7/lib/graph_file.s7i     0.039451            399
+seed7/lib/gtkserver.s7i      0.037995            161
+seed7/lib/gzip.s7i           0.038691            573
+seed7/lib/hash.s7i           0.040879            421
+seed7/lib/hashsetof.s7i      0.040402            499
+seed7/lib/hmac.s7i           0.038500            152
+seed7/lib/html.s7i           0.036434             83
+seed7/lib/html_ent.s7i       0.037514            476
+seed7/lib/htmldom.s7i        0.037928            286
+seed7/lib/http_request.s7i   0.038158            696
+seed7/lib/http_srv_resp.s7i  0.037852            380
+seed7/lib/https_request.s7i  0.038061            211
+seed7/lib/httpserv.s7i       0.037645            345
+seed7/lib/huffman.s7i        0.038005            644
+seed7/lib/ico.s7i            0.038169            221
+seed7/lib/idxarray.s7i       0.037622            232
+seed7/lib/image.s7i          0.037035            156
+seed7/lib/imagefile.s7i      0.039175            171
+seed7/lib/inflate.s7i        0.039516            411
+seed7/lib/inifile.s7i        0.039255            129
+seed7/lib/integer.s7i        0.038855            663
+seed7/lib/iobuffer.s7i       0.039272            289
+seed7/lib/jpeg.s7i           0.039403           1761
+seed7/lib/json.s7i           0.038547            891
+seed7/lib/json_serde.s7i     0.039833            783
+seed7/lib/keybd.s7i          0.038783            639
+seed7/lib/keydescr.s7i       0.040919            192
+seed7/lib/leb128.s7i         0.039285            218
+seed7/lib/line.s7i           0.039036            164
+seed7/lib/listener.s7i       0.038800            247
+seed7/lib/logfile.s7i        0.037635             73
+seed7/lib/lower.s7i          0.038526            142
+seed7/lib/lzma.s7i           0.039571            934
+seed7/lib/lzw.s7i            0.040416            861
+seed7/lib/magic.s7i          0.039949            403
+seed7/lib/mahjng32.s7i       0.038224           1500
+seed7/lib/make.s7i           0.039458            544
+seed7/lib/makedata.s7i       0.039040           1428
+seed7/lib/math.s7i           0.037971            201
+seed7/lib/mixarith.s7i       0.038983            249
+seed7/lib/modern27.s7i       0.040977           1099
+seed7/lib/more.s7i           0.038088            130
+seed7/lib/msgdigest.s7i      0.038775           1222
+seed7/lib/multiscr.s7i       0.038777             68
+seed7/lib/null_file.s7i      0.037415            345
+seed7/lib/osfiles.s7i        0.040779           1085
+seed7/lib/pbm.s7i            0.039486            230
+seed7/lib/pcx.s7i            0.039329            638
+seed7/lib/pem.s7i            0.038882            185
+seed7/lib/pgm.s7i            0.039075            238
+seed7/lib/pic16.s7i          0.038259           1037
+seed7/lib/pic32.s7i          0.038688           2060
+seed7/lib/pic_util.s7i       0.042969            144
+seed7/lib/pixelimage.s7i     0.039271            320
+seed7/lib/pixmap_file.s7i    0.039333            459
+seed7/lib/pixmapfont.s7i     0.040544            184
+seed7/lib/pkcs1.s7i          0.044211            543
+seed7/lib/png.s7i            0.039666           1064
+seed7/lib/poll.s7i           0.037556            313
+seed7/lib/ppm.s7i            0.037641            240
+seed7/lib/process.s7i        0.037746            541
+seed7/lib/progs.s7i          0.042219            789
+seed7/lib/propertyfile.s7i   0.046481            155
+seed7/lib/rational.s7i       0.044054            792
+seed7/lib/ref_list.s7i       0.038339            252
+seed7/lib/reference.s7i      0.037620            126
+seed7/lib/reverse.s7i        0.037369             94
+seed7/lib/rpm.s7i            0.040192           3487
+seed7/lib/rpmext.s7i         0.039691            318
+seed7/lib/scanfile.s7i       0.040045           1779
+seed7/lib/scanjson.s7i       0.039692            413
+seed7/lib/scanstri.s7i       0.039536           1814
+seed7/lib/scantoml.s7i       0.039744           1603
+seed7/lib/seed7_05.s7i       0.041376           1072
+seed7/lib/set.s7i            0.037091             57
+seed7/lib/shell.s7i          0.039821            615
+seed7/lib/showtls.s7i        0.039873            678
+seed7/lib/signature.s7i      0.039255            131
+seed7/lib/smtp.s7i           0.039562            261
+seed7/lib/sockbase.s7i       0.040558            217
+seed7/lib/socket.s7i         0.038940            326
+seed7/lib/sokoban1.s7i       0.038967           1519
+seed7/lib/sql_base.s7i       0.039090           1000
+seed7/lib/stars.s7i          0.041128           1705
+seed7/lib/stdfont10.s7i      0.037945           3347
+seed7/lib/stdfont12.s7i      0.038520           3928
+seed7/lib/stdfont14.s7i      0.039062           4510
+seed7/lib/stdfont16.s7i      0.039016           5092
+seed7/lib/stdfont18.s7i      0.037998           5868
+seed7/lib/stdfont20.s7i      0.037788           6449
+seed7/lib/stdfont24.s7i      0.037847           7421
+seed7/lib/stdfont8.s7i       0.036370           2960
+seed7/lib/stdfont9.s7i       0.036301           3152
+seed7/lib/stdio.s7i          0.040825            192
+seed7/lib/strifile.s7i       0.039394            345
+seed7/lib/string.s7i         0.038633            779
+seed7/lib/stritext.s7i       0.039345            352
+seed7/lib/struct.s7i         0.040877            266
+seed7/lib/struct_elem.s7i    0.038657            129
+seed7/lib/subfile.s7i        0.041180            174
+seed7/lib/subrange.s7i       0.037691             78
+seed7/lib/syntax.s7i         0.038129            294
+seed7/lib/tar.s7i            0.038551           1880
+seed7/lib/tar_cmds.s7i       0.038190            752
+seed7/lib/tdes.s7i           0.038142            143
+seed7/lib/tee.s7i            0.037396            143
+seed7/lib/text.s7i           0.037667            135
+seed7/lib/tga.s7i            0.040040            676
+seed7/lib/tiff.s7i           0.041033           2771
+seed7/lib/time.s7i           0.039034           1191
+seed7/lib/tls.s7i            0.039721           2230
+seed7/lib/unicode.s7i        0.040915            575
+seed7/lib/unionfnd.s7i       0.039152            130
+seed7/lib/upper.s7i          0.038437            142
+seed7/lib/utf16.s7i          0.038692            540
+seed7/lib/utf8.s7i           0.039406            234
+seed7/lib/vecfont10.s7i      0.040887           1056
+seed7/lib/vecfont18.s7i      0.041327           1119
+seed7/lib/vector3d.s7i       0.037913            293
+seed7/lib/vectorfont.s7i     0.038325            239
+seed7/lib/wildcard.s7i       0.038690            140
+seed7/lib/window.s7i         0.039675            455
+seed7/lib/wrinum.s7i         0.039683            248
+seed7/lib/x509cert.s7i       0.039366           1243
+seed7/lib/xml_ent.s7i        0.038956             94
+seed7/lib/xmldom.s7i         0.039227            303
+seed7/lib/xz.s7i             0.038900            442
+seed7/lib/zip.s7i            0.041177           2792
+seed7/lib/zstd.s7i           0.042343           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039160        |
++-----------+-----------------+
+| Minimum   | 0.034891        |
++-----------+-----------------+
+| Maximum   | 0.047221        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.042107            190
+seed7/prg/bas7.sd7           0.337305          11459
+seed7/prg/bifurk.sd7         0.037477             73
+seed7/prg/bigfiles.sd7       0.039613            129
+seed7/prg/brainf7.sd7        0.039934             86
+seed7/prg/calc7.sd7          0.043078            128
+seed7/prg/carddemo.sd7       0.043301            190
+seed7/prg/castle.sd7         0.112137           3148
+seed7/prg/cat.sd7            0.040278             82
+seed7/prg/cellauto.sd7       0.037850             85
+seed7/prg/celsius.sd7        0.037244             42
+seed7/prg/chk_all.sd7        0.061746            843
+seed7/prg/chkarr.sd7         0.367438           8367
+seed7/prg/chkbig.sd7         2.121646          29026
+seed7/prg/chkbin.sd7         0.526988           6469
+seed7/prg/chkbitdata.sd7     0.635044           6624
+seed7/prg/chkbool.sd7        0.118871           3157
+seed7/prg/chkbst.sd7         0.066597            722
+seed7/prg/chkchr.sd7         0.224355           2809
+seed7/prg/chkcmd.sd7         0.068837           1205
+seed7/prg/chkdb.sd7          0.364570           7454
+seed7/prg/chkdecl.sd7        0.061961            448
+seed7/prg/chkenum.sd7        0.071185           1230
+seed7/prg/chkerr.sd7         0.201218           4663
+seed7/prg/chkexc.sd7         0.084504           2627
+seed7/prg/chkfil.sd7         0.076830           1615
+seed7/prg/chkflt.sd7         1.381755          20620
+seed7/prg/chkhent.sd7        0.038649             54
+seed7/prg/chkhsh.sd7         0.256840           4548
+seed7/prg/chkidx.sd7         1.362855          19567
+seed7/prg/chkint.sd7         2.600730          38129
+seed7/prg/chkjson.sd7        0.105256           1764
+seed7/prg/chkovf.sd7         0.579615           8216
+seed7/prg/chkprc.sd7         0.332545          10111
+seed7/prg/chkscan.sd7        0.059807            714
+seed7/prg/chkset.sd7         0.681373          11974
+seed7/prg/chkstr.sd7         1.424580          26952
+seed7/prg/chktime.sd7        0.136461           2025
+seed7/prg/chktoml.sd7        0.112392           1656
+seed7/prg/clock.sd7          0.038220             47
+seed7/prg/clock2.sd7         0.037015             43
+seed7/prg/clock3.sd7         0.039885             95
+seed7/prg/cmpfil.sd7         0.038250             84
+seed7/prg/comanche.sd7       0.041461            180
+seed7/prg/confval.sd7        0.045484            175
+seed7/prg/db7.sd7            0.049884            417
+seed7/prg/diff7.sd7          0.045433            263
+seed7/prg/dirtst.sd7         0.037719             42
+seed7/prg/dirx.sd7           0.039441            152
+seed7/prg/dnafight.sd7       0.068986           1381
+seed7/prg/dragon.sd7         0.038703             73
+seed7/prg/echo.sd7           0.045457             39
+seed7/prg/eliza.sd7          0.045265            302
+seed7/prg/err.sd7            0.042845             96
+seed7/prg/fannkuch.sd7       0.046122            131
+seed7/prg/fib.sd7            0.042892             47
+seed7/prg/find7.sd7          0.042906            133
+seed7/prg/findchar.sd7       0.042580            149
+seed7/prg/fractree.sd7       0.039531             55
+seed7/prg/ftp7.sd7           0.045596            296
+seed7/prg/ftpserv.sd7        0.038887             74
+seed7/prg/gcd.sd7            0.039306            109
+seed7/prg/gkbd.sd7           0.047385            358
+seed7/prg/gtksvtst.sd7       0.037702             94
+seed7/prg/hal.sd7            0.041105            250
+seed7/prg/hamu.sd7           0.050948            573
+seed7/prg/hanoi.sd7          0.036727             55
+seed7/prg/hd.sd7             0.036924             79
+seed7/prg/hello.sd7          0.036558             32
+seed7/prg/hilbert.sd7        0.040839            108
+seed7/prg/ide7.sd7           0.041827            196
+seed7/prg/kbd.sd7            0.036391             49
+seed7/prg/klondike.sd7       0.058049            883
+seed7/prg/lander.sd7         0.076088           1551
+seed7/prg/lst80bas.sd7       0.049467            344
+seed7/prg/lst99bas.sd7       0.051655            401
+seed7/prg/lstgwbas.sd7       0.054382            577
+seed7/prg/mahjong.sd7        0.083353           1943
+seed7/prg/make7.sd7          0.040479            121
+seed7/prg/mandelbr.sd7       0.043109            237
+seed7/prg/mind.sd7           0.045769            443
+seed7/prg/mirror.sd7         0.039137            131
+seed7/prg/ms.sd7             0.049563            641
+seed7/prg/nicoma.sd7         0.040341            135
+seed7/prg/pac.sd7            0.051472            726
+seed7/prg/pairs.sd7          0.086706           2025
+seed7/prg/panic.sd7          0.100956           2634
+seed7/prg/percolation.sd7    0.044336            330
+seed7/prg/planets.sd7        0.077929           1486
+seed7/prg/portfwd7.sd7       0.040271            139
+seed7/prg/prime.sd7          0.038652             74
+seed7/prg/printpi1.sd7       0.041167             56
+seed7/prg/printpi2.sd7       0.038167             54
+seed7/prg/printpi3.sd7       0.038738             60
+seed7/prg/pv7.sd7            0.046039            337
+seed7/prg/queen.sd7          0.039249            149
+seed7/prg/rand.sd7           0.041145            121
+seed7/prg/raytrace.sd7       0.054400            538
+seed7/prg/rever.sd7          0.056264            816
+seed7/prg/roman.sd7          0.036006             38
+seed7/prg/s7c.sd7            0.290187           9060
+seed7/prg/s7check.sd7        0.040803             68
+seed7/prg/savehd7.sd7        0.071854           1110
+seed7/prg/self.sd7           0.041042             49
+seed7/prg/shisen.sd7         0.076099           1423
+seed7/prg/sl.sd7             0.061756           1029
+seed7/prg/snake.sd7          0.049010            615
+seed7/prg/sokoban.sd7        0.057467            891
+seed7/prg/spigotpi.sd7       0.038798             64
+seed7/prg/sql7.sd7           0.043454            278
+seed7/prg/startrek.sd7       0.061857            979
+seed7/prg/sudoku7.sd7        0.106863           2657
+seed7/prg/sydir7.sd7         0.048084            384
+seed7/prg/syntaxhl.sd7       0.043091            177
+seed7/prg/tak.sd7            0.037766             59
+seed7/prg/tar7.sd7           0.040960            121
+seed7/prg/tch.sd7            0.038657             55
+seed7/prg/testfont.sd7       0.039519             95
+seed7/prg/tet.sd7            0.046719            479
+seed7/prg/tetg.sd7           0.047482            501
+seed7/prg/toutf8.sd7         0.045835            240
+seed7/prg/tst_cli.sd7        0.038063             40
+seed7/prg/tst_srv.sd7        0.038115             47
+seed7/prg/wator.sd7          0.055344            651
+seed7/prg/which.sd7          0.038462             65
+seed7/prg/wiz.sd7            0.109156           2833
+seed7/prg/wordcnt.sd7        0.038183             54
+seed7/prg/wrinum.sd7         0.040078             43
+seed7/prg/wumpus.sd7         0.044070            372
+seed7/lib/aes.s7i            0.115777           1144
+seed7/lib/aes_gcm.s7i        0.048393            392
+seed7/lib/ar.s7i             0.077036           1532
+seed7/lib/arc4.s7i           0.039422            144
+seed7/lib/archive.s7i        0.039455            143
+seed7/lib/archive_base.s7i   0.039369            135
+seed7/lib/array.s7i          0.055276            610
+seed7/lib/asn1.s7i           0.047831            544
+seed7/lib/asn1oid.s7i        0.044394            157
+seed7/lib/basearray.s7i      0.050926            450
+seed7/lib/bigfile.s7i        0.040770            136
+seed7/lib/bigint.s7i         0.058550            824
+seed7/lib/bigrat.s7i         0.056860            784
+seed7/lib/bin16.s7i          0.053521            592
+seed7/lib/bin32.s7i          0.050025            490
+seed7/lib/bin64.s7i          0.052211            539
+seed7/lib/bitdata.s7i        0.078459           1330
+seed7/lib/bitmapfont.s7i     0.043032            215
+seed7/lib/bitset.s7i         0.051126            593
+seed7/lib/bitsetof.s7i       0.050858            431
+seed7/lib/blowfish.s7i       0.060158            383
+seed7/lib/bmp.s7i            0.067956            924
+seed7/lib/boolean.s7i        0.047204            403
+seed7/lib/browser.s7i        0.046167            280
+seed7/lib/bstring.s7i        0.043577            227
+seed7/lib/bytedata.s7i       0.052331            482
+seed7/lib/bzip2.s7i          0.064131            887
+seed7/lib/cards.s7i          0.069412           1342
+seed7/lib/category.s7i       0.044208            209
+seed7/lib/cc_conf.s7i        0.081898           1314
+seed7/lib/ccittfax.s7i       0.068804           1022
+seed7/lib/cgi.s7i            0.040105            109
+seed7/lib/cgidialog.s7i      0.063806           1118
+seed7/lib/char.s7i           0.043565            356
+seed7/lib/charsets.s7i       0.084054           2024
+seed7/lib/chartype.s7i       0.041667            121
+seed7/lib/cipher.s7i         0.040787            146
+seed7/lib/cli_cmds.s7i       0.070386           1360
+seed7/lib/clib_file.s7i      0.046702            301
+seed7/lib/color.s7i          0.047804            185
+seed7/lib/complex.s7i        0.051133            464
+seed7/lib/compress.s7i       0.041993            150
+seed7/lib/console.s7i        0.042903            188
+seed7/lib/cpio.s7i           0.090406           1708
+seed7/lib/crc32.s7i          0.046784            193
+seed7/lib/cronos16.s7i       0.095946           1173
+seed7/lib/cronos27.s7i       0.121530           1464
+seed7/lib/csv.s7i            0.042329            201
+seed7/lib/db_prop.s7i        0.065212            991
+seed7/lib/deflate.s7i        0.056963            740
+seed7/lib/des.s7i            0.057947            444
+seed7/lib/dialog.s7i         0.045126            311
+seed7/lib/dir.s7i            0.041475            163
+seed7/lib/draw.s7i           0.062164            854
+seed7/lib/duration.s7i       0.062890           1038
+seed7/lib/echo.s7i           0.038933            132
+seed7/lib/editline.s7i       0.053745            398
+seed7/lib/elf.s7i            0.090344           1560
+seed7/lib/elliptic.s7i       0.056421            649
+seed7/lib/enable_io.s7i      0.045813            312
+seed7/lib/encoding.s7i       0.063534            931
+seed7/lib/enumeration.s7i    0.042771            236
+seed7/lib/environment.s7i    0.039899            175
+seed7/lib/exif.s7i           0.041422            152
+seed7/lib/external_file.s7i  0.056192            340
+seed7/lib/field.s7i          0.046517            268
+seed7/lib/file.s7i           0.046900            372
+seed7/lib/filebits.s7i       0.038066             46
+seed7/lib/filesys.s7i        0.052229            601
+seed7/lib/fileutil.s7i       0.039961            144
+seed7/lib/fixarray.s7i       0.045204            307
+seed7/lib/float.s7i          0.057693            757
+seed7/lib/font.s7i           0.041245            196
+seed7/lib/font8x8.s7i        0.048935            998
+seed7/lib/forloop.s7i        0.047609            449
+seed7/lib/ftp.s7i            0.062514            969
+seed7/lib/ftpserv.s7i        0.055419            631
+seed7/lib/getf.s7i           0.040961            115
+seed7/lib/gethttp.s7i        0.038890             41
+seed7/lib/gethttps.s7i       0.039237             41
+seed7/lib/gif.s7i            0.051550            561
+seed7/lib/graph.s7i          0.050975            415
+seed7/lib/graph_file.s7i     0.046563            399
+seed7/lib/gtkserver.s7i      0.040355            161
+seed7/lib/gzip.s7i           0.050890            573
+seed7/lib/hash.s7i           0.051708            421
+seed7/lib/hashsetof.s7i      0.055994            499
+seed7/lib/hmac.s7i           0.042630            152
+seed7/lib/html.s7i           0.039254             83
+seed7/lib/html_ent.s7i       0.049542            476
+seed7/lib/htmldom.s7i        0.044741            286
+seed7/lib/http_request.s7i   0.053348            696
+seed7/lib/http_srv_resp.s7i  0.048900            380
+seed7/lib/https_request.s7i  0.041894            211
+seed7/lib/httpserv.s7i       0.045561            345
+seed7/lib/huffman.s7i        0.053934            644
+seed7/lib/ico.s7i            0.041877            221
+seed7/lib/idxarray.s7i       0.043096            232
+seed7/lib/image.s7i          0.038220            156
+seed7/lib/imagefile.s7i      0.042260            171
+seed7/lib/inflate.s7i        0.048687            411
+seed7/lib/inifile.s7i        0.038893            129
+seed7/lib/integer.s7i        0.053008            663
+seed7/lib/iobuffer.s7i       0.043796            289
+seed7/lib/jpeg.s7i           0.086568           1761
+seed7/lib/json.s7i           0.058128            891
+seed7/lib/json_serde.s7i     0.054928            783
+seed7/lib/keybd.s7i          0.057522            639
+seed7/lib/keydescr.s7i       0.043000            192
+seed7/lib/leb128.s7i         0.042164            218
+seed7/lib/line.s7i           0.040227            164
+seed7/lib/listener.s7i       0.043568            247
+seed7/lib/logfile.s7i        0.039041             73
+seed7/lib/lower.s7i          0.040656            142
+seed7/lib/lzma.s7i           0.061950            934
+seed7/lib/lzw.s7i            0.061152            861
+seed7/lib/magic.s7i          0.050560            403
+seed7/lib/mahjng32.s7i       0.064632           1500
+seed7/lib/make.s7i           0.050214            544
+seed7/lib/makedata.s7i       0.071471           1428
+seed7/lib/math.s7i           0.042661            201
+seed7/lib/mixarith.s7i       0.046152            249
+seed7/lib/modern27.s7i       0.087732           1099
+seed7/lib/more.s7i           0.040734            130
+seed7/lib/msgdigest.s7i      0.081571           1222
+seed7/lib/multiscr.s7i       0.038765             68
+seed7/lib/null_file.s7i      0.043861            345
+seed7/lib/osfiles.s7i        0.066765           1085
+seed7/lib/pbm.s7i            0.040695            230
+seed7/lib/pcx.s7i            0.052528            638
+seed7/lib/pem.s7i            0.040093            185
+seed7/lib/pgm.s7i            0.041383            238
+seed7/lib/pic16.s7i          0.049184           1037
+seed7/lib/pic32.s7i          0.081685           2060
+seed7/lib/pic_util.s7i       0.040909            144
+seed7/lib/pixelimage.s7i     0.043733            320
+seed7/lib/pixmap_file.s7i    0.051087            459
+seed7/lib/pixmapfont.s7i     0.047652            184
+seed7/lib/pkcs1.s7i          0.061403            543
+seed7/lib/png.s7i            0.068884           1064
+seed7/lib/poll.s7i           0.049507            313
+seed7/lib/ppm.s7i            0.042555            240
+seed7/lib/process.s7i        0.051301            541
+seed7/lib/progs.s7i          0.059029            789
+seed7/lib/propertyfile.s7i   0.042759            155
+seed7/lib/rational.s7i       0.055757            792
+seed7/lib/ref_list.s7i       0.043990            252
+seed7/lib/reference.s7i      0.040116            126
+seed7/lib/reverse.s7i        0.041194             94
+seed7/lib/rpm.s7i            0.149646           3487
+seed7/lib/rpmext.s7i         0.044412            318
+seed7/lib/scanfile.s7i       0.082860           1779
+seed7/lib/scanjson.s7i       0.049011            413
+seed7/lib/scanstri.s7i       0.083127           1814
+seed7/lib/scantoml.s7i       0.073566           1603
+seed7/lib/seed7_05.s7i       0.068823           1072
+seed7/lib/set.s7i            0.036844             57
+seed7/lib/shell.s7i          0.054417            615
+seed7/lib/showtls.s7i        0.056204            678
+seed7/lib/signature.s7i      0.040779            131
+seed7/lib/smtp.s7i           0.042227            261
+seed7/lib/sockbase.s7i       0.044718            217
+seed7/lib/socket.s7i         0.044781            326
+seed7/lib/sokoban1.s7i       0.055799           1519
+seed7/lib/sql_base.s7i       0.066051           1000
+seed7/lib/stars.s7i          0.138834           1705
+seed7/lib/stdfont10.s7i      0.082366           3347
+seed7/lib/stdfont12.s7i      0.095199           3928
+seed7/lib/stdfont14.s7i      0.108064           4510
+seed7/lib/stdfont16.s7i      0.119461           5092
+seed7/lib/stdfont18.s7i      0.135180           5868
+seed7/lib/stdfont20.s7i      0.153781           6449
+seed7/lib/stdfont24.s7i      0.185455           7421
+seed7/lib/stdfont8.s7i       0.081727           2960
+seed7/lib/stdfont9.s7i       0.080367           3152
+seed7/lib/stdio.s7i          0.044535            192
+seed7/lib/strifile.s7i       0.045317            345
+seed7/lib/string.s7i         0.056264            779
+seed7/lib/stritext.s7i       0.043984            352
+seed7/lib/struct.s7i         0.047774            266
+seed7/lib/struct_elem.s7i    0.040537            129
+seed7/lib/subfile.s7i        0.041152            174
+seed7/lib/subrange.s7i       0.038299             78
+seed7/lib/syntax.s7i         0.048750            294
+seed7/lib/tar.s7i            0.084643           1880
+seed7/lib/tar_cmds.s7i       0.058564            752
+seed7/lib/tdes.s7i           0.040006            143
+seed7/lib/tee.s7i            0.039351            143
+seed7/lib/text.s7i           0.039891            135
+seed7/lib/tga.s7i            0.056888            676
+seed7/lib/tiff.s7i           0.127131           2771
+seed7/lib/time.s7i           0.064826           1191
+seed7/lib/tls.s7i            0.109207           2230
+seed7/lib/unicode.s7i        0.053920            575
+seed7/lib/unionfnd.s7i       0.038751            130
+seed7/lib/upper.s7i          0.040660            142
+seed7/lib/utf16.s7i          0.051393            540
+seed7/lib/utf8.s7i           0.044172            234
+seed7/lib/vecfont10.s7i      0.086555           1056
+seed7/lib/vecfont18.s7i      0.093141           1119
+seed7/lib/vector3d.s7i       0.041113            293
+seed7/lib/vectorfont.s7i     0.042729            239
+seed7/lib/wildcard.s7i       0.038934            140
+seed7/lib/window.s7i         0.046069            455
+seed7/lib/wrinum.s7i         0.042319            248
+seed7/lib/x509cert.s7i       0.074910           1243
+seed7/lib/xml_ent.s7i        0.038787             94
+seed7/lib/xmldom.s7i         0.044440            303
+seed7/lib/xz.s7i             0.050480            442
+seed7/lib/zip.s7i            0.123723           2792
+seed7/lib/zstd.s7i           0.071956           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.092942        |
++-----------+-----------------+
+| Minimum   | 0.036006        |
++-----------+-----------------+
+| Maximum   | 2.600730        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.047384            190
+seed7/prg/bas7.sd7           0.796590          11459
+seed7/prg/bifurk.sd7         0.042697             73
+seed7/prg/bigfiles.sd7       0.044803            129
+seed7/prg/brainf7.sd7        0.042425             86
+seed7/prg/calc7.sd7          0.044494            128
+seed7/prg/carddemo.sd7       0.048895            190
+seed7/prg/castle.sd7         0.229441           3148
+seed7/prg/cat.sd7            0.043265             82
+seed7/prg/cellauto.sd7       0.039956             85
+seed7/prg/celsius.sd7        0.037882             42
+seed7/prg/chk_all.sd7        0.084913            843
+seed7/prg/chkarr.sd7         0.894452           8367
+seed7/prg/chkbig.sd7         4.277617          29026
+seed7/prg/chkbin.sd7         1.062097           6469
+seed7/prg/chkbitdata.sd7     1.291751           6624
+seed7/prg/chkbool.sd7        0.243501           3157
+seed7/prg/chkbst.sd7         0.108879            722
+seed7/prg/chkchr.sd7         0.494711           2809
+seed7/prg/chkcmd.sd7         0.119050           1205
+seed7/prg/chkdb.sd7          0.780321           7454
+seed7/prg/chkdecl.sd7        0.102108            448
+seed7/prg/chkenum.sd7        0.126132           1230
+seed7/prg/chkerr.sd7         0.352665           4663
+seed7/prg/chkexc.sd7         0.156637           2627
+seed7/prg/chkfil.sd7         0.133094           1615
+seed7/prg/chkflt.sd7         2.907869          20620
+seed7/prg/chkhent.sd7        0.042157             54
+seed7/prg/chkhsh.sd7         0.516126           4548
+seed7/prg/chkidx.sd7         3.270432          19567
+seed7/prg/chkint.sd7         5.720472          38129
+seed7/prg/chkjson.sd7        0.195194           1764
+seed7/prg/chkovf.sd7         1.242950           8216
+seed7/prg/chkprc.sd7         0.722070          10111
+seed7/prg/chkscan.sd7        0.095986            714
+seed7/prg/chkset.sd7         1.799990          11974
+seed7/prg/chkstr.sd7         3.522019          26952
+seed7/prg/chktime.sd7        0.253122           2025
+seed7/prg/chktoml.sd7        0.203574           1656
+seed7/prg/clock.sd7          0.039328             47
+seed7/prg/clock2.sd7         0.038066             43
+seed7/prg/clock3.sd7         0.043745             95
+seed7/prg/cmpfil.sd7         0.040120             84
+seed7/prg/comanche.sd7       0.048333            180
+seed7/prg/confval.sd7        0.052586            175
+seed7/prg/db7.sd7            0.065949            417
+seed7/prg/diff7.sd7          0.054449            263
+seed7/prg/dirtst.sd7         0.038240             42
+seed7/prg/dirx.sd7           0.044070            152
+seed7/prg/dnafight.sd7       0.121559           1381
+seed7/prg/dragon.sd7         0.039818             73
+seed7/prg/echo.sd7           0.037055             39
+seed7/prg/eliza.sd7          0.054237            302
+seed7/prg/err.sd7            0.044916             96
+seed7/prg/fannkuch.sd7       0.043466            131
+seed7/prg/fib.sd7            0.038003             47
+seed7/prg/find7.sd7          0.043893            133
+seed7/prg/findchar.sd7       0.045779            149
+seed7/prg/fractree.sd7       0.038981             55
+seed7/prg/ftp7.sd7           0.055369            296
+seed7/prg/ftpserv.sd7        0.039384             74
+seed7/prg/gcd.sd7            0.040381            109
+seed7/prg/gkbd.sd7           0.062575            358
+seed7/prg/gtksvtst.sd7       0.038997             94
+seed7/prg/hal.sd7            0.049004            250
+seed7/prg/hamu.sd7           0.067705            573
+seed7/prg/hanoi.sd7          0.037551             55
+seed7/prg/hd.sd7             0.038730             79
+seed7/prg/hello.sd7          0.037817             32
+seed7/prg/hilbert.sd7        0.042281            108
+seed7/prg/ide7.sd7           0.049769            196
+seed7/prg/kbd.sd7            0.038134             49
+seed7/prg/klondike.sd7       0.089832            883
+seed7/prg/lander.sd7         0.135333           1551
+seed7/prg/lst80bas.sd7       0.058780            344
+seed7/prg/lst99bas.sd7       0.062465            401
+seed7/prg/lstgwbas.sd7       0.074995            577
+seed7/prg/mahjong.sd7        0.152862           1943
+seed7/prg/make7.sd7          0.045975            121
+seed7/prg/mandelbr.sd7       0.051819            237
+seed7/prg/mind.sd7           0.061055            443
+seed7/prg/mirror.sd7         0.046073            131
+seed7/prg/ms.sd7             0.073045            641
+seed7/prg/nicoma.sd7         0.044300            135
+seed7/prg/pac.sd7            0.074300            726
+seed7/prg/pairs.sd7          0.143398           2025
+seed7/prg/panic.sd7          0.197501           2634
+seed7/prg/percolation.sd7    0.057672            330
+seed7/prg/planets.sd7        0.140127           1486
+seed7/prg/portfwd7.sd7       0.047610            139
+seed7/prg/prime.sd7          0.039609             74
+seed7/prg/printpi1.sd7       0.039066             56
+seed7/prg/printpi2.sd7       0.039576             54
+seed7/prg/printpi3.sd7       0.039822             60
+seed7/prg/pv7.sd7            0.061191            337
+seed7/prg/queen.sd7          0.044142            149
+seed7/prg/rand.sd7           0.043058            121
+seed7/prg/raytrace.sd7       0.070790            538
+seed7/prg/rever.sd7          0.084114            816
+seed7/prg/roman.sd7          0.038372             38
+seed7/prg/s7c.sd7            0.644513           9060
+seed7/prg/s7check.sd7        0.040473             68
+seed7/prg/savehd7.sd7        0.114481           1110
+seed7/prg/self.sd7           0.037877             49
+seed7/prg/shisen.sd7         0.122925           1423
+seed7/prg/sl.sd7             0.099039           1029
+seed7/prg/snake.sd7          0.068468            615
+seed7/prg/sokoban.sd7        0.083735            891
+seed7/prg/spigotpi.sd7       0.038978             64
+seed7/prg/sql7.sd7           0.052182            278
+seed7/prg/startrek.sd7       0.096463            979
+seed7/prg/sudoku7.sd7        0.202970           2657
+seed7/prg/sydir7.sd7         0.064911            384
+seed7/prg/syntaxhl.sd7       0.050209            177
+seed7/prg/tak.sd7            0.039914             59
+seed7/prg/tar7.sd7           0.047389            121
+seed7/prg/tch.sd7            0.039179             55
+seed7/prg/testfont.sd7       0.043443             95
+seed7/prg/tet.sd7            0.062317            479
+seed7/prg/tetg.sd7           0.063873            501
+seed7/prg/toutf8.sd7         0.053396            240
+seed7/prg/tst_cli.sd7        0.038361             40
+seed7/prg/tst_srv.sd7        0.039088             47
+seed7/prg/wator.sd7          0.081367            651
+seed7/prg/which.sd7          0.046718             65
+seed7/prg/wiz.sd7            0.219166           2833
+seed7/prg/wordcnt.sd7        0.040087             54
+seed7/prg/wrinum.sd7         0.036925             43
+seed7/prg/wumpus.sd7         0.055149            372
+seed7/lib/aes.s7i            0.201910           1144
+seed7/lib/aes_gcm.s7i        0.063944            392
+seed7/lib/ar.s7i             0.128196           1532
+seed7/lib/arc4.s7i           0.045955            144
+seed7/lib/archive.s7i        0.046895            143
+seed7/lib/archive_base.s7i   0.045777            135
+seed7/lib/array.s7i          0.077926            610
+seed7/lib/asn1.s7i           0.065332            544
+seed7/lib/asn1oid.s7i        0.051499            157
+seed7/lib/basearray.s7i      0.066871            450
+seed7/lib/bigfile.s7i        0.042248            136
+seed7/lib/bigint.s7i         0.082193            824
+seed7/lib/bigrat.s7i         0.082390            784
+seed7/lib/bin16.s7i          0.070151            592
+seed7/lib/bin32.s7i          0.064714            490
+seed7/lib/bin64.s7i          0.065525            539
+seed7/lib/bitdata.s7i        0.127370           1330
+seed7/lib/bitmapfont.s7i     0.049110            215
+seed7/lib/bitset.s7i         0.065582            593
+seed7/lib/bitsetof.s7i       0.062314            431
+seed7/lib/blowfish.s7i       0.080480            383
+seed7/lib/bmp.s7i            0.101958            924
+seed7/lib/boolean.s7i        0.057434            403
+seed7/lib/browser.s7i        0.054713            280
+seed7/lib/bstring.s7i        0.047485            227
+seed7/lib/bytedata.s7i       0.068130            482
+seed7/lib/bzip2.s7i          0.093981            887
+seed7/lib/cards.s7i          0.106182           1342
+seed7/lib/category.s7i       0.050400            209
+seed7/lib/cc_conf.s7i        0.124448           1314
+seed7/lib/ccittfax.s7i       0.104466           1022
+seed7/lib/cgi.s7i            0.042991            109
+seed7/lib/cgidialog.s7i      0.101913           1118
+seed7/lib/char.s7i           0.053395            356
+seed7/lib/charsets.s7i       0.128978           2024
+seed7/lib/chartype.s7i       0.049228            121
+seed7/lib/cipher.s7i         0.043405            146
+seed7/lib/cli_cmds.s7i       0.116153           1360
+seed7/lib/clib_file.s7i      0.053554            301
+seed7/lib/color.s7i          0.049596            185
+seed7/lib/complex.s7i        0.061563            464
+seed7/lib/compress.s7i       0.044890            150
+seed7/lib/console.s7i        0.046547            188
+seed7/lib/cpio.s7i           0.149703           1708
+seed7/lib/crc32.s7i          0.056767            193
+seed7/lib/cronos16.s7i       0.202914           1173
+seed7/lib/cronos27.s7i       0.264287           1464
+seed7/lib/csv.s7i            0.049168            201
+seed7/lib/db_prop.s7i        0.103521            991
+seed7/lib/deflate.s7i        0.089539            740
+seed7/lib/des.s7i            0.084163            444
+seed7/lib/dialog.s7i         0.060488            311
+seed7/lib/dir.s7i            0.045111            163
+seed7/lib/draw.s7i           0.089288            854
+seed7/lib/duration.s7i       0.101575           1038
+seed7/lib/echo.s7i           0.044260            132
+seed7/lib/editline.s7i       0.062332            398
+seed7/lib/elf.s7i            0.161355           1560
+seed7/lib/elliptic.s7i       0.079047            649
+seed7/lib/enable_io.s7i      0.054397            312
+seed7/lib/encoding.s7i       0.099861            931
+seed7/lib/enumeration.s7i    0.051123            236
+seed7/lib/environment.s7i    0.044016            175
+seed7/lib/exif.s7i           0.048782            152
+seed7/lib/external_file.s7i  0.054934            340
+seed7/lib/field.s7i          0.053245            268
+seed7/lib/file.s7i           0.055673            372
+seed7/lib/filebits.s7i       0.038834             46
+seed7/lib/filesys.s7i        0.065886            601
+seed7/lib/fileutil.s7i       0.045028            144
+seed7/lib/fixarray.s7i       0.058232            307
+seed7/lib/float.s7i          0.074921            757
+seed7/lib/font.s7i           0.046019            196
+seed7/lib/font8x8.s7i        0.068119            998
+seed7/lib/forloop.s7i        0.061251            449
+seed7/lib/ftp.s7i            0.089882            969
+seed7/lib/ftpserv.s7i        0.078577            631
+seed7/lib/getf.s7i           0.041467            115
+seed7/lib/gethttp.s7i        0.037671             41
+seed7/lib/gethttps.s7i       0.037631             41
+seed7/lib/gif.s7i            0.072893            561
+seed7/lib/graph.s7i          0.066570            415
+seed7/lib/graph_file.s7i     0.060418            399
+seed7/lib/gtkserver.s7i      0.043873            161
+seed7/lib/gzip.s7i           0.070560            573
+seed7/lib/hash.s7i           0.068610            421
+seed7/lib/hashsetof.s7i      0.069373            499
+seed7/lib/hmac.s7i           0.046285            152
+seed7/lib/html.s7i           0.040478             83
+seed7/lib/html_ent.s7i       0.066238            476
+seed7/lib/htmldom.s7i        0.055076            286
+seed7/lib/http_request.s7i   0.085550            696
+seed7/lib/http_srv_resp.s7i  0.061887            380
+seed7/lib/https_request.s7i  0.050227            211
+seed7/lib/httpserv.s7i       0.060986            345
+seed7/lib/huffman.s7i        0.079591            644
+seed7/lib/ico.s7i            0.050389            221
+seed7/lib/idxarray.s7i       0.051086            232
+seed7/lib/image.s7i          0.042269            156
+seed7/lib/imagefile.s7i      0.046633            171
+seed7/lib/inflate.s7i        0.064989            411
+seed7/lib/inifile.s7i        0.044328            129
+seed7/lib/integer.s7i        0.070312            663
+seed7/lib/iobuffer.s7i       0.054207            289
+seed7/lib/jpeg.s7i           0.159837           1761
+seed7/lib/json.s7i           0.082533            891
+seed7/lib/json_serde.s7i     0.079889            783
+seed7/lib/keybd.s7i          0.083432            639
+seed7/lib/keydescr.s7i       0.055795            192
+seed7/lib/leb128.s7i         0.048466            218
+seed7/lib/line.s7i           0.046439            164
+seed7/lib/listener.s7i       0.051053            247
+seed7/lib/logfile.s7i        0.038884             73
+seed7/lib/lower.s7i          0.042496            142
+seed7/lib/lzma.s7i           0.098408            934
+seed7/lib/lzw.s7i            0.091755            861
+seed7/lib/magic.s7i          0.065992            403
+seed7/lib/mahjng32.s7i       0.095771           1500
+seed7/lib/make.s7i           0.071593            544
+seed7/lib/makedata.s7i       0.124620           1428
+seed7/lib/math.s7i           0.045644            201
+seed7/lib/mixarith.s7i       0.047678            249
+seed7/lib/modern27.s7i       0.174938           1099
+seed7/lib/more.s7i           0.044125            130
+seed7/lib/msgdigest.s7i      0.141369           1222
+seed7/lib/multiscr.s7i       0.039121             68
+seed7/lib/null_file.s7i      0.052279            345
+seed7/lib/osfiles.s7i        0.098590           1085
+seed7/lib/pbm.s7i            0.051118            230
+seed7/lib/pcx.s7i            0.081078            638
+seed7/lib/pem.s7i            0.046870            185
+seed7/lib/pgm.s7i            0.050571            238
+seed7/lib/pic16.s7i          0.069060           1037
+seed7/lib/pic32.s7i          0.126389           2060
+seed7/lib/pic_util.s7i       0.049802            144
+seed7/lib/pixelimage.s7i     0.055180            320
+seed7/lib/pixmap_file.s7i    0.065920            459
+seed7/lib/pixmapfont.s7i     0.051806            184
+seed7/lib/pkcs1.s7i          0.083138            543
+seed7/lib/png.s7i            0.111277           1064
+seed7/lib/poll.s7i           0.053242            313
+seed7/lib/ppm.s7i            0.051584            240
+seed7/lib/process.s7i        0.065374            541
+seed7/lib/progs.s7i          0.082294            789
+seed7/lib/propertyfile.s7i   0.045205            155
+seed7/lib/rational.s7i       0.080856            792
+seed7/lib/ref_list.s7i       0.053548            252
+seed7/lib/reference.s7i      0.046053            126
+seed7/lib/reverse.s7i        0.041358             94
+seed7/lib/rpm.s7i            0.301291           3487
+seed7/lib/rpmext.s7i         0.056368            318
+seed7/lib/scanfile.s7i       0.137134           1779
+seed7/lib/scanjson.s7i       0.061902            413
+seed7/lib/scanstri.s7i       0.139927           1814
+seed7/lib/scantoml.s7i       0.139133           1603
+seed7/lib/seed7_05.s7i       0.122097           1072
+seed7/lib/set.s7i            0.039711             57
+seed7/lib/shell.s7i          0.072185            615
+seed7/lib/showtls.s7i        0.087889            678
+seed7/lib/signature.s7i      0.045088            131
+seed7/lib/smtp.s7i           0.049901            261
+seed7/lib/sockbase.s7i       0.052467            217
+seed7/lib/socket.s7i         0.053857            326
+seed7/lib/sokoban1.s7i       0.086545           1519
+seed7/lib/sql_base.s7i       0.096633           1000
+seed7/lib/stars.s7i          0.241627           1705
+seed7/lib/stdfont10.s7i      0.150378           3347
+seed7/lib/stdfont12.s7i      0.172897           3928
+seed7/lib/stdfont14.s7i      0.195128           4510
+seed7/lib/stdfont16.s7i      0.219333           5092
+seed7/lib/stdfont18.s7i      0.254897           5868
+seed7/lib/stdfont20.s7i      0.286859           6449
+seed7/lib/stdfont24.s7i      0.340859           7421
+seed7/lib/stdfont8.s7i       0.130052           2960
+seed7/lib/stdfont9.s7i       0.137665           3152
+seed7/lib/stdio.s7i          0.045456            192
+seed7/lib/strifile.s7i       0.054806            345
+seed7/lib/string.s7i         0.076985            779
+seed7/lib/stritext.s7i       0.057552            352
+seed7/lib/struct.s7i         0.058896            266
+seed7/lib/struct_elem.s7i    0.043592            129
+seed7/lib/subfile.s7i        0.045541            174
+seed7/lib/subrange.s7i       0.041321             78
+seed7/lib/syntax.s7i         0.062222            294
+seed7/lib/tar.s7i            0.149539           1880
+seed7/lib/tar_cmds.s7i       0.085855            752
+seed7/lib/tdes.s7i           0.043680            143
+seed7/lib/tee.s7i            0.041899            143
+seed7/lib/text.s7i           0.043575            135
+seed7/lib/tga.s7i            0.082358            676
+seed7/lib/tiff.s7i           0.252612           2771
+seed7/lib/time.s7i           0.104663           1191
+seed7/lib/tls.s7i            0.205502           2230
+seed7/lib/unicode.s7i        0.079867            575
+seed7/lib/unionfnd.s7i       0.044134            130
+seed7/lib/upper.s7i          0.044194            142
+seed7/lib/utf16.s7i          0.067964            540
+seed7/lib/utf8.s7i           0.049380            234
+seed7/lib/vecfont10.s7i      0.164713           1056
+seed7/lib/vecfont18.s7i      0.184650           1119
+seed7/lib/vector3d.s7i       0.049831            293
+seed7/lib/vectorfont.s7i     0.048995            239
+seed7/lib/wildcard.s7i       0.042511            140
+seed7/lib/window.s7i         0.062021            455
+seed7/lib/wrinum.s7i         0.050678            248
+seed7/lib/x509cert.s7i       0.122351           1243
+seed7/lib/xml_ent.s7i        0.041882             94
+seed7/lib/xmldom.s7i         0.052175            303
+seed7/lib/xz.s7i             0.062330            442
+seed7/lib/zip.s7i            0.241884           2792
+seed7/lib/zstd.s7i           0.122201           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.164089        |
++-----------+-----------------+
+| Minimum   | 0.036925        |
++-----------+-----------------+
+| Maximum   | 5.720472        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033959        | 0.032171        | 0.044017        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039160        | 0.034891        | 0.047221        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.092942        | 0.036006        | 2.600730        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.164089        | 0.036925        | 5.720472        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.873 | 00:00:57.860 | 00:01:10.734 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.852 | 00:01:06.787 | 00:01:21.639 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:37.386 | 00:02:39.277 | 00:03:16.664 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:03.689 | 00:04:40.440 | 00:05:44.129 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:33.175 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-11.3.rst
+++ b/reports/seed7mode-perf-11.3.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-25T15:38:52+0000 W26-4
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 11:43:11 local time
+:Generated on: 2026-06-25 15:54:46 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 183x95 chars
+:Window body: 183x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.033857            190
+seed7/prg/bas7.sd7           0.033562          11459
+seed7/prg/bifurk.sd7         0.032619             73
+seed7/prg/bigfiles.sd7       0.032688            129
+seed7/prg/brainf7.sd7        0.039621             86
+seed7/prg/calc7.sd7          0.037112            128
+seed7/prg/carddemo.sd7       0.034076            190
+seed7/prg/castle.sd7         0.034179           3148
+seed7/prg/cat.sd7            0.033296             82
+seed7/prg/cellauto.sd7       0.033621             85
+seed7/prg/celsius.sd7        0.033239             42
+seed7/prg/chk_all.sd7        0.033519            843
+seed7/prg/chkarr.sd7         0.034050           8367
+seed7/prg/chkbig.sd7         0.038142          29026
+seed7/prg/chkbin.sd7         0.034350           6469
+seed7/prg/chkbitdata.sd7     0.034008           6624
+seed7/prg/chkbool.sd7        0.033487           3157
+seed7/prg/chkbst.sd7         0.033589            722
+seed7/prg/chkchr.sd7         0.034005           2809
+seed7/prg/chkcmd.sd7         0.033445           1205
+seed7/prg/chkdb.sd7          0.034435           7454
+seed7/prg/chkdecl.sd7        0.033453            448
+seed7/prg/chkenum.sd7        0.033337           1230
+seed7/prg/chkerr.sd7         0.033887           4663
+seed7/prg/chkexc.sd7         0.033614           2627
+seed7/prg/chkfil.sd7         0.033353           1615
+seed7/prg/chkflt.sd7         0.036446          20620
+seed7/prg/chkhent.sd7        0.033130             54
+seed7/prg/chkhsh.sd7         0.033864           4548
+seed7/prg/chkidx.sd7         0.036386          19567
+seed7/prg/chkint.sd7         0.039901          38129
+seed7/prg/chkjson.sd7        0.033431           1764
+seed7/prg/chkovf.sd7         0.033402           8216
+seed7/prg/chkprc.sd7         0.033019          10111
+seed7/prg/chkscan.sd7        0.032782            714
+seed7/prg/chkset.sd7         0.033567          11974
+seed7/prg/chkstr.sd7         0.036648          26952
+seed7/prg/chktime.sd7        0.033390           2025
+seed7/prg/chktoml.sd7        0.034554           1656
+seed7/prg/clock.sd7          0.033468             47
+seed7/prg/clock2.sd7         0.033902             43
+seed7/prg/clock3.sd7         0.033622             95
+seed7/prg/cmpfil.sd7         0.034037             84
+seed7/prg/comanche.sd7       0.033403            180
+seed7/prg/confval.sd7        0.033498            175
+seed7/prg/db7.sd7            0.033199            417
+seed7/prg/diff7.sd7          0.032456            263
+seed7/prg/dirtst.sd7         0.032516             42
+seed7/prg/dirx.sd7           0.032571            152
+seed7/prg/dnafight.sd7       0.032777           1381
+seed7/prg/dragon.sd7         0.032665             73
+seed7/prg/echo.sd7           0.033532             39
+seed7/prg/eliza.sd7          0.032512            302
+seed7/prg/err.sd7            0.032941             96
+seed7/prg/fannkuch.sd7       0.032832            131
+seed7/prg/fib.sd7            0.033691             47
+seed7/prg/find7.sd7          0.033254            133
+seed7/prg/findchar.sd7       0.038559            149
+seed7/prg/fractree.sd7       0.039916             55
+seed7/prg/ftp7.sd7           0.036396            296
+seed7/prg/ftpserv.sd7        0.034031             74
+seed7/prg/gcd.sd7            0.033837            109
+seed7/prg/gkbd.sd7           0.033837            358
+seed7/prg/gtksvtst.sd7       0.032983             94
+seed7/prg/hal.sd7            0.032510            250
+seed7/prg/hamu.sd7           0.033532            573
+seed7/prg/hanoi.sd7          0.037831             55
+seed7/prg/hd.sd7             0.037068             79
+seed7/prg/hello.sd7          0.034692             32
+seed7/prg/hilbert.sd7        0.036216            108
+seed7/prg/ide7.sd7           0.034123            196
+seed7/prg/kbd.sd7            0.033466             49
+seed7/prg/klondike.sd7       0.033410            883
+seed7/prg/lander.sd7         0.033432           1551
+seed7/prg/lst80bas.sd7       0.033304            344
+seed7/prg/lst99bas.sd7       0.033493            401
+seed7/prg/lstgwbas.sd7       0.033801            577
+seed7/prg/mahjong.sd7        0.033507           1943
+seed7/prg/make7.sd7          0.033799            121
+seed7/prg/mandelbr.sd7       0.033144            237
+seed7/prg/mind.sd7           0.033201            443
+seed7/prg/mirror.sd7         0.033564            131
+seed7/prg/ms.sd7             0.033352            641
+seed7/prg/nicoma.sd7         0.033218            135
+seed7/prg/pac.sd7            0.033363            726
+seed7/prg/pairs.sd7          0.033438           2025
+seed7/prg/panic.sd7          0.033142           2634
+seed7/prg/percolation.sd7    0.033449            330
+seed7/prg/planets.sd7        0.033559           1486
+seed7/prg/portfwd7.sd7       0.033101            139
+seed7/prg/prime.sd7          0.032967             74
+seed7/prg/printpi1.sd7       0.033360             56
+seed7/prg/printpi2.sd7       0.033053             54
+seed7/prg/printpi3.sd7       0.033377             60
+seed7/prg/pv7.sd7            0.033114            337
+seed7/prg/queen.sd7          0.032402            149
+seed7/prg/rand.sd7           0.032594            121
+seed7/prg/raytrace.sd7       0.032828            538
+seed7/prg/rever.sd7          0.032342            816
+seed7/prg/roman.sd7          0.033422             38
+seed7/prg/s7c.sd7            0.034070           9060
+seed7/prg/s7check.sd7        0.033496             68
+seed7/prg/savehd7.sd7        0.033551           1110
+seed7/prg/self.sd7           0.033350             49
+seed7/prg/shisen.sd7         0.033273           1423
+seed7/prg/sl.sd7             0.037693           1029
+seed7/prg/snake.sd7          0.037962            615
+seed7/prg/sokoban.sd7        0.032528            891
+seed7/prg/spigotpi.sd7       0.032289             64
+seed7/prg/sql7.sd7           0.032239            278
+seed7/prg/startrek.sd7       0.032414            979
+seed7/prg/sudoku7.sd7        0.033235           2657
+seed7/prg/sydir7.sd7         0.033201            384
+seed7/prg/syntaxhl.sd7       0.032438            177
+seed7/prg/tak.sd7            0.032231             59
+seed7/prg/tar7.sd7           0.031949            121
+seed7/prg/tch.sd7            0.033077             55
+seed7/prg/testfont.sd7       0.033304             95
+seed7/prg/tet.sd7            0.033665            479
+seed7/prg/tetg.sd7           0.033222            501
+seed7/prg/toutf8.sd7         0.033568            240
+seed7/prg/tst_cli.sd7        0.033419             40
+seed7/prg/tst_srv.sd7        0.033226             47
+seed7/prg/wator.sd7          0.034167            651
+seed7/prg/which.sd7          0.033740             65
+seed7/prg/wiz.sd7            0.034789           2833
+seed7/prg/wordcnt.sd7        0.033427             54
+seed7/prg/wrinum.sd7         0.032730             43
+seed7/prg/wumpus.sd7         0.032694            372
+seed7/lib/aes.s7i            0.033113           1144
+seed7/lib/aes_gcm.s7i        0.032874            392
+seed7/lib/ar.s7i             0.033420           1532
+seed7/lib/arc4.s7i           0.033581            144
+seed7/lib/archive.s7i        0.033944            143
+seed7/lib/archive_base.s7i   0.033222            135
+seed7/lib/array.s7i          0.033632            610
+seed7/lib/asn1.s7i           0.033806            544
+seed7/lib/asn1oid.s7i        0.033506            157
+seed7/lib/basearray.s7i      0.033408            450
+seed7/lib/bigfile.s7i        0.033602            136
+seed7/lib/bigint.s7i         0.033456            824
+seed7/lib/bigrat.s7i         0.033551            784
+seed7/lib/bin16.s7i          0.033434            592
+seed7/lib/bin32.s7i          0.033313            490
+seed7/lib/bin64.s7i          0.037957            539
+seed7/lib/bitdata.s7i        0.035902           1330
+seed7/lib/bitmapfont.s7i     0.033689            215
+seed7/lib/bitset.s7i         0.033657            593
+seed7/lib/bitsetof.s7i       0.034052            431
+seed7/lib/blowfish.s7i       0.033465            383
+seed7/lib/bmp.s7i            0.033489            924
+seed7/lib/boolean.s7i        0.033736            403
+seed7/lib/browser.s7i        0.033794            280
+seed7/lib/bstring.s7i        0.033352            227
+seed7/lib/bytedata.s7i       0.033635            482
+seed7/lib/bzip2.s7i          0.033205            887
+seed7/lib/cards.s7i          0.033082           1342
+seed7/lib/category.s7i       0.032737            209
+seed7/lib/cc_conf.s7i        0.033136           1314
+seed7/lib/ccittfax.s7i       0.032596           1022
+seed7/lib/cgi.s7i            0.032902            109
+seed7/lib/cgidialog.s7i      0.033288           1118
+seed7/lib/char.s7i           0.032617            356
+seed7/lib/charsets.s7i       0.032639           2024
+seed7/lib/chartype.s7i       0.034062            121
+seed7/lib/cipher.s7i         0.033061            146
+seed7/lib/cli_cmds.s7i       0.034616           1360
+seed7/lib/clib_file.s7i      0.036398            301
+seed7/lib/color.s7i          0.035840            185
+seed7/lib/complex.s7i        0.035934            464
+seed7/lib/compress.s7i       0.036111            150
+seed7/lib/console.s7i        0.036219            188
+seed7/lib/cpio.s7i           0.035564           1708
+seed7/lib/crc32.s7i          0.034818            193
+seed7/lib/cronos16.s7i       0.033676           1173
+seed7/lib/cronos27.s7i       0.033482           1464
+seed7/lib/csv.s7i            0.033542            201
+seed7/lib/db_prop.s7i        0.033966            991
+seed7/lib/deflate.s7i        0.035534            740
+seed7/lib/des.s7i            0.037060            444
+seed7/lib/dialog.s7i         0.033940            311
+seed7/lib/dir.s7i            0.033844            163
+seed7/lib/draw.s7i           0.033618            854
+seed7/lib/duration.s7i       0.033487           1038
+seed7/lib/echo.s7i           0.033522            132
+seed7/lib/editline.s7i       0.033338            398
+seed7/lib/elf.s7i            0.033608           1560
+seed7/lib/elliptic.s7i       0.033483            649
+seed7/lib/enable_io.s7i      0.033650            312
+seed7/lib/encoding.s7i       0.033148            931
+seed7/lib/enumeration.s7i    0.033359            236
+seed7/lib/environment.s7i    0.032435            175
+seed7/lib/exif.s7i           0.032891            152
+seed7/lib/external_file.s7i  0.032663            340
+seed7/lib/field.s7i          0.032309            268
+seed7/lib/file.s7i           0.033306            372
+seed7/lib/filebits.s7i       0.033302             46
+seed7/lib/filesys.s7i        0.033613            601
+seed7/lib/fileutil.s7i       0.033330            144
+seed7/lib/fixarray.s7i       0.033495            307
+seed7/lib/float.s7i          0.033666            757
+seed7/lib/font.s7i           0.033483            196
+seed7/lib/font8x8.s7i        0.033906            998
+seed7/lib/forloop.s7i        0.033007            449
+seed7/lib/ftp.s7i            0.032443            969
+seed7/lib/ftpserv.s7i        0.032956            631
+seed7/lib/getf.s7i           0.033433            115
+seed7/lib/gethttp.s7i        0.033023             41
+seed7/lib/gethttps.s7i       0.033699             41
+seed7/lib/gif.s7i            0.032728            561
+seed7/lib/graph.s7i          0.032594            415
+seed7/lib/graph_file.s7i     0.033761            399
+seed7/lib/gtkserver.s7i      0.036458            161
+seed7/lib/gzip.s7i           0.032836            573
+seed7/lib/hash.s7i           0.033958            421
+seed7/lib/hashsetof.s7i      0.033992            499
+seed7/lib/hmac.s7i           0.033445            152
+seed7/lib/html.s7i           0.033330             83
+seed7/lib/html_ent.s7i       0.033287            476
+seed7/lib/htmldom.s7i        0.033575            286
+seed7/lib/http_request.s7i   0.033012            696
+seed7/lib/http_srv_resp.s7i  0.033023            380
+seed7/lib/https_request.s7i  0.032576            211
+seed7/lib/httpserv.s7i       0.032570            345
+seed7/lib/huffman.s7i        0.032601            644
+seed7/lib/ico.s7i            0.032647            221
+seed7/lib/idxarray.s7i       0.038184            232
+seed7/lib/image.s7i          0.036895            156
+seed7/lib/imagefile.s7i      0.036718            171
+seed7/lib/inflate.s7i        0.036396            411
+seed7/lib/inifile.s7i        0.033777            129
+seed7/lib/integer.s7i        0.033743            663
+seed7/lib/iobuffer.s7i       0.034828            289
+seed7/lib/jpeg.s7i           0.041438           1761
+seed7/lib/json.s7i           0.036343            891
+seed7/lib/json_serde.s7i     0.033709            783
+seed7/lib/keybd.s7i          0.038597            639
+seed7/lib/keydescr.s7i       0.037274            192
+seed7/lib/leb128.s7i         0.034525            218
+seed7/lib/line.s7i           0.034283            164
+seed7/lib/listener.s7i       0.033995            247
+seed7/lib/logfile.s7i        0.032660             73
+seed7/lib/lower.s7i          0.032842            142
+seed7/lib/lzma.s7i           0.032559            934
+seed7/lib/lzw.s7i            0.032767            861
+seed7/lib/magic.s7i          0.032644            403
+seed7/lib/mahjng32.s7i       0.032508           1500
+seed7/lib/make.s7i           0.033569            544
+seed7/lib/makedata.s7i       0.033156           1428
+seed7/lib/math.s7i           0.033048            201
+seed7/lib/mixarith.s7i       0.032458            249
+seed7/lib/modern27.s7i       0.033361           1099
+seed7/lib/more.s7i           0.033083            130
+seed7/lib/msgdigest.s7i      0.032608           1222
+seed7/lib/multiscr.s7i       0.032620             68
+seed7/lib/null_file.s7i      0.033095            345
+seed7/lib/osfiles.s7i        0.035244           1085
+seed7/lib/pbm.s7i            0.033120            230
+seed7/lib/pcx.s7i            0.032813            638
+seed7/lib/pem.s7i            0.032423            185
+seed7/lib/pgm.s7i            0.033864            238
+seed7/lib/pic16.s7i          0.033505           1037
+seed7/lib/pic32.s7i          0.034430           2060
+seed7/lib/pic_util.s7i       0.034327            144
+seed7/lib/pixelimage.s7i     0.034060            320
+seed7/lib/pixmap_file.s7i    0.033426            459
+seed7/lib/pixmapfont.s7i     0.033895            184
+seed7/lib/pkcs1.s7i          0.034016            543
+seed7/lib/png.s7i            0.033356           1064
+seed7/lib/poll.s7i           0.033347            313
+seed7/lib/ppm.s7i            0.033443            240
+seed7/lib/process.s7i        0.034007            541
+seed7/lib/progs.s7i          0.036564            789
+seed7/lib/propertyfile.s7i   0.035514            155
+seed7/lib/rational.s7i       0.036404            792
+seed7/lib/ref_list.s7i       0.032722            252
+seed7/lib/reference.s7i      0.033897            126
+seed7/lib/reverse.s7i        0.034117             94
+seed7/lib/rpm.s7i            0.033860           3487
+seed7/lib/rpmext.s7i         0.032704            318
+seed7/lib/scanfile.s7i       0.032757           1779
+seed7/lib/scanjson.s7i       0.032795            413
+seed7/lib/scanstri.s7i       0.032575           1814
+seed7/lib/scantoml.s7i       0.032345           1603
+seed7/lib/seed7_05.s7i       0.032308           1072
+seed7/lib/set.s7i            0.033791             57
+seed7/lib/shell.s7i          0.033040            615
+seed7/lib/showtls.s7i        0.033674            678
+seed7/lib/signature.s7i      0.033625            131
+seed7/lib/smtp.s7i           0.037365            261
+seed7/lib/sockbase.s7i       0.034682            217
+seed7/lib/socket.s7i         0.033982            326
+seed7/lib/sokoban1.s7i       0.033620           1519
+seed7/lib/sql_base.s7i       0.033441           1000
+seed7/lib/stars.s7i          0.038702           1705
+seed7/lib/stdfont10.s7i      0.036791           3347
+seed7/lib/stdfont12.s7i      0.034403           3928
+seed7/lib/stdfont14.s7i      0.033826           4510
+seed7/lib/stdfont16.s7i      0.033673           5092
+seed7/lib/stdfont18.s7i      0.032559           5868
+seed7/lib/stdfont20.s7i      0.033673           6449
+seed7/lib/stdfont24.s7i      0.033002           7421
+seed7/lib/stdfont8.s7i       0.032292           2960
+seed7/lib/stdfont9.s7i       0.032346           3152
+seed7/lib/stdio.s7i          0.032212            192
+seed7/lib/strifile.s7i       0.032640            345
+seed7/lib/string.s7i         0.032664            779
+seed7/lib/stritext.s7i       0.032537            352
+seed7/lib/struct.s7i         0.032591            266
+seed7/lib/struct_elem.s7i    0.033195            129
+seed7/lib/subfile.s7i        0.033040            174
+seed7/lib/subrange.s7i       0.032383             78
+seed7/lib/syntax.s7i         0.032599            294
+seed7/lib/tar.s7i            0.032697           1880
+seed7/lib/tar_cmds.s7i       0.032903            752
+seed7/lib/tdes.s7i           0.032409            143
+seed7/lib/tee.s7i            0.032840            143
+seed7/lib/text.s7i           0.034667            135
+seed7/lib/tga.s7i            0.033910            676
+seed7/lib/tiff.s7i           0.033670           2771
+seed7/lib/time.s7i           0.033483           1191
+seed7/lib/tls.s7i            0.033362           2230
+seed7/lib/unicode.s7i        0.033522            575
+seed7/lib/unionfnd.s7i       0.033360            130
+seed7/lib/upper.s7i          0.033622            142
+seed7/lib/utf16.s7i          0.033965            540
+seed7/lib/utf8.s7i           0.033587            234
+seed7/lib/vecfont10.s7i      0.033623           1056
+seed7/lib/vecfont18.s7i      0.033352           1119
+seed7/lib/vector3d.s7i       0.033639            293
+seed7/lib/vectorfont.s7i     0.033459            239
+seed7/lib/wildcard.s7i       0.033559            140
+seed7/lib/window.s7i         0.033498            455
+seed7/lib/wrinum.s7i         0.033361            248
+seed7/lib/x509cert.s7i       0.033573           1243
+seed7/lib/xml_ent.s7i        0.033285             94
+seed7/lib/xmldom.s7i         0.033638            303
+seed7/lib/xz.s7i             0.033627            442
+seed7/lib/zip.s7i            0.033676           2792
+seed7/lib/zstd.s7i           0.034137           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033800        |
++-----------+-----------------+
+| Minimum   | 0.031949        |
++-----------+-----------------+
+| Maximum   | 0.041438        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039256            190
+seed7/prg/bas7.sd7           0.041511          11459
+seed7/prg/bifurk.sd7         0.037158             73
+seed7/prg/bigfiles.sd7       0.038655            129
+seed7/prg/brainf7.sd7        0.038247             86
+seed7/prg/calc7.sd7          0.038218            128
+seed7/prg/carddemo.sd7       0.038708            190
+seed7/prg/castle.sd7         0.038106           3148
+seed7/prg/cat.sd7            0.035960             82
+seed7/prg/cellauto.sd7       0.036911             85
+seed7/prg/celsius.sd7        0.035282             42
+seed7/prg/chk_all.sd7        0.038642            843
+seed7/prg/chkarr.sd7         0.040482           8367
+seed7/prg/chkbig.sd7         0.044445          29026
+seed7/prg/chkbin.sd7         0.039072           6469
+seed7/prg/chkbitdata.sd7     0.040234           6624
+seed7/prg/chkbool.sd7        0.038119           3157
+seed7/prg/chkbst.sd7         0.038096            722
+seed7/prg/chkchr.sd7         0.039029           2809
+seed7/prg/chkcmd.sd7         0.039552           1205
+seed7/prg/chkdb.sd7          0.040377           7454
+seed7/prg/chkdecl.sd7        0.038465            448
+seed7/prg/chkenum.sd7        0.038634           1230
+seed7/prg/chkerr.sd7         0.039908           4663
+seed7/prg/chkexc.sd7         0.039246           2627
+seed7/prg/chkfil.sd7         0.040417           1615
+seed7/prg/chkflt.sd7         0.044083          20620
+seed7/prg/chkhent.sd7        0.036607             54
+seed7/prg/chkhsh.sd7         0.040548           4548
+seed7/prg/chkidx.sd7         0.041719          19567
+seed7/prg/chkint.sd7         0.046477          38129
+seed7/prg/chkjson.sd7        0.039522           1764
+seed7/prg/chkovf.sd7         0.040032           8216
+seed7/prg/chkprc.sd7         0.037960          10111
+seed7/prg/chkscan.sd7        0.038495            714
+seed7/prg/chkset.sd7         0.039889          11974
+seed7/prg/chkstr.sd7         0.042438          26952
+seed7/prg/chktime.sd7        0.039072           2025
+seed7/prg/chktoml.sd7        0.039167           1656
+seed7/prg/clock.sd7          0.038011             47
+seed7/prg/clock2.sd7         0.036328             43
+seed7/prg/clock3.sd7         0.039538             95
+seed7/prg/cmpfil.sd7         0.037627             84
+seed7/prg/comanche.sd7       0.038942            180
+seed7/prg/confval.sd7        0.040303            175
+seed7/prg/db7.sd7            0.039553            417
+seed7/prg/diff7.sd7          0.039240            263
+seed7/prg/dirtst.sd7         0.036168             42
+seed7/prg/dirx.sd7           0.038891            152
+seed7/prg/dnafight.sd7       0.039190           1381
+seed7/prg/dragon.sd7         0.036249             73
+seed7/prg/echo.sd7           0.035116             39
+seed7/prg/eliza.sd7          0.037591            302
+seed7/prg/err.sd7            0.040295             96
+seed7/prg/fannkuch.sd7       0.037173            131
+seed7/prg/fib.sd7            0.035214             47
+seed7/prg/find7.sd7          0.037588            133
+seed7/prg/findchar.sd7       0.037436            149
+seed7/prg/fractree.sd7       0.035778             55
+seed7/prg/ftp7.sd7           0.039217            296
+seed7/prg/ftpserv.sd7        0.037847             74
+seed7/prg/gcd.sd7            0.036630            109
+seed7/prg/gkbd.sd7           0.039422            358
+seed7/prg/gtksvtst.sd7       0.039177             94
+seed7/prg/hal.sd7            0.039804            250
+seed7/prg/hamu.sd7           0.041370            573
+seed7/prg/hanoi.sd7          0.036918             55
+seed7/prg/hd.sd7             0.038722             79
+seed7/prg/hello.sd7          0.035952             32
+seed7/prg/hilbert.sd7        0.038264            108
+seed7/prg/ide7.sd7           0.039101            196
+seed7/prg/kbd.sd7            0.035865             49
+seed7/prg/klondike.sd7       0.038213            883
+seed7/prg/lander.sd7         0.039313           1551
+seed7/prg/lst80bas.sd7       0.038347            344
+seed7/prg/lst99bas.sd7       0.039898            401
+seed7/prg/lstgwbas.sd7       0.040687            577
+seed7/prg/mahjong.sd7        0.039489           1943
+seed7/prg/make7.sd7          0.039014            121
+seed7/prg/mandelbr.sd7       0.038993            237
+seed7/prg/mind.sd7           0.039110            443
+seed7/prg/mirror.sd7         0.040175            131
+seed7/prg/ms.sd7             0.041236            641
+seed7/prg/nicoma.sd7         0.041050            135
+seed7/prg/pac.sd7            0.038832            726
+seed7/prg/pairs.sd7          0.039056           2025
+seed7/prg/panic.sd7          0.040385           2634
+seed7/prg/percolation.sd7    0.038307            330
+seed7/prg/planets.sd7        0.038282           1486
+seed7/prg/portfwd7.sd7       0.038123            139
+seed7/prg/prime.sd7          0.036212             74
+seed7/prg/printpi1.sd7       0.035274             56
+seed7/prg/printpi2.sd7       0.037311             54
+seed7/prg/printpi3.sd7       0.036864             60
+seed7/prg/pv7.sd7            0.039942            337
+seed7/prg/queen.sd7          0.039272            149
+seed7/prg/rand.sd7           0.038298            121
+seed7/prg/raytrace.sd7       0.038937            538
+seed7/prg/rever.sd7          0.039060            816
+seed7/prg/roman.sd7          0.036321             38
+seed7/prg/s7c.sd7            0.039834           9060
+seed7/prg/s7check.sd7        0.037753             68
+seed7/prg/savehd7.sd7        0.039691           1110
+seed7/prg/self.sd7           0.037368             49
+seed7/prg/shisen.sd7         0.038684           1423
+seed7/prg/sl.sd7             0.040238           1029
+seed7/prg/snake.sd7          0.039447            615
+seed7/prg/sokoban.sd7        0.037617            891
+seed7/prg/spigotpi.sd7       0.035885             64
+seed7/prg/sql7.sd7           0.037918            278
+seed7/prg/startrek.sd7       0.038228            979
+seed7/prg/sudoku7.sd7        0.038051           2657
+seed7/prg/sydir7.sd7         0.038041            384
+seed7/prg/syntaxhl.sd7       0.040666            177
+seed7/prg/tak.sd7            0.036754             59
+seed7/prg/tar7.sd7           0.037980            121
+seed7/prg/tch.sd7            0.036219             55
+seed7/prg/testfont.sd7       0.041017             95
+seed7/prg/tet.sd7            0.038918            479
+seed7/prg/tetg.sd7           0.037619            501
+seed7/prg/toutf8.sd7         0.044191            240
+seed7/prg/tst_cli.sd7        0.037452             40
+seed7/prg/tst_srv.sd7        0.036091             47
+seed7/prg/wator.sd7          0.039058            651
+seed7/prg/which.sd7          0.037070             65
+seed7/prg/wiz.sd7            0.039227           2833
+seed7/prg/wordcnt.sd7        0.036531             54
+seed7/prg/wrinum.sd7         0.035766             43
+seed7/prg/wumpus.sd7         0.039253            372
+seed7/lib/aes.s7i            0.042482           1144
+seed7/lib/aes_gcm.s7i        0.039904            392
+seed7/lib/ar.s7i             0.039335           1532
+seed7/lib/arc4.s7i           0.039241            144
+seed7/lib/archive.s7i        0.046019            143
+seed7/lib/archive_base.s7i   0.040907            135
+seed7/lib/array.s7i          0.041846            610
+seed7/lib/asn1.s7i           0.037855            544
+seed7/lib/asn1oid.s7i        0.043118            157
+seed7/lib/basearray.s7i      0.040457            450
+seed7/lib/bigfile.s7i        0.038528            136
+seed7/lib/bigint.s7i         0.039201            824
+seed7/lib/bigrat.s7i         0.039788            784
+seed7/lib/bin16.s7i          0.038997            592
+seed7/lib/bin32.s7i          0.039002            490
+seed7/lib/bin64.s7i          0.038307            539
+seed7/lib/bitdata.s7i        0.043705           1330
+seed7/lib/bitmapfont.s7i     0.037808            215
+seed7/lib/bitset.s7i         0.038811            593
+seed7/lib/bitsetof.s7i       0.041078            431
+seed7/lib/blowfish.s7i       0.042689            383
+seed7/lib/bmp.s7i            0.038549            924
+seed7/lib/boolean.s7i        0.037826            403
+seed7/lib/browser.s7i        0.038172            280
+seed7/lib/bstring.s7i        0.038505            227
+seed7/lib/bytedata.s7i       0.038324            482
+seed7/lib/bzip2.s7i          0.037904            887
+seed7/lib/cards.s7i          0.037031           1342
+seed7/lib/category.s7i       0.039284            209
+seed7/lib/cc_conf.s7i        0.038995           1314
+seed7/lib/ccittfax.s7i       0.039148           1022
+seed7/lib/cgi.s7i            0.038636            109
+seed7/lib/cgidialog.s7i      0.038992           1118
+seed7/lib/char.s7i           0.038910            356
+seed7/lib/charsets.s7i       0.040314           2024
+seed7/lib/chartype.s7i       0.042303            121
+seed7/lib/cipher.s7i         0.039306            146
+seed7/lib/cli_cmds.s7i       0.042105           1360
+seed7/lib/clib_file.s7i      0.040081            301
+seed7/lib/color.s7i          0.041318            185
+seed7/lib/complex.s7i        0.037944            464
+seed7/lib/compress.s7i       0.037834            150
+seed7/lib/console.s7i        0.037693            188
+seed7/lib/cpio.s7i           0.038138           1708
+seed7/lib/crc32.s7i          0.038243            193
+seed7/lib/cronos16.s7i       0.042718           1173
+seed7/lib/cronos27.s7i       0.045466           1464
+seed7/lib/csv.s7i            0.038974            201
+seed7/lib/db_prop.s7i        0.039118            991
+seed7/lib/deflate.s7i        0.040022            740
+seed7/lib/des.s7i            0.039942            444
+seed7/lib/dialog.s7i         0.038856            311
+seed7/lib/dir.s7i            0.039270            163
+seed7/lib/draw.s7i           0.039331            854
+seed7/lib/duration.s7i       0.039262           1038
+seed7/lib/echo.s7i           0.039034            132
+seed7/lib/editline.s7i       0.038914            398
+seed7/lib/elf.s7i            0.040674           1560
+seed7/lib/elliptic.s7i       0.037733            649
+seed7/lib/enable_io.s7i      0.037432            312
+seed7/lib/encoding.s7i       0.038403            931
+seed7/lib/enumeration.s7i    0.037886            236
+seed7/lib/environment.s7i    0.037492            175
+seed7/lib/exif.s7i           0.040038            152
+seed7/lib/external_file.s7i  0.037934            340
+seed7/lib/field.s7i          0.037237            268
+seed7/lib/file.s7i           0.038090            372
+seed7/lib/filebits.s7i       0.036181             46
+seed7/lib/filesys.s7i        0.037230            601
+seed7/lib/fileutil.s7i       0.037545            144
+seed7/lib/fixarray.s7i       0.038800            307
+seed7/lib/float.s7i          0.038055            757
+seed7/lib/font.s7i           0.037363            196
+seed7/lib/font8x8.s7i        0.039924            998
+seed7/lib/forloop.s7i        0.040392            449
+seed7/lib/ftp.s7i            0.038749            969
+seed7/lib/ftpserv.s7i        0.038840            631
+seed7/lib/getf.s7i           0.038499            115
+seed7/lib/gethttp.s7i        0.036277             41
+seed7/lib/gethttps.s7i       0.036272             41
+seed7/lib/gif.s7i            0.038803            561
+seed7/lib/graph.s7i          0.040565            415
+seed7/lib/graph_file.s7i     0.039292            399
+seed7/lib/gtkserver.s7i      0.038650            161
+seed7/lib/gzip.s7i           0.039227            573
+seed7/lib/hash.s7i           0.040745            421
+seed7/lib/hashsetof.s7i      0.041412            499
+seed7/lib/hmac.s7i           0.039080            152
+seed7/lib/html.s7i           0.038169             83
+seed7/lib/html_ent.s7i       0.039324            476
+seed7/lib/htmldom.s7i        0.039300            286
+seed7/lib/http_request.s7i   0.039265            696
+seed7/lib/http_srv_resp.s7i  0.039522            380
+seed7/lib/https_request.s7i  0.038602            211
+seed7/lib/httpserv.s7i       0.038620            345
+seed7/lib/huffman.s7i        0.038386            644
+seed7/lib/ico.s7i            0.038394            221
+seed7/lib/idxarray.s7i       0.038041            232
+seed7/lib/image.s7i          0.037421            156
+seed7/lib/imagefile.s7i      0.037232            171
+seed7/lib/inflate.s7i        0.039677            411
+seed7/lib/inifile.s7i        0.038041            129
+seed7/lib/integer.s7i        0.037537            663
+seed7/lib/iobuffer.s7i       0.037341            289
+seed7/lib/jpeg.s7i           0.038653           1761
+seed7/lib/json.s7i           0.037858            891
+seed7/lib/json_serde.s7i     0.037785            783
+seed7/lib/keybd.s7i          0.037181            639
+seed7/lib/keydescr.s7i       0.038820            192
+seed7/lib/leb128.s7i         0.039417            218
+seed7/lib/line.s7i           0.038987            164
+seed7/lib/listener.s7i       0.038932            247
+seed7/lib/logfile.s7i        0.037629             73
+seed7/lib/lower.s7i          0.038323            142
+seed7/lib/lzma.s7i           0.039757            934
+seed7/lib/lzw.s7i            0.039201            861
+seed7/lib/magic.s7i          0.040245            403
+seed7/lib/mahjng32.s7i       0.038522           1500
+seed7/lib/make.s7i           0.038946            544
+seed7/lib/makedata.s7i       0.039000           1428
+seed7/lib/math.s7i           0.040110            201
+seed7/lib/mixarith.s7i       0.039954            249
+seed7/lib/modern27.s7i       0.042257           1099
+seed7/lib/more.s7i           0.037623            130
+seed7/lib/msgdigest.s7i      0.038852           1222
+seed7/lib/multiscr.s7i       0.036048             68
+seed7/lib/null_file.s7i      0.037512            345
+seed7/lib/osfiles.s7i        0.041316           1085
+seed7/lib/pbm.s7i            0.039516            230
+seed7/lib/pcx.s7i            0.039029            638
+seed7/lib/pem.s7i            0.039462            185
+seed7/lib/pgm.s7i            0.039359            238
+seed7/lib/pic16.s7i          0.038734           1037
+seed7/lib/pic32.s7i          0.038162           2060
+seed7/lib/pic_util.s7i       0.038735            144
+seed7/lib/pixelimage.s7i     0.038593            320
+seed7/lib/pixmap_file.s7i    0.038585            459
+seed7/lib/pixmapfont.s7i     0.040631            184
+seed7/lib/pkcs1.s7i          0.044425            543
+seed7/lib/png.s7i            0.039397           1064
+seed7/lib/poll.s7i           0.038880            313
+seed7/lib/ppm.s7i            0.039538            240
+seed7/lib/process.s7i        0.037799            541
+seed7/lib/progs.s7i          0.037742            789
+seed7/lib/propertyfile.s7i   0.037779            155
+seed7/lib/rational.s7i       0.037660            792
+seed7/lib/ref_list.s7i       0.037837            252
+seed7/lib/reference.s7i      0.037554            126
+seed7/lib/reverse.s7i        0.037225             94
+seed7/lib/rpm.s7i            0.038103           3487
+seed7/lib/rpmext.s7i         0.038120            318
+seed7/lib/scanfile.s7i       0.037852           1779
+seed7/lib/scanjson.s7i       0.038509            413
+seed7/lib/scanstri.s7i       0.037673           1814
+seed7/lib/scantoml.s7i       0.038082           1603
+seed7/lib/seed7_05.s7i       0.041829           1072
+seed7/lib/set.s7i            0.037013             57
+seed7/lib/shell.s7i          0.039553            615
+seed7/lib/showtls.s7i        0.039037            678
+seed7/lib/signature.s7i      0.039509            131
+seed7/lib/smtp.s7i           0.039380            261
+seed7/lib/sockbase.s7i       0.040048            217
+seed7/lib/socket.s7i         0.039198            326
+seed7/lib/sokoban1.s7i       0.038551           1519
+seed7/lib/sql_base.s7i       0.039301           1000
+seed7/lib/stars.s7i          0.041828           1705
+seed7/lib/stdfont10.s7i      0.037807           3347
+seed7/lib/stdfont12.s7i      0.039253           3928
+seed7/lib/stdfont14.s7i      0.038875           4510
+seed7/lib/stdfont16.s7i      0.038674           5092
+seed7/lib/stdfont18.s7i      0.038873           5868
+seed7/lib/stdfont20.s7i      0.038943           6449
+seed7/lib/stdfont24.s7i      0.039155           7421
+seed7/lib/stdfont8.s7i       0.037726           2960
+seed7/lib/stdfont9.s7i       0.037606           3152
+seed7/lib/stdio.s7i          0.038425            192
+seed7/lib/strifile.s7i       0.040371            345
+seed7/lib/string.s7i         0.037708            779
+seed7/lib/stritext.s7i       0.038533            352
+seed7/lib/struct.s7i         0.039835            266
+seed7/lib/struct_elem.s7i    0.037508            129
+seed7/lib/subfile.s7i        0.037797            174
+seed7/lib/subrange.s7i       0.037238             78
+seed7/lib/syntax.s7i         0.039499            294
+seed7/lib/tar.s7i            0.038969           1880
+seed7/lib/tar_cmds.s7i       0.038517            752
+seed7/lib/tdes.s7i           0.037211            143
+seed7/lib/tee.s7i            0.037340            143
+seed7/lib/text.s7i           0.037676            135
+seed7/lib/tga.s7i            0.040553            676
+seed7/lib/tiff.s7i           0.039790           2771
+seed7/lib/time.s7i           0.037993           1191
+seed7/lib/tls.s7i            0.038738           2230
+seed7/lib/unicode.s7i        0.041036            575
+seed7/lib/unionfnd.s7i       0.038900            130
+seed7/lib/upper.s7i          0.038533            142
+seed7/lib/utf16.s7i          0.038829            540
+seed7/lib/utf8.s7i           0.040183            234
+seed7/lib/vecfont10.s7i      0.042401           1056
+seed7/lib/vecfont18.s7i      0.042687           1119
+seed7/lib/vector3d.s7i       0.038984            293
+seed7/lib/vectorfont.s7i     0.039294            239
+seed7/lib/wildcard.s7i       0.038828            140
+seed7/lib/window.s7i         0.038038            455
+seed7/lib/wrinum.s7i         0.038242            248
+seed7/lib/x509cert.s7i       0.038114           1243
+seed7/lib/xml_ent.s7i        0.037640             94
+seed7/lib/xmldom.s7i         0.037612            303
+seed7/lib/xz.s7i             0.041049            442
+seed7/lib/zip.s7i            0.047138           2792
+seed7/lib/zstd.s7i           0.039860           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.038936        |
++-----------+-----------------+
+| Minimum   | 0.035116        |
++-----------+-----------------+
+| Maximum   | 0.047138        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.040192            190
+seed7/prg/bas7.sd7           0.335194          11459
+seed7/prg/bifurk.sd7         0.040943             73
+seed7/prg/bigfiles.sd7       0.042553            129
+seed7/prg/brainf7.sd7        0.039200             86
+seed7/prg/calc7.sd7          0.040194            128
+seed7/prg/carddemo.sd7       0.040823            190
+seed7/prg/castle.sd7         0.112424           3148
+seed7/prg/cat.sd7            0.037911             82
+seed7/prg/cellauto.sd7       0.036838             85
+seed7/prg/celsius.sd7        0.036533             42
+seed7/prg/chk_all.sd7        0.062533            843
+seed7/prg/chkarr.sd7         0.371103           8367
+seed7/prg/chkbig.sd7         2.122358          29026
+seed7/prg/chkbin.sd7         0.526938           6469
+seed7/prg/chkbitdata.sd7     0.630248           6624
+seed7/prg/chkbool.sd7        0.119981           3157
+seed7/prg/chkbst.sd7         0.065010            722
+seed7/prg/chkchr.sd7         0.222899           2809
+seed7/prg/chkcmd.sd7         0.068686           1205
+seed7/prg/chkdb.sd7          0.360052           7454
+seed7/prg/chkdecl.sd7        0.059764            448
+seed7/prg/chkenum.sd7        0.070659           1230
+seed7/prg/chkerr.sd7         0.199838           4663
+seed7/prg/chkexc.sd7         0.085741           2627
+seed7/prg/chkfil.sd7         0.078611           1615
+seed7/prg/chkflt.sd7         1.375985          20620
+seed7/prg/chkhent.sd7        0.037629             54
+seed7/prg/chkhsh.sd7         0.255197           4548
+seed7/prg/chkidx.sd7         1.367318          19567
+seed7/prg/chkint.sd7         2.597001          38129
+seed7/prg/chkjson.sd7        0.103502           1764
+seed7/prg/chkovf.sd7         0.579505           8216
+seed7/prg/chkprc.sd7         0.329303          10111
+seed7/prg/chkscan.sd7        0.058260            714
+seed7/prg/chkset.sd7         0.678180          11974
+seed7/prg/chkstr.sd7         1.419730          26952
+seed7/prg/chktime.sd7        0.133369           2025
+seed7/prg/chktoml.sd7        0.109948           1656
+seed7/prg/clock.sd7          0.038069             47
+seed7/prg/clock2.sd7         0.037350             43
+seed7/prg/clock3.sd7         0.039864             95
+seed7/prg/cmpfil.sd7         0.037826             84
+seed7/prg/comanche.sd7       0.041542            180
+seed7/prg/confval.sd7        0.045873            175
+seed7/prg/db7.sd7            0.049089            417
+seed7/prg/diff7.sd7          0.044594            263
+seed7/prg/dirtst.sd7         0.037257             42
+seed7/prg/dirx.sd7           0.040208            152
+seed7/prg/dnafight.sd7       0.074260           1381
+seed7/prg/dragon.sd7         0.038534             73
+seed7/prg/echo.sd7           0.036415             39
+seed7/prg/eliza.sd7          0.043795            302
+seed7/prg/err.sd7            0.040232             96
+seed7/prg/fannkuch.sd7       0.038484            131
+seed7/prg/fib.sd7            0.037827             47
+seed7/prg/find7.sd7          0.039749            133
+seed7/prg/findchar.sd7       0.040346            149
+seed7/prg/fractree.sd7       0.038348             55
+seed7/prg/ftp7.sd7           0.043785            296
+seed7/prg/ftpserv.sd7        0.038599             74
+seed7/prg/gcd.sd7            0.038911            109
+seed7/prg/gkbd.sd7           0.046558            358
+seed7/prg/gtksvtst.sd7       0.037502             94
+seed7/prg/hal.sd7            0.041408            250
+seed7/prg/hamu.sd7           0.049718            573
+seed7/prg/hanoi.sd7          0.036255             55
+seed7/prg/hd.sd7             0.036844             79
+seed7/prg/hello.sd7          0.036504             32
+seed7/prg/hilbert.sd7        0.037678            108
+seed7/prg/ide7.sd7           0.041360            196
+seed7/prg/kbd.sd7            0.037449             49
+seed7/prg/klondike.sd7       0.057189            883
+seed7/prg/lander.sd7         0.074518           1551
+seed7/prg/lst80bas.sd7       0.046835            344
+seed7/prg/lst99bas.sd7       0.045438            401
+seed7/prg/lstgwbas.sd7       0.052155            577
+seed7/prg/mahjong.sd7        0.087500           1943
+seed7/prg/make7.sd7          0.042521            121
+seed7/prg/mandelbr.sd7       0.043393            237
+seed7/prg/mind.sd7           0.047711            443
+seed7/prg/mirror.sd7         0.041348            131
+seed7/prg/ms.sd7             0.050682            641
+seed7/prg/nicoma.sd7         0.041148            135
+seed7/prg/pac.sd7            0.051075            726
+seed7/prg/pairs.sd7          0.085212           2025
+seed7/prg/panic.sd7          0.101254           2634
+seed7/prg/percolation.sd7    0.044612            330
+seed7/prg/planets.sd7        0.079606           1486
+seed7/prg/portfwd7.sd7       0.040176            139
+seed7/prg/prime.sd7          0.037820             74
+seed7/prg/printpi1.sd7       0.037874             56
+seed7/prg/printpi2.sd7       0.037619             54
+seed7/prg/printpi3.sd7       0.037442             60
+seed7/prg/pv7.sd7            0.044990            337
+seed7/prg/queen.sd7          0.038824            149
+seed7/prg/rand.sd7           0.038100            121
+seed7/prg/raytrace.sd7       0.049596            538
+seed7/prg/rever.sd7          0.054624            816
+seed7/prg/roman.sd7          0.036688             38
+seed7/prg/s7c.sd7            0.289365           9060
+seed7/prg/s7check.sd7        0.039822             68
+seed7/prg/savehd7.sd7        0.069838           1110
+seed7/prg/self.sd7           0.037984             49
+seed7/prg/shisen.sd7         0.074067           1423
+seed7/prg/sl.sd7             0.062392           1029
+seed7/prg/snake.sd7          0.048701            615
+seed7/prg/sokoban.sd7        0.056879            891
+seed7/prg/spigotpi.sd7       0.037762             64
+seed7/prg/sql7.sd7           0.043738            278
+seed7/prg/startrek.sd7       0.060998            979
+seed7/prg/sudoku7.sd7        0.102686           2657
+seed7/prg/sydir7.sd7         0.047207            384
+seed7/prg/syntaxhl.sd7       0.041531            177
+seed7/prg/tak.sd7            0.036352             59
+seed7/prg/tar7.sd7           0.039627            121
+seed7/prg/tch.sd7            0.038304             55
+seed7/prg/testfont.sd7       0.039674             95
+seed7/prg/tet.sd7            0.046580            479
+seed7/prg/tetg.sd7           0.047003            501
+seed7/prg/toutf8.sd7         0.044615            240
+seed7/prg/tst_cli.sd7        0.037324             40
+seed7/prg/tst_srv.sd7        0.037955             47
+seed7/prg/wator.sd7          0.053366            651
+seed7/prg/which.sd7          0.038403             65
+seed7/prg/wiz.sd7            0.107769           2833
+seed7/prg/wordcnt.sd7        0.037120             54
+seed7/prg/wrinum.sd7         0.036473             43
+seed7/prg/wumpus.sd7         0.043422            372
+seed7/lib/aes.s7i            0.112690           1144
+seed7/lib/aes_gcm.s7i        0.048642            392
+seed7/lib/ar.s7i             0.074902           1532
+seed7/lib/arc4.s7i           0.038651            144
+seed7/lib/archive.s7i        0.038586            143
+seed7/lib/archive_base.s7i   0.039514            135
+seed7/lib/array.s7i          0.054474            610
+seed7/lib/asn1.s7i           0.050184            544
+seed7/lib/asn1oid.s7i        0.044311            157
+seed7/lib/basearray.s7i      0.052142            450
+seed7/lib/bigfile.s7i        0.040008            136
+seed7/lib/bigint.s7i         0.064151            824
+seed7/lib/bigrat.s7i         0.056562            784
+seed7/lib/bin16.s7i          0.053420            592
+seed7/lib/bin32.s7i          0.050343            490
+seed7/lib/bin64.s7i          0.051611            539
+seed7/lib/bitdata.s7i        0.081576           1330
+seed7/lib/bitmapfont.s7i     0.043185            215
+seed7/lib/bitset.s7i         0.050801            593
+seed7/lib/bitsetof.s7i       0.049461            431
+seed7/lib/blowfish.s7i       0.058537            383
+seed7/lib/bmp.s7i            0.063642            924
+seed7/lib/boolean.s7i        0.053702            403
+seed7/lib/browser.s7i        0.044202            280
+seed7/lib/bstring.s7i        0.043989            227
+seed7/lib/bytedata.s7i       0.052728            482
+seed7/lib/bzip2.s7i          0.060169            887
+seed7/lib/cards.s7i          0.069455           1342
+seed7/lib/category.s7i       0.042076            209
+seed7/lib/cc_conf.s7i        0.079831           1314
+seed7/lib/ccittfax.s7i       0.069295           1022
+seed7/lib/cgi.s7i            0.041749            109
+seed7/lib/cgidialog.s7i      0.063072           1118
+seed7/lib/char.s7i           0.046171            356
+seed7/lib/charsets.s7i       0.085158           2024
+seed7/lib/chartype.s7i       0.041708            121
+seed7/lib/cipher.s7i         0.040389            146
+seed7/lib/cli_cmds.s7i       0.071246           1360
+seed7/lib/clib_file.s7i      0.045601            301
+seed7/lib/color.s7i          0.042142            185
+seed7/lib/complex.s7i        0.047257            464
+seed7/lib/compress.s7i       0.040231            150
+seed7/lib/console.s7i        0.040847            188
+seed7/lib/cpio.s7i           0.083139           1708
+seed7/lib/crc32.s7i          0.046173            193
+seed7/lib/cronos16.s7i       0.097574           1173
+seed7/lib/cronos27.s7i       0.121368           1464
+seed7/lib/csv.s7i            0.042541            201
+seed7/lib/db_prop.s7i        0.065673            991
+seed7/lib/deflate.s7i        0.058206            740
+seed7/lib/des.s7i            0.057581            444
+seed7/lib/dialog.s7i         0.045336            311
+seed7/lib/dir.s7i            0.039570            163
+seed7/lib/draw.s7i           0.058358            854
+seed7/lib/duration.s7i       0.063113           1038
+seed7/lib/echo.s7i           0.039895            132
+seed7/lib/editline.s7i       0.046687            398
+seed7/lib/elf.s7i            0.088079           1560
+seed7/lib/elliptic.s7i       0.053704            649
+seed7/lib/enable_io.s7i      0.043909            312
+seed7/lib/encoding.s7i       0.062681            931
+seed7/lib/enumeration.s7i    0.042686            236
+seed7/lib/environment.s7i    0.040892            175
+seed7/lib/exif.s7i           0.041061            152
+seed7/lib/external_file.s7i  0.044828            340
+seed7/lib/field.s7i          0.042450            268
+seed7/lib/file.s7i           0.045163            372
+seed7/lib/filebits.s7i       0.037029             46
+seed7/lib/filesys.s7i        0.050699            601
+seed7/lib/fileutil.s7i       0.040219            144
+seed7/lib/fixarray.s7i       0.045732            307
+seed7/lib/float.s7i          0.060973            757
+seed7/lib/font.s7i           0.043753            196
+seed7/lib/font8x8.s7i        0.050953            998
+seed7/lib/forloop.s7i        0.047516            449
+seed7/lib/ftp.s7i            0.060053            969
+seed7/lib/ftpserv.s7i        0.053070            631
+seed7/lib/getf.s7i           0.038594            115
+seed7/lib/gethttp.s7i        0.037988             41
+seed7/lib/gethttps.s7i       0.037787             41
+seed7/lib/gif.s7i            0.051978            561
+seed7/lib/graph.s7i          0.049424            415
+seed7/lib/graph_file.s7i     0.045374            399
+seed7/lib/gtkserver.s7i      0.039126            161
+seed7/lib/gzip.s7i           0.049745            573
+seed7/lib/hash.s7i           0.051362            421
+seed7/lib/hashsetof.s7i      0.050215            499
+seed7/lib/hmac.s7i           0.040559            152
+seed7/lib/html.s7i           0.038099             83
+seed7/lib/html_ent.s7i       0.049045            476
+seed7/lib/htmldom.s7i        0.044393            286
+seed7/lib/http_request.s7i   0.053593            696
+seed7/lib/http_srv_resp.s7i  0.047910            380
+seed7/lib/https_request.s7i  0.042662            211
+seed7/lib/httpserv.s7i       0.045283            345
+seed7/lib/huffman.s7i        0.055862            644
+seed7/lib/ico.s7i            0.042787            221
+seed7/lib/idxarray.s7i       0.043712            232
+seed7/lib/image.s7i          0.039811            156
+seed7/lib/imagefile.s7i      0.040750            171
+seed7/lib/inflate.s7i        0.049642            411
+seed7/lib/inifile.s7i        0.039580            129
+seed7/lib/integer.s7i        0.054804            663
+seed7/lib/iobuffer.s7i       0.043072            289
+seed7/lib/jpeg.s7i           0.086531           1761
+seed7/lib/json.s7i           0.057515            891
+seed7/lib/json_serde.s7i     0.053812            783
+seed7/lib/keybd.s7i          0.058146            639
+seed7/lib/keydescr.s7i       0.043207            192
+seed7/lib/leb128.s7i         0.047782            218
+seed7/lib/line.s7i           0.047012            164
+seed7/lib/listener.s7i       0.046891            247
+seed7/lib/logfile.s7i        0.043876             73
+seed7/lib/lower.s7i          0.046779            142
+seed7/lib/lzma.s7i           0.066659            934
+seed7/lib/lzw.s7i            0.065690            861
+seed7/lib/magic.s7i          0.051347            403
+seed7/lib/mahjng32.s7i       0.070827           1500
+seed7/lib/make.s7i           0.052898            544
+seed7/lib/makedata.s7i       0.073105           1428
+seed7/lib/math.s7i           0.041806            201
+seed7/lib/mixarith.s7i       0.045193            249
+seed7/lib/modern27.s7i       0.089906           1099
+seed7/lib/more.s7i           0.038950            130
+seed7/lib/msgdigest.s7i      0.080223           1222
+seed7/lib/multiscr.s7i       0.040952             68
+seed7/lib/null_file.s7i      0.049462            345
+seed7/lib/osfiles.s7i        0.070587           1085
+seed7/lib/pbm.s7i            0.041800            230
+seed7/lib/pcx.s7i            0.054715            638
+seed7/lib/pem.s7i            0.041505            185
+seed7/lib/pgm.s7i            0.042050            238
+seed7/lib/pic16.s7i          0.055230           1037
+seed7/lib/pic32.s7i          0.085347           2060
+seed7/lib/pic_util.s7i       0.041307            144
+seed7/lib/pixelimage.s7i     0.044495            320
+seed7/lib/pixmap_file.s7i    0.048690            459
+seed7/lib/pixmapfont.s7i     0.042097            184
+seed7/lib/pkcs1.s7i          0.061374            543
+seed7/lib/png.s7i            0.068016           1064
+seed7/lib/poll.s7i           0.045531            313
+seed7/lib/ppm.s7i            0.046135            240
+seed7/lib/process.s7i        0.055349            541
+seed7/lib/progs.s7i          0.058469            789
+seed7/lib/propertyfile.s7i   0.041487            155
+seed7/lib/rational.s7i       0.054307            792
+seed7/lib/ref_list.s7i       0.044242            252
+seed7/lib/reference.s7i      0.040182            126
+seed7/lib/reverse.s7i        0.039082             94
+seed7/lib/rpm.s7i            0.150322           3487
+seed7/lib/rpmext.s7i         0.044183            318
+seed7/lib/scanfile.s7i       0.083053           1779
+seed7/lib/scanjson.s7i       0.050901            413
+seed7/lib/scanstri.s7i       0.084974           1814
+seed7/lib/scantoml.s7i       0.076805           1603
+seed7/lib/seed7_05.s7i       0.072142           1072
+seed7/lib/set.s7i            0.039152             57
+seed7/lib/shell.s7i          0.056823            615
+seed7/lib/showtls.s7i        0.058253            678
+seed7/lib/signature.s7i      0.040310            131
+seed7/lib/smtp.s7i           0.042679            261
+seed7/lib/sockbase.s7i       0.043539            217
+seed7/lib/socket.s7i         0.047440            326
+seed7/lib/sokoban1.s7i       0.061537           1519
+seed7/lib/sql_base.s7i       0.070169           1000
+seed7/lib/stars.s7i          0.142358           1705
+seed7/lib/stdfont10.s7i      0.083896           3347
+seed7/lib/stdfont12.s7i      0.095398           3928
+seed7/lib/stdfont14.s7i      0.105791           4510
+seed7/lib/stdfont16.s7i      0.121092           5092
+seed7/lib/stdfont18.s7i      0.139587           5868
+seed7/lib/stdfont20.s7i      0.154388           6449
+seed7/lib/stdfont24.s7i      0.186483           7421
+seed7/lib/stdfont8.s7i       0.081330           2960
+seed7/lib/stdfont9.s7i       0.080368           3152
+seed7/lib/stdio.s7i          0.044056            192
+seed7/lib/strifile.s7i       0.050252            345
+seed7/lib/string.s7i         0.061569            779
+seed7/lib/stritext.s7i       0.045260            352
+seed7/lib/struct.s7i         0.045808            266
+seed7/lib/struct_elem.s7i    0.040649            129
+seed7/lib/subfile.s7i        0.040805            174
+seed7/lib/subrange.s7i       0.037840             78
+seed7/lib/syntax.s7i         0.049583            294
+seed7/lib/tar.s7i            0.087385           1880
+seed7/lib/tar_cmds.s7i       0.060861            752
+seed7/lib/tdes.s7i           0.039108            143
+seed7/lib/tee.s7i            0.037728            143
+seed7/lib/text.s7i           0.037974            135
+seed7/lib/tga.s7i            0.053993            676
+seed7/lib/tiff.s7i           0.127760           2771
+seed7/lib/time.s7i           0.064357           1191
+seed7/lib/tls.s7i            0.109842           2230
+seed7/lib/unicode.s7i        0.054085            575
+seed7/lib/unionfnd.s7i       0.043397            130
+seed7/lib/upper.s7i          0.042899            142
+seed7/lib/utf16.s7i          0.052961            540
+seed7/lib/utf8.s7i           0.055683            234
+seed7/lib/vecfont10.s7i      0.083928           1056
+seed7/lib/vecfont18.s7i      0.094396           1119
+seed7/lib/vector3d.s7i       0.044817            293
+seed7/lib/vectorfont.s7i     0.043415            239
+seed7/lib/wildcard.s7i       0.040621            140
+seed7/lib/window.s7i         0.048723            455
+seed7/lib/wrinum.s7i         0.042370            248
+seed7/lib/x509cert.s7i       0.073874           1243
+seed7/lib/xml_ent.s7i        0.038274             94
+seed7/lib/xmldom.s7i         0.043193            303
+seed7/lib/xz.s7i             0.047580            442
+seed7/lib/zip.s7i            0.126608           2792
+seed7/lib/zstd.s7i           0.076207           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.092767        |
++-----------+-----------------+
+| Minimum   | 0.036255        |
++-----------+-----------------+
+| Maximum   | 2.597001        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.048079            190
+seed7/prg/bas7.sd7           0.794633          11459
+seed7/prg/bifurk.sd7         0.041362             73
+seed7/prg/bigfiles.sd7       0.045058            129
+seed7/prg/brainf7.sd7        0.041502             86
+seed7/prg/calc7.sd7          0.042704            128
+seed7/prg/carddemo.sd7       0.048892            190
+seed7/prg/castle.sd7         0.229449           3148
+seed7/prg/cat.sd7            0.040109             82
+seed7/prg/cellauto.sd7       0.040856             85
+seed7/prg/celsius.sd7        0.039199             42
+seed7/prg/chk_all.sd7        0.084406            843
+seed7/prg/chkarr.sd7         0.886990           8367
+seed7/prg/chkbig.sd7         4.266189          29026
+seed7/prg/chkbin.sd7         1.054493           6469
+seed7/prg/chkbitdata.sd7     1.282834           6624
+seed7/prg/chkbool.sd7        0.238557           3157
+seed7/prg/chkbst.sd7         0.105658            722
+seed7/prg/chkchr.sd7         0.501780           2809
+seed7/prg/chkcmd.sd7         0.113411           1205
+seed7/prg/chkdb.sd7          0.774768           7454
+seed7/prg/chkdecl.sd7        0.095428            448
+seed7/prg/chkenum.sd7        0.123057           1230
+seed7/prg/chkerr.sd7         0.350251           4663
+seed7/prg/chkexc.sd7         0.154817           2627
+seed7/prg/chkfil.sd7         0.135081           1615
+seed7/prg/chkflt.sd7         2.918974          20620
+seed7/prg/chkhent.sd7        0.043506             54
+seed7/prg/chkhsh.sd7         0.516734           4548
+seed7/prg/chkidx.sd7         3.283932          19567
+seed7/prg/chkint.sd7         5.733136          38129
+seed7/prg/chkjson.sd7        0.197322           1764
+seed7/prg/chkovf.sd7         1.249010           8216
+seed7/prg/chkprc.sd7         0.723489          10111
+seed7/prg/chkscan.sd7        0.098886            714
+seed7/prg/chkset.sd7         1.812547          11974
+seed7/prg/chkstr.sd7         3.539529          26952
+seed7/prg/chktime.sd7        0.259539           2025
+seed7/prg/chktoml.sd7        0.203921           1656
+seed7/prg/clock.sd7          0.043252             47
+seed7/prg/clock2.sd7         0.038359             43
+seed7/prg/clock3.sd7         0.043755             95
+seed7/prg/cmpfil.sd7         0.042016             84
+seed7/prg/comanche.sd7       0.050037            180
+seed7/prg/confval.sd7        0.057874            175
+seed7/prg/db7.sd7            0.063921            417
+seed7/prg/diff7.sd7          0.054570            263
+seed7/prg/dirtst.sd7         0.038558             42
+seed7/prg/dirx.sd7           0.048662            152
+seed7/prg/dnafight.sd7       0.121731           1381
+seed7/prg/dragon.sd7         0.041125             73
+seed7/prg/echo.sd7           0.040868             39
+seed7/prg/eliza.sd7          0.054193            302
+seed7/prg/err.sd7            0.046508             96
+seed7/prg/fannkuch.sd7       0.044949            131
+seed7/prg/fib.sd7            0.039276             47
+seed7/prg/find7.sd7          0.047551            133
+seed7/prg/findchar.sd7       0.044570            149
+seed7/prg/fractree.sd7       0.039187             55
+seed7/prg/ftp7.sd7           0.056189            296
+seed7/prg/ftpserv.sd7        0.041817             74
+seed7/prg/gcd.sd7            0.042336            109
+seed7/prg/gkbd.sd7           0.063180            358
+seed7/prg/gtksvtst.sd7       0.040939             94
+seed7/prg/hal.sd7            0.049407            250
+seed7/prg/hamu.sd7           0.069235            573
+seed7/prg/hanoi.sd7          0.038743             55
+seed7/prg/hd.sd7             0.040455             79
+seed7/prg/hello.sd7          0.037476             32
+seed7/prg/hilbert.sd7        0.051180            108
+seed7/prg/ide7.sd7           0.052366            196
+seed7/prg/kbd.sd7            0.038704             49
+seed7/prg/klondike.sd7       0.091436            883
+seed7/prg/lander.sd7         0.136856           1551
+seed7/prg/lst80bas.sd7       0.056278            344
+seed7/prg/lst99bas.sd7       0.062854            401
+seed7/prg/lstgwbas.sd7       0.075499            577
+seed7/prg/mahjong.sd7        0.155116           1943
+seed7/prg/make7.sd7          0.044369            121
+seed7/prg/mandelbr.sd7       0.050343            237
+seed7/prg/mind.sd7           0.062963            443
+seed7/prg/mirror.sd7         0.048332            131
+seed7/prg/ms.sd7             0.074993            641
+seed7/prg/nicoma.sd7         0.045476            135
+seed7/prg/pac.sd7            0.081968            726
+seed7/prg/pairs.sd7          0.145156           2025
+seed7/prg/panic.sd7          0.203860           2634
+seed7/prg/percolation.sd7    0.060269            330
+seed7/prg/planets.sd7        0.144397           1486
+seed7/prg/portfwd7.sd7       0.048156            139
+seed7/prg/prime.sd7          0.039495             74
+seed7/prg/printpi1.sd7       0.046711             56
+seed7/prg/printpi2.sd7       0.043126             54
+seed7/prg/printpi3.sd7       0.040175             60
+seed7/prg/pv7.sd7            0.065648            337
+seed7/prg/queen.sd7          0.045500            149
+seed7/prg/rand.sd7           0.043138            121
+seed7/prg/raytrace.sd7       0.072178            538
+seed7/prg/rever.sd7          0.091007            816
+seed7/prg/roman.sd7          0.040083             38
+seed7/prg/s7c.sd7            0.647746           9060
+seed7/prg/s7check.sd7        0.041126             68
+seed7/prg/savehd7.sd7        0.119044           1110
+seed7/prg/self.sd7           0.040103             49
+seed7/prg/shisen.sd7         0.126000           1423
+seed7/prg/sl.sd7             0.105694           1029
+seed7/prg/snake.sd7          0.070006            615
+seed7/prg/sokoban.sd7        0.086598            891
+seed7/prg/spigotpi.sd7       0.039067             64
+seed7/prg/sql7.sd7           0.053040            278
+seed7/prg/startrek.sd7       0.100711            979
+seed7/prg/sudoku7.sd7        0.208265           2657
+seed7/prg/sydir7.sd7         0.062609            384
+seed7/prg/syntaxhl.sd7       0.049103            177
+seed7/prg/tak.sd7            0.041755             59
+seed7/prg/tar7.sd7           0.047370            121
+seed7/prg/tch.sd7            0.039262             55
+seed7/prg/testfont.sd7       0.046070             95
+seed7/prg/tet.sd7            0.063034            479
+seed7/prg/tetg.sd7           0.065919            501
+seed7/prg/toutf8.sd7         0.057176            240
+seed7/prg/tst_cli.sd7        0.041873             40
+seed7/prg/tst_srv.sd7        0.040112             47
+seed7/prg/wator.sd7          0.081845            651
+seed7/prg/which.sd7          0.038339             65
+seed7/prg/wiz.sd7            0.215788           2833
+seed7/prg/wordcnt.sd7        0.040391             54
+seed7/prg/wrinum.sd7         0.040573             43
+seed7/prg/wumpus.sd7         0.056678            372
+seed7/lib/aes.s7i            0.204990           1144
+seed7/lib/aes_gcm.s7i        0.068672            392
+seed7/lib/ar.s7i             0.129193           1532
+seed7/lib/arc4.s7i           0.043745            144
+seed7/lib/archive.s7i        0.045424            143
+seed7/lib/archive_base.s7i   0.046838            135
+seed7/lib/array.s7i          0.076976            610
+seed7/lib/asn1.s7i           0.066644            544
+seed7/lib/asn1oid.s7i        0.051376            157
+seed7/lib/basearray.s7i      0.065930            450
+seed7/lib/bigfile.s7i        0.044145            136
+seed7/lib/bigint.s7i         0.084743            824
+seed7/lib/bigrat.s7i         0.084347            784
+seed7/lib/bin16.s7i          0.071755            592
+seed7/lib/bin32.s7i          0.069242            490
+seed7/lib/bin64.s7i          0.066821            539
+seed7/lib/bitdata.s7i        0.129269           1330
+seed7/lib/bitmapfont.s7i     0.048578            215
+seed7/lib/bitset.s7i         0.066094            593
+seed7/lib/bitsetof.s7i       0.064860            431
+seed7/lib/blowfish.s7i       0.080662            383
+seed7/lib/bmp.s7i            0.103358            924
+seed7/lib/boolean.s7i        0.056330            403
+seed7/lib/browser.s7i        0.057583            280
+seed7/lib/bstring.s7i        0.048063            227
+seed7/lib/bytedata.s7i       0.067784            482
+seed7/lib/bzip2.s7i          0.091670            887
+seed7/lib/cards.s7i          0.106483           1342
+seed7/lib/category.s7i       0.051247            209
+seed7/lib/cc_conf.s7i        0.124453           1314
+seed7/lib/ccittfax.s7i       0.105158           1022
+seed7/lib/cgi.s7i            0.042021            109
+seed7/lib/cgidialog.s7i      0.100096           1118
+seed7/lib/char.s7i           0.053470            356
+seed7/lib/charsets.s7i       0.127155           2024
+seed7/lib/chartype.s7i       0.048388            121
+seed7/lib/cipher.s7i         0.042873            146
+seed7/lib/cli_cmds.s7i       0.117144           1360
+seed7/lib/clib_file.s7i      0.051795            301
+seed7/lib/color.s7i          0.052945            185
+seed7/lib/complex.s7i        0.068501            464
+seed7/lib/compress.s7i       0.048478            150
+seed7/lib/console.s7i        0.048219            188
+seed7/lib/cpio.s7i           0.149238           1708
+seed7/lib/crc32.s7i          0.055828            193
+seed7/lib/cronos16.s7i       0.203481           1173
+seed7/lib/cronos27.s7i       0.265854           1464
+seed7/lib/csv.s7i            0.050074            201
+seed7/lib/db_prop.s7i        0.103991            991
+seed7/lib/deflate.s7i        0.091670            740
+seed7/lib/des.s7i            0.084049            444
+seed7/lib/dialog.s7i         0.058326            311
+seed7/lib/dir.s7i            0.043205            163
+seed7/lib/draw.s7i           0.091089            854
+seed7/lib/duration.s7i       0.099721           1038
+seed7/lib/echo.s7i           0.043948            132
+seed7/lib/editline.s7i       0.063036            398
+seed7/lib/elf.s7i            0.163674           1560
+seed7/lib/elliptic.s7i       0.078046            649
+seed7/lib/enable_io.s7i      0.053832            312
+seed7/lib/encoding.s7i       0.098568            931
+seed7/lib/enumeration.s7i    0.051638            236
+seed7/lib/environment.s7i    0.044485            175
+seed7/lib/exif.s7i           0.049587            152
+seed7/lib/external_file.s7i  0.059170            340
+seed7/lib/field.s7i          0.056996            268
+seed7/lib/file.s7i           0.056010            372
+seed7/lib/filebits.s7i       0.043111             46
+seed7/lib/filesys.s7i        0.068750            601
+seed7/lib/fileutil.s7i       0.045686            144
+seed7/lib/fixarray.s7i       0.055928            307
+seed7/lib/float.s7i          0.082767            757
+seed7/lib/font.s7i           0.049860            196
+seed7/lib/font8x8.s7i        0.069975            998
+seed7/lib/forloop.s7i        0.063037            449
+seed7/lib/ftp.s7i            0.089840            969
+seed7/lib/ftpserv.s7i        0.077232            631
+seed7/lib/getf.s7i           0.044812            115
+seed7/lib/gethttp.s7i        0.039949             41
+seed7/lib/gethttps.s7i       0.044611             41
+seed7/lib/gif.s7i            0.073354            561
+seed7/lib/graph.s7i          0.068542            415
+seed7/lib/graph_file.s7i     0.061811            399
+seed7/lib/gtkserver.s7i      0.046226            161
+seed7/lib/gzip.s7i           0.071288            573
+seed7/lib/hash.s7i           0.073258            421
+seed7/lib/hashsetof.s7i      0.072146            499
+seed7/lib/hmac.s7i           0.048225            152
+seed7/lib/html.s7i           0.045693             83
+seed7/lib/html_ent.s7i       0.066849            476
+seed7/lib/htmldom.s7i        0.056097            286
+seed7/lib/http_request.s7i   0.085044            696
+seed7/lib/http_srv_resp.s7i  0.066314            380
+seed7/lib/https_request.s7i  0.051269            211
+seed7/lib/httpserv.s7i       0.057060            345
+seed7/lib/huffman.s7i        0.077893            644
+seed7/lib/ico.s7i            0.050625            221
+seed7/lib/idxarray.s7i       0.053242            232
+seed7/lib/image.s7i          0.044576            156
+seed7/lib/imagefile.s7i      0.047523            171
+seed7/lib/inflate.s7i        0.068482            411
+seed7/lib/inifile.s7i        0.044304            129
+seed7/lib/integer.s7i        0.073183            663
+seed7/lib/iobuffer.s7i       0.054498            289
+seed7/lib/jpeg.s7i           0.160305           1761
+seed7/lib/json.s7i           0.083722            891
+seed7/lib/json_serde.s7i     0.082153            783
+seed7/lib/keybd.s7i          0.084579            639
+seed7/lib/keydescr.s7i       0.051684            192
+seed7/lib/leb128.s7i         0.048911            218
+seed7/lib/line.s7i           0.047642            164
+seed7/lib/listener.s7i       0.054424            247
+seed7/lib/logfile.s7i        0.042224             73
+seed7/lib/lower.s7i          0.049108            142
+seed7/lib/lzma.s7i           0.101956            934
+seed7/lib/lzw.s7i            0.093048            861
+seed7/lib/magic.s7i          0.067770            403
+seed7/lib/mahjng32.s7i       0.098618           1500
+seed7/lib/make.s7i           0.072697            544
+seed7/lib/makedata.s7i       0.128358           1428
+seed7/lib/math.s7i           0.061166            201
+seed7/lib/mixarith.s7i       0.054257            249
+seed7/lib/modern27.s7i       0.181932           1099
+seed7/lib/more.s7i           0.044522            130
+seed7/lib/msgdigest.s7i      0.141831           1222
+seed7/lib/multiscr.s7i       0.040197             68
+seed7/lib/null_file.s7i      0.055085            345
+seed7/lib/osfiles.s7i        0.100215           1085
+seed7/lib/pbm.s7i            0.050989            230
+seed7/lib/pcx.s7i            0.082496            638
+seed7/lib/pem.s7i            0.046671            185
+seed7/lib/pgm.s7i            0.049863            238
+seed7/lib/pic16.s7i          0.070859           1037
+seed7/lib/pic32.s7i          0.128589           2060
+seed7/lib/pic_util.s7i       0.048261            144
+seed7/lib/pixelimage.s7i     0.060012            320
+seed7/lib/pixmap_file.s7i    0.066108            459
+seed7/lib/pixmapfont.s7i     0.048233            184
+seed7/lib/pkcs1.s7i          0.080311            543
+seed7/lib/png.s7i            0.112308           1064
+seed7/lib/poll.s7i           0.062538            313
+seed7/lib/ppm.s7i            0.054939            240
+seed7/lib/process.s7i        0.067993            541
+seed7/lib/progs.s7i          0.086433            789
+seed7/lib/propertyfile.s7i   0.052118            155
+seed7/lib/rational.s7i       0.082640            792
+seed7/lib/ref_list.s7i       0.051292            252
+seed7/lib/reference.s7i      0.043567            126
+seed7/lib/reverse.s7i        0.045118             94
+seed7/lib/rpm.s7i            0.298008           3487
+seed7/lib/rpmext.s7i         0.056838            318
+seed7/lib/scanfile.s7i       0.138587           1779
+seed7/lib/scanjson.s7i       0.069472            413
+seed7/lib/scanstri.s7i       0.146226           1814
+seed7/lib/scantoml.s7i       0.139543           1603
+seed7/lib/seed7_05.s7i       0.117985           1072
+seed7/lib/set.s7i            0.042930             57
+seed7/lib/shell.s7i          0.074052            615
+seed7/lib/showtls.s7i        0.091159            678
+seed7/lib/signature.s7i      0.049904            131
+seed7/lib/smtp.s7i           0.055523            261
+seed7/lib/sockbase.s7i       0.050736            217
+seed7/lib/socket.s7i         0.054734            326
+seed7/lib/sokoban1.s7i       0.087903           1519
+seed7/lib/sql_base.s7i       0.100103           1000
+seed7/lib/stars.s7i          0.247730           1705
+seed7/lib/stdfont10.s7i      0.152102           3347
+seed7/lib/stdfont12.s7i      0.174814           3928
+seed7/lib/stdfont14.s7i      0.198580           4510
+seed7/lib/stdfont16.s7i      0.222783           5092
+seed7/lib/stdfont18.s7i      0.259463           5868
+seed7/lib/stdfont20.s7i      0.288338           6449
+seed7/lib/stdfont24.s7i      0.347548           7421
+seed7/lib/stdfont8.s7i       0.131694           2960
+seed7/lib/stdfont9.s7i       0.141252           3152
+seed7/lib/stdio.s7i          0.050292            192
+seed7/lib/strifile.s7i       0.060410            345
+seed7/lib/string.s7i         0.078304            779
+seed7/lib/stritext.s7i       0.057934            352
+seed7/lib/struct.s7i         0.059448            266
+seed7/lib/struct_elem.s7i    0.043591            129
+seed7/lib/subfile.s7i        0.046414            174
+seed7/lib/subrange.s7i       0.041803             78
+seed7/lib/syntax.s7i         0.065984            294
+seed7/lib/tar.s7i            0.153383           1880
+seed7/lib/tar_cmds.s7i       0.093948            752
+seed7/lib/tdes.s7i           0.044658            143
+seed7/lib/tee.s7i            0.042243            143
+seed7/lib/text.s7i           0.043068            135
+seed7/lib/tga.s7i            0.087395            676
+seed7/lib/tiff.s7i           0.254328           2771
+seed7/lib/time.s7i           0.109363           1191
+seed7/lib/tls.s7i            0.210530           2230
+seed7/lib/unicode.s7i        0.079271            575
+seed7/lib/unionfnd.s7i       0.044602            130
+seed7/lib/upper.s7i          0.044527            142
+seed7/lib/utf16.s7i          0.069750            540
+seed7/lib/utf8.s7i           0.052225            234
+seed7/lib/vecfont10.s7i      0.167873           1056
+seed7/lib/vecfont18.s7i      0.189285           1119
+seed7/lib/vector3d.s7i       0.052337            293
+seed7/lib/vectorfont.s7i     0.054146            239
+seed7/lib/wildcard.s7i       0.045677            140
+seed7/lib/window.s7i         0.065160            455
+seed7/lib/wrinum.s7i         0.054340            248
+seed7/lib/x509cert.s7i       0.126777           1243
+seed7/lib/xml_ent.s7i        0.044385             94
+seed7/lib/xmldom.s7i         0.055840            303
+seed7/lib/xz.s7i             0.067971            442
+seed7/lib/zip.s7i            0.241600           2792
+seed7/lib/zstd.s7i           0.127808           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.165701        |
++-----------+-----------------+
+| Minimum   | 0.037476        |
++-----------+-----------------+
+| Maximum   | 5.733136        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033800        | 0.031949        | 0.041438        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.038936        | 0.035116        | 0.047138        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.092767        | 0.036255        | 2.597001        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.165701        | 0.037476        | 5.733136        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.244 | 00:00:57.587 | 00:01:09.832 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.873 | 00:01:06.391 | 00:01:21.265 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:36.978 | 00:02:38.960 | 00:03:15.938 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:03.887 | 00:04:43.236 | 00:05:47.124 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:34.166 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260625.0929
+;; Package-Version: 20260625.1041
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -538,7 +538,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-25T13:29:52+0000 W26-4"
+(defconst seed7-mode-version-timestamp "2026-06-25T14:41:17+0000 W26-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5778,90 +5778,104 @@ If it finds something it returns a list that holds the following information:
         (end-of-line)
         (while (and keep-searching
                     (not (bobp)))
-          (when (seed7-re-search-backward seed7-block-line-start-regexp beg-bound)
-            ;; get match text, normalize matching hard tabs to spaces.
-            (setq match-text (replace-regexp-in-string
-                              "[[:blank:]]+$" " "
-                              (substring-no-properties (match-string 1))))
-            (setq block-start-pos (point)) ; start point: line start.
-            (skip-chars-forward " \t")
-            (setq block-start-indent-column (current-column))
-            ;; Identify the end position and start position of the currently
-            ;; enclosing block
-            (save-excursion
-              (setq enclosing-block-end-pos (seed7--block-end-pos-for match-text))
-              ;; Identify the beginning of the enclosing top-level block
-              (setq enclosing-block-start-pos
-                    (seed7-to-block-backward nil :dont-push-mark)))
-            (when (<= block-start-pos current-pos enclosing-block-end-pos)
-              ;; It's a real and valid block: 3 cases are possible:
-              (cond
-               ;; Case 1: point is on the start line of a top level block.
-               ((and (seed7--on-lineof block-start-pos current-pos)
-                     (member match-text '("const proc: "
-                                          "const func "
-                                          "const type: ")))
-                ;; In that case the enclosing block start should be the same as
-                ;; the block start.  If it's not the case there's a logic error.
-                (when (eq enclosing-block-start-pos block-start-pos)
-                  ;; When at the line of top-level enclosing block, use the
-                  ;; `seed7-calc-indent' to get the indentation of the line just
-                  ;; above the current line, as if the previous line was a noop
-                  ;; statement.  Simulate the noop statement by temporary
-                  ;; inserting it in the above line.  This way it will be
-                  ;; possible to handle the case where the statement is inside
-                  ;; the first line of another block statement like an if
-                  ;; statement.
-                  ;; Note that calling `seed7-calc-indent' means recursing into
-                  ;; it since it's `seed7-calc-indent' that calls
-                  ;; `seed7-line-inside-a-block'.  But doing it this way we use
-                  ;; all the logic necessary to compute the indentation for this
-                  ;; case.
-                  ;; Allow modification of a read-only buffer and ensure that
-                  ;; the undo history is not modified by the insertion and
-                  ;; removal operations.
-                  (let ((inhibit-read-only t))
-                    (with-silent-modifications
-                      (setq keep-searching nil
-                            result (list
-                                    (save-excursion
-                                      (forward-line 0)
-                                      (let ((noop-start (point))
-                                            (noop-end nil))
-                                        (insert " noop;\n")
-                                        (setq noop-end (point))
-                                        (forward-line -1)
-                                        (unwind-protect
-                                            ;; compute indentation with noop
-                                            (seed7-calc-indent)
-                                          ;; always delete inserted noop
-                                          (delete-region noop-start noop-end))))
-                                    match-text
-                                    enclosing-block-start-pos
-                                    enclosing-block-end-pos
-                                    block-start-indent-column))))))
-               ;;
-               ;; Case 2: point is on an internal block start line.
-               ((seed7--on-lineof block-start-pos current-pos)
-                ;; Look for the previous block and use info from it.
-                (goto-char block-start-pos)
-                (when (seed7-re-search-backward
-                       seed7-block-line-start-regexp)
-                  (setq match-text (replace-regexp-in-string
-                                    "[[:blank:]]+$" " "
-                                    (substring-no-properties (match-string 1))))
-                  (setq block-start-pos (point))
-                  (skip-chars-forward " \t")
-                  (setq block-start-indent-column (current-column))
-                  ;; Identify the end position and start position of the
-                  ;; currently enclosing block
-                  (save-excursion
-                    (setq enclosing-block-end-pos
-                          (seed7--block-end-pos-for match-text))
-                    ;; Identify the beginning of the enclosing top-level block
-                    (setq enclosing-block-start-pos
-                          (seed7-to-block-backward nil :dont-push-mark)))
-                  (when (<= block-start-pos current-pos enclosing-block-end-pos)
+          (if (seed7-re-search-backward seed7-block-line-start-regexp beg-bound)
+              (progn
+                ;; get match text, normalize matching hard tabs to spaces.
+                (setq match-text (replace-regexp-in-string
+                                  "[[:blank:]]+$" " "
+                                  (substring-no-properties (match-string 1))))
+                (setq block-start-pos (point)) ; start point: line start.
+                (skip-chars-forward " \t")
+                (setq block-start-indent-column (current-column))
+                ;; Identify the end position and start position of the currently
+                ;; enclosing block
+                (save-excursion
+                  (setq enclosing-block-end-pos (seed7--block-end-pos-for match-text))
+                  ;; Identify the beginning of the enclosing top-level block
+                  (setq enclosing-block-start-pos
+                        (seed7-to-block-backward nil :dont-push-mark)))
+                (when (<= block-start-pos current-pos enclosing-block-end-pos)
+                  ;; It's a real and valid block: 3 cases are possible:
+                  (cond
+                   ;; Case 1: point is on the start line of a top level block.
+                   ((and (seed7--on-lineof block-start-pos current-pos)
+                         (member match-text '("const proc: "
+                                              "const func "
+                                              "const type: ")))
+                    ;; In that case the enclosing block start should be the same as
+                    ;; the block start.  If it's not the case there's a logic error.
+                    (when (eq enclosing-block-start-pos block-start-pos)
+                      ;; When at the line of top-level enclosing block, use the
+                      ;; `seed7-calc-indent' to get the indentation of the line just
+                      ;; above the current line, as if the previous line was a noop
+                      ;; statement.  Simulate the noop statement by temporary
+                      ;; inserting it in the above line.  This way it will be
+                      ;; possible to handle the case where the statement is inside
+                      ;; the first line of another block statement like an if
+                      ;; statement.
+                      ;; Note that calling `seed7-calc-indent' means recursing into
+                      ;; it since it's `seed7-calc-indent' that calls
+                      ;; `seed7-line-inside-a-block'.  But doing it this way we use
+                      ;; all the logic necessary to compute the indentation for this
+                      ;; case.
+                      ;; Allow modification of a read-only buffer and ensure that
+                      ;; the undo history is not modified by the insertion and
+                      ;; removal operations.
+                      (let ((inhibit-read-only t))
+                        (with-silent-modifications
+                          (setq keep-searching nil
+                                result (list
+                                        (save-excursion
+                                          (forward-line 0)
+                                          (let ((noop-start (point))
+                                                (noop-end nil))
+                                            (insert " noop;\n")
+                                            (setq noop-end (point))
+                                            (forward-line -1)
+                                            (unwind-protect
+                                                ;; compute indentation with noop
+                                                (seed7-calc-indent)
+                                              ;; always delete inserted noop
+                                              (delete-region noop-start noop-end))))
+                                        match-text
+                                        enclosing-block-start-pos
+                                        enclosing-block-end-pos
+                                        block-start-indent-column))))))
+                   ;;
+                   ;; Case 2: point is on an internal block start line.
+                   ((seed7--on-lineof block-start-pos current-pos)
+                    ;; Look for the previous block and use info from it.
+                    (goto-char block-start-pos)
+                    (when (seed7-re-search-backward
+                           seed7-block-line-start-regexp beg-bound)
+                      (setq match-text (replace-regexp-in-string
+                                        "[[:blank:]]+$" " "
+                                        (substring-no-properties (match-string 1))))
+                      (setq block-start-pos (point))
+                      (skip-chars-forward " \t")
+                      (setq block-start-indent-column (current-column))
+                      ;; Identify the end position and start position of the
+                      ;; currently enclosing block
+                      (save-excursion
+                        (setq enclosing-block-end-pos
+                              (seed7--block-end-pos-for match-text))
+                        ;; Identify the beginning of the enclosing top-level block
+                        (setq enclosing-block-start-pos
+                              (seed7-to-block-backward nil :dont-push-mark)))
+                      (when (<= block-start-pos current-pos enclosing-block-end-pos)
+                        (setq keep-searching nil
+                              result (list (+ block-start-indent-column
+                                              (seed7--indent-offset-for
+                                               match-text
+                                               line-n-first-text))
+                                           match-text
+                                           block-start-pos
+                                           enclosing-block-end-pos
+                                           block-start-indent-column)))))
+                   ;;
+                   ;; Case 3: point is on a line that is not on the block start,
+                   ;;         but between the block start and the block end.
+                   (t
                     (setq keep-searching nil
                           result (list (+ block-start-indent-column
                                           (seed7--indent-offset-for
@@ -5871,28 +5885,17 @@ If it finds something it returns a list that holds the following information:
                                        block-start-pos
                                        enclosing-block-end-pos
                                        block-start-indent-column)))))
-               ;;
-               ;; Case 3: point is on a line that is not on the block start,
-               ;;         but between the block start and the block end.
-               (t
-                (setq keep-searching nil
-                      result (list (+ block-start-indent-column
-                                      (seed7--indent-offset-for
-                                       match-text
-                                       line-n-first-text))
-                                   match-text
-                                   block-start-pos
-                                   enclosing-block-end-pos
-                                   block-start-indent-column)))))
-            (when keep-searching
-              ;; Found something that looks like a block, but either not
-              ;; a real block or not the block that holds the line.
-              ;; Need to search back further for a bigger block.  If
-              ;; block-start-pos is not a column 0, then keep searching
-              ;; above for the beginning of a larger block.
-              (if (eq (current-column) 0)
-                  (setq keep-searching nil)
-                (goto-char (1- block-start-pos))))))
+                (when keep-searching
+                  ;; Found something that looks like a block, but either not
+                  ;; a real block or not the block that holds the line.
+                  ;; Need to search back further for a bigger block.  If
+                  ;; block-start-pos is not a column 0, then keep searching
+                  ;; above for the beginning of a larger block.
+                  (if (eq (current-column) 0)
+                      (setq keep-searching nil)
+                    (goto-char (1- block-start-pos)))))
+            ;; No more candidate block start within the allowed range
+            (setq keep-searching nil)))
         result))))
 
 ;; --
@@ -6832,7 +6835,7 @@ cycles: word → symbol → line → [block …] → defun."
 ;;** Seed7 Indentation Comment Checking Function
 ;;   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-(defun seed7-comment-column (recurse-count)
+(defun seed7-comment-column ()
   "Return the column number for comment start or continuation.
 The RECURSE-COUNT argument should be 0 on first call, incremented by 1 on each
 recursive call."
@@ -6863,17 +6866,13 @@ recursive call."
               ;; `seed7-calc-indent' to get the indentation.  Only 1 level of
               ;; recursion should be necessary (and allowed).
               (condition-case nil
-                  (seed7-calc-indent
-                   :treat-comment-line-as-code
-                   (1+ recurse-count))
+                  (seed7-calc-indent :treat-comment-line-as-code)
                 ;; If no rule was found for the code, force the indentation to
                 ;; 0 as if there was no statements above.
                 (error 0))))
         ;; If there are no statements above indent a column 0.
         (condition-case nil
-            (seed7-calc-indent
-             :treat-comment-line-as-code
-             (1+ recurse-count))
+            (seed7-calc-indent :treat-comment-line-as-code)
           ;; If no rule was found for the code, force the indentation to
           ;; 0 as if there was no statements above.
           (error 0))))
@@ -6937,13 +6936,22 @@ Skip comment unless DONT-SKIP-COMMENT is non-nil."
 ;;** Seed7 Indentation Calculator Function
 ;;   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-(defun seed7-calc-indent (&optional treat-comment-line-as-code recurse-count)
+(defvar seed7--calc-indent-depth 0
+  "Dynamic recursion depth for `seed7-calc-indent'.
+
+This is call-stack state, used only to prevent runaway recursive
+indentation paths.  It is intentionally not buffer-local.")
+
+(defconst seed7--calc-indent-depth-max 8
+  "Maximum allowed recursive depth for `seed7-calc-indent'.")
+
+(defun seed7-calc-indent (&optional treat-comment-line-as-code)
   "Calculate and return indentation (in columns) of current line of code.
 When TREAT-COMMENT-LINE-AS-CODE is non-nil a comment line is processed as if
   it was a code line, allowing the indentation logic to handle comments.
 The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
   call.  Only one recursion is allowed."
-  (let* ((recurse-count (or recurse-count 0))
+  (let* ((seed7--calc-indent-depth (1+ seed7--calc-indent-depth))
          ;; Expensive fallback lower bound for the generic block path.
          ;; Compute lazily only if the cheap cached block bounds are unavailable.
          (indent-bound nil)
@@ -6971,17 +6979,17 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
          (indent-column nil)
          (indent-column2 nil)
          (spec-list nil))
+    (when (> seed7--calc-indent-depth seed7--calc-indent-depth-max)
+      (error "seed7-calc-indent: recursion depth exceeded at line %d"
+             (line-number-at-pos)))
     ;; don't indent blank lines
     (unless (and (not first-word-on-line)
                  (seed7-blank-line-p))
       (cond
-       ((> recurse-count 1)
-        (error "Recursion done more than once: implementation logic error!"))
-
        ;; in comment
        ((and (seed7-current-line-start-inside-comment-p)
              (not treat-comment-line-as-code))
-        (setq indent-column (seed7-comment-column recurse-count)))
+        (setq indent-column (seed7-comment-column)))
 
        ;; In an array or set definition, indent 1 level unless the line is
        ;; inside 2 nested parens.  In that case align with the inside of
@@ -7104,7 +7112,7 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                 (message
                  "At line %d: string line syntax not yet supported! Recurse count=%d Please report."
                  (seed7-current-line-number)
-                 recurse-count)))))))
+                 seed7--calc-indent-depth)))))))
 
        ;; -- Special rule: if a line starts with a Seed7 assignment operator,
        ;; consider that line manually indented and keep it where it is.
@@ -7150,10 +7158,10 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
 
        ((seed7--set (seed7-line-inside-a-block-cached
                      0 nil
-                      (or early-begin-pos
-                          indent-bound
-                          (setq indent-bound
-                                (seed7--indent-search-boundary))))
+                     (or early-begin-pos
+                         indent-bound
+                         (setq indent-bound
+                               (seed7--indent-search-boundary))))
                     spec-list)
         ;; Inside a block.  Check if inside any special zones first.
         ;; For all of those extra checks limit the zone to the scope of the

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.1606
+;; Package-Version: 20260624.1710
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T20:06:11+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-24T21:10:39+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1508,6 +1508,31 @@ Match group 1")
                'words)
    "\\)")
   "Regexp for the top of a Seed7 block.  One capture group.")
+
+(defconst seed7--callable-declaration-start-regexp
+  (concat
+   "\\("
+   (regexp-opt '("const array" "const func" "const proc:"
+                 "const set"   "const type:" "var array" "var set"))
+   "[[:blank:]]\\)")
+  "Regexp matching the start of a Seed7 callable or type declaration.
+This is a strict subset of `seed7-block-top-start-regexp' that excludes
+all control-flow keywords (`if', `while', `for', `elsif', `case', `catch')
+and structural markers (`begin', `local', `result', `else', `exception',
+`global', `repeat', `block').
+
+Used by `seed7--to-top' to find the enclosing top-level or template-level
+declaration without visiting every control-flow keyword on the way.
+
+Performance improvement (measured keyword match counts):
+  chkarr.sd7 : 2,943 total keywords → ~150 declarations  (~20× fewer iters)
+  castle.sd7  :   706 total keywords →  ~50 declarations  (~14× fewer iters)
+
+The column check in `seed7--to-top' (< start-col) is still correct for
+indented `const func'/`const proc' in .s7i template bodies such as
+`ENABLE_SORT' in aarray.s7i, since those are either `is action \"...\"'
+one-liners or short `return...;' functions — neither creates a
+`begin...end func' block you can be indenting code *inside*.")
 
 ;;** Seed7 Array Regexp
 ;;   ------------------
@@ -3286,7 +3311,8 @@ Seed7 template bodies (in .s7i files)."
           (line-number-at-pos (point))))
       (while (and (not found)
                   (not (bobp))
-                  (seed7-re-search-backward seed7-block-top-start-regexp))
+                  (seed7-re-search-backward
+                   seed7--callable-declaration-start-regexp))
         (seed7-to-indent)
         ;; Stop as soon as we find a block-start keyword whose column is
         ;; strictly less than the starting column.  This correctly handles:

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.1048
+;; Package-Version: 20260624.1302
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T14:48:55+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-24T17:02:38+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -778,11 +778,12 @@ and the default path is not appropriate."
   "[^\\0]"
   "Match any character including new-line.")
 
-(defconst seed7--any-wp-text-re
-  (format "\\(?:%s+?.+?\\)+?"
-          seed7--whitespace-re)
-  "Any sequence of whitespace followed by non-whitespace.
-Inside a non-capturing group.")
+(defconst seed7--any-non-semicolon-re
+  "[^;]+"
+  "Any sequence of non-semicolon characters.
+Used in `return'-statement patterns to match the body up to the terminating `;'.
+Uses a negated character class instead of nested lazy quantifiers to prevent
+catastrophic backtracking (ReDoS) on large files.")
 
 ;; --
 ;; Note: Ensure that something like 0_ is not matched by seed7-name-identifier-nc-re
@@ -1913,10 +1914,12 @@ Group 4: - \"func\" for proc or function that ends with \"end func\".
   "Regexp to detect end of procedure or long function.  No group.")
 
 (defconst seed7-short-func-end-regexp
-  (format "^[[:blank:]]+?return\\(?:%s+?.+?\\)+?;"
-          ;;                        %
-          seed7--whitespace-re)
-  "Regexp to detect end of short function.  No group.")
+  "^[[:blank:]]+return[^;]*;"
+  "Regexp to detect end of short function.  No group.
+Uses `[^;]*' (negated character class) instead of nested lazy quantifiers
+to prevent catastrophic backtracking on large files.
+Matches a return statement starting on a line beginning with whitespace,
+spanning any number of continuation lines, ending at the first `;'.")
 
 (defconst seed7-forward-declaration-end-regexp
   "[[:blank:]]*?is[[:blank:]]+?forward;"
@@ -2932,16 +2935,17 @@ Move point."
         (keep-searching t)
         ;; prevent case fold searching: Seed7 is case sensitive.
         (case-fold-search nil))
-    (while (and keep-searching
-                (not (bobp)))
-      (if (re-search-backward regexp bound :noerror)
-          (unless (or (seed7-inside-comment-p)
-                      (seed7-inside-string-p))
-            ;; Found in code!
-            (setq found-pos (point))
-            (setq keep-searching nil))
-        ;; Not found. stop.
-        (setq keep-searching nil)))
+    (with-timeout (10 nil) ; ← give up after 10 s; returns nil
+      (while (and keep-searching
+                  (not (bobp)))
+        (if (re-search-backward regexp bound :noerror)
+            (unless (or (seed7-inside-comment-p)
+                        (seed7-inside-string-p))
+              ;; Found in code!
+              (setq found-pos (point))
+              (setq keep-searching nil))
+          ;; Not found. stop.
+          (setq keep-searching nil))))
     found-pos))
 
 (defun seed7-re-search-backward-closest (regexps &optional get-end-pos)
@@ -3381,13 +3385,16 @@ Arguments:
   "Group 1: complete text.")
 
 ;; [ TODO 2025-06-30, by Pierre Rouleau: Add support for multiple lines]
+;; AFTER — with fixed seed7--any-wp-text-re the format is already correct;
+;;          also drop the extra +? that caused the +?+? double-quantifier:
 (defconst seed7---inner-callables-2
-  ;;              (---------------)
-  ;;     (----------------------------)     (--------------)
-  ;;  (--------------------------------------------------------)
   (format
-   "\\(\\(?:end \\(?:func\\|proc\\);\\)\\|\\(?:return%s+?;\\)\\)"
-   seed7--any-wp-text-re)
+   "\\(\\(?:end \\(?:func\\|proc\\);\\)\\|\\(?:return%s;\\)\\)"
+   ;;                                                ^^ no +? here; [^;]+ already quantifies
+   ;;             (---------------)
+   ;;    (----------------------------)     (-------------)
+   ;;  (-----------------------------------------------------)
+   seed7--any-non-semicolon-re)
   "Group 1: entire text.")
 
 
@@ -3395,8 +3402,8 @@ Arguments:
   "const proc: .+? is forward;")
 
 (defconst seed7--callable-return-re
-  (format "return%s+?;"
-          seed7--any-wp-text-re))
+  (format "return%s+;"
+          seed7--any-non-semicolon-re))
 
 (defconst seed7--inner-callables-triplets-re
   (format

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260625.0827
+;; Package-Version: 20260625.0929
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -538,7 +538,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-25T12:27:54+0000 W26-4"
+(defconst seed7-mode-version-timestamp "2026-06-25T13:29:52+0000 W26-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6004,23 +6004,31 @@ If a block is found, return a list of 5 elements:
 - 2: block start position (the beginning of the start keyword line),
 - 3: enclosing block end position,
 - 4: indent column of the block start line."
-  (if beg-bound
-      ;; Bounded search: bypass cache completely.
-      (seed7-line-inside-a-block n dont-skip-comment-start beg-bound)
-    ;; Unbounded search: use the cache if necessary.
-    (or (and (eq n 0)
-             (not dont-skip-comment-start)
-             (seed7--cached-block-spec-current-line))
-        (let ((spec (seed7-line-inside-a-block n dont-skip-comment-start)))
-          (when (and (eq n 0) spec)
-            (setq seed7--indent-last-block-spec
-                  (seed7--cache-block-spec spec))
-            ;; Also update the lightweight bounds cache used for early-bound
-            ;; lookups at the top of `seed7-calc-indent'.
-            (setq seed7--indent-block-bounds
-                  (cons (nth 2 seed7--indent-last-block-spec)
-                        (nth 3 seed7--indent-last-block-spec))))
-          spec))))
+  (let ((cached-spec
+         (and (eq n 0)
+              (not dont-skip-comment-start)
+              (seed7--cached-block-spec-current-line))))
+    (cond
+     ;; Fast path: cached spec is still valid for current line, and if a
+     ;; lower bound is supplied, the cached block still starts at or after it.
+     ((and cached-spec
+           (or (not beg-bound)
+               (<= beg-bound (nth 2 cached-spec))))
+      cached-spec)
+     ;;
+     ;; Cache miss or cached block is outside requested lower bound.
+     (t
+      (let ((spec (seed7-line-inside-a-block
+                   n dont-skip-comment-start beg-bound)))
+        (when (and (eq n 0) spec)
+          (setq seed7--indent-last-block-spec
+                (seed7--cache-block-spec spec))
+          ;; Also update the lightweight bounds cache used for early-bound
+          ;; lookups at the top of `seed7-calc-indent'.
+          (setq seed7--indent-block-bounds
+                (cons (nth 2 seed7--indent-last-block-spec)
+                      (nth 3 seed7--indent-last-block-spec))))
+        spec)))))
 
 ;; ---------------------------------------------------------------------------
 
@@ -6936,8 +6944,9 @@ When TREAT-COMMENT-LINE-AS-CODE is non-nil a comment line is processed as if
 The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
   call.  Only one recursion is allowed."
   (let* ((recurse-count (or recurse-count 0))
-         ;; [:todo 2026-06-25, by Pierre Rouleau: Activate boundary??? it slows indentation!]
-         (indent-bound nil)             ; (seed7--indent-search-boundary)
+         ;; Expensive fallback lower bound for the generic block path.
+         ;; Compute lazily only if the cheap cached block bounds are unavailable.
+         (indent-bound nil)
          ;; Eagerly probe the previous call's block boundaries.
          ;; Cost: O(1) — two marker-position comparisons, uses (point)
          ;;              directly; no `seed7-to-indent' overhead.
@@ -7139,7 +7148,13 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
           (setq indent-step 1))
          (t (setq indent-step 0))))
 
-       ((seed7--set (seed7-line-inside-a-block-cached 0 indent-bound) spec-list)
+       ((seed7--set (seed7-line-inside-a-block-cached
+                     0 nil
+                      (or early-begin-pos
+                          indent-bound
+                          (setq indent-bound
+                                (seed7--indent-search-boundary))))
+                    spec-list)
         ;; Inside a block.  Check if inside any special zones first.
         ;; For all of those extra checks limit the zone to the scope of the
         ;; current block to improve efficiency. Extend the boundary by 1

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260622.1719
+;; Package-Version: 20260623.1055
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -534,7 +534,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-22T21:19:10+0000 W26-1"
+(defconst seed7-mode-version-timestamp "2026-06-23T14:55:49+0000 W26-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1510,9 +1510,14 @@ Match group 1")
 ;;   ----------------------
 
 (defconst seed7--array-definition-start-regexp
-  "\\(?:const\\|var\\) +?array[[:blank:]]+?.+?:.+?("
+  ;; "\\(?:const\\|var\\) +?array[[:blank:]]+?.+?:.+?("
+  "\\(?:const\\|var\\) +array[[:blank:]]+.+:.+("
   "Regexp matching the start of a Seed7 array definition block header.
 See `seed7--set-definition-start-regexp' for the whitespace convention.")
+
+;; Note: another possibility for seed7--array-definition-start-regexp would
+;; be: ?:const\\|var\\)[[:blank:]]+array[[:blank:]]+[^:\n]+:[^(;\n]*("
+
 
 (defconst seed7--line-array-definition-start-regexp
   (concat "^[[:blank:]]*?" seed7--array-definition-start-regexp)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.1034
+;; Package-Version: 20260624.1048
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T14:34:31+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-24T14:48:55+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6976,7 +6976,7 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                      ;; Look for an assignment operator anywhere on this line.
                      (goto-char lbeg)
                      (when (seed7-re-search-forward
-                            seed7-predef-assignment-operator-regexp lend
+                            seed7-predef-assignment-operator-regexp lend)
                        ;; Column of the first non-whitespace char after the
                        ;; operator — that is where the RHS expression begins.
                        (skip-chars-forward " \t")

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.1302
+;; Package-Version: 20260624.1430
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T17:02:38+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-24T18:30:15+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -2935,7 +2935,15 @@ Move point."
         (keep-searching t)
         ;; prevent case fold searching: Seed7 is case sensitive.
         (case-fold-search nil))
-    (with-timeout (10 nil) ; ← give up after 10 s; returns nil
+    (with-timeout
+        (10                             ; ← give up after 10 s; warn user.
+         (message
+          (concat "seed7-mode: regexp search timed out at line %d. "
+                  "This indicates a catastrophic-backtracking bug. "
+                  "Please enable the debugger (M-x toggle-debug-on-quit), "
+                  "reproduce with C-g, and report the backtrace together "
+                  "with the current file and line number.")
+          (line-number-at-pos (point))))
       (while (and keep-searching
                   (not (bobp)))
         (if (re-search-backward regexp bound :noerror)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.1553
+;; Package-Version: 20260624.1606
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T19:53:10+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-24T20:06:11+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3428,7 +3428,7 @@ Arguments:
   "const proc: .+? is forward;")
 
 (defconst seed7--callable-return-re
-  (format "return%s+;"
+  (format "return%s;"
           seed7--any-non-semicolon-re))
 
 (defconst seed7--inner-callables-triplets-re

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260625.1041
+;; Package-Version: 20260625.1138
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -378,6 +378,7 @@
 ;;       . `seed7-line-inside-syntax-parens-pair'
 ;;         . `seed7--paren-pair-string'
 ;;     . `seed7-line-inside-parens-pair-column'
+;;     . `seed7-line-starts-with-open-paren-after-logic-operator'
 ;;     . `seed7-line-inside-nested-parens-pairs'
 ;;     . `seed7-line-inside-nested-parens-pairs-column'
 ;;     . `seed7-indentation-of-previous-non-string-line'
@@ -538,7 +539,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-25T14:41:17+0000 W26-4"
+(defconst seed7-mode-version-timestamp "2026-06-25T15:38:52+0000 W26-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6587,6 +6588,30 @@ of the character after the opening parens."
                                            scope-end-pos
                                            dont-skip-comment-start)))
 
+(defconst seed7--line-ends-with-logic-operator-regexp
+  "\\_<\\(?:and\\|or\\)\\_>[[:blank:]]*$"
+  "Regexp matching a line that ends with the logical operators `and' or `or'.")
+
+(defun seed7-line-starts-with-open-paren-after-logic-operator
+    (n &optional dont-skip-comment-start)
+  "Return indent column for a `(' continuation line after `and' or `or'.
+
+When line N starts with `(' and the previous non-empty line ends with
+the logical operator `and' or `or', return the indentation column of
+that previous non-empty line.  Return nil when the pattern does not apply."
+  (save-excursion
+    (when (and (seed7-line-starts-with n "(" dont-skip-comment-start)
+               (seed7-move-to-line :previous-non-empty dont-skip-comment-start))
+      (let ((prev-indent (progn
+                           (skip-chars-forward " \t")
+                           (current-column)))
+            (lbeg (line-beginning-position))
+            (lend (line-end-position)))
+        (goto-char lbeg)
+        (when (re-search-forward
+               seed7--line-ends-with-logic-operator-regexp lend t)
+          prev-indent)))))
+
 (defun seed7-line-inside-nested-parens-pairs (n nested-depth
                                                 &optional
                                                 scope-begin-pos
@@ -7211,15 +7236,24 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                                  (seed7-line-indent-step :previous-non-empty))
                              2)))
        ;;
-       ;;
        ((string= first-word-on-line "until")
         (setq indent-step (1- (or indent-step
                                   (seed7-line-indent-step :previous-non-empty)))))
        ;;
-       ;;
        ((and (string= first-word-on-line "var")
              (seed7-line-starts-with :previous-non-empty "include "))
         (setq indent-step 0))
+
+       ;;
+       ;; Indentation of lines like line 696 of bas7.sd7:
+       ;; 693 const func boolean: isStringExpr (in string: symbol) is
+       ;; 694   return symbol in string_var_name or
+       ;; 695          symbol <> "" and
+       ;; 696         (symbol[length(symbol)] = '$' or symbol[1] = '\"' or symbol[1] in defstr_var and
+       ;; 697          not symbol[length(symbol)] in numeric_var_suffix);
+       ((seed7--set
+         (seed7-line-starts-with-open-paren-after-logic-operator 0)
+         indent-column))
 
        ((seed7-line-starts-with 0 "(")
         ;; for block comment comments or code within parentheses,

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260623.1055
+;; Package-Version: 20260623.1206
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -534,7 +534,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-23T14:55:49+0000 W26-2"
+(defconst seed7-mode-version-timestamp "2026-06-23T16:06:22+0000 W26-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1506,8 +1506,8 @@ Match group 1")
    "\\)")
   "Regexp for the top of a Seed7 block.  One capture group.")
 
-;;** Seed7 Array/Set Regexp
-;;   ----------------------
+;;** Seed7 Array Regexp
+;;   ------------------
 
 (defconst seed7--array-definition-start-regexp
   ;; "\\(?:const\\|var\\) +?array[[:blank:]]+?.+?:.+?("
@@ -1518,10 +1518,24 @@ See `seed7--set-definition-start-regexp' for the whitespace convention.")
 ;; Note: another possibility for seed7--array-definition-start-regexp would
 ;; be: ?:const\\|var\\)[[:blank:]]+array[[:blank:]]+[^:\n]+:[^(;\n]*("
 
-
 (defconst seed7--line-array-definition-start-regexp
   (concat "^[[:blank:]]*?" seed7--array-definition-start-regexp)
   "Regexp matching line starting with a  Seed7 array definition block header.")
+
+(defconst seed7--array-definition-name-regexp
+  (concat "\\(?:const\\|var\\)[[:blank:]]+"
+          "array[[:blank:]]+[^:\n]+:"
+          "[[:blank:]]*\\([[:alpha:]][[:alnum:]_]*\\)")
+  "Regexp matching a Seed7 array declaration; group 1 is the entity name.
+The name is the first identifier that follows the `:' in the declaration.
+Unlike `seed7--array-definition-start-regexp', this regexp captures the name.
+
+Example matches:
+  const array integer: myArray is (1, 2, 3);   → group 1: myArray
+  var   array string:  names;                  → group 1: names")
+
+;;** Seed7 Set Regexp
+;;   ----------------
 
 (defconst seed7--set-definition-start-regexp
   "\\(?:const\\|var\\) +?set[[:blank:]]+?.+?:.+?{"
@@ -1534,6 +1548,18 @@ Design note: a literal space (` +?') is required between `const'/`var' and
 per Seed7 style (dual-keyword restriction).  A hard tab or space
 \(`[[:blank:]]') is accepted after `set', because `set' is the last keyword
 in the phrase before the user-supplied identifier.")
+
+(defconst seed7--set-definition-name-regexp
+  (concat "\\(?:const\\|var\\)[[:blank:]]+"
+          "set[[:blank:]]+[^{:\n]+:"
+          "[[:blank:]]*\\([[:alpha:]][[:alnum:]_]*\\)")
+  "Regexp matching a Seed7 set declaration; group 1 is the entity name.
+The name is the first identifier that follows the `:' in the declaration.
+Unlike `seed7--set-definition-start-regexp', this regexp captures the name.
+
+Example matches:
+  const set of integer: mySet is {1, 2, 3};    → group 1: mySet
+  var   set of string:  names;                 → group 1: names")
 
 (defconst seed7--line-set-definition-start-regexp
   (concat "^[[:blank:]]*?" seed7--set-definition-start-regexp)
@@ -9464,6 +9490,233 @@ current Emacs session without restarting Emacs."
 (seed7-rebuild-abbrev-table 'quietly)
 
 ;; ---------------------------------------------------------------------------
+;;* Seed7 Entity Browser Mode
+;;  =========================
+;;
+;; A special mode that lists all Seed7 elements defined in a Seed7 buffer and
+;; allows moving to anyone by typing RET on its line.
+
+(defun seed7-buffer-entities ()
+  "Return all named entities declared in the current Seed7 buffer.
+
+Each element of the returned list is a list (TYPE NAME LINE-NUMBER) where:
+- TYPE        is a symbol: `function', `procedure', `structure',
+              `enumeration', `array', or `set'.
+- NAME        is the entity name as a string.
+- LINE-NUMBER is the line number (integer ≥ 1) of the declaration.
+
+The list is sorted by LINE-NUMBER in ascending order.
+Only code outside comments and strings is examined
+\(via `seed7-re-search-forward').
+
+This function does not move point (all searches use `save-excursion')."
+  (let ((entities '()))
+    ;; -- Functions and procedures ------------------------------
+    (save-excursion
+      (goto-char (point-min))
+      (while (seed7-re-search-forward seed7-procfunc-regexp)
+        (let ((raw-type (match-string-no-properties
+                         seed7-procfunc-regexp-item-type-group))
+              (name     (match-string-no-properties
+                         seed7-procfunc-regexp-item-name-group)))
+          (when name
+            (push (list (if (string= raw-type "proc") 'procedure 'function)
+                        name
+                        (line-number-at-pos
+                         (match-beginning seed7-procfunc-regexp-item-name-group)))
+                  entities)))))
+    ;; -- Enumerations ------------------------------------------
+    (save-excursion
+      (goto-char (point-min))
+      (while (seed7-re-search-forward seed7-enum-regexp-4imenu)
+        (push (list 'enumeration
+                    (match-string-no-properties 1)
+                    (line-number-at-pos (match-beginning 1)))
+              entities)))
+    ;; -- Structures --------------------------------------------
+    (save-excursion
+      (goto-char (point-min))
+      (while (seed7-re-search-forward seed7-struct-regexp-4imenu)
+        (push (list 'structure
+                    (match-string-no-properties 1)
+                    (line-number-at-pos (match-beginning 1)))
+              entities)))
+    ;; -- Arrays ------------------------------------------------
+    (save-excursion
+      (goto-char (point-min))
+      (while (seed7-re-search-forward seed7--array-definition-name-regexp)
+        (push (list 'array
+                    (match-string-no-properties 1)
+                    (line-number-at-pos (match-beginning 1)))
+              entities)))
+    ;; -- Sets --------------------------------------------------
+    (save-excursion
+      (goto-char (point-min))
+      (while (seed7-re-search-forward seed7--set-definition-name-regexp)
+        (push (list 'set
+                    (match-string-no-properties 1)
+                    (line-number-at-pos (match-beginning 1)))
+              entities)))
+    ;; -- Sort by line number and return-------------------------
+    (sort entities (lambda (a b) (< (nth 2 a) (nth 2 b))))))
+
+
+;;** Seed7 entity browser (tabulated-list-mode)
+;;   ------------------------------------------
+
+(defvar-local sd7-ent--source-buffer nil
+  "The Seed7 source buffer that this entity browser was built from.")
+
+(defvar-local sd7-ent--source-file nil
+  "File path of the Seed7 source buffer; used when the buffer is killed.")
+
+(defvar seed7-entities-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map tabulated-list-mode-map)
+    (define-key map (kbd "RET") #'sd7-ent--visit-entity)
+    (define-key map (kbd "o")   #'sd7-ent--visit-entity-other-window)
+    (define-key map (kbd "g")   #'sd7-ent--refresh)
+    map)
+  "Keymap for `seed7-entities-mode'.
+
+\\{seed7-entities-mode-map}")
+
+(define-derived-mode seed7-entities-mode tabulated-list-mode "Seed7-Entities"
+  "Major mode for browsing named entities declared in a Seed7 buffer.
+
+Each row shows the line number, entity type, and name.
+\\<seed7-entities-mode-map>
+\\[sd7-ent--visit-entity] Go to the declaration in the source buffer.
+\\[sd7-ent--visit-entity-other-window]   Go to the declaration in the other window.
+\\[sd7-ent--refresh]   Re-scan the source buffer and redisplay.
+\\[tabulated-list-sort]   Sort by the column at point.
+
+The entry ID of each row is (SOURCE-BUFFER . LINE-NUMBER), so the browser
+always navigates to the exact line regardless of how the table is sorted."
+  (setq tabulated-list-format
+        (vector
+         (list "Line" 6
+               (lambda (a b)
+                 ;; Sort numerically on the LINE column (column 0).
+                 (< (string-to-number (aref (cadr a) 0))
+                    (string-to-number (aref (cadr b) 0)))))
+         (list "Type" 13 t)
+         (list "Name" 50 t)))
+  (setq tabulated-list-padding 1)
+  (setq tabulated-list-sort-key nil)
+  (tabulated-list-init-header))
+
+;;** Seed7 entity browser helpers
+;;   ----------------------------
+
+(defun sd7-ent--entry-id ()
+  "Return the entry-id of the row at point, or signal an error."
+  (let ((id (tabulated-list-get-id)))
+    (unless id
+      (user-error "No entity at point"))
+    id))
+
+(defun sd7-ent--resolve-source (entry-id)
+  "Return a live buffer for ENTRY-ID = (SOURCE-BUFFER . LINE).
+If the originally recorded buffer is no longer live, try to re-visit
+`sd7-ent--source-file'.  Signals `user-error' if neither is possible."
+  (let* ((src-buf  (car entry-id))
+         (file     sd7-ent--source-file))
+    (cond
+     ;; Original buffer still live.
+     ((buffer-live-p src-buf) src-buf)
+     ;; Buffer killed but we have a file path — re-visit it.
+     ((and file (file-readable-p file))
+      (find-file-noselect file))
+     (t
+      (user-error "Source buffer is no longer available")))))
+
+(defun sd7-ent--goto-line-in-buffer (buf line-no)
+  "Switch to BUF and move point to LINE-NO."
+  (switch-to-buffer buf)
+  (goto-char (point-min))
+  (forward-line (1- line-no))
+  (recenter))
+
+(defun sd7-ent--goto-line-in-buffer-other-window (buf line-no)
+  "Display BUF in the other window and move point to LINE-NO."
+  (switch-to-buffer-other-window buf)
+  (goto-char (point-min))
+  (forward-line (1- line-no))
+  (recenter))
+
+;;** Seed7 entity browser interactive commands
+
+(defun sd7-ent--visit-entity ()
+  "Go to the declaration of the entity on the current line.
+Switches to the source Seed7 buffer and moves point to the declaration line."
+  (interactive)
+  (let* ((id      (sd7-ent--entry-id))
+         (line-no (cdr id))
+         (src-buf (sd7-ent--resolve-source id)))
+    (sd7-ent--goto-line-in-buffer src-buf line-no)))
+
+(defun sd7-ent--visit-entity-other-window ()
+  "Go to the declaration of the entity, displayed in the other window."
+  (interactive)
+  (let* ((id      (sd7-ent--entry-id))
+         (line-no (cdr id))
+         (src-buf (sd7-ent--resolve-source id)))
+    (sd7-ent--goto-line-in-buffer-other-window src-buf line-no)))
+
+(defun sd7-ent--refresh ()
+  "Re-scan the source buffer and redisplay the entity list."
+  (interactive)
+  (let ((src-buf (sd7-ent--resolve-source (cons sd7-ent--source-buffer 1))))
+    (with-current-buffer src-buf
+      (seed7-list-entities))))
+
+;;** Seed7 entity browser helper - public entry point
+;;   ------------------------------------------------
+
+;;;###autoload
+(defun seed7-list-entities ()
+  "Display all named entities in the current Seed7 buffer in a browser window.
+
+Builds or refreshes a `seed7-entities-mode' buffer with one row per entity
+\(functions, procedures, structures, enumerations, arrays, sets).
+
+Keys in the browser:
+  RET   — go to the declaration (replaces current window).
+  o     — go to the declaration in the other window.
+  g     — refresh the browser from the source buffer.
+  S     — sort by the column at point (`tabulated-list-sort').
+
+The browser name is  *Seed7 Entities: BUFFER-NAME*."
+  (interactive)
+  (unless (derived-mode-p 'seed7-mode)
+    (user-error "Current buffer is not in seed7-mode"))
+  (let* ((source-buf  (current-buffer))
+         (source-file (buffer-file-name))
+         (entities    (seed7-buffer-entities))
+         (bname       (format "*Seed7 Entities: %s*" (buffer-name source-buf)))
+         (browser-buf (get-buffer-create bname)))
+    (with-current-buffer browser-buf
+      (seed7-entities-mode)
+      (setq sd7-ent--source-buffer source-buf
+            sd7-ent--source-file   source-file)
+      (setq tabulated-list-entries
+            (mapcar (lambda (e)
+                      (let ((type (nth 0 e))
+                            (name (nth 1 e))
+                            (line (nth 2 e)))
+                        ;; Entry ID is (source-buffer . line-no) so RET can
+                        ;; always navigate even when the table is sorted by
+                        ;; a column other than Line.
+                        (list (cons source-buf line)
+                              (vector (number-to-string line)
+                                      (symbol-name type)
+                                      name))))
+                    entities))
+      (tabulated-list-print :remember-pos))
+    (pop-to-buffer browser-buf)))
+
+;; ---------------------------------------------------------------------------
 ;;* Seed7 Key Map
 ;;  =============
 ;;
@@ -9476,6 +9729,7 @@ current Emacs session without restarting Emacs."
     (define-key map (kbd "C-c =") 'seed7-toggle-menu-sorting)
     (define-key map (kbd "C-c C-a") 'seed7-to-block-backward)
     (define-key map (kbd "C-c C-e") 'seed7-to-block-forward)
+    (define-key map (kbd "C-c C-l") 'seed7-list-entities)
     (define-key map (kbd "C-c C-n") 'seed7-beg-of-next-defun)
     (define-key map (kbd "C-c C-t") 'seed7-to-top-of-block)
     (define-key map "\M-\C-a"       'seed7-beg-of-defun)
@@ -9507,7 +9761,6 @@ current Emacs session without restarting Emacs."
     ["Toggle abbrev-mode"   abbrev-mode]
     ["List abbreviations"   list-abbrevs]
     ["Reload abbreviations table" seed7-rebuild-abbrev-table]
-
     "---"
     ("Align"
      ["Align current section" align-current]
@@ -9567,6 +9820,7 @@ current Emacs session without restarting Emacs."
       ["While"              seed7-insert-while]
       ["Error handler block" seed7-insert-block]
       ["Global block"       seed7-insert-global]))
+    ["List Seed7 Entities" seed7-list-entities]
     ("Mark"
      ["Mark Function/Procedure" seed7-mark-defun ])
     "---"

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.2305
+;; Package-Version: 20260625.0827
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -330,6 +330,8 @@
 ;;       . `seed7-inside-line-indent-p'
 ;;       . `seed7-inside-line-trailing-whitespace-before-line-end-comment-p'
 ;;         . `seed7-inside-line-indent-before-comment-p'
+;;     - Seed7 Indentation search boundary helper
+;;       . `seed7--indent-search-boundary'
 ;;     - Seed7 Indentation Code Character Search Utilities
 ;;       . `seed7-backward-char-pos'
 ;;       . `seed7-forward-char-pos'
@@ -536,7 +538,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-25T03:05:30+0000 W26-4"
+(defconst seed7-mode-version-timestamp "2026-06-25T12:27:54+0000 W26-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3295,8 +3297,11 @@ Negative N: point is on a line that contains a line comment.
 ;;*** Navigation to Outer Block
 ;;    ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-(defun seed7--to-top (&optional pos)
+(defun seed7--to-top (&optional pos beg-bound)
   "Move point to beginning of outer block surrounding code at POS or point.
+
+When BEG-BOUND is non-nil, do not search before that position.
+
 Searches backward for the nearest enclosing block-start keyword whose
 column is strictly less than the column at POS.  This is O(nesting depth),
 not O(number-of-keyword-occurrences), and correctly handles both top-level
@@ -3314,7 +3319,7 @@ Seed7 template bodies (in .s7i files)."
       (while (and (not found)
                   (not (bobp))
                   (seed7-re-search-backward
-                   seed7--callable-declaration-start-regexp))
+                   seed7--callable-declaration-start-regexp beg-bound))
         (seed7-to-indent)
         ;; Stop as soon as we find a block-start keyword whose column is
         ;; strictly less than the starting column.  This correctly handles:
@@ -5018,8 +5023,6 @@ Toggles listing them together or separately.
 ;;* Seed7 Code Marking
 ;;  ==================
 
-;; [ TODO 2025-06-21, by Pierre Rouleau: Perhaps this can use
-;; `seed7-to-top-of-block' to handle more blocks?]
 (defun seed7-mark-defun ()
   "Mark the current Seed7 function or procedure.
 Put the mark at the end and point at the beginning.
@@ -5215,6 +5218,31 @@ Return nil otherwise."
       (skip-chars-forward " \t")
       (and (looking-at-p "#")
            (seed7-inside-comment-p)))))
+
+;;*** Seed7 Indentation search boundary helper
+
+(defun seed7--indent-search-boundary (&optional pos)
+  "Return the lower bound to use for indentation look-back.
+
+The boundary is the beginning of the nearest previous code line whose
+indentation is strictly less than the indentation at POS or point.
+
+Blank lines and lines inside strings/comments are ignored.
+Return nil when no such line exists."
+  (save-excursion
+    (when pos
+      (goto-char pos))
+    (seed7-to-indent)
+    (let ((target-col (current-column))
+          bound)
+      (while (and (not bound)
+                  (= (forward-line -1) 0))
+        (seed7-to-indent)
+        (let ((ppss (syntax-ppss)))
+          (unless (or (eolp) (nth 3 ppss) (nth 4 ppss))
+            (when (< (current-column) target-col)
+              (setq bound (line-beginning-position))))))
+      bound)))
 
 
 ;;*** Seed7 Indentation Code Character Search Utilities
@@ -5713,13 +5741,14 @@ Move point."
       (save-excursion (goto-char start-pos)
                       (line-end-position))))
 
-(defun seed7-line-inside-a-block (n &optional dont-skip-comment-start)
+(defun seed7-line-inside-a-block (n &optional dont-skip-comment-start beg-bound)
   "Check if line N is inside a Seed7 block.
 N is: - :previous-non-empty for the previous non-empty line,
         skipping lines with starting comments unless DONT-SKIP-COMMENT-START
          is non-nil,
       - 0 for the current line,
       - A negative number for previous lines: -1 previous, -2 line before...
+When BEG-BOUND is non-nil, do not search before that position.
 If nothing found it returns nil.
 If it finds something it returns a list that holds the following information:
 - 0: indent column : indentation column the line N should use,
@@ -5749,7 +5778,7 @@ If it finds something it returns a list that holds the following information:
         (end-of-line)
         (while (and keep-searching
                     (not (bobp)))
-          (when (seed7-re-search-backward seed7-block-line-start-regexp)
+          (when (seed7-re-search-backward seed7-block-line-start-regexp beg-bound)
             ;; get match text, normalize matching hard tabs to spaces.
             (setq match-text (replace-regexp-in-string
                               "[[:blank:]]+$" " "
@@ -5937,7 +5966,7 @@ column) is not exposed."
               end-pos
               (nth 4 seed7--indent-last-block-spec))))))
 
-(defun seed7-line-inside-a-block-cached (n &optional dont-skip-comment-start)
+(defun seed7-line-inside-a-block-cached (n &optional dont-skip-comment-start beg-bound)
   "Cached variant of `seed7-line-inside-a-block' for indentation.
 
 N is: - :previous-non-empty for the previous non-empty line,
@@ -5950,6 +5979,10 @@ When N is 0 and DONT-SKIP-COMMENT-START is nil, the function first
 checks `seed7--cached-block-spec-current-line'; if the cache is still
 valid it returns the cached spec immediately without re-scanning (O(1)
 fast path).
+
+When BEG-BOUND is non-nil, bypass the current cache and delegate
+directly to `seed7-line-inside-a-block'.  This keeps the existing cache
+semantics unchanged for the unbounded case.
 
 On a cache miss the function delegates to `seed7-line-inside-a-block'.
 When N is 0 and a block is found, two caches are updated as side effects:
@@ -5971,19 +6004,23 @@ If a block is found, return a list of 5 elements:
 - 2: block start position (the beginning of the start keyword line),
 - 3: enclosing block end position,
 - 4: indent column of the block start line."
-  (or (and (eq n 0)
-           (not dont-skip-comment-start)
-           (seed7--cached-block-spec-current-line))
-      (let ((spec (seed7-line-inside-a-block n dont-skip-comment-start)))
-        (when (and (eq n 0) spec)
-          (setq seed7--indent-last-block-spec
-                (seed7--cache-block-spec spec))
-          ;; Also update the lightweight bounds cache used for early-bound
-          ;; lookups at the top of `seed7-calc-indent'.
-          (setq seed7--indent-block-bounds
-                (cons (nth 2 seed7--indent-last-block-spec)
-                      (nth 3 seed7--indent-last-block-spec))))
-        spec)))
+  (if beg-bound
+      ;; Bounded search: bypass cache completely.
+      (seed7-line-inside-a-block n dont-skip-comment-start beg-bound)
+    ;; Unbounded search: use the cache if necessary.
+    (or (and (eq n 0)
+             (not dont-skip-comment-start)
+             (seed7--cached-block-spec-current-line))
+        (let ((spec (seed7-line-inside-a-block n dont-skip-comment-start)))
+          (when (and (eq n 0) spec)
+            (setq seed7--indent-last-block-spec
+                  (seed7--cache-block-spec spec))
+            ;; Also update the lightweight bounds cache used for early-bound
+            ;; lookups at the top of `seed7-calc-indent'.
+            (setq seed7--indent-block-bounds
+                  (cons (nth 2 seed7--indent-last-block-spec)
+                        (nth 3 seed7--indent-last-block-spec))))
+          spec))))
 
 ;; ---------------------------------------------------------------------------
 
@@ -6899,6 +6936,8 @@ When TREAT-COMMENT-LINE-AS-CODE is non-nil a comment line is processed as if
 The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
   call.  Only one recursion is allowed."
   (let* ((recurse-count (or recurse-count 0))
+         ;; [:todo 2026-06-25, by Pierre Rouleau: Activate boundary??? it slows indentation!]
+         (indent-bound nil)             ; (seed7--indent-search-boundary)
          ;; Eagerly probe the previous call's block boundaries.
          ;; Cost: O(1) — two marker-position comparisons, uses (point)
          ;;              directly; no `seed7-to-indent' overhead.
@@ -6918,7 +6957,7 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
          (early-end-pos   (when cached-bounds
                             (min (point-max) (1+ (cdr cached-bounds)))))
          ;;
-         (indent-step nil) ; will be initialized later only if needed
+         (indent-step nil)          ; will be initialized later only if needed
          (first-word-on-line (seed7--current-line-nth-word 1))
          (indent-column nil)
          (indent-column2 nil)
@@ -7100,7 +7139,7 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
           (setq indent-step 1))
          (t (setq indent-step 0))))
 
-       ((seed7--set (seed7-line-inside-a-block-cached 0) spec-list)
+       ((seed7--set (seed7-line-inside-a-block-cached 0 indent-bound) spec-list)
         ;; Inside a block.  Check if inside any special zones first.
         ;; For all of those extra checks limit the zone to the scope of the
         ;; current block to improve efficiency. Extend the boundary by 1

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.1430
+;; Package-Version: 20260624.1553
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T18:30:15+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-24T19:53:10+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3269,15 +3269,33 @@ Negative N: point is on a line that contains a line comment.
 ;;    ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (defun seed7--to-top (&optional pos)
-  "Move point to beginning of outer block surrounding code at POS or point."
+  "Move point to beginning of outer block surrounding code at POS or point.
+Searches backward for the nearest enclosing block-start keyword whose
+column is strictly less than the column at POS.  This is O(nesting depth),
+not O(number-of-keyword-occurrences), and correctly handles both top-level
+declarations at column 0 (in .sd7 files) and indented declarations inside
+Seed7 template bodies (in .s7i files)."
   (when pos (goto-char pos))
-  (let ((keep-searching t))
-    (while (and keep-searching
-                (not (bobp))
-                (seed7-re-search-backward seed7-block-top-start-regexp))
-      (seed7-to-indent)
-      (when (= (current-column) 0)
-        (setq keep-searching nil)))))
+  (let ((start-col (current-column))
+        (found nil))
+    (with-timeout
+        (15
+         (message
+          (concat "seed7-mode: seed7--to-top timed out at line %d "
+                  "(could not find enclosing block start). Please report.")
+          (line-number-at-pos (point))))
+      (while (and (not found)
+                  (not (bobp))
+                  (seed7-re-search-backward seed7-block-top-start-regexp))
+        (seed7-to-indent)
+        ;; Stop as soon as we find a block-start keyword whose column is
+        ;; strictly less than the starting column.  This correctly handles:
+        ;; • .sd7 files: indented lines (col ≥ 2) → column-0 keyword found
+        ;;   in 1–2 iterations.
+        ;; • .s7i template bodies: indented `const func' (col 4) → enclosing
+        ;;   `begin' or `const proc:' at col 0 found in 1–3 iterations.
+        (when (< (current-column) start-col)
+          (setq found t))))))
 
 (defun seed7-to-top-of-block ()
   "Move point to the top of the current block."

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260623.1206
+;; Package-Version: 20260623.1241
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -519,6 +519,8 @@
 (require 'seq)        ; use: `seq-filter'
 (require 'which-func) ; use: `which-func-functions'
 (require 'add-log)    ; use: `add-log-current-defun-function'
+(require 'tabulated-list) ; use: `tabulated-list-mode',
+;;                        ; `tabulated-list-mode-map'
 
 ;;; --------------------------------------------------------------------------
 ;;; Code:
@@ -534,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-23T16:06:22+0000 W26-2"
+(defconst seed7-mode-version-timestamp "2026-06-23T16:41:17+0000 W26-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.0912
+;; Package-Version: 20260624.1034
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T13:12:22+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-24T14:34:31+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6975,8 +6975,8 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                               (= (char-before (point)) ?&))
                      ;; Look for an assignment operator anywhere on this line.
                      (goto-char lbeg)
-                     (when (re-search-forward
-                            seed7-predef-assignment-operator-regexp lend t)
+                     (when (seed7-re-search-forward
+                            seed7-predef-assignment-operator-regexp lend
                        ;; Column of the first non-whitespace char after the
                        ;; operator — that is where the RHS expression begins.
                        (skip-chars-forward " \t")

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260623.1241
+;; Package-Version: 20260623.2312
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-23T16:41:17+0000 W26-2"
+(defconst seed7-mode-version-timestamp "2026-06-24T03:12:51+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6919,14 +6919,48 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
             (forward-line -1)
             (search-forward "\"")
             (setq indent-column (1- (current-column))))
+           ;;
+           ;; If the previous non-empty line ends with the Seed7 string-
+           ;; concatenation operator `<&' AND that line itself contains a `"',
+           ;; align the current string's opening `"' to the column of that `"'.
+           ;;
+           ;; Handles multi-line string-concatenation expressions such as:
+           ;;
+           ;;   return "(" <& bitfield.mask radix 2 lpad0 32 <&
+           ;;         ", " <& bitfield.rShift lpad 2 <&     ← aligned to "("
+           ;;         ", " <& bitfield.scale <& ")";
+           ;;
+           ;; When the previous line ends with `<&' but has no `"' (e.g. a
+           ;; non-string expression like `header.fileSize rpad 10 <&'), this
+           ;; case produces nil and the `t' fallback below handles it correctly.
+           ((seed7--set
+             (save-excursion
+               (when (seed7-move-to-line :previous-non-empty)
+                 (let* ((lbeg (line-beginning-position))
+                        (lend (line-end-position)))
+                   (goto-char lend)
+                   (skip-chars-backward " \t" lbeg)
+                   (when (and (>= (- (point) lbeg) 2)
+                              (string= "<&"
+                                       (buffer-substring-no-properties
+                                        (- (point) 2) (point))))
+                     (goto-char lbeg)
+                     (when (search-forward "\"" lend t)
+                       (1- (current-column)))))))
+             indent-column))
+           ;;
+           ;; Fallthrough: use the indentation of the nearest preceding
+           ;; non-string line.  Only warn when that heuristic also fails
+           ;; (i.e. when `seed7-indentation-of-previous-non-string-line'
+           ;; returns nil), meaning the indentation is truly unresolvable.
            (t
             (let ((col (seed7-indentation-of-previous-non-string-line)))
-              (when col
-                (setq indent-column col)))
-            (message
-             "At line %d: string line syntax not yet supported! Recurse count=%d Please report."
-             (seed7-current-line-number)
-             recurse-count)))))
+              (if col
+                  (setq indent-column col)
+                (message
+                 "At line %d: string line syntax not yet supported! Recurse count=%d Please report."
+                 (seed7-current-line-number)
+                 recurse-count)))))))
 
        ;; Special rule: if a line starts with a Seed7 assignment operator,
        ;; consider that line manually indented and keep it where it is.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260624.1710
+;; Package-Version: 20260624.2305
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T21:10:39+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-25T03:05:30+0000 W26-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1539,7 +1539,8 @@ one-liners or short `return...;' functions — neither creates a
 
 (defconst seed7--array-definition-start-regexp
   ;; "\\(?:const\\|var\\) +?array[[:blank:]]+?.+?:.+?("
-  "\\(?:const\\|var\\) +array[[:blank:]]+.+:.+("
+  ;; "\\(?:const\\|var\\) +array[[:blank:]]+.+:.+("
+  "\\(?:const\\|var\\) +array[[:blank:]]+[^:\n]+:[^(;\n]*("
   "Regexp matching the start of a Seed7 array definition block header.
 See `seed7--set-definition-start-regexp' for the whitespace convention.")
 
@@ -1566,7 +1567,8 @@ Example matches:
 ;;   ----------------
 
 (defconst seed7--set-definition-start-regexp
-  "\\(?:const\\|var\\) +?set[[:blank:]]+?.+?:.+?{"
+  ;; "\\(?:const\\|var\\) +?set[[:blank:]]+?.+?:.+?{"
+  "\\(?:const\\|var\\) +set[[:blank:]]+[^:\n]+:[^{;\n]*{"
   "Regexp matching the start of a Seed7 set definition block header.
 Matches `const set' or `var set' followed by a type annotation and the
 opening `{'.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260623.2312
+;; Package-Version: 20260624.0912
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -536,7 +536,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-24T03:12:51+0000 W26-3"
+(defconst seed7-mode-version-timestamp "2026-06-24T13:12:22+0000 W26-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6892,7 +6892,7 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
           (setq indent-column (+ (nth 0 spec-list)
                                  seed7-indent-width))))
 
-       ;; in string
+       ;; -- in string -------------------------
        ((seed7-line-isa-string 0)
         (save-excursion
           (cond
@@ -6949,12 +6949,47 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                        (1- (current-column)))))))
              indent-column))
            ;;
+           ;; If the previous non-empty line ends with `&' or `<&' AND that
+           ;; line also contains an assignment operator (`:=', `&:=', etc.),
+           ;; align the current string to the column of the RHS of that
+           ;; assignment — i.e. the first non-space character after the
+           ;; operator on that line.
+           ;;
+           ;; Handles: (bmp.s7i line 888)
+           ;;   stri &:= bytes(rawDataSize + 54, UNSIGNED, LE, 4) &
+           ;;            "\0;" mult 4  &   ← aligns to "bytes(" = column 13
+           ;;
+           ;; This clause fires only when the `<&'+`"' clause above did NOT
+           ;; fire (the previous line either ends with plain `&' rather than
+           ;; `<&', or ends with `<&' but contains no `"').
+           ((seed7--set
+             (save-excursion
+               (when (seed7-move-to-line :previous-non-empty)
+                 (let* ((lbeg (line-beginning-position))
+                        (lend (line-end-position)))
+                   ;; The previous line must end with `&' (covers both plain
+                   ;; `&' and `<&', since both have `&' as the last char).
+                   (goto-char lend)
+                   (skip-chars-backward " \t" lbeg)
+                   (when (and (> (point) lbeg)
+                              (= (char-before (point)) ?&))
+                     ;; Look for an assignment operator anywhere on this line.
+                     (goto-char lbeg)
+                     (when (re-search-forward
+                            seed7-predef-assignment-operator-regexp lend t)
+                       ;; Column of the first non-whitespace char after the
+                       ;; operator — that is where the RHS expression begins.
+                       (skip-chars-forward " \t")
+                       (current-column))))))
+             indent-column))
+           ;;
            ;; Fallthrough: use the indentation of the nearest preceding
            ;; non-string line.  Only warn when that heuristic also fails
            ;; (i.e. when `seed7-indentation-of-previous-non-string-line'
            ;; returns nil), meaning the indentation is truly unresolvable.
            (t
             (let ((col (seed7-indentation-of-previous-non-string-line)))
+              ;; [ TODO 2026-06-24, by Pierre Rouleau: replace if by when for testing?]
               (if col
                   (setq indent-column col)
                 (message
@@ -6962,7 +6997,7 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                  (seed7-current-line-number)
                  recurse-count)))))))
 
-       ;; Special rule: if a line starts with a Seed7 assignment operator,
+       ;; -- Special rule: if a line starts with a Seed7 assignment operator,
        ;; consider that line manually indented and keep it where it is.
        ;; This allows a long multi-line statement to be lined up on the
        ;; assignment operator placed on the line after its rvalue for the

--- a/tests/emacs-analysis/seed7-test-tools.el
+++ b/tests/emacs-analysis/seed7-test-tools.el
@@ -2,12 +2,12 @@
 
 ;; Created   : Monday, July 14 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2025-07-15 09:30:05 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:04:09 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
-;; Copyright (C) 2025  Pierre Rouleau
+;; Copyright (C) 2025, 2026  Pierre Rouleau
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/tests/ert-tests/seed7-test-arrays-01.el
+++ b/tests/ert-tests/seed7-test-arrays-01.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Friday, July 11 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-17 11:09:03 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:04:28 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2025, 2026  Pierre Rouleau

--- a/tests/ert-tests/seed7-test-font-lock-01.el
+++ b/tests/ert-tests/seed7-test-font-lock-01.el
@@ -2,7 +2,7 @@
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tests/ert-tests/seed7-test-font-lock-02.el
+++ b/tests/ert-tests/seed7-test-font-lock-02.el
@@ -2,7 +2,7 @@
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tests/ert-tests/seed7-test-font-lock-02b.el
+++ b/tests/ert-tests/seed7-test-font-lock-02b.el
@@ -2,7 +2,7 @@
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-25 12:10:06 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:26:07 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -34,80 +34,100 @@
 ;;
 ;; The main regression shape comes from `prg/bas7.sd7` around Line 696.
 
+;; Regression tests for indentation of a multi-line boolean expression
+;; like the one in prg/bas7.sd7 where:
+;; - one continuation line ends with `and'
+;; - the next continuation line starts with `('
+;;
+;; The expected indentation shape is:
+;;
+;;   const func boolean: ... is                     ; column 0
+;;     return ...                                  ; column 2
+;;            symbol <> "" and                     ; column 9
+;;           (symbol[length(symbol)] = '$' ...     ; column 8
+;;            not symbol[length(symbol)] ...       ; column 9
+
+;; ---------------------------------------------------------------------------
 ;;; Code:
 
 (require 'ert)
 (require 'seed7-mode)
 
-(defconst seed7-test-indent--open-paren-after-and-code
+(defconst seed7-test-indent--bas7-correct-code
   (concat
    "const func boolean: isStringExpr (in string: symbol) is\n"
    "  return symbol in string_var_name or\n"
    "         symbol <> \"\" and\n"
-   "(symbol[length(symbol)] = '$' or symbol[1] = '\\\"' or symbol[1] in defstr_var and\n"
+   "        (symbol[length(symbol)] = '$' or symbol[1] = '\\\"' or symbol[1] in defstr_var and\n"
    "         not symbol[length(symbol)] in numeric_var_suffix);\n")
-  "Fixture modeled after `prg/bas7.sd7`.
-Where a continuation line starts with `(' after `and'.")
+  "Correctly indented bas7-style fixture.")
 
-(defconst seed7-test-indent--open-paren-after-or-code
+(defconst seed7-test-indent--bas7-misaligned-code
   (concat
-   "const func boolean: needsWrap (in string: symbol) is\n"
-   "  return symbol = \"abc\" or\n"
-   "         symbol = \"def\" or\n"
-   "(symbol[1] = 'A' or symbol[1] = 'B');\n")
-  "Fixture for the analogous continuation case after `or'.")
+   "const func boolean: isStringExpr (in string: symbol) is\n"
+   "  return symbol in string_var_name or\n"
+   "symbol <> \"\" and\n"
+   "(symbol[length(symbol)] = '$' or symbol[1] = '\\\"' or symbol[1] in defstr_var and\n"
+   "not symbol[length(symbol)] in numeric_var_suffix);\n")
+  "Misindented version of `seed7-test-indent--bas7-correct-code'.")
 
 (defun seed7-test-indent--goto-line (line)
-  "Move point to the beginning of LINE."
+  "Move point to the beginning of LINE (1-based)."
   (goto-char (point-min))
   (forward-line (1- line)))
 
 (defun seed7-test-indent--line-indentation (line)
-  "Return indentation of LINE."
+  "Return indentation of LINE (1-based)."
   (save-excursion
     (seed7-test-indent--goto-line line)
     (current-indentation)))
 
 (defun seed7-test-indent--line-first-char (line)
-  "Return first non-whitespace character of LINE."
+  "Return first non-whitespace character of LINE (1-based)."
   (save-excursion
     (seed7-test-indent--goto-line line)
     (back-to-indentation)
     (char-after)))
 
-(ert-deftest seed7-indent/open-paren-after-and-indent-region ()
-  "Indenting a bas7-style continuation line starting with `(' after `and' must not error."
+(ert-deftest seed7-indent/bas7-shape-indent-region-keeps-correct-layout ()
+  "Indenting an already-correct bas7-style expression keeps the same layout."
   (with-temp-buffer
     (setq-local indent-tabs-mode nil)
-    (insert seed7-test-indent--open-paren-after-and-code)
-    (seed7-mode)
-
-    ;; This previously failed during full-file indentation.
-    (indent-region (point-min) (point-max))
-
-    ;; Line 4 starts with `(' and should now be indented as a continuation line.
-    (should (eq (seed7-test-indent--line-first-char 4) ?\())
-    (should (> (seed7-test-indent--line-indentation 4) 0))
-
-    ;; It should align with the previous continuation line.
-    (should (= (seed7-test-indent--line-indentation 4)
-               (seed7-test-indent--line-indentation 3)))))
-
-(ert-deftest seed7-indent/open-paren-after-or-indent-region ()
-  "Indenting a continuation line starting with `(' after `or' must not error."
-  (with-temp-buffer
-    (setq-local indent-tabs-mode nil)
-    (insert seed7-test-indent--open-paren-after-or-code)
+    (insert seed7-test-indent--bas7-correct-code)
     (seed7-mode)
 
     (indent-region (point-min) (point-max))
 
-    ;; Line 4 starts with `(' and should be indented as a continuation line.
-    (should (eq (seed7-test-indent--line-first-char 4) ?\())
-    (should (> (seed7-test-indent--line-indentation 4) 0))
-    (should (= (seed7-test-indent--line-indentation 4)
-               (seed7-test-indent--line-indentation 3)))))
+    (should (= (seed7-test-indent--line-indentation 1) 0))
+    (should (= (seed7-test-indent--line-indentation 2) 2))
+    (should (= (seed7-test-indent--line-indentation 3) 9))
+    (should (= (seed7-test-indent--line-indentation 4) 8))
+    (should (= (seed7-test-indent--line-indentation 5) 9))
 
+    (should (eq (seed7-test-indent--line-first-char 4) ?\())
+    (should (string= (buffer-string)
+                     seed7-test-indent--bas7-correct-code))))
+
+(ert-deftest seed7-indent/bas7-shape-indent-region-fixes-misaligned-layout ()
+  "Indenting a misaligned bas7-style expression restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent--bas7-misaligned-code)
+    (seed7-mode)
+
+    (indent-region (point-min) (point-max))
+
+    (should (= (seed7-test-indent--line-indentation 1) 0))
+    (should (= (seed7-test-indent--line-indentation 2) 2))
+    (should (= (seed7-test-indent--line-indentation 3) 9))
+    (should (= (seed7-test-indent--line-indentation 4) 8))
+    (should (= (seed7-test-indent--line-indentation 5) 9))
+
+    (should (eq (seed7-test-indent--line-first-char 4) ?\())
+    (should (string= (buffer-string)
+                     seed7-test-indent--bas7-correct-code))))
+
+;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-01)
 
 ;;; seed7-test-indent-01.el ends here

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,0 +1,113 @@
+;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
+
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-06-25 12:10:06 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the SEED7-MODE package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Regression tests for continuation lines that start with `(' after a
+;; previous non-empty line ending with the logical operators `and' or `or'.
+;;
+;; These cases previously fell through to the final fallback in
+;; `seed7-calc-indent' and raised:
+;;
+;;   No rule yet to indent line N
+;;
+;; The main regression shape comes from `prg/bas7.sd7` around Line 696.
+
+;;; Code:
+
+(require 'ert)
+(require 'seed7-mode)
+
+(defconst seed7-test-indent--open-paren-after-and-code
+  (concat
+   "const func boolean: isStringExpr (in string: symbol) is\n"
+   "  return symbol in string_var_name or\n"
+   "         symbol <> \"\" and\n"
+   "(symbol[length(symbol)] = '$' or symbol[1] = '\\\"' or symbol[1] in defstr_var and\n"
+   "         not symbol[length(symbol)] in numeric_var_suffix);\n")
+  "Fixture modeled after `prg/bas7.sd7`.
+Where a continuation line starts with `(' after `and'.")
+
+(defconst seed7-test-indent--open-paren-after-or-code
+  (concat
+   "const func boolean: needsWrap (in string: symbol) is\n"
+   "  return symbol = \"abc\" or\n"
+   "         symbol = \"def\" or\n"
+   "(symbol[1] = 'A' or symbol[1] = 'B');\n")
+  "Fixture for the analogous continuation case after `or'.")
+
+(defun seed7-test-indent--goto-line (line)
+  "Move point to the beginning of LINE."
+  (goto-char (point-min))
+  (forward-line (1- line)))
+
+(defun seed7-test-indent--line-indentation (line)
+  "Return indentation of LINE."
+  (save-excursion
+    (seed7-test-indent--goto-line line)
+    (current-indentation)))
+
+(defun seed7-test-indent--line-first-char (line)
+  "Return first non-whitespace character of LINE."
+  (save-excursion
+    (seed7-test-indent--goto-line line)
+    (back-to-indentation)
+    (char-after)))
+
+(ert-deftest seed7-indent/open-paren-after-and-indent-region ()
+  "Indenting a bas7-style continuation line starting with `(' after `and' must not error."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent--open-paren-after-and-code)
+    (seed7-mode)
+
+    ;; This previously failed during full-file indentation.
+    (indent-region (point-min) (point-max))
+
+    ;; Line 4 starts with `(' and should now be indented as a continuation line.
+    (should (eq (seed7-test-indent--line-first-char 4) ?\())
+    (should (> (seed7-test-indent--line-indentation 4) 0))
+
+    ;; It should align with the previous continuation line.
+    (should (= (seed7-test-indent--line-indentation 4)
+               (seed7-test-indent--line-indentation 3)))))
+
+(ert-deftest seed7-indent/open-paren-after-or-indent-region ()
+  "Indenting a continuation line starting with `(' after `or' must not error."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent--open-paren-after-or-code)
+    (seed7-mode)
+
+    (indent-region (point-min) (point-max))
+
+    ;; Line 4 starts with `(' and should be indented as a continuation line.
+    (should (eq (seed7-test-indent--line-first-char 4) ?\())
+    (should (> (seed7-test-indent--line-indentation 4) 0))
+    (should (= (seed7-test-indent--line-indentation 4)
+               (seed7-test-indent--line-indentation 3)))))
+
+(provide 'seed7-test-indent-01)
+
+;;; seed7-test-indent-01.el ends here

--- a/tests/ert-tests/seed7-test-mark-defun-01.el
+++ b/tests/ert-tests/seed7-test-mark-defun-01.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Sunday, July 20 2025.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-17 11:09:00 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:05:24 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2025, 2026  Pierre Rouleau

--- a/tests/ert-tests/seed7-test-nav-array-01.el
+++ b/tests/ert-tests/seed7-test-nav-array-01.el
@@ -2,7 +2,7 @@
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tests/ert-tests/seed7-test-nav-final-pos-01.el
+++ b/tests/ert-tests/seed7-test-nav-final-pos-01.el
@@ -2,7 +2,7 @@
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tests/ert-tests/seed7-test-nav-nested-01.el
+++ b/tests/ert-tests/seed7-test-nav-nested-01.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Saturday, June 13 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-17 10:49:27 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:05:58 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tests/ert-tests/seed7-test-syntax-propertize-01.el
+++ b/tests/ert-tests/seed7-test-syntax-propertize-01.el
@@ -2,7 +2,7 @@
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tools/run-sd7-benchmark.el
+++ b/tools/run-sd7-benchmark.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Saturday, June 21 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-20 18:56:14 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:06:45 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 16:11:06 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 16:13:53 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -55,6 +55,7 @@
 ;;
 ;; 1. Interactive (preferred):
 ;;
+;;      M-: (setq debug-on-quit t)
 ;;      M-x sd7-indent-perf-run
 ;;
 ;;    Prompts for INPUT-DIR, OUTPUT-DIR, REPORT-DIR, and ID.

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 14:37:57 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 16:11:06 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -152,11 +152,13 @@ Strings matching \"not yet supported\" or \"timed out\" are appended to
                  (apply #'format fmt args)
                (error (format "%s" fmt)))))
     (when (string-match-p
-           (rx (or "not yet supported"  ; in string handling in `seed7-calc-indent'
-                   "timed out"))        ; timed out in seed7-re-search-backward
+           (rx (or "not yet supported" ; in string handling in `seed7-calc-indent'
+                   "timed out"))       ; timed out in `seed7--to-top' or
+                                       ; `seed7-re-search-backward'
            txt)
       (push txt sd7-indent-perf--current-warnings))
-    (apply orig-fn fmt args)))
+    (unless (string-match-p "Indenting region" txt)
+      (apply orig-fn fmt args))))
 
 ;;; --------------------------------------------------------------------------
 ;;; Helpers

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 16:13:53 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 17:21:12 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -148,30 +148,41 @@ Reset to nil at the start of each file; populated by
 (defun sd7-indent-perf--capture-advice (orig-fn fmt &rest args)
   "Advice around `message' to capture seed7-mode indentation warnings.
 Strings matching \"not yet supported\" or \"timed out\" are appended to
-`sd7-indent-perf--current-warnings' in addition to being displayed normally."
+`sd7-indent-perf--current-warnings' in addition to being displayed normally.
+Strings matching \"Indenting region\" or \"delay-mode-hooks\" are suppressed
+so they do not overwrite the tool's own progress messages in the echo area."
   (let ((txt (condition-case nil
                  (apply #'format fmt args)
                (error (format "%s" fmt)))))
     (when (string-match-p
-           (rx (or "not yet supported" ; in string handling in `seed7-calc-indent'
-                   "timed out"))       ; timed out in `seed7--to-top' or
-                                       ; `seed7-re-search-backward'
+           (rx (or "not yet supported"  ; in string handling in `seed7-calc-indent'
+                   "timed out"))        ; timed out in `seed7--to-top' or
+                                        ; `seed7-re-search-backward'
            txt)
       (push txt sd7-indent-perf--current-warnings))
-    (unless (string-match-p "Indenting region" txt)
+    (unless (string-match-p
+             (rx (or "Indenting region"
+                     "delay-mode-hooks"))   ; ← suppress Emacs internal noise
+             txt)
       (apply orig-fn fmt args))))
 
 ;;; --------------------------------------------------------------------------
 ;;; Helpers
 
+(defconst sd7-indent-perf--progress-buffer "*sd7-indent-perf*"
+  "Buffer name for live progress output during an `sd7-indent-perf-run' session.")
+
 (defun sd7-indent-perf--message (fmt &rest args)
-  "Emit a timestamped progress message.
-In batch mode uses `message'; in interactive mode also uses `message' (which
-appears in *Messages* and the echo area)."
-  (let ((text (apply #'format fmt args)))
-    (message "[%s] %s"
-             (format-time-string "%H:%M:%S")
-             text)))
+  "Emit a timestamped progress message to `*Messages*' and `*sd7-indent-perf*'."
+  (let ((text (format "[%s] %s"
+                      (format-time-string "%H:%M:%S")
+                      (apply #'format fmt args))))
+    ;; Write to *Messages* / echo area.
+    (message "%s" text)
+    ;; Also append to the dedicated progress buffer (creates it if absent).
+    (with-current-buffer (get-buffer-create sd7-indent-perf--progress-buffer)
+      (goto-char (point-max))
+      (insert text "\n"))))
 
 (defun sd7-indent-perf--format-duration (seconds)
   "Format SECONDS as MM:SS.mmm."
@@ -231,35 +242,32 @@ Returns a plist:
     (sd7-indent-perf--message "  indenting %s …" rel)
     (condition-case err
         (progn
-          (with-temp-buffer
-            (insert-file-contents input-file)
-            ;; Activate seed7-mode.  `delay-mode-hooks' suppresses hooks that
-            ;; might open windows or visit other files, but the warning
-            ;; "Making delay-mode-hooks buffer-local while locally let-bound!"
-            ;; is harmless — it fires because seed7-mode itself sets the var.
-            (let ((delay-mode-hooks t))
-              (seed7-mode))
-            (setq line-count (line-number-at-pos (point-max)))
-            ;; Install warning capture, then time indent-region.
-            (setq sd7-indent-perf--current-warnings nil)
-            (advice-add 'message :around #'sd7-indent-perf--capture-advice)
-            (unwind-protect
+          ;; Install warning capture BEFORE with-temp-buffer so that
+          ;; messages emitted during seed7-mode activation (e.g.
+          ;; "Making delay-mode-hooks buffer-local while locally let-bound!")
+          ;; are also filtered by `sd7-indent-perf--capture-advice'.
+          (setq sd7-indent-perf--current-warnings nil)
+          (advice-add 'message :around #'sd7-indent-perf--capture-advice)
+          (unwind-protect
+              (with-temp-buffer
+                (insert-file-contents input-file)
+                (let ((delay-mode-hooks t))
+                  (seed7-mode))
+                (setq line-count (line-number-at-pos (point-max)))
                 (let ((t0 (current-time)))
                   (setq file-start (float-time t0))
                   (indent-region (point-min) (point-max))
                   (setq indent-time
                         (float-time (time-subtract (current-time) t0))))
-              ;; Always remove the advice, even if indent-region signals.
-              (advice-remove 'message #'sd7-indent-perf--capture-advice)
-              (setq warnings (nreverse sd7-indent-perf--current-warnings)))
-            ;; Write the re-indented content immediately — before the next
-            ;; file is processed — so snapshots are available even if the
-            ;; run is interrupted.
-            (make-directory out-parent t)
-            (let ((coding-system-for-write 'undecided))
-              (write-region (point-min) (point-max) out-file nil :silent))))
+                (make-directory out-parent t)
+                (let ((coding-system-for-write 'undecided))
+                  (write-region (point-min) (point-max) out-file nil :silent)))
+            ;; Always remove the advice.
+            (advice-remove 'message #'sd7-indent-perf--capture-advice)
+            (setq warnings (nreverse sd7-indent-perf--current-warnings))))
       (error
        (setq err-msg (format "%s" (cadr err)))))
+
     ;; Progress message: elapsed time + warning count + written path.
     (if err-msg
         (sd7-indent-perf--message "  ERROR %s: %s" rel err-msg)
@@ -504,12 +512,17 @@ The RST report is written to REPORT-DIR/seed7mode-indent-perf-ID.rst."
                          sd7-indent-perf--last-id)
                  nil nil sd7-indent-perf--last-id)))
   (setq sd7-indent-perf--last-input-dir  (directory-file-name
-                                           (expand-file-name input-dir))
+                                          (expand-file-name input-dir))
         sd7-indent-perf--last-output-dir (directory-file-name
-                                           (expand-file-name output-dir))
+                                          (expand-file-name output-dir))
         sd7-indent-perf--last-report-dir (directory-file-name
-                                           (expand-file-name report-dir))
+                                          (expand-file-name report-dir))
         sd7-indent-perf--last-id         id)
+  ;; Show the live progress buffer in another window before starting.
+  (with-current-buffer (get-buffer-create sd7-indent-perf--progress-buffer)
+    (erase-buffer))
+  (display-buffer sd7-indent-perf--progress-buffer
+                  '((display-buffer-pop-up-window) (inhibit-same-window . t)))
   (sd7-indent-perf-run-core input-dir output-dir report-dir id))
 
 ;;; --------------------------------------------------------------------------

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 10:39:57 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 10:43:13 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -296,13 +296,14 @@ Returns the path of the written report file."
                        (format "seed7mode-indent-perf-%s.rst" id)
                        report-dir))
          (timestamp   (format-time-string "%Y-%m-%dT%H:%M:%S%z"))
-         (times       (mapcar (lambda (r) (plist-get r :indent-time)) results))
-         (errors      (cl-remove-if-not (lambda (r) (plist-get r :error))
-                                        results))
+         (errors      (cl-remove-if-not (lambda (r) (plist-get r :error)) results))
+         (ok-results  (cl-remove-if (lambda (r) (plist-get r :error)) results))
+         (times       (mapcar (lambda (r) (plist-get r :indent-time)) ok-results))
          (n           (length results))
-         (avg         (if (> n 0) (/ (apply #'+ times) (float n)) 0.0))
-         (mn          (if (> n 0) (apply #'min times) 0.0))
-         (mx          (if (> n 0) (apply #'max times) 0.0))
+         (n-ok        (length ok-results))
+         (avg         (if (> n-ok 0) (/ (apply #'+ times) (float n-ok)) 0.0))
+         (mn          (if (> n-ok 0) (apply #'min times) 0.0))
+         (mx          (if (> n-ok 0) (apply #'max times) 0.0))
          (total-time  (apply #'+ times))
          (fw          sd7-indent-perf--col-file)
          (lw          sd7-indent-perf--col-lines)
@@ -323,6 +324,7 @@ Returns the path of the written report file."
                       (file-name-as-directory (expand-file-name output-dir))))
       (insert (format ":Generated on    : %s\n" timestamp))
       (insert (format ":Files processed : %d\n" n))
+      (insert (format ":Files succeeded : %d\n" n-ok))
       (when errors
         (insert (format ":Files with errors: %d\n" (length errors))))
       (insert (format ":Total indent time: %.3f s\n" total-time))

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 10:36:35 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 10:39:57 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -427,6 +427,10 @@ Returns the absolute path of the written report file."
                                            default-directory))))
   (unless (file-directory-p input-dir)
     (user-error "Not a directory: %s" input-dir))
+  (when (file-equal-p input-dir output-dir)
+    (user-error "OUTPUT-DIR must be different from INPUT-DIR"))
+  (when (file-in-directory-p output-dir input-dir)
+    (user-error "OUTPUT-DIR must not be inside INPUT-DIR: %s" output-dir))
   (unless (and (stringp id) (not (string-empty-p id)))
     (user-error "ID must be a non-empty string, got: %S" id))
 

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 17:35:04 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 23:00:13 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -259,7 +259,7 @@ Returns a plist:
           (unwind-protect
               (with-temp-buffer
                 (insert-file-contents input-file)
-                (let ((delay-mode-hooks t))
+                (delay-mode-hooks
                   (seed7-mode))
                 (setq line-count (line-number-at-pos (point-max)))
                 (let ((t0 (current-time)))

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 17:21:12 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 17:35:04 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -182,7 +182,15 @@ so they do not overwrite the tool's own progress messages in the echo area."
     ;; Also append to the dedicated progress buffer (creates it if absent).
     (with-current-buffer (get-buffer-create sd7-indent-perf--progress-buffer)
       (goto-char (point-max))
-      (insert text "\n"))))
+      (insert text "\n")
+      ;; Scroll any window showing this buffer to the bottom so the user
+      ;; can see the latest message without manually scrolling.
+      (let ((win (get-buffer-window sd7-indent-perf--progress-buffer t)))
+        (when win
+          (set-window-point win (point-max)))))
+    ;; Force Emacs to repaint the screen so the message appears immediately
+    ;; even while a long computation (e.g. indent-region) is running.
+    (redisplay)))
 
 (defun sd7-indent-perf--format-duration (seconds)
   "Format SECONDS as MM:SS.mmm."
@@ -408,9 +416,11 @@ Returns the path of the written report file."
         (when warn-results
           (insert "Indentation Warnings\n")
           (insert "====================\n\n")
-          (insert "Lines where seed7-mode reported \"not yet supported\" during indentation.\n")
-          (insert "These indicate Seed7 syntax constructs not yet handled by the indentation\n")
-          (insert "engine.  The indented output for those lines may be incorrect.\n\n")
+          (insert "Lines where seed7-mode reported \"not yet supported\" or \"timed out\"\n")
+          (insert "during indentation.  \"not yet supported\" indicates a Seed7 syntax\n")
+          (insert "construct not yet handled by the indentation engine.  \"timed out\"\n")
+          (insert "indicates a catastrophic search in `seed7-re-search-backward' or\n")
+          (insert "`seed7--to-top' — see the fix proposals in the PR comments.\n\n")
           (dolist (r warn-results)
             (insert (format "``%s``\n" (plist-get r :file)))
             (dolist (w (plist-get r :warnings))

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 10:43:13 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 10:45:38 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -250,7 +250,7 @@ Returns a plist:
             ;; file is processed — so snapshots are available even if the
             ;; run is interrupted.
             (make-directory out-parent t)
-            (let ((coding-system-for-write 'utf-8-unix))
+            (let ((coding-system-for-write 'undecided))
               (write-region (point-min) (point-max) out-file nil :silent))))
       (error
        (setq err-msg (format "%s" (cadr err)))))

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-23 15:55:18 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-23 23:14:19 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -133,6 +133,29 @@
   "Last report ID used.  Offered as default in `sd7-indent-perf-run'.")
 
 ;;; --------------------------------------------------------------------------
+;;; Warning capture
+
+(defvar sd7-indent-perf--current-warnings nil
+  "Warnings collected from seed7-mode during the current file's `indent-region'.
+Each element is a string of the form produced by seed7-calc-indent when it
+encounters a construct it cannot indent, e.g.:
+  \"At line 183: string line syntax not yet supported!
+    Recurse count=0 Please report.\"
+Reset to nil at the start of each file; populated by
+`sd7-indent-perf--capture-advice'.")
+
+(defun sd7-indent-perf--capture-advice (orig-fn fmt &rest args)
+  "Advice around `message' to capture seed7-mode indentation warnings.
+Strings matching \"not yet supported\" are appended to
+`sd7-indent-perf--current-warnings' in addition to being displayed normally."
+  (let ((txt (condition-case nil
+                 (apply #'format fmt args)
+               (error (format "%s" fmt)))))
+    (when (string-match-p "not yet supported" txt)
+      (push txt sd7-indent-perf--current-warnings))
+    (apply orig-fn fmt args)))
+
+;;; --------------------------------------------------------------------------
 ;;; Helpers
 
 (defun sd7-indent-perf--message (fmt &rest args)
@@ -155,15 +178,18 @@ appears in *Messages* and the echo area)."
       (format "%02d:%02d.%03d" m s ms))))
 
 (defun sd7-indent-perf--seed7-files (input-dir)
-  "Return a sorted list of all .sd7 and .s7i files under INPUT-DIR."
-  (let ((files '()))
-    (dolist (ext '("sd7" "s7i"))
-      (setq files
-            (append files
-                    (directory-files-recursively
-                     input-dir
-                     (concat "\\." (regexp-quote ext) "\\'")))))
-    (sort files #'string<)))
+  "Return a sorted list of all .sd7 and .s7i files under INPUT-DIR.
+Files are returned in spec-list order: prg/*.sd7 alphabetically first,
+then lib/*.s7i alphabetically — matching the ordering used by sd7-perf.el
+and sd7-nav-index.el."
+  (let ((prg-files (directory-files-recursively
+                    (expand-file-name "prg" input-dir)
+                    "\\.sd7\\'"))
+        (lib-files (directory-files-recursively
+                    (expand-file-name "lib" input-dir)
+                    "\\.s7i\\'")))
+    (append (sort prg-files #'string<)
+            (sort lib-files #'string<))))
 
 (defun sd7-indent-perf--output-path (input-file input-dir output-dir)
   "Return the output file path for INPUT-FILE mirroring INPUT-DIR under OUTPUT-DIR."
@@ -177,45 +203,72 @@ appears in *Messages* and the echo area)."
   "Re-indent INPUT-FILE with seed7-mode and write result to the output tree.
 
 The original INPUT-FILE is never modified.  The re-indented content is
-written to OUTPUT-DIR/<relative-path-from-INPUT-DIR>.
+written to OUTPUT-DIR/<relative-path-from-INPUT-DIR> **immediately** after
+indentation completes, before any subsequent file is processed.
 
 Returns a plist:
   :file        abbreviated file name (relative to INPUT-DIR)
   :lines       line count of the file
+  :file-start  wall-clock time (float) when indentation started
   :indent-time elapsed time in seconds for `indent-region'
+  :warnings    list of captured indentation-warning strings (may be nil)
   :error       error message string if processing failed, or nil"
-  (let* ((rel       (file-relative-name input-file input-dir))
-         (out-file  (sd7-indent-perf--output-path input-file input-dir output-dir))
+  (let* ((rel        (file-relative-name input-file input-dir))
+         (out-file   (sd7-indent-perf--output-path input-file input-dir output-dir))
          (out-parent (file-name-directory out-file))
          line-count
          indent-time
+         file-start
+         warnings
          err-msg)
+    ;; Announce the start of this file with a wall-clock timestamp.
+    (sd7-indent-perf--message "  indenting %s …" rel)
     (condition-case err
         (progn
-          ;; Read the file into a temp buffer and activate seed7-mode.
           (with-temp-buffer
             (insert-file-contents input-file)
-            ;; Activate seed7-mode without hooks that might open other buffers.
+            ;; Activate seed7-mode.  `delay-mode-hooks' suppresses hooks that
+            ;; might open windows or visit other files, but the warning
+            ;; "Making delay-mode-hooks buffer-local while locally let-bound!"
+            ;; is harmless — it fires because seed7-mode itself sets the var.
             (let ((delay-mode-hooks t))
               (seed7-mode))
-            ;; Ensure font-lock keywords are compiled (mode may lazily compile).
-            ;; indent-region does not need fontification, but activating the
-            ;; full mode prevents any lazy-initialization surprises.
             (setq line-count (line-number-at-pos (point-max)))
-            ;; Time the re-indentation of the complete buffer.
-            (let* ((t0      (current-time))
-                   (_       (indent-region (point-min) (point-max)))
-                   (elapsed (float-time (time-subtract (current-time) t0))))
-              (setq indent-time elapsed))
-            ;; Write the re-indented content to the output tree.
+            ;; Install warning capture, then time indent-region.
+            (setq sd7-indent-perf--current-warnings nil)
+            (advice-add 'message :around #'sd7-indent-perf--capture-advice)
+            (unwind-protect
+                (let ((t0 (current-time)))
+                  (setq file-start (float-time t0))
+                  (indent-region (point-min) (point-max))
+                  (setq indent-time
+                        (float-time (time-subtract (current-time) t0))))
+              ;; Always remove the advice, even if indent-region signals.
+              (advice-remove 'message #'sd7-indent-perf--capture-advice)
+              (setq warnings (nreverse sd7-indent-perf--current-warnings)))
+            ;; Write the re-indented content immediately — before the next
+            ;; file is processed — so snapshots are available even if the
+            ;; run is interrupted.
             (make-directory out-parent t)
             (let ((coding-system-for-write 'utf-8-unix))
               (write-region (point-min) (point-max) out-file nil :silent))))
       (error
        (setq err-msg (format "%s" (cadr err)))))
+    ;; Progress message: elapsed time + warning count + written path.
+    (if err-msg
+        (sd7-indent-perf--message "  ERROR %s: %s" rel err-msg)
+      (sd7-indent-perf--message
+       "  done  %s  %.3fs  %d line(s)%s  → %s"
+       rel
+       (or indent-time 0.0)
+       (or line-count 0)
+       (if warnings (format "  [%d warning(s)]" (length warnings)) "")
+       out-file))
     (list :file        rel
           :lines       (or line-count 0)
+          :file-start  (or file-start 0.0)
           :indent-time (or indent-time 0.0)
+          :warnings    warnings
           :error       err-msg)))
 
 ;;; --------------------------------------------------------------------------
@@ -331,6 +384,23 @@ Returns the path of the written report file."
                           (plist-get r :file)
                           (plist-get r :error))))
         (insert "\n"))
+
+      ;; ---- Indentation warnings (files with "not yet supported" messages) ----
+      (let ((warn-results (cl-remove-if-not
+                           (lambda (r) (plist-get r :warnings))
+                           results)))
+        (when warn-results
+          (insert "Indentation Warnings\n")
+          (insert "====================\n\n")
+          (insert "Lines where seed7-mode reported \"not yet supported\" during indentation.\n")
+          (insert "These indicate Seed7 syntax constructs not yet handled by the indentation\n")
+          (insert "engine.  The indented output for those lines may be incorrect.\n\n")
+          (dolist (r warn-results)
+            (insert (format "``%s``\n" (plist-get r :file)))
+            (dolist (w (plist-get r :warnings))
+              (insert (format "  - %s\n" w)))
+            (insert "\n"))))
+
       ;; Terminator
       (insert "\n.. ---------------------------------------------------------------------------\n"))
     report-file))
@@ -376,11 +446,15 @@ Returns the absolute path of the written report file."
          (n           0))
     (dolist (f files)
       (cl-incf n)
+      ;; Announce file number + wall-clock start time before entering the
+      ;; (potentially long) per-file indentation.
       (sd7-indent-perf--message
-       "[%d/%d] %s" n total-files
-       (file-relative-name f input-dir))
+       "[%d/%d]  started %s"
+       n total-files
+       (format-time-string "%H:%M:%S"))
       (push (sd7-indent-perf--process-file f input-dir output-dir)
             results))
+
     (let* ((total-elapsed (- (float-time) total-start))
            (results-fwd   (nreverse results))
            (report        (sd7-indent-perf--write-report

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-23 23:14:19 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 10:36:35 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -523,8 +523,8 @@ Exits Emacs with 0 on success or 1 on error."
           (sd7-indent-perf-run-core
            (nth 0 args) (nth 1 args) (nth 2 args) (nth 3 args))
           (kill-emacs 0))
-      (user-error
-       (message "ERROR: %s" (cadr err))
+      (error
+       (message "ERROR: %s" (error-message-string err))
        (kill-emacs 1)))))
 
 ;;; --------------------------------------------------------------------------

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 10:45:38 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-24 14:37:57 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7 package.
 ;; This file is not part of GNU Emacs.
@@ -146,12 +146,15 @@ Reset to nil at the start of each file; populated by
 
 (defun sd7-indent-perf--capture-advice (orig-fn fmt &rest args)
   "Advice around `message' to capture seed7-mode indentation warnings.
-Strings matching \"not yet supported\" are appended to
+Strings matching \"not yet supported\" or \"timed out\" are appended to
 `sd7-indent-perf--current-warnings' in addition to being displayed normally."
   (let ((txt (condition-case nil
                  (apply #'format fmt args)
                (error (format "%s" fmt)))))
-    (when (string-match-p "not yet supported" txt)
+    (when (string-match-p
+           (rx (or "not yet supported"  ; in string handling in `seed7-calc-indent'
+                   "timed out"))        ; timed out in seed7-re-search-backward
+           txt)
       (push txt sd7-indent-perf--current-warnings))
     (apply orig-fn fmt args)))
 

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -1,0 +1,465 @@
+;;; tools/sd7-indent-perf.el --- Seed7 indentation performance & correctness benchmark  -*- lexical-binding: t; -*-
+
+;; Created   : Tuesday, June 24 2026.
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-06-23 15:55:18 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the SEED7 package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Measures the time taken by `indent-region' to re-indent every Seed7 file
+;; found (recursively) under INPUT-DIR, writes the re-indented content to a
+;; mirrored OUTPUT-DIR tree (leaving the originals untouched), and produces an
+;; RST benchmark + correctness report.
+;;
+;; The two-tree design is the key feature:
+;;
+;;   INPUT-DIR/prg/chkint.sd7   (never modified)
+;;   OUTPUT-DIR/prg/chkint.sd7  (content after re-indentation by seed7-mode)
+;;
+;; Comparing the two trees with:
+;;
+;;   diff -r INPUT-DIR OUTPUT-DIR
+;;
+;; shows every line that seed7-mode would change when indenting a file.
+;; Running the tool before and after a change to seed7-mode.el and then
+;; diffing the two OUTPUT-DIRs reveals any behavioural regression introduced
+;; by the change.
+;;
+;; Indentation exercises `seed7-calc-indent' on every line.  That function
+;; calls (among others) `seed7-line-inside-array-definition-block' which
+;; uses `seed7--array-definition-start-regexp' — the regexp simplified in
+;; this PR.  This benchmark is therefore the correct tool for measuring the
+;; impact of changes to indentation-path regexps.
+;;
+;; Usage
+;; -----
+;;
+;; 1. Interactive (preferred):
+;;
+;;      M-x sd7-indent-perf-run
+;;
+;;    Prompts for INPUT-DIR, OUTPUT-DIR, REPORT-DIR, and ID.
+;;
+;; 2. Batch:
+;;
+;;      emacs -Q --batch --load tools/sd7-indent-perf.el \
+;;            -- INPUT_DIR OUTPUT_DIR REPORT_DIR ID
+;;
+;; 3. Makefile:
+;;
+;;      $(EMACS) -Q --batch --load tools/sd7-indent-perf.el \
+;;               -- $(INPUT_DIR) $(OUTPUT_DIR) $(REPORT_DIR) $(ID)
+;;
+;; Arguments:
+;;   INPUT_DIR  : root of the input directory tree (read-only)
+;;   OUTPUT_DIR : root of the output directory tree (created/overwritten)
+;;   REPORT_DIR : directory where the RST report is written (created if absent)
+;;   ID         : free-form report identifier (e.g. "01", "before-simplify")
+;;
+;; Output:
+;;   OUTPUT_DIR/  — mirrored tree with re-indented .sd7 / .s7i files
+;;   REPORT_DIR/seed7mode-indent-perf-ID.rst
+
+;;; --------------------------------------------------------------------------
+;;; Load-path bootstrap
+
+(eval-and-compile
+  (let* ((this-file (or load-file-name
+                        (and (boundp 'byte-compile-current-file)
+                             (stringp byte-compile-current-file)
+                             byte-compile-current-file)
+                        buffer-file-name)))
+    (when this-file
+      (let* ((tools-dir (file-name-directory (expand-file-name this-file)))
+             (root-dir  (expand-file-name ".." tools-dir)))
+        (dolist (dir (list root-dir tools-dir))
+          (unless (member dir load-path)
+            (push dir load-path)))))))
+
+(require 'seed7-mode)
+(require 'cl-lib)
+
+;;; --------------------------------------------------------------------------
+;;; Repository root
+
+(defvar sd7-indent-perf--repo-root
+  (let* ((this-file (or load-file-name
+                        (and (boundp 'byte-compile-current-file)
+                             (stringp byte-compile-current-file)
+                             byte-compile-current-file)
+                        buffer-file-name)))
+    (when this-file
+      (expand-file-name
+       ".."
+       (file-name-directory (expand-file-name this-file)))))
+  "Absolute path to the seed7-mode repository root.")
+
+;;; --------------------------------------------------------------------------
+;;; Remembered defaults
+
+(defvar sd7-indent-perf--last-input-dir
+  (expand-file-name "~/src/seed7")
+  "Last INPUT-DIR used.  Offered as default in `sd7-indent-perf-run'.")
+
+(defvar sd7-indent-perf--last-output-dir
+  (expand-file-name "~/tmp/sd7-indent-out")
+  "Last OUTPUT-DIR used.  Offered as default in `sd7-indent-perf-run'.")
+
+(defvar sd7-indent-perf--last-report-dir
+  (when sd7-indent-perf--repo-root
+    (expand-file-name "reports" sd7-indent-perf--repo-root))
+  "Last REPORT-DIR used.  Defaults to reports/ in the repo root.")
+
+(defvar sd7-indent-perf--last-id "01"
+  "Last report ID used.  Offered as default in `sd7-indent-perf-run'.")
+
+;;; --------------------------------------------------------------------------
+;;; Helpers
+
+(defun sd7-indent-perf--message (fmt &rest args)
+  "Emit a timestamped progress message.
+In batch mode uses `message'; in interactive mode also uses `message' (which
+appears in *Messages* and the echo area)."
+  (let ((text (apply #'format fmt args)))
+    (message "[%s] %s"
+             (format-time-string "%H:%M:%S")
+             text)))
+
+(defun sd7-indent-perf--format-duration (seconds)
+  "Format SECONDS as MM:SS.mmm."
+  (if (null seconds)
+      "—"
+    (let* ((whole (floor seconds))
+           (m     (/ whole 60))
+           (s     (% whole 60))
+           (ms    (floor (* (- seconds whole) 1000))))
+      (format "%02d:%02d.%03d" m s ms))))
+
+(defun sd7-indent-perf--seed7-files (input-dir)
+  "Return a sorted list of all .sd7 and .s7i files under INPUT-DIR."
+  (let ((files '()))
+    (dolist (ext '("sd7" "s7i"))
+      (setq files
+            (append files
+                    (directory-files-recursively
+                     input-dir
+                     (concat "\\." (regexp-quote ext) "\\'")))))
+    (sort files #'string<)))
+
+(defun sd7-indent-perf--output-path (input-file input-dir output-dir)
+  "Return the output file path for INPUT-FILE mirroring INPUT-DIR under OUTPUT-DIR."
+  (let* ((rel (file-relative-name input-file input-dir)))
+    (expand-file-name rel output-dir)))
+
+;;; --------------------------------------------------------------------------
+;;; Per-file processing
+
+(defun sd7-indent-perf--process-file (input-file input-dir output-dir)
+  "Re-indent INPUT-FILE with seed7-mode and write result to the output tree.
+
+The original INPUT-FILE is never modified.  The re-indented content is
+written to OUTPUT-DIR/<relative-path-from-INPUT-DIR>.
+
+Returns a plist:
+  :file        abbreviated file name (relative to INPUT-DIR)
+  :lines       line count of the file
+  :indent-time elapsed time in seconds for `indent-region'
+  :error       error message string if processing failed, or nil"
+  (let* ((rel       (file-relative-name input-file input-dir))
+         (out-file  (sd7-indent-perf--output-path input-file input-dir output-dir))
+         (out-parent (file-name-directory out-file))
+         line-count
+         indent-time
+         err-msg)
+    (condition-case err
+        (progn
+          ;; Read the file into a temp buffer and activate seed7-mode.
+          (with-temp-buffer
+            (insert-file-contents input-file)
+            ;; Activate seed7-mode without hooks that might open other buffers.
+            (let ((delay-mode-hooks t))
+              (seed7-mode))
+            ;; Ensure font-lock keywords are compiled (mode may lazily compile).
+            ;; indent-region does not need fontification, but activating the
+            ;; full mode prevents any lazy-initialization surprises.
+            (setq line-count (line-number-at-pos (point-max)))
+            ;; Time the re-indentation of the complete buffer.
+            (let* ((t0      (current-time))
+                   (_       (indent-region (point-min) (point-max)))
+                   (elapsed (float-time (time-subtract (current-time) t0))))
+              (setq indent-time elapsed))
+            ;; Write the re-indented content to the output tree.
+            (make-directory out-parent t)
+            (let ((coding-system-for-write 'utf-8-unix))
+              (write-region (point-min) (point-max) out-file nil :silent))))
+      (error
+       (setq err-msg (format "%s" (cadr err)))))
+    (list :file        rel
+          :lines       (or line-count 0)
+          :indent-time (or indent-time 0.0)
+          :error       err-msg)))
+
+;;; --------------------------------------------------------------------------
+;;; RST report
+
+(defconst sd7-indent-perf--col-file  50 "Width of the File column.")
+(defconst sd7-indent-perf--col-lines  7 "Width of the Lines column.")
+(defconst sd7-indent-perf--col-time  16 "Width of the Time column.")
+
+(defun sd7-indent-perf--rst-rule ()
+  "Return one RST simple-table rule line."
+  (format "%s %s %s"
+          (make-string sd7-indent-perf--col-file  ?=)
+          (make-string sd7-indent-perf--col-lines ?=)
+          (make-string sd7-indent-perf--col-time  ?=)))
+
+(defun sd7-indent-perf--write-report (results input-dir output-dir
+                                               report-dir id
+                                               total-elapsed)
+  "Write the RST indentation benchmark report.
+
+RESULTS is a list of plists as returned by `sd7-indent-perf--process-file'.
+Returns the path of the written report file."
+  (let* ((report-file (expand-file-name
+                       (format "seed7mode-indent-perf-%s.rst" id)
+                       report-dir))
+         (timestamp   (format-time-string "%Y-%m-%dT%H:%M:%S%z"))
+         (times       (mapcar (lambda (r) (plist-get r :indent-time)) results))
+         (errors      (cl-remove-if-not (lambda (r) (plist-get r :error))
+                                        results))
+         (n           (length results))
+         (avg         (if (> n 0) (/ (apply #'+ times) (float n)) 0.0))
+         (mn          (if (> n 0) (apply #'min times) 0.0))
+         (mx          (if (> n 0) (apply #'max times) 0.0))
+         (total-time  (apply #'+ times))
+         (fw          sd7-indent-perf--col-file)
+         (lw          sd7-indent-perf--col-lines)
+         (tw          sd7-indent-perf--col-time)
+         (rule        (sd7-indent-perf--rst-rule)))
+    (make-directory report-dir t)
+    (with-temp-file report-file
+      ;; Title
+      (let* ((title "Seed7 Mode — Indentation Performance & Correctness Benchmark")
+             (bar   (make-string (length title) ?=)))
+        (insert bar "\n" title "\n" bar "\n\n"))
+      ;; Metadata
+      (insert (format ":Running with    : seed7-mode %s\n"
+                      seed7-mode-version-timestamp))
+      (insert (format ":Input dir       : %s\n"
+                      (file-name-as-directory (expand-file-name input-dir))))
+      (insert (format ":Output dir      : %s\n"
+                      (file-name-as-directory (expand-file-name output-dir))))
+      (insert (format ":Generated on    : %s\n" timestamp))
+      (insert (format ":Files processed : %d\n" n))
+      (when errors
+        (insert (format ":Files with errors: %d\n" (length errors))))
+      (insert (format ":Total indent time: %.3f s\n" total-time))
+      (insert (format ":Wall-clock time   : %s\n\n"
+                      (sd7-indent-perf--format-duration total-elapsed)))
+      ;; Correctness note
+      (insert "Correctness Check\n")
+      (insert "=================\n\n")
+      (insert "To check whether re-indentation changed any file, run::\n\n")
+      (insert (format "  diff -r %s \\\n          %s\n\n"
+                      (file-name-as-directory (expand-file-name input-dir))
+                      (file-name-as-directory (expand-file-name output-dir))))
+      (insert "No output from ``diff -r`` means seed7-mode indentation is idempotent\n")
+      (insert "for all files in the input tree.\n\n")
+      (insert "To compare two OUTPUT-DIRs produced by different versions of seed7-mode::\n\n")
+      (insert "  diff -r OUTPUT_DIR_BEFORE OUTPUT_DIR_AFTER\n\n")
+      (insert "Any line in the diff output indicates a change in indentation decisions.\n\n")
+      ;; File table
+      (insert "File Indentation Times\n")
+      (insert "======================\n\n")
+      (insert rule "\n")
+      (insert (format (format "%%-%ds %%%dd %%%ds\n" fw lw tw)
+                      "File Name" (length "Lines") "Indent Time (s)"))
+      (insert rule "\n")
+      (dolist (r results)
+        (let ((file  (plist-get r :file))
+              (lines (plist-get r :lines))
+              (time  (plist-get r :indent-time))
+              (err   (plist-get r :error)))
+          (if err
+              (insert (format (format "%%-%ds %%%ds %%s\n" fw lw)
+                              file "—" (format "ERROR: %s" err)))
+            (insert (format (format "%%-%ds %%%dd %%.6f\n" fw lw)
+                            file lines time)))))
+      (insert rule "\n\n")
+      ;; Statistics
+      (insert "Statistical Summary\n")
+      (insert "===================\n\n")
+      (insert "Per-file `indent-region' times (seconds).\n\n")
+      (insert "+-----------+------------------+\n")
+      (insert "| Metric    | Time (s)         |\n")
+      (insert "+===========+==================+\n")
+      (insert (format "| Files     | %-16d |\n" n))
+      (insert "+-----------+------------------+\n")
+      (insert (format "| Average   | %-16.6f |\n" avg))
+      (insert "+-----------+------------------+\n")
+      (insert (format "| Minimum   | %-16.6f |\n" mn))
+      (insert "+-----------+------------------+\n")
+      (insert (format "| Maximum   | %-16.6f |\n" mx))
+      (insert "+-----------+------------------+\n")
+      (insert (format "| Total     | %-16.6f |\n" total-time))
+      (insert "+-----------+------------------+\n\n")
+      ;; Error table (only if there were errors)
+      (when errors
+        (insert "Files with Errors\n")
+        (insert "=================\n\n")
+        (dolist (r errors)
+          (insert (format "- ``%s``: %s\n"
+                          (plist-get r :file)
+                          (plist-get r :error))))
+        (insert "\n"))
+      ;; Terminator
+      (insert "\n.. ---------------------------------------------------------------------------\n"))
+    report-file))
+
+;;; --------------------------------------------------------------------------
+;;; Core runner
+
+(defun sd7-indent-perf-run-core (input-dir output-dir report-dir id)
+  "Re-indent all Seed7 files under INPUT-DIR and write a benchmark report.
+
+INPUT-DIR  : root of the directory tree to scan (never modified).
+OUTPUT-DIR : root of the output tree; re-indented files are written here
+             with the same relative paths as in INPUT-DIR.
+REPORT-DIR : directory where the RST report is written (created if absent).
+ID         : free-form report identifier used verbatim in the filename.
+
+Returns the absolute path of the written report file."
+  (setq input-dir  (expand-file-name input-dir)
+        output-dir (expand-file-name output-dir)
+        report-dir (if (file-name-absolute-p report-dir)
+                       (expand-file-name report-dir)
+                     (expand-file-name report-dir
+                                       (or sd7-indent-perf--repo-root
+                                           default-directory))))
+  (unless (file-directory-p input-dir)
+    (user-error "Not a directory: %s" input-dir))
+  (unless (and (stringp id) (not (string-empty-p id)))
+    (user-error "ID must be a non-empty string, got: %S" id))
+
+  (sd7-indent-perf--message
+   "Seed7 Mode — Indentation Performance & Correctness Benchmark")
+  (sd7-indent-perf--message "seed7-mode: %s" seed7-mode-version-timestamp)
+  (sd7-indent-perf--message "Input dir : %s" input-dir)
+  (sd7-indent-perf--message "Output dir: %s" output-dir)
+  (sd7-indent-perf--message "Report dir: %s" report-dir)
+  (sd7-indent-perf--message "Report ID : %s" id)
+
+  (let* ((files       (sd7-indent-perf--seed7-files input-dir))
+         (total-files (length files))
+         (_ (sd7-indent-perf--message "Files found: %d" total-files))
+         (total-start (float-time))
+         (results     '())
+         (n           0))
+    (dolist (f files)
+      (cl-incf n)
+      (sd7-indent-perf--message
+       "[%d/%d] %s" n total-files
+       (file-relative-name f input-dir))
+      (push (sd7-indent-perf--process-file f input-dir output-dir)
+            results))
+    (let* ((total-elapsed (- (float-time) total-start))
+           (results-fwd   (nreverse results))
+           (report        (sd7-indent-perf--write-report
+                           results-fwd input-dir output-dir
+                           report-dir id total-elapsed)))
+      (sd7-indent-perf--message
+       "Done.  Wall clock: %s"
+       (sd7-indent-perf--format-duration total-elapsed))
+      (sd7-indent-perf--message "Report: %s" report)
+      report)))
+
+;;; --------------------------------------------------------------------------
+;;; Interactive entry point
+
+;;;###autoload
+(defun sd7-indent-perf-run (input-dir output-dir report-dir id)
+  "Interactively run the Seed7 indentation benchmark.
+
+Prompts for INPUT-DIR, OUTPUT-DIR, REPORT-DIR, and ID.
+Previous values are offered as defaults and remembered within the session.
+
+OUTPUT-DIR will mirror INPUT-DIR with re-indented file content; it is
+created if absent.  The original files in INPUT-DIR are never modified.
+
+The RST report is written to REPORT-DIR/seed7mode-indent-perf-ID.rst."
+  (interactive
+   (list
+    (read-directory-name "Input directory (Seed7 source tree): "
+                         sd7-indent-perf--last-input-dir)
+    (read-directory-name "Output directory (re-indented tree): "
+                         sd7-indent-perf--last-output-dir)
+    (read-directory-name "Report directory: "
+                         sd7-indent-perf--last-report-dir)
+    (read-string (format "Report ID (default %S): "
+                         sd7-indent-perf--last-id)
+                 nil nil sd7-indent-perf--last-id)))
+  (setq sd7-indent-perf--last-input-dir  (directory-file-name
+                                           (expand-file-name input-dir))
+        sd7-indent-perf--last-output-dir (directory-file-name
+                                           (expand-file-name output-dir))
+        sd7-indent-perf--last-report-dir (directory-file-name
+                                           (expand-file-name report-dir))
+        sd7-indent-perf--last-id         id)
+  (sd7-indent-perf-run-core input-dir output-dir report-dir id))
+
+;;; --------------------------------------------------------------------------
+;;; Batch / CLI entry point
+
+(defun sd7-indent-perf-main ()
+  "Parse `command-line-args-left' and call `sd7-indent-perf-run-core'.
+
+Expected positional arguments (after --)::
+
+  INPUT_DIR OUTPUT_DIR REPORT_DIR ID
+
+Exits Emacs with 0 on success or 1 on error."
+  (let ((args command-line-args-left))
+    (setq command-line-args-left nil)
+    (when (equal (car args) "--")
+      (setq args (cdr args)))
+    (when (< (length args) 4)
+      (message "Usage: -- INPUT_DIR OUTPUT_DIR REPORT_DIR ID")
+      (kill-emacs 1))
+    (condition-case err
+        (progn
+          (sd7-indent-perf-run-core
+           (nth 0 args) (nth 1 args) (nth 2 args) (nth 3 args))
+          (kill-emacs 0))
+      (user-error
+       (message "ERROR: %s" (cadr err))
+       (kill-emacs 1)))))
+
+;;; --------------------------------------------------------------------------
+;;; Auto-dispatch in batch mode
+
+(when noninteractive
+  (sd7-indent-perf-main))
+
+;;; --------------------------------------------------------------------------
+(provide 'sd7-indent-perf)
+
+;;; sd7-indent-perf.el ends here

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-24 23:00:13 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:06:59 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tools/sd7-nav-index.el
+++ b/tools/sd7-nav-index.el
@@ -1,0 +1,499 @@
+;;; tools/sd7-nav-index.el --- Seed7 navigation entity index reporter  -*- lexical-binding: t; -*-
+
+;; Created   : Tuesday, June 24 2026.
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-06-23 15:36:11 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the SEED7 package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Scans every Seed7 file in SEED7_DIR/prg/ (*.sd7) and SEED7_DIR/lib/ (*.s7i)
+;; — the same spec list as `sd7-perf.el' — activates `seed7-mode' in each
+;; buffer, calls `seed7-buffer-entities' to collect all named entities
+;; (functions, procedures, structures, enumerations, arrays, sets), and writes
+;; an RST report with one section per file.
+;;
+;; Each section contains a fixed-width RST grid table of entities sorted by
+;; line number.  Fixed column widths keep table framing identical across runs,
+;; so diffing two reports reveals only rows that changed.
+;;
+;; Typical workflow
+;; ----------------
+;;
+;;   # baseline — before any change
+;;   emacs -Q --batch --load tools/sd7-nav-index.el \
+;;         -- ~/src/seed7 reports before-opt
+;;
+;;   # make a change to seed7-mode.el …
+;;
+;;   # after the change
+;;   emacs -Q --batch --load tools/sd7-nav-index.el \
+;;         -- ~/src/seed7 reports after-opt
+;;
+;;   # compare
+;;   diff reports/seed7mode-nav-index-before-opt.rst \
+;;        reports/seed7mode-nav-index-after-opt.rst
+;;
+;; Usage
+;; -----
+;;
+;; 1. Interactive (preferred):
+;;
+;;      M-x sd7-nav-index-run
+;;
+;;    Prompts for SEED7_DIR, REPORT_DIR, and ID.
+;;    Previous values are offered as defaults and remembered within the session.
+;;
+;; 2. Batch (command-line):
+;;
+;;      emacs -Q --batch --load tools/sd7-nav-index.el \
+;;            -- SEED7_DIR REPORT_DIR ID
+;;
+;; 3. Makefile:
+;;
+;;      $(EMACS) -Q --batch --load tools/sd7-nav-index.el \
+;;               -- $(SEED7_DIR) $(REPORT_DIR) $(ID)
+;;
+;; Arguments:
+;;   SEED7_DIR  : path to the Seed7 source tree (must contain prg/ and lib/)
+;;   REPORT_DIR : directory where the report file is written (created if absent)
+;;   ID         : free-form report identifier (e.g. "01", "before-opt")
+;;
+;; Output:
+;;   REPORT_DIR/seed7mode-nav-index-ID.rst
+
+;;; --------------------------------------------------------------------------
+;;; Load-path bootstrap
+;;
+;; Runs at both load time and byte-compile time.
+
+(eval-and-compile
+  (let* ((this-file (or load-file-name
+                        (and (boundp 'byte-compile-current-file)
+                             (stringp byte-compile-current-file)
+                             byte-compile-current-file)
+                        buffer-file-name)))
+    (when this-file
+      (let* ((tools-dir (file-name-directory (expand-file-name this-file)))
+             (root-dir  (expand-file-name ".." tools-dir)))
+        (dolist (dir (list root-dir tools-dir))
+          (unless (member dir load-path)
+            (push dir load-path)))))))
+
+(require 'seed7-mode)
+(require 'cl-lib)
+
+;;; --------------------------------------------------------------------------
+;;; Repository root
+
+(defvar sd7-nav-index--repo-root
+  (let* ((this-file (or load-file-name
+                        (and (boundp 'byte-compile-current-file)
+                             (stringp byte-compile-current-file)
+                             byte-compile-current-file)
+                        buffer-file-name)))
+    (when this-file
+      (expand-file-name
+       ".."
+       (file-name-directory (expand-file-name this-file)))))
+  "Absolute path to the seed7-mode repository root.
+Derived from the location of this file at load or byte-compile time.")
+
+;;; --------------------------------------------------------------------------
+;;; Remembered defaults (persist across invocations within a session)
+
+(defvar sd7-nav-index--last-seed7-dir
+  (expand-file-name "~/src/seed7")
+  "Last Seed7 source directory used.
+Offered as default in `sd7-nav-index-run'.")
+
+(defvar sd7-nav-index--last-report-dir
+  (when sd7-nav-index--repo-root
+    (expand-file-name "reports" sd7-nav-index--repo-root))
+  "Last report output directory.  Defaults to reports/ in the repo root.
+Offered as default in `sd7-nav-index-run'.")
+
+(defvar sd7-nav-index--last-id "01"
+  "Last report ID used.  Offered as default in `sd7-nav-index-run'.")
+
+;;; --------------------------------------------------------------------------
+;;; Progress helpers
+
+(defvar sd7-nav-index--current-file nil
+  "File currently being indexed, or nil.")
+
+(defun sd7-nav-index--message (fmt &rest args)
+  "Emit a timestamped progress message."
+  (let ((text (apply #'format fmt args)))
+    (message "[%s] %s"
+             (format-time-string "%H:%M:%S")
+             text)))
+
+;;; --------------------------------------------------------------------------
+;;; Validation
+
+(defun sd7-nav-index--validate-seed7-dir (seed7-dir)
+  "Signal `user-error' if SEED7-DIR does not contain prg/ and lib/."
+  (unless (file-directory-p seed7-dir)
+    (user-error "Not a directory: %s" seed7-dir))
+  (dolist (sub '("prg" "lib"))
+    (unless (file-directory-p (expand-file-name sub seed7-dir))
+      (user-error "Expected sub-directory '%s/' not found under: %s"
+                  sub seed7-dir))))
+
+;;; --------------------------------------------------------------------------
+;;; File-name abbreviation  (same convention as sd7-perf.el)
+
+(defun sd7-nav-index--abbrev (file-name)
+  "Strip the leading path prefix, keeping from the Seed7 dir name onward.
+
+Example:
+  /home/user/src/seed7/prg/chkint.sd7  →  seed7/prg/chkint.sd7
+  /opt/seed7/lib/string.s7i             →  seed7/lib/string.s7i"
+  (replace-regexp-in-string
+   "^.*/\\([^/]+/\\(?:prg\\|lib\\)/\\)" "\\1" file-name))
+
+;;; --------------------------------------------------------------------------
+;;; Fixed RST table column widths
+;;
+;; Keeping widths fixed across runs ensures that table framing is byte-for-byte
+;; identical; `diff' then shows only changed data rows, not reflowed framing.
+
+(defconst sd7-nav-index--col-line  6  "Width of the Line column (digits).")
+(defconst sd7-nav-index--col-type 11  "Width of the Type column ('enumeration' = 11).")
+(defconst sd7-nav-index--col-name 50  "Width of the Name column.")
+
+;;; --------------------------------------------------------------------------
+;;; RST simple-table helpers
+;;
+;; Produces the compact RST "simple table" format:
+;;
+;;   ======== ============= ====================================================
+;;    Line     Type          Name
+;;   ======== ============= ====================================================
+;;   18        procedure     checkInt
+;;   42        function      readInteger
+;;   ======== ============= ====================================================
+;;
+;; All three rule lines are identical (all `='), so table framing is byte-for-byte
+;; the same across runs — `diff' shows only changed data rows.
+
+(defun sd7-nav-index--rst-rule ()
+  "Return the RST simple-table rule line (used for top, header-sep, and bottom)."
+  (format "%s %s %s"
+          (make-string sd7-nav-index--col-line ?=)
+          (make-string sd7-nav-index--col-type ?=)
+          (make-string sd7-nav-index--col-name ?=)))
+
+(defun sd7-nav-index--rst-header-row ()
+  "Return the simple-table header row string."
+  (format (format " %%-%ds %%-%ds %%-%ds"
+                  sd7-nav-index--col-line
+                  sd7-nav-index--col-type
+                  sd7-nav-index--col-name)
+          "Line" "Type" "Name"))
+
+(defun sd7-nav-index--rst-data-row (line-no type name)
+  "Return one RST simple-table data row string."
+  (format (format "%%-%dd %%-%ds %%-%ds"
+                  sd7-nav-index--col-line
+                  sd7-nav-index--col-type
+                  sd7-nav-index--col-name)
+          line-no type (format "``%s``" name)))
+
+(defun sd7-nav-index--rst-table (entities)
+  "Return an RST simple table string for ENTITIES ((TYPE NAME LINE) ...).
+Returns the string \"(none)\" when ENTITIES is nil."
+  (if (null entities)
+      "(none)\n"
+    (let* ((rule (sd7-nav-index--rst-rule))
+           (rows (list rule
+                       (sd7-nav-index--rst-header-row)
+                       rule)))
+      (dolist (e entities)
+        (push (sd7-nav-index--rst-data-row
+               (nth 2 e) (symbol-name (nth 0 e)) (nth 1 e))
+              rows))
+      (push rule rows)
+      (mapconcat #'identity (nreverse rows) "\n"))))
+
+;;; --------------------------------------------------------------------------
+;;; Per-file processing
+
+(defun sd7-nav-index--process-file (file-path seed7-dir)
+  "Load FILE-PATH, activate `seed7-mode', collect entities.
+
+Returns a plist:
+  :abbrev     abbreviated file name (relative to the Seed7 dir name)
+  :rel        path relative to SEED7-DIR
+  :lines      line count
+  :entities   list from `seed7-buffer-entities'
+  :error      error string, or nil on success"
+  (let* ((abbrev  (sd7-nav-index--abbrev file-path))
+         (rel     (file-relative-name file-path seed7-dir))
+         line-count entities err-msg)
+    (condition-case err
+        (let ((buf (find-file-noselect file-path t)))
+          (with-current-buffer buf
+            (unless (eq major-mode 'seed7-mode)
+              (seed7-mode))
+            (setq line-count (line-number-at-pos (point-max))
+                  entities   (seed7-buffer-entities)))
+          (kill-buffer buf))
+      (error
+       (setq err-msg (format "%s" (cadr err)))))
+    (list :abbrev   abbrev
+          :rel      rel
+          :lines    (or line-count 0)
+          :entities (or entities '())
+          :error    err-msg)))
+
+;;; --------------------------------------------------------------------------
+;;; Core runner
+
+(defun sd7-nav-index-run-core (seed7-dir report-dir id)
+  "Index all Seed7 entities in SEED7-DIR and write an RST report.
+
+SEED7-DIR  : Seed7 source tree root (must contain prg/ and lib/).
+REPORT-DIR : directory where the RST report is written (created if absent).
+ID         : free-form identifier used verbatim in the output filename.
+
+Files are processed in spec-list order:
+  prg/*.sd7  (alphabetical), then  lib/*.s7i  (alphabetical)
+— the same order as sd7-perf.el.
+
+Returns the absolute path of the written report file."
+  (setq seed7-dir  (expand-file-name seed7-dir)
+        report-dir (if (file-name-absolute-p report-dir)
+                       (expand-file-name report-dir)
+                     (expand-file-name report-dir
+                                       (or sd7-nav-index--repo-root
+                                           default-directory))))
+  (sd7-nav-index--validate-seed7-dir seed7-dir)
+  (unless (and (stringp id) (not (string-empty-p id)))
+    (user-error "ID must be a non-empty string, got: %S" id))
+
+  (let* ((dir-specs        (list (list (expand-file-name "prg" seed7-dir) "sd7")
+                                 (list (expand-file-name "lib" seed7-dir) "s7i")))
+         (out-file         (expand-file-name
+                            (format "seed7mode-nav-index-%s.rst" id)
+                            report-dir))
+         (timestamp        (format-time-string "%Y-%m-%dT%H:%M:%S%z"))
+         (total-start      (float-time))
+         (file-count       0)
+         (error-count      0)
+         ;; results-by-spec : list of (SPEC-NAME . FILE-RESULTS-LIST)
+         ;; Built up per spec-group so the RST writer can emit group headings.
+         results-by-spec
+         ;; results : flat list of all file plists (for statistics/errors).
+         results)
+
+    (make-directory report-dir t)
+
+    (sd7-nav-index--message "Seed7 Navigation Entity Index")
+    (sd7-nav-index--message "seed7-mode  : %s" seed7-mode-version-timestamp)
+    (sd7-nav-index--message "Seed7 dir   : %s" seed7-dir)
+    (sd7-nav-index--message "Report dir  : %s" report-dir)
+    (sd7-nav-index--message "Report ID   : %s" id)
+
+    ;; ── Collect entities per spec-group ────────────────────────────────────
+    (dolist (spec dir-specs)
+      (let* ((dir       (car spec))
+             (ext       (cadr spec))
+             (spec-name (file-name-nondirectory (directory-file-name dir)))
+             (pat       (concat "\\." (regexp-quote ext) "\\'"))
+             spec-results)
+        (dolist (f (directory-files dir t pat))
+          (setq sd7-nav-index--current-file f)
+          (cl-incf file-count)
+          (sd7-nav-index--message "[%d] %s" file-count
+                                   (sd7-nav-index--abbrev f))
+          (let ((r (sd7-nav-index--process-file f seed7-dir)))
+            (when (plist-get r :error)
+              (cl-incf error-count)
+              (sd7-nav-index--message "  ERROR: %s" (plist-get r :error)))
+            (push r spec-results)))
+        (push (cons spec-name (nreverse spec-results)) results-by-spec)))
+
+    (setq results-by-spec (nreverse results-by-spec))
+    ;; Flat list derived from the grouped results — used for stats/errors below.
+    (setq results (apply #'append (mapcar #'cdr results-by-spec)))
+
+    (let ((total-elapsed (- (float-time) total-start)))
+      (sd7-nav-index--message
+       "Indexed %d file(s) in %.1f s (%d error(s))"
+       file-count total-elapsed error-count)
+
+      ;; ── Write RST report ──────────────────────────────────────────────────
+      (with-temp-file out-file
+
+        ;; ---- Document title ----
+        (let* ((title "Seed7 Navigation Entity Index")
+               (rule  (make-string (length title) ?=)))
+          (insert rule "\n" title "\n" rule "\n\n"))
+
+        ;; ---- Metadata ----
+        (insert (format "- Running with: seed7-mode %s\n"
+                        seed7-mode-version-timestamp))
+        (insert (format "- Seed7 dir: %s\n"
+                        (file-name-as-directory seed7-dir)))
+        (insert (format "- Generated on: %s\n" timestamp))
+        (insert (format "- Files indexed: %d\n" file-count))
+        (when (> error-count 0)
+          (insert (format "- Files errored: %d\n" error-count)))
+        (insert "\n")
+        (insert ".. sectnum::\n")
+        (insert "   :depth: 2\n\n")
+        (insert ".. contents:: Table of Contents\n")
+        (insert "   :depth: 2\n\n")
+
+        (insert ".. ---------------------------------------------------------------------------\n\n")
+
+        ;; ---- One RST section per spec-group (prg / lib),
+        ;;      then one subsection per file (- underline) ----
+        (dolist (spec-group results-by-spec)
+          (let* ((spec-name      (car spec-group))
+                 (spec-underline (make-string (length spec-name) ?=)))
+            ;; Group heading: "prg\n===" or "lib\n==="
+            (insert spec-name "\n" spec-underline "\n\n"))
+          (dolist (r (cdr spec-group))
+            (let* ((rel       (plist-get r :rel))
+                   (lines     (plist-get r :lines))
+                   (entities  (plist-get r :entities))
+                   (err       (plist-get r :error))
+                   (underline (make-string (length rel) ?-)))
+              ;; File subsection heading (one level below group with `-')
+              (insert rel "\n" underline "\n\n")
+              (if err
+                  (progn
+                    (insert (format ":Lines:    %d\n" lines))
+                    (insert (format ":Error:    %s\n\n" err)))
+                (insert (format ":Lines:    %d\n" lines))
+                (insert (format ":Entities: %d\n\n" (length entities)))
+                (insert (sd7-nav-index--rst-table entities))
+                (insert "\n\n")))))
+
+        ;; ---- Files with errors (only emitted when at least one file failed) ----
+        (let ((errored (cl-remove-if-not
+                        (lambda (r) (plist-get r :error))
+                        results)))
+          (when errored
+            (insert "Files with Errors\n")
+            (insert (make-string (length "Files with Errors") ?=) "\n\n")
+            (dolist (r errored)
+              (insert (format "- ``%s``: %s\n"
+                              (plist-get r :rel)
+                              (plist-get r :error))))
+            (insert "\n")))
+
+        ;; ---- Document terminator ----
+        (insert "\n.. ---------------------------------------------------------------------------\n"))
+
+      (sd7-nav-index--message "Report written to: %s" out-file)
+      out-file)))
+
+;;; --------------------------------------------------------------------------
+;;; Interactive entry point
+
+;;;###autoload
+(defun sd7-nav-index-run (seed7-dir report-dir id)
+  "Interactively index Seed7 entities and write an RST report.
+
+Prompts for SEED7-DIR, REPORT-DIR, and ID.  Previous values are offered as
+defaults and remembered within the session.
+
+Report written to: REPORT-DIR/seed7mode-nav-index-ID.rst"
+  (interactive
+   (list
+    (read-directory-name "Seed7 source directory: "
+                         sd7-nav-index--last-seed7-dir nil nil)
+    (read-directory-name "Report output directory: "
+                         sd7-nav-index--last-report-dir nil nil)
+    (read-string (format "Report ID (default %S): " sd7-nav-index--last-id)
+                 nil nil sd7-nav-index--last-id)))
+  (setq sd7-nav-index--last-seed7-dir  (directory-file-name
+                                         (expand-file-name seed7-dir))
+        sd7-nav-index--last-report-dir (directory-file-name
+                                         (expand-file-name report-dir))
+        sd7-nav-index--last-id         id)
+  (sd7-nav-index-run-core seed7-dir report-dir id))
+
+;;; --------------------------------------------------------------------------
+;;; CLI entry point
+
+(defun sd7-nav-index--cli-help-and-exit (exit-code)
+  "Print usage to *Messages* and exit with EXIT-CODE."
+  (message "\
+Usage (batch):
+  emacs -Q --batch --load tools/sd7-nav-index.el \\
+        -- SEED7_DIR REPORT_DIR ID
+
+  SEED7_DIR   root of the Seed7 source tree (must contain prg/ and lib/)
+  REPORT_DIR  directory where the RST report is written
+  ID          report identifier string (e.g.  01  or  before-opt)
+
+Output: REPORT_DIR/seed7mode-nav-index-ID.rst
+
+Diff workflow:
+  # baseline
+  emacs -Q --batch --load tools/sd7-nav-index.el \\
+        -- ~/src/seed7 reports before-opt
+  # after a change to seed7-mode.el
+  emacs -Q --batch --load tools/sd7-nav-index.el \\
+        -- ~/src/seed7 reports after-opt
+  # compare
+  diff reports/seed7mode-nav-index-before-opt.rst \\
+       reports/seed7mode-nav-index-after-opt.rst")
+  (kill-emacs exit-code))
+
+(defun sd7-nav-index-main ()
+  "Parse `command-line-args-left' and call `sd7-nav-index-run-core'.
+CLI / Makefile entry point.  Exits Emacs with 0 on success or 1 on error."
+  (let ((args command-line-args-left))
+    (setq command-line-args-left nil)
+    (when (equal (car args) "--")
+      (setq args (cdr args)))
+    (when (< (length args) 3)
+      (sd7-nav-index--cli-help-and-exit 1))
+    (let* ((seed7-dir  (nth 0 args))
+           (report-dir (nth 1 args))
+           (id         (nth 2 args)))
+      (when (string-empty-p id)
+        (message "ERROR: ID must be a non-empty string")
+        (kill-emacs 1))
+      (condition-case err
+          (progn
+            (sd7-nav-index-run-core seed7-dir report-dir id)
+            (kill-emacs 0))
+        (user-error
+         (message "ERROR: %s" (cadr err))
+         (kill-emacs 1))))))
+
+;;; --------------------------------------------------------------------------
+;;; Auto-dispatch (mirrors sd7-perf.el: batch fires automatically)
+
+(when noninteractive
+  (sd7-nav-index-main))
+
+;;; --------------------------------------------------------------------------
+(provide 'sd7-nav-index)
+
+;;; sd7-nav-index.el ends here

--- a/tools/sd7-nav-index.el
+++ b/tools/sd7-nav-index.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-23 15:36:11 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:07:11 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tools/sd7-perf.el
+++ b/tools/sd7-perf.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Sunday, June 22 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-22 22:44:35 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:07:24 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tools/seed7-fopen-controlled.el
+++ b/tools/seed7-fopen-controlled.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Friday, June 19 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-22 22:39:59 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:07:37 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tools/seed7-fopen-time.el
+++ b/tools/seed7-fopen-time.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Friday, June 19 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-21 10:05:29 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:07:51 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tools/seed7-indent-bench.el
+++ b/tools/seed7-indent-bench.el
@@ -2,9 +2,9 @@
 
 ;; Created   : ...
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-15 12:21:31 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:08:05 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau

--- a/tools/seed7-mode-time.el
+++ b/tools/seed7-mode-time.el
@@ -2,9 +2,9 @@
 
 ;; Created   : Wednesday, June  3 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-18 14:21:54 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 12:08:16 EDT, updated by Pierre Rouleau>
 
-;; This file is part of the SEED7 package.
+;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
 
 ;; Copyright (C) 2026  Pierre Rouleau


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Seed7 Entity Browser that scans the current buffer and shows a sortable entity list with one-click navigation to declarations.
  * New command: `seed7-list-entities` (bound to `C-c C-l`) and added to the Seed7 mode menu.

* **Improvements**
  * Improved indentation alignment for multi-line Seed7 string concatenations and related indentation scenarios.
  * Enhanced parsing of array and set declaration names.

* **Documentation**
  * Updated `NEWS` and `README` for the new entity-list command.
  * Added a new four-mode Seed7 performance benchmark report.

* **Chores**
  * Updated package metadata.
  * Added repository indexing and indentation performance report tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->