### PR TITLE
Investigate the failing test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ ALL_TEST_FILES := tests/ert-tests/seed7-test-arrays-01.el \
                   tests/ert-tests/seed7-test-font-lock-01.el \
                   tests/ert-tests/seed7-test-font-lock-02.el \
                   tests/ert-tests/seed7-test-font-lock-02b.el \
+                  tests/ert-tests/seed7-test-indent-01.el \
                   tests/ert-tests/seed7-test-mark-defun-01.el \
                   tests/ert-tests/seed7-test-nav-array-01.el \
                   tests/ert-tests/seed7-test-nav-final-pos-01.el \
@@ -290,6 +291,7 @@ tests/ert-tests/seed7-test-arrays-01.el.test-passed:             seed7-mode.elc 
 tests/ert-tests/seed7-test-font-lock-01.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-01.elc
 tests/ert-tests/seed7-test-font-lock-02.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02.elc
 tests/ert-tests/seed7-test-font-lock-02b.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02b.elc
+tests/ert-tests/seed7-test-indent-01.el.test-passed:             seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-01.elc
 tests/ert-tests/seed7-test-mark-defun-01.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-mark-defun-01.el
 tests/ert-tests/seed7-test-nav-array-01.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-array-01.elc
 tests/ert-tests/seed7-test-nav-final-pos-01.el.test-passed:      seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-final-pos-01.elc

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ ALL_TEST_FILES := tests/ert-tests/seed7-test-arrays-01.el \
                   tests/ert-tests/seed7-test-font-lock-02.el \
                   tests/ert-tests/seed7-test-font-lock-02b.el \
                   tests/ert-tests/seed7-test-indent-01.el \
+                  tests/ert-tests/seed7-test-indent-02.el \
                   tests/ert-tests/seed7-test-mark-defun-01.el \
                   tests/ert-tests/seed7-test-nav-array-01.el \
                   tests/ert-tests/seed7-test-nav-final-pos-01.el \
@@ -292,6 +293,7 @@ tests/ert-tests/seed7-test-font-lock-01.el.test-passed:          seed7-mode.elc 
 tests/ert-tests/seed7-test-font-lock-02.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02.elc
 tests/ert-tests/seed7-test-font-lock-02b.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02b.elc
 tests/ert-tests/seed7-test-indent-01.el.test-passed:             seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-01.elc
+tests/ert-tests/seed7-test-indent-02.el.test-passed:             seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-02.elc
 tests/ert-tests/seed7-test-mark-defun-01.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-mark-defun-01.el
 tests/ert-tests/seed7-test-nav-array-01.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-array-01.elc
 tests/ert-tests/seed7-test-nav-final-pos-01.el.test-passed:      seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-final-pos-01.elc

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260625.1525
+;; Package-Version: 20260625.1549
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -540,7 +540,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-25T19:25:32+0000 W26-4"
+(defconst seed7-mode-version-timestamp "2026-06-25T19:49:14+0000 W26-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -7204,6 +7204,13 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
           (setq indent-step 1))
          (t (setq indent-step 0))))
 
+       ;; First continuation after:
+       ;;   return ... and/or
+       ;; Align under the expression following `return '.
+       ((seed7--set
+         (seed7-line-after-func-return-logic-operator-column 0)
+         indent-column))
+
        ((seed7--set (seed7-line-inside-a-block-cached
                      0 nil
                      (or early-begin-pos
@@ -7218,13 +7225,6 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
         (let ((begin-pos (max (point-min) (1- (nth 2 spec-list))))
               (end-pos   (min (point-max) (1+ (nth 3 spec-list)))))
           (cond
-           ;; First continuation after:
-           ;;   return ... and/or
-           ;; Align under the expression following `return '.
-           ((seed7--set
-             (seed7-line-after-func-return-logic-operator-column 0)
-             indent-column))
-
            ((seed7--set                 ; inside parens pair?
              (seed7-line-inside-parens-pair-column 0 begin-pos end-pos)
              indent-column))

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260625.1138
+;; Package-Version: 20260625.1525
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -378,6 +378,7 @@
 ;;       . `seed7-line-inside-syntax-parens-pair'
 ;;         . `seed7--paren-pair-string'
 ;;     . `seed7-line-inside-parens-pair-column'
+;;     . `seed7-line-after-func-return-logic-operator-column'
 ;;     . `seed7-line-starts-with-open-paren-after-logic-operator'
 ;;     . `seed7-line-inside-nested-parens-pairs'
 ;;     . `seed7-line-inside-nested-parens-pairs-column'
@@ -539,7 +540,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-25T15:38:52+0000 W26-4"
+(defconst seed7-mode-version-timestamp "2026-06-25T19:25:32+0000 W26-4"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6099,7 +6100,7 @@ N is: - :previous-non-empty for the previous non-empty line,
       - A negative number for previous lines: -1 previous, -2 line before...
 SCOPE-BEGIN-POS and SCOPE-END-POS are the search begin and end boundaries.
 If it finds that the line is inside the func return statement, it
-returns the indentation column of the return keyword.
+returns the continuation anchor column after `return '.
 If it detects that it is outside, it returns nil."
   (unless (or (not scope-end-pos)
               (< (or scope-begin-pos 0) scope-end-pos))
@@ -6121,7 +6122,8 @@ If it detects that it is outside, it returns nil."
                 (setq keep-searching nil)
                 (seed7-to-indent)
                 (setq start-pos (point))
-                (setq found-column (+  (current-column) 5))
+                (re-search-forward "return[[:blank:]]+" (line-end-position) t)
+                (setq found-column (current-column))
                 (setq end-pos (seed7-forward-char-pos ";" scope-end-pos
                                                       'point-after))
                 (unless (and end-pos
@@ -6591,6 +6593,27 @@ of the character after the opening parens."
 (defconst seed7--line-ends-with-logic-operator-regexp
   "\\_<\\(?:and\\|or\\)\\_>[[:blank:]]*$"
   "Regexp matching a line that ends with the logical operators `and' or `or'.")
+
+(defun seed7-line-after-func-return-logic-operator-column
+    (n &optional dont-skip-comment-start)
+  "Return hanging-indent column for the first continuation of `return ... and/or'.
+
+When the previous non-empty line starts with `return' and ends with
+the logical operators `and' or `or', return the column of the first
+character after `return '.  Return nil otherwise."
+  (save-excursion
+    (when (and (seed7-move-to-line n dont-skip-comment-start)
+               (seed7-move-to-line :previous-non-empty dont-skip-comment-start))
+      (let ((lbeg (line-beginning-position))
+            (lend (line-end-position)))
+        (goto-char lbeg)
+        (when (and (re-search-forward
+                    "^[[:blank:]]+return[[:blank:]]+" lend t)
+                   (save-excursion
+                     (goto-char lbeg)
+                     (re-search-forward
+                      seed7--line-ends-with-logic-operator-regexp lend t)))
+          (current-column))))))
 
 (defun seed7-line-starts-with-open-paren-after-logic-operator
     (n &optional dont-skip-comment-start)
@@ -7195,6 +7218,13 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
         (let ((begin-pos (max (point-min) (1- (nth 2 spec-list))))
               (end-pos   (min (point-max) (1+ (nth 3 spec-list)))))
           (cond
+           ;; First continuation after:
+           ;;   return ... and/or
+           ;; Align under the expression following `return '.
+           ((seed7--set
+             (seed7-line-after-func-return-logic-operator-column 0)
+             indent-column))
+
            ((seed7--set                 ; inside parens pair?
              (seed7-line-inside-parens-pair-column 0 begin-pos end-pos)
              indent-column))
@@ -7210,8 +7240,7 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
              indent-column))
            ((seed7--set                 ; inside func return?
              (seed7-line-inside-func-return-statement 0 begin-pos end-pos)
-             indent-column)
-            (setq indent-column (+ indent-column seed7-indent-width)))
+             indent-column))
            ;; Not inside any special zones.
            ;; Use indentation identified by `seed7-line-inside-a-block'.
            (t (setq indent-column (nth 0 spec-list))))))

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-25 13:30:31 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 13:43:30 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -68,8 +68,8 @@
    "const func boolean: isStringExpr (in string: symbol) is\n"
    "  return symbol in string_var_name or\n"
    "         symbol <> \"\" and\n"
-   "        (symbol[length(symbol)] = '$' or symbol[1] = '\\\"' or symbol[1] in defstr_var and\n"
-   "         not symbol[length(symbol)] in numeric_var_suffix);\n")
+   "         (symbol[length(symbol)] = '$' or symbol[1] = '\\\"' or symbol[1] in defstr_var and\n"
+   "          not symbol[length(symbol)] in numeric_var_suffix);\n")
   "Correctly indented bas7-style fixture.")
 
 (defconst seed7-test-indent--bas7-misaligned-code
@@ -111,8 +111,8 @@
     (should (= (seed7-test-indent--line-indentation 1) 0))
     (should (= (seed7-test-indent--line-indentation 2) 2))
     (should (= (seed7-test-indent--line-indentation 3) 9))
-    (should (= (seed7-test-indent--line-indentation 4) 8))
-    (should (= (seed7-test-indent--line-indentation 5) 9))
+    (should (= (seed7-test-indent--line-indentation 4) 9))
+    (should (= (seed7-test-indent--line-indentation 5) 10))
 
     (should (eq (seed7-test-indent--line-first-char 4) ?\())
     (should (string= (buffer-string)
@@ -130,8 +130,8 @@
     (should (= (seed7-test-indent--line-indentation 1) 0))
     (should (= (seed7-test-indent--line-indentation 2) 2))
     (should (= (seed7-test-indent--line-indentation 3) 9))
-    (should (= (seed7-test-indent--line-indentation 4) 8))
-    (should (= (seed7-test-indent--line-indentation 5) 9))
+    (should (= (seed7-test-indent--line-indentation 4) 9))
+    (should (= (seed7-test-indent--line-indentation 5) 10))
 
     (should (eq (seed7-test-indent--line-first-char 4) ?\())
     (should (string= (buffer-string)

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-25 13:43:30 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 15:36:04 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -51,11 +51,11 @@
 ;;
 ;; The expected indentation shape is:
 ;;
-;;   const func boolean: ... is                     ; column 0
+;;   const func boolean: ... is                    ; column 0
 ;;     return ...                                  ; column 2
 ;;            symbol <> "" and                     ; column 9
-;;           (symbol[length(symbol)] = '$' ...     ; column 8
-;;            not symbol[length(symbol)] ...       ; column 9
+;;            (symbol[length(symbol)] = '$' ...    ; column 9
+;;             not symbol[length(symbol)] ...      ; column 10
 
 ;; ---------------------------------------------------------------------------
 ;;; Code:

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-25 12:26:07 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 13:30:31 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -32,8 +32,18 @@
 ;;
 ;;   No rule yet to indent line N
 ;;
-;; The main regression shape comes from `prg/bas7.sd7` around Line 696.
-
+;; The main regression shape comes from `prg/bas7.sd7` around Line 696,
+;; in the following Seed7 bas67.sd7 code, shown with their line numbers:
+;;
+;; 692
+;; 693 const func boolean: isStringExpr (in string: symbol) is
+;; 694   return symbol in string_var_name or
+;; 695          symbol <> "" and
+;; 696         (symbol[length(symbol)] = '$' or symbol[1] = '\"' or symbol[1] in defstr_var and
+;; 697          not symbol[length(symbol)] in numeric_var_suffix);
+;; 698
+;;
+;;
 ;; Regression tests for indentation of a multi-line boolean expression
 ;; like the one in prg/bas7.sd7 where:
 ;; - one continuation line ends with `and'

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-25 16:07:43 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-06-25 16:15:53 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -249,7 +249,7 @@
 (defconst seed7-test-indent-02--is-return-misaligned
   (concat
    "const func boolean: alwaysTrue is\n"
-   "return TRUE;\n")
+   "  return TRUE;\n")
   "Misaligned `is return' function.")
 
 (ert-deftest seed7-indent/is-return-keeps-correct-layout ()

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,0 +1,926 @@
+;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
+
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+;; Time-stamp: <2026-06-25 16:07:43 EDT, updated by Pierre Rouleau>
+
+;; This file is part of the SEED7-MODE package.
+;; This file is not part of GNU Emacs.
+
+;; Copyright (C) 2026  Pierre Rouleau
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Comprehensive indentation tests covering as many Seed7 indentation schemes
+;; as possible.  Each test group covers one structural pattern, verifying both
+;; that `indent-region' preserves correctly-indented code and that it fixes
+;; misaligned code.
+;;
+;; Patterns covered:
+;;
+;; 1. Simple procedure with `is func / begin / end func'
+;;    - Top-level declaration: column 0
+;;    - `begin' and `end func;': column 2
+;;    - Body statements: column 4
+;;
+;; 2. Function with `result', `local', and `begin' sections
+;;    - Section keywords (`result', `local', `begin', `end func;'): column 2
+;;    - Variables inside sections: column 4
+;;    - Body statements inside `begin': column 4
+;;
+;; 3. Expression function with `is return'
+;;    - Declaration: column 0
+;;    - `return' line: column 2
+;;
+;; 4. `if / elsif / else / end if' inside a proc body
+;;    - `if', `elsif', `else', `end if;': column 4
+;;    - Conditional bodies: column 6
+;;
+;; 5. `for' loop inside a proc body
+;;    - `for ... do' and `end for;': column 4
+;;    - Loop body: column 6
+;;
+;; 6. `while' loop inside a proc body
+;;    - `while ... do' and `end while;': column 4
+;;    - Loop body: column 6
+;;
+;; 7. `repeat / until' loop inside a proc body
+;;    - `repeat' and `until ...;': column 4
+;;    - Loop body: column 6
+;;
+;; 8. Nested `if' inside `for' inside a proc body
+;;    - Outer `for' / `end for;': column 4
+;;    - `if', `else', `end if;' inside for: column 6
+;;    - Bodies inside if/else: column 8
+;;
+;; 9. `block / exception / end block' inside a proc body
+;;    - `block', `exception', `end block;': column 4
+;;    - Body inside block: column 6
+;;    - `catch' line: column 6
+;;    - Catch body: column 8
+;;
+;; 10. Multi-line `return' with `or' / `and' continuation
+;;     - `return' line: column 2
+;;     - First continuation (after `or'): column 9 (after `return ')
+;;     - Subsequent continuation starting with `(': column 9
+;;     - Line inside parens after that: column 10
+;;
+;; 11. Array definition block
+;;     - Declaration: column 0
+;;     - Array elements: column 2
+;;
+;; 12. Set definition block
+;;     - Declaration: column 0
+;;     - Set elements: column 2
+
+;; ---------------------------------------------------------------------------
+;;; Code:
+
+(require 'ert)
+(require 'seed7-mode)
+
+;; ---------------------------------------------------------------------------
+;; Shared test helpers (also defined in seed7-test-indent-01.el, but each
+;; test file is self-contained so they are redefined here).
+
+(defun seed7-test-indent-02--goto-line (line)
+  "Move point to the beginning of LINE (1-based)."
+  (goto-char (point-min))
+  (forward-line (1- line)))
+
+(defun seed7-test-indent-02--line-indentation (line)
+  "Return indentation column of LINE (1-based)."
+  (save-excursion
+    (seed7-test-indent-02--goto-line line)
+    (current-indentation)))
+
+;; ---------------------------------------------------------------------------
+;; 1. Simple procedure: `is func / begin / end func'
+;; -------------------------------------------------
+;;
+;;   const proc: simpleProcedure is func      ; col 0
+;;     begin                                  ; col 2
+;;       writeln("hello");                    ; col 4
+;;     end func;                              ; col 2
+
+(defconst seed7-test-indent-02--simple-proc-correct
+  (concat
+   "const proc: simpleProcedure is func\n"
+   "  begin\n"
+   "    writeln(\"hello\");\n"
+   "  end func;\n")
+  "Correctly-indented simple procedure fixture.")
+
+(defconst seed7-test-indent-02--simple-proc-misaligned
+  (concat
+   "const proc: simpleProcedure is func\n"
+   "begin\n"
+   "writeln(\"hello\");\n"
+   "end func;\n")
+  "Misaligned simple procedure fixture.")
+
+(ert-deftest seed7-indent/simple-proc-keeps-correct-layout ()
+  "Indenting an already-correct simple procedure keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--simple-proc-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--simple-proc-correct))))
+
+(ert-deftest seed7-indent/simple-proc-fixes-misaligned-layout ()
+  "Indenting a misaligned simple procedure restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--simple-proc-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--simple-proc-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Function with result / local / begin sections
+;; ------------------------------------------------
+;;
+;;   const func integer: countItems is func   ; col 0
+;;     result                                 ; col 2
+;;       var integer: n is 0;                 ; col 4
+;;     local                                  ; col 2
+;;       var integer: i is 0;                 ; col 4
+;;     begin                                  ; col 2
+;;       n := 42;                             ; col 4
+;;     end func;                              ; col 2
+
+(defconst seed7-test-indent-02--func-sections-correct
+  (concat
+   "const func integer: countItems is func\n"
+   "  result\n"
+   "    var integer: n is 0;\n"
+   "  local\n"
+   "    var integer: i is 0;\n"
+   "  begin\n"
+   "    n := 42;\n"
+   "  end func;\n")
+  "Correctly-indented func with result/local/begin sections.")
+
+(defconst seed7-test-indent-02--func-sections-misaligned
+  (concat
+   "const func integer: countItems is func\n"
+   "result\n"
+   "var integer: n is 0;\n"
+   "local\n"
+   "var integer: i is 0;\n"
+   "begin\n"
+   "n := 42;\n"
+   "end func;\n")
+  "Misaligned func with result/local/begin sections.")
+
+(ert-deftest seed7-indent/func-sections-keeps-correct-layout ()
+  "Indenting an already-correct func with result/local/begin keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--func-sections-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 2))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--func-sections-correct))))
+
+(ert-deftest seed7-indent/func-sections-fixes-misaligned-layout ()
+  "Indenting a misaligned func with result/local/begin restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--func-sections-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 2))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--func-sections-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Expression function with `is return'
+;; ---------------------------------------
+;;
+;;   const func boolean: alwaysTrue is   ; col 0
+;;     return TRUE;                      ; col 2
+
+(defconst seed7-test-indent-02--is-return-correct
+  (concat
+   "const func boolean: alwaysTrue is\n"
+   "  return TRUE;\n")
+  "Correctly-indented `is return' function.")
+
+(defconst seed7-test-indent-02--is-return-misaligned
+  (concat
+   "const func boolean: alwaysTrue is\n"
+   "return TRUE;\n")
+  "Misaligned `is return' function.")
+
+(ert-deftest seed7-indent/is-return-keeps-correct-layout ()
+  "Indenting an already-correct `is return' function keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--is-return-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--is-return-correct))))
+
+(ert-deftest seed7-indent/is-return-fixes-misaligned-layout ()
+  "Indenting a misaligned `is return' function restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--is-return-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--is-return-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 4. `if / elsif / else / end if' inside a proc body
+;; ---------------------------------------------------
+;;
+;;   const proc: classify (in integer: n) is func   ; col 0
+;;     begin                                        ; col 2
+;;       if n > 0 then                              ; col 4
+;;         writeln("positive");                     ; col 6
+;;       elsif n < 0 then                           ; col 4
+;;         writeln("negative");                     ; col 6
+;;       else                                       ; col 4
+;;         writeln("zero");                         ; col 6
+;;       end if;                                    ; col 4
+;;     end func;                                    ; col 2
+
+(defconst seed7-test-indent-02--if-elsif-else-correct
+  (concat
+   "const proc: classify (in integer: n) is func\n"
+   "  begin\n"
+   "    if n > 0 then\n"
+   "      writeln(\"positive\");\n"
+   "    elsif n < 0 then\n"
+   "      writeln(\"negative\");\n"
+   "    else\n"
+   "      writeln(\"zero\");\n"
+   "    end if;\n"
+   "  end func;\n")
+  "Correctly-indented if/elsif/else/end if fixture.")
+
+(defconst seed7-test-indent-02--if-elsif-else-misaligned
+  (concat
+   "const proc: classify (in integer: n) is func\n"
+   "begin\n"
+   "if n > 0 then\n"
+   "writeln(\"positive\");\n"
+   "elsif n < 0 then\n"
+   "writeln(\"negative\");\n"
+   "else\n"
+   "writeln(\"zero\");\n"
+   "end if;\n"
+   "end func;\n")
+  "Misaligned if/elsif/else/end if fixture.")
+
+(ert-deftest seed7-indent/if-elsif-else-keeps-correct-layout ()
+  "Indenting an already-correct if/elsif/else block keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--if-elsif-else-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 6))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 6))
+    (should (= (seed7-test-indent-02--line-indentation 9) 4))
+    (should (= (seed7-test-indent-02--line-indentation 10) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--if-elsif-else-correct))))
+
+(ert-deftest seed7-indent/if-elsif-else-fixes-misaligned-layout ()
+  "Indenting a misaligned if/elsif/else block restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--if-elsif-else-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 6))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 6))
+    (should (= (seed7-test-indent-02--line-indentation 9) 4))
+    (should (= (seed7-test-indent-02--line-indentation 10) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--if-elsif-else-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 5. `for' loop inside a proc body
+;; ---------------------------------
+;;
+;;   const proc: countUp is func     ; col 0
+;;     local                         ; col 2
+;;       var integer: i is 0;        ; col 4
+;;     begin                         ; col 2
+;;       for i range 1 to 5 do       ; col 4
+;;         writeln(i);               ; col 6
+;;       end for;                    ; col 4
+;;     end func;                     ; col 2
+
+(defconst seed7-test-indent-02--for-loop-correct
+  (concat
+   "const proc: countUp is func\n"
+   "  local\n"
+   "    var integer: i is 0;\n"
+   "  begin\n"
+   "    for i range 1 to 5 do\n"
+   "      writeln(i);\n"
+   "    end for;\n"
+   "  end func;\n")
+  "Correctly-indented for loop fixture.")
+
+(defconst seed7-test-indent-02--for-loop-misaligned
+  (concat
+   "const proc: countUp is func\n"
+   "local\n"
+   "var integer: i is 0;\n"
+   "begin\n"
+   "for i range 1 to 5 do\n"
+   "writeln(i);\n"
+   "end for;\n"
+   "end func;\n")
+  "Misaligned for loop fixture.")
+
+(ert-deftest seed7-indent/for-loop-keeps-correct-layout ()
+  "Indenting an already-correct for loop keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--for-loop-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--for-loop-correct))))
+
+(ert-deftest seed7-indent/for-loop-fixes-misaligned-layout ()
+  "Indenting a misaligned for loop restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--for-loop-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--for-loop-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 6. `while' loop inside a proc body
+;; ------------------------------------
+;;
+;;   const proc: countdown is func   ; col 0
+;;     local                         ; col 2
+;;       var integer: n is 10;       ; col 4
+;;     begin                         ; col 2
+;;       while n > 0 do              ; col 4
+;;         n -:= 1;                  ; col 6
+;;       end while;                  ; col 4
+;;     end func;                     ; col 2
+
+(defconst seed7-test-indent-02--while-loop-correct
+  (concat
+   "const proc: countdown is func\n"
+   "  local\n"
+   "    var integer: n is 10;\n"
+   "  begin\n"
+   "    while n > 0 do\n"
+   "      n -:= 1;\n"
+   "    end while;\n"
+   "  end func;\n")
+  "Correctly-indented while loop fixture.")
+
+(defconst seed7-test-indent-02--while-loop-misaligned
+  (concat
+   "const proc: countdown is func\n"
+   "local\n"
+   "var integer: n is 10;\n"
+   "begin\n"
+   "while n > 0 do\n"
+   "n -:= 1;\n"
+   "end while;\n"
+   "end func;\n")
+  "Misaligned while loop fixture.")
+
+(ert-deftest seed7-indent/while-loop-keeps-correct-layout ()
+  "Indenting an already-correct while loop keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--while-loop-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--while-loop-correct))))
+
+(ert-deftest seed7-indent/while-loop-fixes-misaligned-layout ()
+  "Indenting a misaligned while loop restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--while-loop-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--while-loop-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 7. `repeat / until' loop inside a proc body
+;; ---------------------------------------------
+;;
+;;   const proc: repeatLoop is func   ; col 0
+;;     local                          ; col 2
+;;       var integer: n is 0;         ; col 4
+;;     begin                          ; col 2
+;;       repeat                       ; col 4
+;;         n +:= 1;                   ; col 6
+;;       until n >= 10;               ; col 4
+;;     end func;                      ; col 2
+
+(defconst seed7-test-indent-02--repeat-loop-correct
+  (concat
+   "const proc: repeatLoop is func\n"
+   "  local\n"
+   "    var integer: n is 0;\n"
+   "  begin\n"
+   "    repeat\n"
+   "      n +:= 1;\n"
+   "    until n >= 10;\n"
+   "  end func;\n")
+  "Correctly-indented repeat/until loop fixture.")
+
+(defconst seed7-test-indent-02--repeat-loop-misaligned
+  (concat
+   "const proc: repeatLoop is func\n"
+   "local\n"
+   "var integer: n is 0;\n"
+   "begin\n"
+   "repeat\n"
+   "n +:= 1;\n"
+   "until n >= 10;\n"
+   "end func;\n")
+  "Misaligned repeat/until loop fixture.")
+
+(ert-deftest seed7-indent/repeat-loop-keeps-correct-layout ()
+  "Indenting an already-correct repeat/until loop keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--repeat-loop-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--repeat-loop-correct))))
+
+(ert-deftest seed7-indent/repeat-loop-fixes-misaligned-layout ()
+  "Indenting a misaligned repeat/until loop restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--repeat-loop-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--repeat-loop-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 8. Nested `if / else / end if' inside `for' inside a proc body
+;; --------------------------------------------------------------
+;;
+;;   const proc: nestedBlocks is func   ; col 0
+;;     local                            ; col 2
+;;       var integer: i is 0;           ; col 4
+;;     begin                            ; col 2
+;;       for i range 1 to 10 do         ; col 4
+;;         if i > 5 then                ; col 6
+;;           writeln("big");            ; col 8
+;;         else                         ; col 6
+;;           writeln("small");          ; col 8
+;;         end if;                      ; col 6
+;;       end for;                       ; col 4
+;;     end func;                        ; col 2
+
+(defconst seed7-test-indent-02--nested-if-in-for-correct
+  (concat
+   "const proc: nestedBlocks is func\n"
+   "  local\n"
+   "    var integer: i is 0;\n"
+   "  begin\n"
+   "    for i range 1 to 10 do\n"
+   "      if i > 5 then\n"
+   "        writeln(\"big\");\n"
+   "      else\n"
+   "        writeln(\"small\");\n"
+   "      end if;\n"
+   "    end for;\n"
+   "  end func;\n")
+  "Correctly-indented nested if-in-for fixture.")
+
+(defconst seed7-test-indent-02--nested-if-in-for-misaligned
+  (concat
+   "const proc: nestedBlocks is func\n"
+   "local\n"
+   "var integer: i is 0;\n"
+   "begin\n"
+   "for i range 1 to 10 do\n"
+   "if i > 5 then\n"
+   "writeln(\"big\");\n"
+   "else\n"
+   "writeln(\"small\");\n"
+   "end if;\n"
+   "end for;\n"
+   "end func;\n")
+  "Misaligned nested if-in-for fixture.")
+
+(ert-deftest seed7-indent/nested-if-in-for-keeps-correct-layout ()
+  "Indenting an already-correct nested if-in-for keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--nested-if-in-for-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 8))
+    (should (= (seed7-test-indent-02--line-indentation 8) 6))
+    (should (= (seed7-test-indent-02--line-indentation 9) 8))
+    (should (= (seed7-test-indent-02--line-indentation 10) 6))
+    (should (= (seed7-test-indent-02--line-indentation 11) 4))
+    (should (= (seed7-test-indent-02--line-indentation 12) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--nested-if-in-for-correct))))
+
+(ert-deftest seed7-indent/nested-if-in-for-fixes-misaligned-layout ()
+  "Indenting a misaligned nested if-in-for restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--nested-if-in-for-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 8))
+    (should (= (seed7-test-indent-02--line-indentation 8) 6))
+    (should (= (seed7-test-indent-02--line-indentation 9) 8))
+    (should (= (seed7-test-indent-02--line-indentation 10) 6))
+    (should (= (seed7-test-indent-02--line-indentation 11) 4))
+    (should (= (seed7-test-indent-02--line-indentation 12) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--nested-if-in-for-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 9. `block / exception / end block' inside a proc body
+;; ------------------------------------------------------
+;;
+;;   const proc: blockTest is func   ; col 0
+;;     begin                         ; col 2
+;;       block                       ; col 4
+;;         foo;                      ; col 6
+;;       exception                   ; col 4
+;;         catch RANGE_ERROR:        ; col 6
+;;           bar;                    ; col 8
+;;       end block;                  ; col 4
+;;     end func;                     ; col 2
+
+(defconst seed7-test-indent-02--block-exception-correct
+  (concat
+   "const proc: blockTest is func\n"
+   "  begin\n"
+   "    block\n"
+   "      foo;\n"
+   "    exception\n"
+   "      catch RANGE_ERROR:\n"
+   "        bar;\n"
+   "    end block;\n"
+   "  end func;\n")
+  "Correctly-indented block/exception/end block fixture.")
+
+(defconst seed7-test-indent-02--block-exception-misaligned
+  (concat
+   "const proc: blockTest is func\n"
+   "begin\n"
+   "block\n"
+   "foo;\n"
+   "exception\n"
+   "catch RANGE_ERROR:\n"
+   "bar;\n"
+   "end block;\n"
+   "end func;\n")
+  "Misaligned block/exception/end block fixture.")
+
+(ert-deftest seed7-indent/block-exception-keeps-correct-layout ()
+  "Indenting an already-correct block/exception keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--block-exception-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 6))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 8))
+    (should (= (seed7-test-indent-02--line-indentation 8) 4))
+    (should (= (seed7-test-indent-02--line-indentation 9) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--block-exception-correct))))
+
+(ert-deftest seed7-indent/block-exception-fixes-misaligned-layout ()
+  "Indenting a misaligned block/exception restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--block-exception-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 6))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 6))
+    (should (= (seed7-test-indent-02--line-indentation 7) 8))
+    (should (= (seed7-test-indent-02--line-indentation 8) 4))
+    (should (= (seed7-test-indent-02--line-indentation 9) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--block-exception-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 10. Multi-line `return' with `or' / `and' continuation (regression)
+;; --------------------------------------------------------------------
+;;
+;; This is the regression case from prg/bas7.sd7 around line 696.
+;;
+;;   const func boolean: isStringVar (in string: symbol) is   ; col 0
+;;     return symbol in string_var_name or                    ; col 2
+;;            symbol <> "" and                                ; col 9
+;;            (symbol[length(symbol)] = '$' or ... and        ; col 9
+;;             not symbol[length(symbol)] ...);               ; col 10
+
+(defconst seed7-test-indent-02--return-or-and-correct
+  (concat
+   "const func boolean: isStringVar (in string: symbol) is\n"
+   "  return symbol in string_var_name or\n"
+   "         symbol <> \"\" and\n"
+   "         (symbol[length(symbol)] = '$' or symbol[1] in defstr_var and\n"
+   "          not symbol[length(symbol)] in numeric_var_suffix);\n")
+  "Correctly-indented multi-line return with or/and fixture.")
+
+(defconst seed7-test-indent-02--return-or-and-misaligned
+  (concat
+   "const func boolean: isStringVar (in string: symbol) is\n"
+   "  return symbol in string_var_name or\n"
+   "symbol <> \"\" and\n"
+   "(symbol[length(symbol)] = '$' or symbol[1] in defstr_var and\n"
+   "not symbol[length(symbol)] in numeric_var_suffix);\n")
+  "Misaligned multi-line return with or/and fixture.")
+
+(ert-deftest seed7-indent/return-or-and-keeps-correct-layout ()
+  "Indenting an already-correct multi-line return with or/and keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--return-or-and-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 9))
+    (should (= (seed7-test-indent-02--line-indentation 4) 9))
+    (should (= (seed7-test-indent-02--line-indentation 5) 10))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--return-or-and-correct))))
+
+(ert-deftest seed7-indent/return-or-and-fixes-misaligned-layout ()
+  "Indenting a misaligned multi-line return with or/and restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--return-or-and-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 9))
+    (should (= (seed7-test-indent-02--line-indentation 4) 9))
+    (should (= (seed7-test-indent-02--line-indentation 5) 10))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--return-or-and-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 11. Array definition block
+;; --------------------------
+;;
+;;   const array integer: primes is [1] (   ; col 0
+;;     2,                                   ; col 2
+;;     3,                                   ; col 2
+;;     5,                                   ; col 2
+;;     7);                                  ; col 2
+
+(defconst seed7-test-indent-02--array-def-correct
+  (concat
+   "const array integer: primes is [1] (\n"
+   "  2,\n"
+   "  3,\n"
+   "  5,\n"
+   "  7);\n")
+  "Correctly-indented array definition fixture.")
+
+(defconst seed7-test-indent-02--array-def-misaligned
+  (concat
+   "const array integer: primes is [1] (\n"
+   "2,\n"
+   "3,\n"
+   "5,\n"
+   "7);\n")
+  "Misaligned array definition fixture.")
+
+(ert-deftest seed7-indent/array-def-keeps-correct-layout ()
+  "Indenting an already-correct array definition keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--array-def-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--array-def-correct))))
+
+(ert-deftest seed7-indent/array-def-fixes-misaligned-layout ()
+  "Indenting a misaligned array definition restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--array-def-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--array-def-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 12. Set definition block
+;; ------------------------
+;;
+;;   var set of string: keywords is {   ; col 0
+;;     "for",                           ; col 2
+;;     "while",                         ; col 2
+;;     "repeat"};                       ; col 2
+
+(defconst seed7-test-indent-02--set-def-correct
+  (concat
+   "var set of string: keywords is {\n"
+   "  \"for\",\n"
+   "  \"while\",\n"
+   "  \"repeat\"};\n")
+  "Correctly-indented set definition fixture.")
+
+(defconst seed7-test-indent-02--set-def-misaligned
+  (concat
+   "var set of string: keywords is {\n"
+   "\"for\",\n"
+   "\"while\",\n"
+   "\"repeat\"};\n")
+  "Misaligned set definition fixture.")
+
+(ert-deftest seed7-indent/set-def-keeps-correct-layout ()
+  "Indenting an already-correct set definition keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--set-def-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--set-def-correct))))
+
+(ert-deftest seed7-indent/set-def-fixes-misaligned-layout ()
+  "Indenting a misaligned set definition restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--set-def-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--set-def-correct))))
+
+;; ---------------------------------------------------------------------------
+(provide 'seed7-test-indent-02)
+
+;;; seed7-test-indent-02.el ends here


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Seed7 indentation for `return ... and/or ...` wrapped across multiple lines, including proper alignment of continuation lines.
* **Tests**
  * Updated regression test fixtures and indentation expectations to match the corrected formatting behavior.
* **Documentation**
  * Expanded the regression-case description in the test fixture comment.
  * Refreshed Seed7 mode metadata/timestamps to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->