### PR TITLE
Add report for 2026-06-26T02:09:26+0000 W26-5

### DIFF
--- a/reports/seed7mode-perf-15.1.rst
+++ b/reports/seed7mode-perf-15.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-26T02:09:26+0000 W26-5
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 07:51:41 local time
+:Generated on: 2026-06-26 12:02:51 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 211x95 chars
+:Window body: 211x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.034750            190
+seed7/prg/bas7.sd7           0.033432          11459
+seed7/prg/bifurk.sd7         0.032463             73
+seed7/prg/bigfiles.sd7       0.032571            129
+seed7/prg/brainf7.sd7        0.032651             86
+seed7/prg/calc7.sd7          0.033284            128
+seed7/prg/carddemo.sd7       0.033112            190
+seed7/prg/castle.sd7         0.034655           3148
+seed7/prg/cat.sd7            0.033679             82
+seed7/prg/cellauto.sd7       0.033358             85
+seed7/prg/celsius.sd7        0.033470             42
+seed7/prg/chk_all.sd7        0.033758            843
+seed7/prg/chkarr.sd7         0.034293           8367
+seed7/prg/chkbig.sd7         0.037962          29026
+seed7/prg/chkbin.sd7         0.034597           6469
+seed7/prg/chkbitdata.sd7     0.034452           6624
+seed7/prg/chkbool.sd7        0.033817           3157
+seed7/prg/chkbst.sd7         0.033723            722
+seed7/prg/chkchr.sd7         0.034932           2809
+seed7/prg/chkcmd.sd7         0.033693           1205
+seed7/prg/chkdb.sd7          0.035037           7454
+seed7/prg/chkdecl.sd7        0.033827            448
+seed7/prg/chkenum.sd7        0.033505           1230
+seed7/prg/chkerr.sd7         0.034238           4663
+seed7/prg/chkexc.sd7         0.033889           2627
+seed7/prg/chkfil.sd7         0.033567           1615
+seed7/prg/chkflt.sd7         0.036546          20620
+seed7/prg/chkhent.sd7        0.033907             54
+seed7/prg/chkhsh.sd7         0.033943           4548
+seed7/prg/chkidx.sd7         0.036050          19567
+seed7/prg/chkint.sd7         0.039571          38129
+seed7/prg/chkjson.sd7        0.032892           1764
+seed7/prg/chkovf.sd7         0.033316           8216
+seed7/prg/chkprc.sd7         0.035171          10111
+seed7/prg/chkscan.sd7        0.036247            714
+seed7/prg/chkset.sd7         0.035238          11974
+seed7/prg/chkstr.sd7         0.039972          26952
+seed7/prg/chktime.sd7        0.034250           2025
+seed7/prg/chktoml.sd7        0.037616           1656
+seed7/prg/clock.sd7          0.036085             47
+seed7/prg/clock2.sd7         0.033564             43
+seed7/prg/clock3.sd7         0.033566             95
+seed7/prg/cmpfil.sd7         0.033630             84
+seed7/prg/comanche.sd7       0.033556            180
+seed7/prg/confval.sd7        0.033691            175
+seed7/prg/db7.sd7            0.033771            417
+seed7/prg/diff7.sd7          0.033513            263
+seed7/prg/dirtst.sd7         0.034032             42
+seed7/prg/dirx.sd7           0.033578            152
+seed7/prg/dnafight.sd7       0.033829           1381
+seed7/prg/dragon.sd7         0.033439             73
+seed7/prg/echo.sd7           0.033536             39
+seed7/prg/eliza.sd7          0.033595            302
+seed7/prg/err.sd7            0.033764             96
+seed7/prg/fannkuch.sd7       0.033471            131
+seed7/prg/fib.sd7            0.033609             47
+seed7/prg/find7.sd7          0.033549            133
+seed7/prg/findchar.sd7       0.033407            149
+seed7/prg/fractree.sd7       0.033777             55
+seed7/prg/ftp7.sd7           0.033392            296
+seed7/prg/ftpserv.sd7        0.040001             74
+seed7/prg/gcd.sd7            0.037155            109
+seed7/prg/gkbd.sd7           0.034517            358
+seed7/prg/gtksvtst.sd7       0.033741             94
+seed7/prg/hal.sd7            0.032922            250
+seed7/prg/hamu.sd7           0.032791            573
+seed7/prg/hanoi.sd7          0.032755             55
+seed7/prg/hd.sd7             0.034857             79
+seed7/prg/hello.sd7          0.033560             32
+seed7/prg/hilbert.sd7        0.033660            108
+seed7/prg/ide7.sd7           0.034188            196
+seed7/prg/kbd.sd7            0.034031             49
+seed7/prg/klondike.sd7       0.033905            883
+seed7/prg/lander.sd7         0.033764           1551
+seed7/prg/lst80bas.sd7       0.033537            344
+seed7/prg/lst99bas.sd7       0.033656            401
+seed7/prg/lstgwbas.sd7       0.033462            577
+seed7/prg/mahjong.sd7        0.033491           1943
+seed7/prg/make7.sd7          0.033685            121
+seed7/prg/mandelbr.sd7       0.033543            237
+seed7/prg/mind.sd7           0.033672            443
+seed7/prg/mirror.sd7         0.033366            131
+seed7/prg/ms.sd7             0.033701            641
+seed7/prg/nicoma.sd7         0.033187            135
+seed7/prg/pac.sd7            0.033755            726
+seed7/prg/pairs.sd7          0.033886           2025
+seed7/prg/panic.sd7          0.033648           2634
+seed7/prg/percolation.sd7    0.033626            330
+seed7/prg/planets.sd7        0.033663           1486
+seed7/prg/portfwd7.sd7       0.033676            139
+seed7/prg/prime.sd7          0.033558             74
+seed7/prg/printpi1.sd7       0.034065             56
+seed7/prg/printpi2.sd7       0.033099             54
+seed7/prg/printpi3.sd7       0.032863             60
+seed7/prg/pv7.sd7            0.032983            337
+seed7/prg/queen.sd7          0.033305            149
+seed7/prg/rand.sd7           0.032610            121
+seed7/prg/raytrace.sd7       0.032413            538
+seed7/prg/rever.sd7          0.033405            816
+seed7/prg/roman.sd7          0.033650             38
+seed7/prg/s7c.sd7            0.033057           9060
+seed7/prg/s7check.sd7        0.032497             68
+seed7/prg/savehd7.sd7        0.033661           1110
+seed7/prg/self.sd7           0.033600             49
+seed7/prg/shisen.sd7         0.033641           1423
+seed7/prg/sl.sd7             0.033702           1029
+seed7/prg/snake.sd7          0.033684            615
+seed7/prg/sokoban.sd7        0.033639            891
+seed7/prg/spigotpi.sd7       0.033444             64
+seed7/prg/sql7.sd7           0.033557            278
+seed7/prg/startrek.sd7       0.033666            979
+seed7/prg/sudoku7.sd7        0.033849           2657
+seed7/prg/sydir7.sd7         0.033415            384
+seed7/prg/syntaxhl.sd7       0.033830            177
+seed7/prg/tak.sd7            0.033378             59
+seed7/prg/tar7.sd7           0.033724            121
+seed7/prg/tch.sd7            0.033548             55
+seed7/prg/testfont.sd7       0.033737             95
+seed7/prg/tet.sd7            0.033647            479
+seed7/prg/tetg.sd7           0.033291            501
+seed7/prg/toutf8.sd7         0.033483            240
+seed7/prg/tst_cli.sd7        0.033602             40
+seed7/prg/tst_srv.sd7        0.033669             47
+seed7/prg/wator.sd7          0.033896            651
+seed7/prg/which.sd7          0.033727             65
+seed7/prg/wiz.sd7            0.033422           2833
+seed7/prg/wordcnt.sd7        0.032795             54
+seed7/prg/wrinum.sd7         0.032988             43
+seed7/prg/wumpus.sd7         0.032732            372
+seed7/lib/aes.s7i            0.032894           1144
+seed7/lib/aes_gcm.s7i        0.033918            392
+seed7/lib/ar.s7i             0.033902           1532
+seed7/lib/arc4.s7i           0.033211            144
+seed7/lib/archive.s7i        0.033960            143
+seed7/lib/archive_base.s7i   0.033537            135
+seed7/lib/array.s7i          0.033617            610
+seed7/lib/asn1.s7i           0.033467            544
+seed7/lib/asn1oid.s7i        0.033268            157
+seed7/lib/basearray.s7i      0.033651            450
+seed7/lib/bigfile.s7i        0.033816            136
+seed7/lib/bigint.s7i         0.033497            824
+seed7/lib/bigrat.s7i         0.033617            784
+seed7/lib/bin16.s7i          0.033497            592
+seed7/lib/bin32.s7i          0.033415            490
+seed7/lib/bin64.s7i          0.033592            539
+seed7/lib/bitdata.s7i        0.033706           1330
+seed7/lib/bitmapfont.s7i     0.033607            215
+seed7/lib/bitset.s7i         0.033729            593
+seed7/lib/bitsetof.s7i       0.033771            431
+seed7/lib/blowfish.s7i       0.033678            383
+seed7/lib/bmp.s7i            0.034142            924
+seed7/lib/boolean.s7i        0.033774            403
+seed7/lib/browser.s7i        0.033824            280
+seed7/lib/bstring.s7i        0.033664            227
+seed7/lib/bytedata.s7i       0.033555            482
+seed7/lib/bzip2.s7i          0.033883            887
+seed7/lib/cards.s7i          0.033096           1342
+seed7/lib/category.s7i       0.032576            209
+seed7/lib/cc_conf.s7i        0.032611           1314
+seed7/lib/ccittfax.s7i       0.032831           1022
+seed7/lib/cgi.s7i            0.034409            109
+seed7/lib/cgidialog.s7i      0.036556           1118
+seed7/lib/char.s7i           0.034877            356
+seed7/lib/charsets.s7i       0.034355           2024
+seed7/lib/chartype.s7i       0.033773            121
+seed7/lib/cipher.s7i         0.033658            146
+seed7/lib/cli_cmds.s7i       0.033780           1360
+seed7/lib/clib_file.s7i      0.033778            301
+seed7/lib/color.s7i          0.033841            185
+seed7/lib/complex.s7i        0.034060            464
+seed7/lib/compress.s7i       0.033645            150
+seed7/lib/console.s7i        0.033797            188
+seed7/lib/cpio.s7i           0.033915           1708
+seed7/lib/crc32.s7i          0.033588            193
+seed7/lib/cronos16.s7i       0.033837           1173
+seed7/lib/cronos27.s7i       0.034062           1464
+seed7/lib/csv.s7i            0.033737            201
+seed7/lib/db_prop.s7i        0.033693            991
+seed7/lib/deflate.s7i        0.033668            740
+seed7/lib/des.s7i            0.033767            444
+seed7/lib/dialog.s7i         0.033591            311
+seed7/lib/dir.s7i            0.033520            163
+seed7/lib/draw.s7i           0.033958            854
+seed7/lib/duration.s7i       0.033744           1038
+seed7/lib/echo.s7i           0.033508            132
+seed7/lib/editline.s7i       0.034143            398
+seed7/lib/elf.s7i            0.033877           1560
+seed7/lib/elliptic.s7i       0.033630            649
+seed7/lib/enable_io.s7i      0.032618            312
+seed7/lib/encoding.s7i       0.032598            931
+seed7/lib/enumeration.s7i    0.032771            236
+seed7/lib/environment.s7i    0.032501            175
+seed7/lib/exif.s7i           0.032762            152
+seed7/lib/external_file.s7i  0.033111            340
+seed7/lib/field.s7i          0.034281            268
+seed7/lib/file.s7i           0.033678            372
+seed7/lib/filebits.s7i       0.033451             46
+seed7/lib/filesys.s7i        0.033506            601
+seed7/lib/fileutil.s7i       0.033890            144
+seed7/lib/fixarray.s7i       0.033457            307
+seed7/lib/float.s7i          0.033667            757
+seed7/lib/font.s7i           0.033585            196
+seed7/lib/font8x8.s7i        0.033487            998
+seed7/lib/forloop.s7i        0.033705            449
+seed7/lib/ftp.s7i            0.033359            969
+seed7/lib/ftpserv.s7i        0.033631            631
+seed7/lib/getf.s7i           0.033769            115
+seed7/lib/gethttp.s7i        0.033698             41
+seed7/lib/gethttps.s7i       0.033522             41
+seed7/lib/gif.s7i            0.033820            561
+seed7/lib/graph.s7i          0.034507            415
+seed7/lib/graph_file.s7i     0.033767            399
+seed7/lib/gtkserver.s7i      0.033915            161
+seed7/lib/gzip.s7i           0.033784            573
+seed7/lib/hash.s7i           0.033667            421
+seed7/lib/hashsetof.s7i      0.033903            499
+seed7/lib/hmac.s7i           0.033942            152
+seed7/lib/html.s7i           0.033527             83
+seed7/lib/html_ent.s7i       0.033842            476
+seed7/lib/htmldom.s7i        0.033582            286
+seed7/lib/http_request.s7i   0.032711            696
+seed7/lib/http_srv_resp.s7i  0.033965            380
+seed7/lib/https_request.s7i  0.033082            211
+seed7/lib/httpserv.s7i       0.032839            345
+seed7/lib/huffman.s7i        0.032883            644
+seed7/lib/ico.s7i            0.033869            221
+seed7/lib/idxarray.s7i       0.033659            232
+seed7/lib/image.s7i          0.033639            156
+seed7/lib/imagefile.s7i      0.033934            171
+seed7/lib/inflate.s7i        0.033784            411
+seed7/lib/inifile.s7i        0.033701            129
+seed7/lib/integer.s7i        0.033705            663
+seed7/lib/iobuffer.s7i       0.033821            289
+seed7/lib/jpeg.s7i           0.033881           1761
+seed7/lib/json.s7i           0.033899            891
+seed7/lib/json_serde.s7i     0.033672            783
+seed7/lib/keybd.s7i          0.034071            639
+seed7/lib/keydescr.s7i       0.033844            192
+seed7/lib/leb128.s7i         0.033827            218
+seed7/lib/line.s7i           0.033536            164
+seed7/lib/listener.s7i       0.034283            247
+seed7/lib/logfile.s7i        0.034124             73
+seed7/lib/lower.s7i          0.033823            142
+seed7/lib/lzma.s7i           0.033898            934
+seed7/lib/lzw.s7i            0.033707            861
+seed7/lib/magic.s7i          0.033891            403
+seed7/lib/mahjng32.s7i       0.033804           1500
+seed7/lib/make.s7i           0.034119            544
+seed7/lib/makedata.s7i       0.033949           1428
+seed7/lib/math.s7i           0.033768            201
+seed7/lib/mixarith.s7i       0.033882            249
+seed7/lib/modern27.s7i       0.033131           1099
+seed7/lib/more.s7i           0.032575            130
+seed7/lib/msgdigest.s7i      0.033488           1222
+seed7/lib/multiscr.s7i       0.032999             68
+seed7/lib/null_file.s7i      0.032880            345
+seed7/lib/osfiles.s7i        0.032698           1085
+seed7/lib/pbm.s7i            0.034806            230
+seed7/lib/pcx.s7i            0.034209            638
+seed7/lib/pem.s7i            0.034056            185
+seed7/lib/pgm.s7i            0.033866            238
+seed7/lib/pic16.s7i          0.033695           1037
+seed7/lib/pic32.s7i          0.033902           2060
+seed7/lib/pic_util.s7i       0.033895            144
+seed7/lib/pixelimage.s7i     0.033682            320
+seed7/lib/pixmap_file.s7i    0.033788            459
+seed7/lib/pixmapfont.s7i     0.033973            184
+seed7/lib/pkcs1.s7i          0.033779            543
+seed7/lib/png.s7i            0.033696           1064
+seed7/lib/poll.s7i           0.034114            313
+seed7/lib/ppm.s7i            0.034223            240
+seed7/lib/process.s7i        0.033382            541
+seed7/lib/progs.s7i          0.033836            789
+seed7/lib/propertyfile.s7i   0.033960            155
+seed7/lib/rational.s7i       0.033816            792
+seed7/lib/ref_list.s7i       0.033422            252
+seed7/lib/reference.s7i      0.033973            126
+seed7/lib/reverse.s7i        0.033990             94
+seed7/lib/rpm.s7i            0.034326           3487
+seed7/lib/rpmext.s7i         0.033513            318
+seed7/lib/scanfile.s7i       0.032914           1779
+seed7/lib/scanjson.s7i       0.034104            413
+seed7/lib/scanstri.s7i       0.033702           1814
+seed7/lib/scantoml.s7i       0.032508           1603
+seed7/lib/seed7_05.s7i       0.032992           1072
+seed7/lib/set.s7i            0.032789             57
+seed7/lib/shell.s7i          0.032709            615
+seed7/lib/showtls.s7i        0.032678            678
+seed7/lib/signature.s7i      0.033597            131
+seed7/lib/smtp.s7i           0.034199            261
+seed7/lib/sockbase.s7i       0.033716            217
+seed7/lib/socket.s7i         0.033764            326
+seed7/lib/sokoban1.s7i       0.033830           1519
+seed7/lib/sql_base.s7i       0.033878           1000
+seed7/lib/stars.s7i          0.033738           1705
+seed7/lib/stdfont10.s7i      0.033907           3347
+seed7/lib/stdfont12.s7i      0.033701           3928
+seed7/lib/stdfont14.s7i      0.033828           4510
+seed7/lib/stdfont16.s7i      0.033948           5092
+seed7/lib/stdfont18.s7i      0.034216           5868
+seed7/lib/stdfont20.s7i      0.034145           6449
+seed7/lib/stdfont24.s7i      0.034188           7421
+seed7/lib/stdfont8.s7i       0.033860           2960
+seed7/lib/stdfont9.s7i       0.033808           3152
+seed7/lib/stdio.s7i          0.033793            192
+seed7/lib/strifile.s7i       0.033878            345
+seed7/lib/string.s7i         0.033707            779
+seed7/lib/stritext.s7i       0.033856            352
+seed7/lib/struct.s7i         0.033774            266
+seed7/lib/struct_elem.s7i    0.033797            129
+seed7/lib/subfile.s7i        0.033779            174
+seed7/lib/subrange.s7i       0.033719             78
+seed7/lib/syntax.s7i         0.033800            294
+seed7/lib/tar.s7i            0.033786           1880
+seed7/lib/tar_cmds.s7i       0.034776            752
+seed7/lib/tdes.s7i           0.035977            143
+seed7/lib/tee.s7i            0.034059            143
+seed7/lib/text.s7i           0.032832            135
+seed7/lib/tga.s7i            0.032783            676
+seed7/lib/tiff.s7i           0.033790           2771
+seed7/lib/time.s7i           0.034411           1191
+seed7/lib/tls.s7i            0.034079           2230
+seed7/lib/unicode.s7i        0.035167            575
+seed7/lib/unionfnd.s7i       0.040304            130
+seed7/lib/upper.s7i          0.034753            142
+seed7/lib/utf16.s7i          0.034148            540
+seed7/lib/utf8.s7i           0.034109            234
+seed7/lib/vecfont10.s7i      0.034115           1056
+seed7/lib/vecfont18.s7i      0.033795           1119
+seed7/lib/vector3d.s7i       0.033674            293
+seed7/lib/vectorfont.s7i     0.034263            239
+seed7/lib/wildcard.s7i       0.033959            140
+seed7/lib/window.s7i         0.033921            455
+seed7/lib/wrinum.s7i         0.033849            248
+seed7/lib/x509cert.s7i       0.034393           1243
+seed7/lib/xml_ent.s7i        0.034037             94
+seed7/lib/xmldom.s7i         0.034798            303
+seed7/lib/xz.s7i             0.034445            442
+seed7/lib/zip.s7i            0.033999           2792
+seed7/lib/zstd.s7i           0.033723           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033834        |
++-----------+-----------------+
+| Minimum   | 0.032413        |
++-----------+-----------------+
+| Maximum   | 0.040304        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039504            190
+seed7/prg/bas7.sd7           0.041365          11459
+seed7/prg/bifurk.sd7         0.036988             73
+seed7/prg/bigfiles.sd7       0.038882            129
+seed7/prg/brainf7.sd7        0.036939             86
+seed7/prg/calc7.sd7          0.037251            128
+seed7/prg/carddemo.sd7       0.037790            190
+seed7/prg/castle.sd7         0.037970           3148
+seed7/prg/cat.sd7            0.035930             82
+seed7/prg/cellauto.sd7       0.037907             85
+seed7/prg/celsius.sd7        0.037388             42
+seed7/prg/chk_all.sd7        0.039602            843
+seed7/prg/chkarr.sd7         0.039507           8367
+seed7/prg/chkbig.sd7         0.044307          29026
+seed7/prg/chkbin.sd7         0.040495           6469
+seed7/prg/chkbitdata.sd7     0.040712           6624
+seed7/prg/chkbool.sd7        0.039445           3157
+seed7/prg/chkbst.sd7         0.039615            722
+seed7/prg/chkchr.sd7         0.040549           2809
+seed7/prg/chkcmd.sd7         0.039615           1205
+seed7/prg/chkdb.sd7          0.040272           7454
+seed7/prg/chkdecl.sd7        0.039827            448
+seed7/prg/chkenum.sd7        0.039039           1230
+seed7/prg/chkerr.sd7         0.039865           4663
+seed7/prg/chkexc.sd7         0.038015           2627
+seed7/prg/chkfil.sd7         0.038969           1615
+seed7/prg/chkflt.sd7         0.043539          20620
+seed7/prg/chkhent.sd7        0.036290             54
+seed7/prg/chkhsh.sd7         0.040309           4548
+seed7/prg/chkidx.sd7         0.041353          19567
+seed7/prg/chkint.sd7         0.046597          38129
+seed7/prg/chkjson.sd7        0.038203           1764
+seed7/prg/chkovf.sd7         0.038803           8216
+seed7/prg/chkprc.sd7         0.037360          10111
+seed7/prg/chkscan.sd7        0.037768            714
+seed7/prg/chkset.sd7         0.039717          11974
+seed7/prg/chkstr.sd7         0.043684          26952
+seed7/prg/chktime.sd7        0.040285           2025
+seed7/prg/chktoml.sd7        0.039379           1656
+seed7/prg/clock.sd7          0.036369             47
+seed7/prg/clock2.sd7         0.036076             43
+seed7/prg/clock3.sd7         0.039481             95
+seed7/prg/cmpfil.sd7         0.037916             84
+seed7/prg/comanche.sd7       0.039207            180
+seed7/prg/confval.sd7        0.039915            175
+seed7/prg/db7.sd7            0.039167            417
+seed7/prg/diff7.sd7          0.039424            263
+seed7/prg/dirtst.sd7         0.036269             42
+seed7/prg/dirx.sd7           0.039139            152
+seed7/prg/dnafight.sd7       0.038944           1381
+seed7/prg/dragon.sd7         0.037042             73
+seed7/prg/echo.sd7           0.035944             39
+seed7/prg/eliza.sd7          0.039201            302
+seed7/prg/err.sd7            0.041915             96
+seed7/prg/fannkuch.sd7       0.038928            131
+seed7/prg/fib.sd7            0.036169             47
+seed7/prg/find7.sd7          0.038724            133
+seed7/prg/findchar.sd7       0.038870            149
+seed7/prg/fractree.sd7       0.036310             55
+seed7/prg/ftp7.sd7           0.037770            296
+seed7/prg/ftpserv.sd7        0.036377             74
+seed7/prg/gcd.sd7            0.037006            109
+seed7/prg/gkbd.sd7           0.039152            358
+seed7/prg/gtksvtst.sd7       0.041561             94
+seed7/prg/hal.sd7            0.040063            250
+seed7/prg/hamu.sd7           0.039682            573
+seed7/prg/hanoi.sd7          0.036655             55
+seed7/prg/hd.sd7             0.037475             79
+seed7/prg/hello.sd7          0.035937             32
+seed7/prg/hilbert.sd7        0.038356            108
+seed7/prg/ide7.sd7           0.038934            196
+seed7/prg/kbd.sd7            0.036476             49
+seed7/prg/klondike.sd7       0.039511            883
+seed7/prg/lander.sd7         0.039501           1551
+seed7/prg/lst80bas.sd7       0.038437            344
+seed7/prg/lst99bas.sd7       0.040147            401
+seed7/prg/lstgwbas.sd7       0.039903            577
+seed7/prg/mahjong.sd7        0.039398           1943
+seed7/prg/make7.sd7          0.038722            121
+seed7/prg/mandelbr.sd7       0.038814            237
+seed7/prg/mind.sd7           0.039440            443
+seed7/prg/mirror.sd7         0.040096            131
+seed7/prg/ms.sd7             0.039086            641
+seed7/prg/nicoma.sd7         0.038666            135
+seed7/prg/pac.sd7            0.038863            726
+seed7/prg/pairs.sd7          0.037560           2025
+seed7/prg/panic.sd7          0.038533           2634
+seed7/prg/percolation.sd7    0.037873            330
+seed7/prg/planets.sd7        0.038426           1486
+seed7/prg/portfwd7.sd7       0.037250            139
+seed7/prg/prime.sd7          0.038280             74
+seed7/prg/printpi1.sd7       0.037189             56
+seed7/prg/printpi2.sd7       0.036890             54
+seed7/prg/printpi3.sd7       0.037230             60
+seed7/prg/pv7.sd7            0.039078            337
+seed7/prg/queen.sd7          0.041099            149
+seed7/prg/rand.sd7           0.041895            121
+seed7/prg/raytrace.sd7       0.039400            538
+seed7/prg/rever.sd7          0.039329            816
+seed7/prg/roman.sd7          0.036425             38
+seed7/prg/s7c.sd7            0.039311           9060
+seed7/prg/s7check.sd7        0.037039             68
+seed7/prg/savehd7.sd7        0.039460           1110
+seed7/prg/self.sd7           0.036770             49
+seed7/prg/shisen.sd7         0.038733           1423
+seed7/prg/sl.sd7             0.039075           1029
+seed7/prg/snake.sd7          0.039385            615
+seed7/prg/sokoban.sd7        0.039532            891
+seed7/prg/spigotpi.sd7       0.036988             64
+seed7/prg/sql7.sd7           0.038994            278
+seed7/prg/startrek.sd7       0.039429            979
+seed7/prg/sudoku7.sd7        0.038548           2657
+seed7/prg/sydir7.sd7         0.038118            384
+seed7/prg/syntaxhl.sd7       0.040328            177
+seed7/prg/tak.sd7            0.035564             59
+seed7/prg/tar7.sd7           0.039651            121
+seed7/prg/tch.sd7            0.036859             55
+seed7/prg/testfont.sd7       0.039249             95
+seed7/prg/tet.sd7            0.039238            479
+seed7/prg/tetg.sd7           0.039395            501
+seed7/prg/toutf8.sd7         0.040476            240
+seed7/prg/tst_cli.sd7        0.036109             40
+seed7/prg/tst_srv.sd7        0.036450             47
+seed7/prg/wator.sd7          0.039008            651
+seed7/prg/which.sd7          0.037079             65
+seed7/prg/wiz.sd7            0.039239           2833
+seed7/prg/wordcnt.sd7        0.036437             54
+seed7/prg/wrinum.sd7         0.035994             43
+seed7/prg/wumpus.sd7         0.038827            372
+seed7/lib/aes.s7i            0.042689           1144
+seed7/lib/aes_gcm.s7i        0.040004            392
+seed7/lib/ar.s7i             0.039395           1532
+seed7/lib/arc4.s7i           0.039232            144
+seed7/lib/archive.s7i        0.038951            143
+seed7/lib/archive_base.s7i   0.039195            135
+seed7/lib/array.s7i          0.039712            610
+seed7/lib/asn1.s7i           0.037621            544
+seed7/lib/asn1oid.s7i        0.043125            157
+seed7/lib/basearray.s7i      0.040247            450
+seed7/lib/bigfile.s7i        0.037134            136
+seed7/lib/bigint.s7i         0.037168            824
+seed7/lib/bigrat.s7i         0.037742            784
+seed7/lib/bin16.s7i          0.037548            592
+seed7/lib/bin32.s7i          0.037407            490
+seed7/lib/bin64.s7i          0.040269            539
+seed7/lib/bitdata.s7i        0.044954           1330
+seed7/lib/bitmapfont.s7i     0.039095            215
+seed7/lib/bitset.s7i         0.038771            593
+seed7/lib/bitsetof.s7i       0.040287            431
+seed7/lib/blowfish.s7i       0.042158            383
+seed7/lib/bmp.s7i            0.039458            924
+seed7/lib/boolean.s7i        0.039040            403
+seed7/lib/browser.s7i        0.039361            280
+seed7/lib/bstring.s7i        0.038748            227
+seed7/lib/bytedata.s7i       0.039377            482
+seed7/lib/bzip2.s7i          0.039300            887
+seed7/lib/cards.s7i          0.037244           1342
+seed7/lib/category.s7i       0.038844            209
+seed7/lib/cc_conf.s7i        0.038198           1314
+seed7/lib/ccittfax.s7i       0.039502           1022
+seed7/lib/cgi.s7i            0.038383            109
+seed7/lib/cgidialog.s7i      0.038842           1118
+seed7/lib/char.s7i           0.038696            356
+seed7/lib/charsets.s7i       0.039481           2024
+seed7/lib/chartype.s7i       0.043175            121
+seed7/lib/cipher.s7i         0.040347            146
+seed7/lib/cli_cmds.s7i       0.040275           1360
+seed7/lib/clib_file.s7i      0.039305            301
+seed7/lib/color.s7i          0.038616            185
+seed7/lib/complex.s7i        0.038627            464
+seed7/lib/compress.s7i       0.039000            150
+seed7/lib/console.s7i        0.039108            188
+seed7/lib/cpio.s7i           0.039514           1708
+seed7/lib/crc32.s7i          0.039728            193
+seed7/lib/cronos16.s7i       0.042456           1173
+seed7/lib/cronos27.s7i       0.043420           1464
+seed7/lib/csv.s7i            0.039246            201
+seed7/lib/db_prop.s7i        0.039510            991
+seed7/lib/deflate.s7i        0.039093            740
+seed7/lib/des.s7i            0.039711            444
+seed7/lib/dialog.s7i         0.039267            311
+seed7/lib/dir.s7i            0.038762            163
+seed7/lib/draw.s7i           0.039366            854
+seed7/lib/duration.s7i       0.039125           1038
+seed7/lib/echo.s7i           0.039130            132
+seed7/lib/editline.s7i       0.038882            398
+seed7/lib/elf.s7i            0.040774           1560
+seed7/lib/elliptic.s7i       0.038831            649
+seed7/lib/enable_io.s7i      0.039091            312
+seed7/lib/encoding.s7i       0.039549            931
+seed7/lib/enumeration.s7i    0.039245            236
+seed7/lib/environment.s7i    0.038406            175
+seed7/lib/exif.s7i           0.040049            152
+seed7/lib/external_file.s7i  0.037741            340
+seed7/lib/field.s7i          0.037488            268
+seed7/lib/file.s7i           0.037723            372
+seed7/lib/filebits.s7i       0.035854             46
+seed7/lib/filesys.s7i        0.038192            601
+seed7/lib/fileutil.s7i       0.039884            144
+seed7/lib/fixarray.s7i       0.039918            307
+seed7/lib/float.s7i          0.038962            757
+seed7/lib/font.s7i           0.038690            196
+seed7/lib/font8x8.s7i        0.039372            998
+seed7/lib/forloop.s7i        0.040041            449
+seed7/lib/ftp.s7i            0.038724            969
+seed7/lib/ftpserv.s7i        0.039106            631
+seed7/lib/getf.s7i           0.038618            115
+seed7/lib/gethttp.s7i        0.036420             41
+seed7/lib/gethttps.s7i       0.036089             41
+seed7/lib/gif.s7i            0.039028            561
+seed7/lib/graph.s7i          0.041190            415
+seed7/lib/graph_file.s7i     0.038989            399
+seed7/lib/gtkserver.s7i      0.038295            161
+seed7/lib/gzip.s7i           0.039011            573
+seed7/lib/hash.s7i           0.040607            421
+seed7/lib/hashsetof.s7i      0.040896            499
+seed7/lib/hmac.s7i           0.038666            152
+seed7/lib/html.s7i           0.037449             83
+seed7/lib/html_ent.s7i       0.039299            476
+seed7/lib/htmldom.s7i        0.039287            286
+seed7/lib/http_request.s7i   0.038396            696
+seed7/lib/http_srv_resp.s7i  0.037971            380
+seed7/lib/https_request.s7i  0.037696            211
+seed7/lib/httpserv.s7i       0.037623            345
+seed7/lib/huffman.s7i        0.037943            644
+seed7/lib/ico.s7i            0.039971            221
+seed7/lib/idxarray.s7i       0.039350            232
+seed7/lib/image.s7i          0.038404            156
+seed7/lib/imagefile.s7i      0.039045            171
+seed7/lib/inflate.s7i        0.039430            411
+seed7/lib/inifile.s7i        0.038744            129
+seed7/lib/integer.s7i        0.038944            663
+seed7/lib/iobuffer.s7i       0.038615            289
+seed7/lib/jpeg.s7i           0.039100           1761
+seed7/lib/json.s7i           0.039093            891
+seed7/lib/json_serde.s7i     0.044919            783
+seed7/lib/keybd.s7i          0.042180            639
+seed7/lib/keydescr.s7i       0.040467            192
+seed7/lib/leb128.s7i         0.039315            218
+seed7/lib/line.s7i           0.038998            164
+seed7/lib/listener.s7i       0.038967            247
+seed7/lib/logfile.s7i        0.037640             73
+seed7/lib/lower.s7i          0.038350            142
+seed7/lib/lzma.s7i           0.039814            934
+seed7/lib/lzw.s7i            0.040207            861
+seed7/lib/magic.s7i          0.040464            403
+seed7/lib/mahjng32.s7i       0.038705           1500
+seed7/lib/make.s7i           0.038038            544
+seed7/lib/makedata.s7i       0.037703           1428
+seed7/lib/math.s7i           0.037657            201
+seed7/lib/mixarith.s7i       0.037353            249
+seed7/lib/modern27.s7i       0.040917           1099
+seed7/lib/more.s7i           0.039620            130
+seed7/lib/msgdigest.s7i      0.040491           1222
+seed7/lib/multiscr.s7i       0.037292             68
+seed7/lib/null_file.s7i      0.038969            345
+seed7/lib/osfiles.s7i        0.040554           1085
+seed7/lib/pbm.s7i            0.039249            230
+seed7/lib/pcx.s7i            0.038724            638
+seed7/lib/pem.s7i            0.038614            185
+seed7/lib/pgm.s7i            0.039193            238
+seed7/lib/pic16.s7i          0.038551           1037
+seed7/lib/pic32.s7i          0.038532           2060
+seed7/lib/pic_util.s7i       0.038953            144
+seed7/lib/pixelimage.s7i     0.039152            320
+seed7/lib/pixmap_file.s7i    0.039180            459
+seed7/lib/pixmapfont.s7i     0.040474            184
+seed7/lib/pkcs1.s7i          0.044329            543
+seed7/lib/png.s7i            0.038879           1064
+seed7/lib/poll.s7i           0.038491            313
+seed7/lib/ppm.s7i            0.039096            240
+seed7/lib/process.s7i        0.039209            541
+seed7/lib/progs.s7i          0.039422            789
+seed7/lib/propertyfile.s7i   0.039114            155
+seed7/lib/rational.s7i       0.038345            792
+seed7/lib/ref_list.s7i       0.038174            252
+seed7/lib/reference.s7i      0.041366            126
+seed7/lib/reverse.s7i        0.040582             94
+seed7/lib/rpm.s7i            0.038742           3487
+seed7/lib/rpmext.s7i         0.039595            318
+seed7/lib/scanfile.s7i       0.039262           1779
+seed7/lib/scanjson.s7i       0.039495            413
+seed7/lib/scanstri.s7i       0.039398           1814
+seed7/lib/scantoml.s7i       0.039232           1603
+seed7/lib/seed7_05.s7i       0.041013           1072
+seed7/lib/set.s7i            0.037023             57
+seed7/lib/shell.s7i          0.039669            615
+seed7/lib/showtls.s7i        0.039110            678
+seed7/lib/signature.s7i      0.038666            131
+seed7/lib/smtp.s7i           0.039245            261
+seed7/lib/sockbase.s7i       0.040120            217
+seed7/lib/socket.s7i         0.038971            326
+seed7/lib/sokoban1.s7i       0.038395           1519
+seed7/lib/sql_base.s7i       0.039058           1000
+seed7/lib/stars.s7i          0.041286           1705
+seed7/lib/stdfont10.s7i      0.037640           3347
+seed7/lib/stdfont12.s7i      0.038622           3928
+seed7/lib/stdfont14.s7i      0.038720           4510
+seed7/lib/stdfont16.s7i      0.038968           5092
+seed7/lib/stdfont18.s7i      0.039063           5868
+seed7/lib/stdfont20.s7i      0.038644           6449
+seed7/lib/stdfont24.s7i      0.038233           7421
+seed7/lib/stdfont8.s7i       0.036158           2960
+seed7/lib/stdfont9.s7i       0.036241           3152
+seed7/lib/stdio.s7i          0.037297            192
+seed7/lib/strifile.s7i       0.037497            345
+seed7/lib/string.s7i         0.037861            779
+seed7/lib/stritext.s7i       0.039131            352
+seed7/lib/struct.s7i         0.040698            266
+seed7/lib/struct_elem.s7i    0.039007            129
+seed7/lib/subfile.s7i        0.038638            174
+seed7/lib/subrange.s7i       0.037600             78
+seed7/lib/syntax.s7i         0.039330            294
+seed7/lib/tar.s7i            0.039605           1880
+seed7/lib/tar_cmds.s7i       0.039312            752
+seed7/lib/tdes.s7i           0.038822            143
+seed7/lib/tee.s7i            0.038848            143
+seed7/lib/text.s7i           0.038638            135
+seed7/lib/tga.s7i            0.041382            676
+seed7/lib/tiff.s7i           0.040992           2771
+seed7/lib/time.s7i           0.037744           1191
+seed7/lib/tls.s7i            0.037085           2230
+seed7/lib/unicode.s7i        0.039596            575
+seed7/lib/unionfnd.s7i       0.038146            130
+seed7/lib/upper.s7i          0.037812            142
+seed7/lib/utf16.s7i          0.038877            540
+seed7/lib/utf8.s7i           0.040053            234
+seed7/lib/vecfont10.s7i      0.041923           1056
+seed7/lib/vecfont18.s7i      0.042335           1119
+seed7/lib/vector3d.s7i       0.037958            293
+seed7/lib/vectorfont.s7i     0.037482            239
+seed7/lib/wildcard.s7i       0.037884            140
+seed7/lib/window.s7i         0.037461            455
+seed7/lib/wrinum.s7i         0.037818            248
+seed7/lib/x509cert.s7i       0.041107           1243
+seed7/lib/xml_ent.s7i        0.038743             94
+seed7/lib/xmldom.s7i         0.038813            303
+seed7/lib/xz.s7i             0.038818            442
+seed7/lib/zip.s7i            0.039388           2792
+seed7/lib/zstd.s7i           0.038859           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039011        |
++-----------+-----------------+
+| Minimum   | 0.035564        |
++-----------+-----------------+
+| Maximum   | 0.046597        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039764            190
+seed7/prg/bas7.sd7           0.321936          11459
+seed7/prg/bifurk.sd7         0.036554             73
+seed7/prg/bigfiles.sd7       0.037739            129
+seed7/prg/brainf7.sd7        0.036525             86
+seed7/prg/calc7.sd7          0.037998            128
+seed7/prg/carddemo.sd7       0.038748            190
+seed7/prg/castle.sd7         0.107160           3148
+seed7/prg/cat.sd7            0.037145             82
+seed7/prg/cellauto.sd7       0.037129             85
+seed7/prg/celsius.sd7        0.035233             42
+seed7/prg/chk_all.sd7        0.056597            843
+seed7/prg/chkarr.sd7         0.349444           8367
+seed7/prg/chkbig.sd7         2.042448          29026
+seed7/prg/chkbin.sd7         0.508849           6469
+seed7/prg/chkbitdata.sd7     0.605344           6624
+seed7/prg/chkbool.sd7        0.114544           3157
+seed7/prg/chkbst.sd7         0.061603            722
+seed7/prg/chkchr.sd7         0.214072           2809
+seed7/prg/chkcmd.sd7         0.066553           1205
+seed7/prg/chkdb.sd7          0.344592           7454
+seed7/prg/chkdecl.sd7        0.056097            448
+seed7/prg/chkenum.sd7        0.067946           1230
+seed7/prg/chkerr.sd7         0.191770           4663
+seed7/prg/chkexc.sd7         0.081648           2627
+seed7/prg/chkfil.sd7         0.074780           1615
+seed7/prg/chkflt.sd7         1.325862          20620
+seed7/prg/chkhent.sd7        0.036707             54
+seed7/prg/chkhsh.sd7         0.242468           4548
+seed7/prg/chkidx.sd7         1.309349          19567
+seed7/prg/chkint.sd7         2.502998          38129
+seed7/prg/chkjson.sd7        0.099954           1764
+seed7/prg/chkovf.sd7         0.553705           8216
+seed7/prg/chkprc.sd7         0.318710          10111
+seed7/prg/chkscan.sd7        0.056328            714
+seed7/prg/chkset.sd7         0.651022          11974
+seed7/prg/chkstr.sd7         1.372398          26952
+seed7/prg/chktime.sd7        0.129079           2025
+seed7/prg/chktoml.sd7        0.106405           1656
+seed7/prg/clock.sd7          0.048014             47
+seed7/prg/clock2.sd7         0.039865             43
+seed7/prg/clock3.sd7         0.037416             95
+seed7/prg/cmpfil.sd7         0.036478             84
+seed7/prg/comanche.sd7       0.039895            180
+seed7/prg/confval.sd7        0.041056            175
+seed7/prg/db7.sd7            0.045597            417
+seed7/prg/diff7.sd7          0.040968            263
+seed7/prg/dirtst.sd7         0.034377             42
+seed7/prg/dirx.sd7           0.036912            152
+seed7/prg/dnafight.sd7       0.067213           1381
+seed7/prg/dragon.sd7         0.036207             73
+seed7/prg/echo.sd7           0.035409             39
+seed7/prg/eliza.sd7          0.042390            302
+seed7/prg/err.sd7            0.039730             96
+seed7/prg/fannkuch.sd7       0.037331            131
+seed7/prg/fib.sd7            0.035254             47
+seed7/prg/find7.sd7          0.037935            133
+seed7/prg/findchar.sd7       0.038442            149
+seed7/prg/fractree.sd7       0.034892             55
+seed7/prg/ftp7.sd7           0.042008            296
+seed7/prg/ftpserv.sd7        0.036757             74
+seed7/prg/gcd.sd7            0.036597            109
+seed7/prg/gkbd.sd7           0.045662            358
+seed7/prg/gtksvtst.sd7       0.037172             94
+seed7/prg/hal.sd7            0.040437            250
+seed7/prg/hamu.sd7           0.049206            573
+seed7/prg/hanoi.sd7          0.036956             55
+seed7/prg/hd.sd7             0.037407             79
+seed7/prg/hello.sd7          0.035841             32
+seed7/prg/hilbert.sd7        0.037923            108
+seed7/prg/ide7.sd7           0.039847            196
+seed7/prg/kbd.sd7            0.034671             49
+seed7/prg/klondike.sd7       0.052717            883
+seed7/prg/lander.sd7         0.068888           1551
+seed7/prg/lst80bas.sd7       0.042117            344
+seed7/prg/lst99bas.sd7       0.046364            401
+seed7/prg/lstgwbas.sd7       0.050419            577
+seed7/prg/mahjong.sd7        0.079995           1943
+seed7/prg/make7.sd7          0.037934            121
+seed7/prg/mandelbr.sd7       0.040810            237
+seed7/prg/mind.sd7           0.044832            443
+seed7/prg/mirror.sd7         0.038895            131
+seed7/prg/ms.sd7             0.048589            641
+seed7/prg/nicoma.sd7         0.037815            135
+seed7/prg/pac.sd7            0.049050            726
+seed7/prg/pairs.sd7          0.082373           2025
+seed7/prg/panic.sd7          0.096532           2634
+seed7/prg/percolation.sd7    0.042509            330
+seed7/prg/planets.sd7        0.075876           1486
+seed7/prg/portfwd7.sd7       0.038672            139
+seed7/prg/prime.sd7          0.035484             74
+seed7/prg/printpi1.sd7       0.034732             56
+seed7/prg/printpi2.sd7       0.034403             54
+seed7/prg/printpi3.sd7       0.034771             60
+seed7/prg/pv7.sd7            0.042633            337
+seed7/prg/queen.sd7          0.036509            149
+seed7/prg/rand.sd7           0.037803            121
+seed7/prg/raytrace.sd7       0.048471            538
+seed7/prg/rever.sd7          0.053835            816
+seed7/prg/roman.sd7          0.036246             38
+seed7/prg/s7c.sd7            0.277804           9060
+seed7/prg/s7check.sd7        0.036598             68
+seed7/prg/savehd7.sd7        0.066581           1110
+seed7/prg/self.sd7           0.035810             49
+seed7/prg/shisen.sd7         0.071797           1423
+seed7/prg/sl.sd7             0.059165           1029
+seed7/prg/snake.sd7          0.046763            615
+seed7/prg/sokoban.sd7        0.056095            891
+seed7/prg/spigotpi.sd7       0.034918             64
+seed7/prg/sql7.sd7           0.040039            278
+seed7/prg/startrek.sd7       0.057051            979
+seed7/prg/sudoku7.sd7        0.101480           2657
+seed7/prg/sydir7.sd7         0.046150            384
+seed7/prg/syntaxhl.sd7       0.041272            177
+seed7/prg/tak.sd7            0.036430             59
+seed7/prg/tar7.sd7           0.037912            121
+seed7/prg/tch.sd7            0.035794             55
+seed7/prg/testfont.sd7       0.037157             95
+seed7/prg/tet.sd7            0.044369            479
+seed7/prg/tetg.sd7           0.045751            501
+seed7/prg/toutf8.sd7         0.042777            240
+seed7/prg/tst_cli.sd7        0.035578             40
+seed7/prg/tst_srv.sd7        0.035559             47
+seed7/prg/wator.sd7          0.052077            651
+seed7/prg/which.sd7          0.036038             65
+seed7/prg/wiz.sd7            0.104594           2833
+seed7/prg/wordcnt.sd7        0.036056             54
+seed7/prg/wrinum.sd7         0.035145             43
+seed7/prg/wumpus.sd7         0.042452            372
+seed7/lib/aes.s7i            0.108449           1144
+seed7/lib/aes_gcm.s7i        0.045274            392
+seed7/lib/ar.s7i             0.071795           1532
+seed7/lib/arc4.s7i           0.036792            144
+seed7/lib/archive.s7i        0.038422            143
+seed7/lib/archive_base.s7i   0.039082            135
+seed7/lib/array.s7i          0.053669            610
+seed7/lib/asn1.s7i           0.047142            544
+seed7/lib/asn1oid.s7i        0.041537            157
+seed7/lib/basearray.s7i      0.048699            450
+seed7/lib/bigfile.s7i        0.038537            136
+seed7/lib/bigint.s7i         0.055426            824
+seed7/lib/bigrat.s7i         0.053865            784
+seed7/lib/bin16.s7i          0.050650            592
+seed7/lib/bin32.s7i          0.048007            490
+seed7/lib/bin64.s7i          0.049431            539
+seed7/lib/bitdata.s7i        0.076040           1330
+seed7/lib/bitmapfont.s7i     0.040194            215
+seed7/lib/bitset.s7i         0.049333            593
+seed7/lib/bitsetof.s7i       0.047233            431
+seed7/lib/blowfish.s7i       0.056228            383
+seed7/lib/bmp.s7i            0.059436            924
+seed7/lib/boolean.s7i        0.043084            403
+seed7/lib/browser.s7i        0.041603            280
+seed7/lib/bstring.s7i        0.039642            227
+seed7/lib/bytedata.s7i       0.048167            482
+seed7/lib/bzip2.s7i          0.059041            887
+seed7/lib/cards.s7i          0.065975           1342
+seed7/lib/category.s7i       0.041159            209
+seed7/lib/cc_conf.s7i        0.081754           1314
+seed7/lib/ccittfax.s7i       0.065940           1022
+seed7/lib/cgi.s7i            0.037827            109
+seed7/lib/cgidialog.s7i      0.060230           1118
+seed7/lib/char.s7i           0.043245            356
+seed7/lib/charsets.s7i       0.082033           2024
+seed7/lib/chartype.s7i       0.039951            121
+seed7/lib/cipher.s7i         0.038216            146
+seed7/lib/cli_cmds.s7i       0.068397           1360
+seed7/lib/clib_file.s7i      0.043337            301
+seed7/lib/color.s7i          0.040925            185
+seed7/lib/complex.s7i        0.047470            464
+seed7/lib/compress.s7i       0.038595            150
+seed7/lib/console.s7i        0.038338            188
+seed7/lib/cpio.s7i           0.079475           1708
+seed7/lib/crc32.s7i          0.042348            193
+seed7/lib/cronos16.s7i       0.090160           1173
+seed7/lib/cronos27.s7i       0.117156           1464
+seed7/lib/csv.s7i            0.041102            201
+seed7/lib/db_prop.s7i        0.065525            991
+seed7/lib/deflate.s7i        0.057176            740
+seed7/lib/des.s7i            0.055425            444
+seed7/lib/dialog.s7i         0.044366            311
+seed7/lib/dir.s7i            0.038092            163
+seed7/lib/draw.s7i           0.055738            854
+seed7/lib/duration.s7i       0.061095           1038
+seed7/lib/echo.s7i           0.038098            132
+seed7/lib/editline.s7i       0.045685            398
+seed7/lib/elf.s7i            0.085390           1560
+seed7/lib/elliptic.s7i       0.052484            649
+seed7/lib/enable_io.s7i      0.043087            312
+seed7/lib/encoding.s7i       0.059305            931
+seed7/lib/enumeration.s7i    0.040700            236
+seed7/lib/environment.s7i    0.037946            175
+seed7/lib/exif.s7i           0.038286            152
+seed7/lib/external_file.s7i  0.043957            340
+seed7/lib/field.s7i          0.042478            268
+seed7/lib/file.s7i           0.044508            372
+seed7/lib/filebits.s7i       0.036510             46
+seed7/lib/filesys.s7i        0.048614            601
+seed7/lib/fileutil.s7i       0.038340            144
+seed7/lib/fixarray.s7i       0.043323            307
+seed7/lib/float.s7i          0.055247            757
+seed7/lib/font.s7i           0.039398            196
+seed7/lib/font8x8.s7i        0.048323            998
+seed7/lib/forloop.s7i        0.045595            449
+seed7/lib/ftp.s7i            0.104439            969
+seed7/lib/ftpserv.s7i        0.065253            631
+seed7/lib/getf.s7i           0.043046            115
+seed7/lib/gethttp.s7i        0.036955             41
+seed7/lib/gethttps.s7i       0.035746             41
+seed7/lib/gif.s7i            0.049734            561
+seed7/lib/graph.s7i          0.048600            415
+seed7/lib/graph_file.s7i     0.044870            399
+seed7/lib/gtkserver.s7i      0.039093            161
+seed7/lib/gzip.s7i           0.049345            573
+seed7/lib/hash.s7i           0.050564            421
+seed7/lib/hashsetof.s7i      0.049260            499
+seed7/lib/hmac.s7i           0.040857            152
+seed7/lib/html.s7i           0.036629             83
+seed7/lib/html_ent.s7i       0.046337            476
+seed7/lib/htmldom.s7i        0.042722            286
+seed7/lib/http_request.s7i   0.051432            696
+seed7/lib/http_srv_resp.s7i  0.046060            380
+seed7/lib/https_request.s7i  0.040159            211
+seed7/lib/httpserv.s7i       0.045784            345
+seed7/lib/huffman.s7i        0.054878            644
+seed7/lib/ico.s7i            0.041714            221
+seed7/lib/idxarray.s7i       0.042624            232
+seed7/lib/image.s7i          0.038591            156
+seed7/lib/imagefile.s7i      0.040254            171
+seed7/lib/inflate.s7i        0.047569            411
+seed7/lib/inifile.s7i        0.038900            129
+seed7/lib/integer.s7i        0.052677            663
+seed7/lib/iobuffer.s7i       0.042698            289
+seed7/lib/jpeg.s7i           0.082889           1761
+seed7/lib/json.s7i           0.054908            891
+seed7/lib/json_serde.s7i     0.054791            783
+seed7/lib/keybd.s7i          0.056901            639
+seed7/lib/keydescr.s7i       0.044017            192
+seed7/lib/leb128.s7i         0.040612            218
+seed7/lib/line.s7i           0.039780            164
+seed7/lib/listener.s7i       0.041918            247
+seed7/lib/logfile.s7i        0.038771             73
+seed7/lib/lower.s7i          0.039407            142
+seed7/lib/lzma.s7i           0.059873            934
+seed7/lib/lzw.s7i            0.059240            861
+seed7/lib/magic.s7i          0.048941            403
+seed7/lib/mahjng32.s7i       0.067525           1500
+seed7/lib/make.s7i           0.050853            544
+seed7/lib/makedata.s7i       0.070051           1428
+seed7/lib/math.s7i           0.039739            201
+seed7/lib/mixarith.s7i       0.039934            249
+seed7/lib/modern27.s7i       0.083331           1099
+seed7/lib/more.s7i           0.037815            130
+seed7/lib/msgdigest.s7i      0.078120           1222
+seed7/lib/multiscr.s7i       0.037036             68
+seed7/lib/null_file.s7i      0.042307            345
+seed7/lib/osfiles.s7i        0.064216           1085
+seed7/lib/pbm.s7i            0.040382            230
+seed7/lib/pcx.s7i            0.053733            638
+seed7/lib/pem.s7i            0.040306            185
+seed7/lib/pgm.s7i            0.040730            238
+seed7/lib/pic16.s7i          0.049312           1037
+seed7/lib/pic32.s7i          0.080315           2060
+seed7/lib/pic_util.s7i       0.039138            144
+seed7/lib/pixelimage.s7i     0.042815            320
+seed7/lib/pixmap_file.s7i    0.046569            459
+seed7/lib/pixmapfont.s7i     0.040177            184
+seed7/lib/pkcs1.s7i          0.059480            543
+seed7/lib/png.s7i            0.066368           1064
+seed7/lib/poll.s7i           0.044810            313
+seed7/lib/ppm.s7i            0.041224            240
+seed7/lib/process.s7i        0.049096            541
+seed7/lib/progs.s7i          0.057124            789
+seed7/lib/propertyfile.s7i   0.038885            155
+seed7/lib/rational.s7i       0.053076            792
+seed7/lib/ref_list.s7i       0.041251            252
+seed7/lib/reference.s7i      0.037685            126
+seed7/lib/reverse.s7i        0.036993             94
+seed7/lib/rpm.s7i            0.143279           3487
+seed7/lib/rpmext.s7i         0.048900            318
+seed7/lib/scanfile.s7i       0.081651           1779
+seed7/lib/scanjson.s7i       0.046655            413
+seed7/lib/scanstri.s7i       0.079743           1814
+seed7/lib/scantoml.s7i       0.075361           1603
+seed7/lib/seed7_05.s7i       0.066537           1072
+seed7/lib/set.s7i            0.037489             57
+seed7/lib/shell.s7i          0.052914            615
+seed7/lib/showtls.s7i        0.054753            678
+seed7/lib/signature.s7i      0.038890            131
+seed7/lib/smtp.s7i           0.041594            261
+seed7/lib/sockbase.s7i       0.043149            217
+seed7/lib/socket.s7i         0.043510            326
+seed7/lib/sokoban1.s7i       0.053642           1519
+seed7/lib/sql_base.s7i       0.064131           1000
+seed7/lib/stars.s7i          0.134601           1705
+seed7/lib/stdfont10.s7i      0.082480           3347
+seed7/lib/stdfont12.s7i      0.092180           3928
+seed7/lib/stdfont14.s7i      0.103090           4510
+seed7/lib/stdfont16.s7i      0.114946           5092
+seed7/lib/stdfont18.s7i      0.131378           5868
+seed7/lib/stdfont20.s7i      0.146978           6449
+seed7/lib/stdfont24.s7i      0.177940           7421
+seed7/lib/stdfont8.s7i       0.072888           2960
+seed7/lib/stdfont9.s7i       0.075238           3152
+seed7/lib/stdio.s7i          0.039093            192
+seed7/lib/strifile.s7i       0.044037            345
+seed7/lib/string.s7i         0.057085            779
+seed7/lib/stritext.s7i       0.043498            352
+seed7/lib/struct.s7i         0.045642            266
+seed7/lib/struct_elem.s7i    0.039301            129
+seed7/lib/subfile.s7i        0.039349            174
+seed7/lib/subrange.s7i       0.037231             78
+seed7/lib/syntax.s7i         0.047014            294
+seed7/lib/tar.s7i            0.082214           1880
+seed7/lib/tar_cmds.s7i       0.055377            752
+seed7/lib/tdes.s7i           0.038718            143
+seed7/lib/tee.s7i            0.037149            143
+seed7/lib/text.s7i           0.037755            135
+seed7/lib/tga.s7i            0.053507            676
+seed7/lib/tiff.s7i           0.120268           2771
+seed7/lib/time.s7i           0.062407           1191
+seed7/lib/tls.s7i            0.104867           2230
+seed7/lib/unicode.s7i        0.051637            575
+seed7/lib/unionfnd.s7i       0.037909            130
+seed7/lib/upper.s7i          0.038645            142
+seed7/lib/utf16.s7i          0.049307            540
+seed7/lib/utf8.s7i           0.046557            234
+seed7/lib/vecfont10.s7i      0.079925           1056
+seed7/lib/vecfont18.s7i      0.087911           1119
+seed7/lib/vector3d.s7i       0.041615            293
+seed7/lib/vectorfont.s7i     0.041328            239
+seed7/lib/wildcard.s7i       0.039033            140
+seed7/lib/window.s7i         0.046156            455
+seed7/lib/wrinum.s7i         0.041817            248
+seed7/lib/x509cert.s7i       0.072236           1243
+seed7/lib/xml_ent.s7i        0.038849             94
+seed7/lib/xmldom.s7i         0.041993            303
+seed7/lib/xz.s7i             0.046382            442
+seed7/lib/zip.s7i            0.118847           2792
+seed7/lib/zstd.s7i           0.070525           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.088926        |
++-----------+-----------------+
+| Minimum   | 0.034377        |
++-----------+-----------------+
+| Maximum   | 2.502998        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.045143            190
+seed7/prg/bas7.sd7           0.756285          11459
+seed7/prg/bifurk.sd7         0.038129             73
+seed7/prg/bigfiles.sd7       0.042612            129
+seed7/prg/brainf7.sd7        0.039191             86
+seed7/prg/calc7.sd7          0.042081            128
+seed7/prg/carddemo.sd7       0.047280            190
+seed7/prg/castle.sd7         0.211426           3148
+seed7/prg/cat.sd7            0.038902             82
+seed7/prg/cellauto.sd7       0.039598             85
+seed7/prg/celsius.sd7        0.036850             42
+seed7/prg/chk_all.sd7        0.081114            843
+seed7/prg/chkarr.sd7         0.849173           8367
+seed7/prg/chkbig.sd7         4.076068          29026
+seed7/prg/chkbin.sd7         1.014353           6469
+seed7/prg/chkbitdata.sd7     1.232161           6624
+seed7/prg/chkbool.sd7        0.227118           3157
+seed7/prg/chkbst.sd7         0.099885            722
+seed7/prg/chkchr.sd7         0.472826           2809
+seed7/prg/chkcmd.sd7         0.109480           1205
+seed7/prg/chkdb.sd7          0.744541           7454
+seed7/prg/chkdecl.sd7        0.091884            448
+seed7/prg/chkenum.sd7        0.121114           1230
+seed7/prg/chkerr.sd7         0.335979           4663
+seed7/prg/chkexc.sd7         0.146589           2627
+seed7/prg/chkfil.sd7         0.126968           1615
+seed7/prg/chkflt.sd7         2.788370          20620
+seed7/prg/chkhent.sd7        0.039077             54
+seed7/prg/chkhsh.sd7         0.494080           4548
+seed7/prg/chkidx.sd7         3.271977          19567
+seed7/prg/chkint.sd7         5.534053          38129
+seed7/prg/chkjson.sd7        0.185405           1764
+seed7/prg/chkovf.sd7         1.192760           8216
+seed7/prg/chkprc.sd7         0.691074          10111
+seed7/prg/chkscan.sd7        0.089620            714
+seed7/prg/chkset.sd7         1.723667          11974
+seed7/prg/chkstr.sd7         3.383229          26952
+seed7/prg/chktime.sd7        0.243340           2025
+seed7/prg/chktoml.sd7        0.193388           1656
+seed7/prg/clock.sd7          0.037057             47
+seed7/prg/clock2.sd7         0.036482             43
+seed7/prg/clock3.sd7         0.041677             95
+seed7/prg/cmpfil.sd7         0.038725             84
+seed7/prg/comanche.sd7       0.046605            180
+seed7/prg/confval.sd7        0.052119            175
+seed7/prg/db7.sd7            0.062537            417
+seed7/prg/diff7.sd7          0.051474            263
+seed7/prg/dirtst.sd7         0.036907             42
+seed7/prg/dirx.sd7           0.042936            152
+seed7/prg/dnafight.sd7       0.116939           1381
+seed7/prg/dragon.sd7         0.038223             73
+seed7/prg/echo.sd7           0.036875             39
+seed7/prg/eliza.sd7          0.052023            302
+seed7/prg/err.sd7            0.045168             96
+seed7/prg/fannkuch.sd7       0.045289            131
+seed7/prg/fib.sd7            0.044387             47
+seed7/prg/find7.sd7          0.042466            133
+seed7/prg/findchar.sd7       0.044233            149
+seed7/prg/fractree.sd7       0.037733             55
+seed7/prg/ftp7.sd7           0.054035            296
+seed7/prg/ftpserv.sd7        0.039749             74
+seed7/prg/gcd.sd7            0.041220            109
+seed7/prg/gkbd.sd7           0.061043            358
+seed7/prg/gtksvtst.sd7       0.039189             94
+seed7/prg/hal.sd7            0.046616            250
+seed7/prg/hamu.sd7           0.066398            573
+seed7/prg/hanoi.sd7          0.039101             55
+seed7/prg/hd.sd7             0.039544             79
+seed7/prg/hello.sd7          0.036521             32
+seed7/prg/hilbert.sd7        0.041215            108
+seed7/prg/ide7.sd7           0.048051            196
+seed7/prg/kbd.sd7            0.037312             49
+seed7/prg/klondike.sd7       0.087184            883
+seed7/prg/lander.sd7         0.131605           1551
+seed7/prg/lst80bas.sd7       0.055280            344
+seed7/prg/lst99bas.sd7       0.058888            401
+seed7/prg/lstgwbas.sd7       0.072729            577
+seed7/prg/mahjong.sd7        0.147289           1943
+seed7/prg/make7.sd7          0.042041            121
+seed7/prg/mandelbr.sd7       0.048935            237
+seed7/prg/mind.sd7           0.058489            443
+seed7/prg/mirror.sd7         0.045946            131
+seed7/prg/ms.sd7             0.073537            641
+seed7/prg/nicoma.sd7         0.044644            135
+seed7/prg/pac.sd7            0.071628            726
+seed7/prg/pairs.sd7          0.137794           2025
+seed7/prg/panic.sd7          0.190260           2634
+seed7/prg/percolation.sd7    0.056363            330
+seed7/prg/planets.sd7        0.137123           1486
+seed7/prg/portfwd7.sd7       0.042735            139
+seed7/prg/prime.sd7          0.037724             74
+seed7/prg/printpi1.sd7       0.036951             56
+seed7/prg/printpi2.sd7       0.036788             54
+seed7/prg/printpi3.sd7       0.037436             60
+seed7/prg/pv7.sd7            0.057162            337
+seed7/prg/queen.sd7          0.042115            149
+seed7/prg/rand.sd7           0.040729            121
+seed7/prg/raytrace.sd7       0.069131            538
+seed7/prg/rever.sd7          0.080565            816
+seed7/prg/roman.sd7          0.036393             38
+seed7/prg/s7c.sd7            0.613974           9060
+seed7/prg/s7check.sd7        0.038617             68
+seed7/prg/savehd7.sd7        0.110814           1110
+seed7/prg/self.sd7           0.037935             49
+seed7/prg/shisen.sd7         0.119765           1423
+seed7/prg/sl.sd7             0.096091           1029
+seed7/prg/snake.sd7          0.065571            615
+seed7/prg/sokoban.sd7        0.081878            891
+seed7/prg/spigotpi.sd7       0.038281             64
+seed7/prg/sql7.sd7           0.052618            278
+seed7/prg/startrek.sd7       0.092559            979
+seed7/prg/sudoku7.sd7        0.193323           2657
+seed7/prg/sydir7.sd7         0.062320            384
+seed7/prg/syntaxhl.sd7       0.047816            177
+seed7/prg/tak.sd7            0.037897             59
+seed7/prg/tar7.sd7           0.042920            121
+seed7/prg/tch.sd7            0.037964             55
+seed7/prg/testfont.sd7       0.041443             95
+seed7/prg/tet.sd7            0.059702            479
+seed7/prg/tetg.sd7           0.062297            501
+seed7/prg/toutf8.sd7         0.051063            240
+seed7/prg/tst_cli.sd7        0.036010             40
+seed7/prg/tst_srv.sd7        0.039560             47
+seed7/prg/wator.sd7          0.078546            651
+seed7/prg/which.sd7          0.037858             65
+seed7/prg/wiz.sd7            0.204926           2833
+seed7/prg/wordcnt.sd7        0.036725             54
+seed7/prg/wrinum.sd7         0.036441             43
+seed7/prg/wumpus.sd7         0.055414            372
+seed7/lib/aes.s7i            0.194765           1144
+seed7/lib/aes_gcm.s7i        0.061034            392
+seed7/lib/ar.s7i             0.125575           1532
+seed7/lib/arc4.s7i           0.043005            144
+seed7/lib/archive.s7i        0.045350            143
+seed7/lib/archive_base.s7i   0.047175            135
+seed7/lib/array.s7i          0.074623            610
+seed7/lib/asn1.s7i           0.063453            544
+seed7/lib/asn1oid.s7i        0.049486            157
+seed7/lib/basearray.s7i      0.062790            450
+seed7/lib/bigfile.s7i        0.041220            136
+seed7/lib/bigint.s7i         0.076882            824
+seed7/lib/bigrat.s7i         0.078862            784
+seed7/lib/bin16.s7i          0.066651            592
+seed7/lib/bin32.s7i          0.060182            490
+seed7/lib/bin64.s7i          0.061924            539
+seed7/lib/bitdata.s7i        0.121633           1330
+seed7/lib/bitmapfont.s7i     0.046958            215
+seed7/lib/bitset.s7i         0.063054            593
+seed7/lib/bitsetof.s7i       0.060382            431
+seed7/lib/blowfish.s7i       0.077545            383
+seed7/lib/bmp.s7i            0.098855            924
+seed7/lib/boolean.s7i        0.054513            403
+seed7/lib/browser.s7i        0.052416            280
+seed7/lib/bstring.s7i        0.048244            227
+seed7/lib/bytedata.s7i       0.065534            482
+seed7/lib/bzip2.s7i          0.087375            887
+seed7/lib/cards.s7i          0.101083           1342
+seed7/lib/category.s7i       0.048543            209
+seed7/lib/cc_conf.s7i        0.117400           1314
+seed7/lib/ccittfax.s7i       0.099260           1022
+seed7/lib/cgi.s7i            0.041108            109
+seed7/lib/cgidialog.s7i      0.095458           1118
+seed7/lib/char.s7i           0.050371            356
+seed7/lib/charsets.s7i       0.123951           2024
+seed7/lib/chartype.s7i       0.047754            121
+seed7/lib/cipher.s7i         0.041256            146
+seed7/lib/cli_cmds.s7i       0.111095           1360
+seed7/lib/clib_file.s7i      0.050827            301
+seed7/lib/color.s7i          0.045961            185
+seed7/lib/complex.s7i        0.058776            464
+seed7/lib/compress.s7i       0.042711            150
+seed7/lib/console.s7i        0.044680            188
+seed7/lib/cpio.s7i           0.141742           1708
+seed7/lib/crc32.s7i          0.052645            193
+seed7/lib/cronos16.s7i       0.190471           1173
+seed7/lib/cronos27.s7i       0.254153           1464
+seed7/lib/csv.s7i            0.047503            201
+seed7/lib/db_prop.s7i        0.099513            991
+seed7/lib/deflate.s7i        0.085213            740
+seed7/lib/des.s7i            0.079415            444
+seed7/lib/dialog.s7i         0.056829            311
+seed7/lib/dir.s7i            0.043008            163
+seed7/lib/draw.s7i           0.083215            854
+seed7/lib/duration.s7i       0.095440           1038
+seed7/lib/echo.s7i           0.042056            132
+seed7/lib/editline.s7i       0.059100            398
+seed7/lib/elf.s7i            0.151560           1560
+seed7/lib/elliptic.s7i       0.075563            649
+seed7/lib/enable_io.s7i      0.052713            312
+seed7/lib/encoding.s7i       0.096619            931
+seed7/lib/enumeration.s7i    0.049233            236
+seed7/lib/environment.s7i    0.043515            175
+seed7/lib/exif.s7i           0.045009            152
+seed7/lib/external_file.s7i  0.050999            340
+seed7/lib/field.s7i          0.050750            268
+seed7/lib/file.s7i           0.054964            372
+seed7/lib/filebits.s7i       0.037939             46
+seed7/lib/filesys.s7i        0.064352            601
+seed7/lib/fileutil.s7i       0.042701            144
+seed7/lib/fixarray.s7i       0.052889            307
+seed7/lib/float.s7i          0.072896            757
+seed7/lib/font.s7i           0.044060            196
+seed7/lib/font8x8.s7i        0.065847            998
+seed7/lib/forloop.s7i        0.062727            449
+seed7/lib/ftp.s7i            0.087640            969
+seed7/lib/ftpserv.s7i        0.076497            631
+seed7/lib/getf.s7i           0.042699            115
+seed7/lib/gethttp.s7i        0.037562             41
+seed7/lib/gethttps.s7i       0.036489             41
+seed7/lib/gif.s7i            0.069380            561
+seed7/lib/graph.s7i          0.063937            415
+seed7/lib/graph_file.s7i     0.059169            399
+seed7/lib/gtkserver.s7i      0.041190            161
+seed7/lib/gzip.s7i           0.067471            573
+seed7/lib/hash.s7i           0.064103            421
+seed7/lib/hashsetof.s7i      0.064130            499
+seed7/lib/hmac.s7i           0.043510            152
+seed7/lib/html.s7i           0.037969             83
+seed7/lib/html_ent.s7i       0.062570            476
+seed7/lib/htmldom.s7i        0.051590            286
+seed7/lib/http_request.s7i   0.076140            696
+seed7/lib/http_srv_resp.s7i  0.058214            380
+seed7/lib/https_request.s7i  0.047522            211
+seed7/lib/httpserv.s7i       0.054840            345
+seed7/lib/huffman.s7i        0.074562            644
+seed7/lib/ico.s7i            0.057581            221
+seed7/lib/idxarray.s7i       0.059197            232
+seed7/lib/image.s7i          0.042162            156
+seed7/lib/imagefile.s7i      0.044012            171
+seed7/lib/inflate.s7i        0.062592            411
+seed7/lib/inifile.s7i        0.042011            129
+seed7/lib/integer.s7i        0.067093            663
+seed7/lib/iobuffer.s7i       0.049993            289
+seed7/lib/jpeg.s7i           0.153435           1761
+seed7/lib/json.s7i           0.079251            891
+seed7/lib/json_serde.s7i     0.077662            783
+seed7/lib/keybd.s7i          0.078258            639
+seed7/lib/keydescr.s7i       0.049240            192
+seed7/lib/leb128.s7i         0.065746            218
+seed7/lib/line.s7i           0.050535            164
+seed7/lib/listener.s7i       0.050210            247
+seed7/lib/logfile.s7i        0.039620             73
+seed7/lib/lower.s7i          0.042177            142
+seed7/lib/lzma.s7i           0.106792            934
+seed7/lib/lzw.s7i            0.088251            861
+seed7/lib/magic.s7i          0.063678            403
+seed7/lib/mahjng32.s7i       0.092432           1500
+seed7/lib/make.s7i           0.068938            544
+seed7/lib/makedata.s7i       0.120896           1428
+seed7/lib/math.s7i           0.045164            201
+seed7/lib/mixarith.s7i       0.046599            249
+seed7/lib/modern27.s7i       0.168401           1099
+seed7/lib/more.s7i           0.041915            130
+seed7/lib/msgdigest.s7i      0.136405           1222
+seed7/lib/multiscr.s7i       0.039325             68
+seed7/lib/null_file.s7i      0.051238            345
+seed7/lib/osfiles.s7i        0.094658           1085
+seed7/lib/pbm.s7i            0.048478            230
+seed7/lib/pcx.s7i            0.076947            638
+seed7/lib/pem.s7i            0.044900            185
+seed7/lib/pgm.s7i            0.048688            238
+seed7/lib/pic16.s7i          0.066669           1037
+seed7/lib/pic32.s7i          0.121261           2060
+seed7/lib/pic_util.s7i       0.043914            144
+seed7/lib/pixelimage.s7i     0.052745            320
+seed7/lib/pixmap_file.s7i    0.062157            459
+seed7/lib/pixmapfont.s7i     0.046750            184
+seed7/lib/pkcs1.s7i          0.075587            543
+seed7/lib/png.s7i            0.105412           1064
+seed7/lib/poll.s7i           0.050894            313
+seed7/lib/ppm.s7i            0.049881            240
+seed7/lib/process.s7i        0.064272            541
+seed7/lib/progs.s7i          0.079283            789
+seed7/lib/propertyfile.s7i   0.044501            155
+seed7/lib/rational.s7i       0.078746            792
+seed7/lib/ref_list.s7i       0.048813            252
+seed7/lib/reference.s7i      0.042176            126
+seed7/lib/reverse.s7i        0.039444             94
+seed7/lib/rpm.s7i            0.284843           3487
+seed7/lib/rpmext.s7i         0.052847            318
+seed7/lib/scanfile.s7i       0.131237           1779
+seed7/lib/scanjson.s7i       0.059470            413
+seed7/lib/scanstri.s7i       0.135627           1814
+seed7/lib/scantoml.s7i       0.130556           1603
+seed7/lib/seed7_05.s7i       0.110852           1072
+seed7/lib/set.s7i            0.038363             57
+seed7/lib/shell.s7i          0.068785            615
+seed7/lib/showtls.s7i        0.085161            678
+seed7/lib/signature.s7i      0.043009            131
+seed7/lib/smtp.s7i           0.048649            261
+seed7/lib/sockbase.s7i       0.050258            217
+seed7/lib/socket.s7i         0.052701            326
+seed7/lib/sokoban1.s7i       0.080815           1519
+seed7/lib/sql_base.s7i       0.093206           1000
+seed7/lib/stars.s7i          0.231514           1705
+seed7/lib/stdfont10.s7i      0.143193           3347
+seed7/lib/stdfont12.s7i      0.164822           3928
+seed7/lib/stdfont14.s7i      0.187831           4510
+seed7/lib/stdfont16.s7i      0.211072           5092
+seed7/lib/stdfont18.s7i      0.242551           5868
+seed7/lib/stdfont20.s7i      0.270513           6449
+seed7/lib/stdfont24.s7i      0.329902           7421
+seed7/lib/stdfont8.s7i       0.126798           2960
+seed7/lib/stdfont9.s7i       0.133192           3152
+seed7/lib/stdio.s7i          0.044616            192
+seed7/lib/strifile.s7i       0.052832            345
+seed7/lib/string.s7i         0.075104            779
+seed7/lib/stritext.s7i       0.053078            352
+seed7/lib/struct.s7i         0.053289            266
+seed7/lib/struct_elem.s7i    0.042227            129
+seed7/lib/subfile.s7i        0.043928            174
+seed7/lib/subrange.s7i       0.039424             78
+seed7/lib/syntax.s7i         0.060524            294
+seed7/lib/tar.s7i            0.145160           1880
+seed7/lib/tar_cmds.s7i       0.085043            752
+seed7/lib/tdes.s7i           0.044124            143
+seed7/lib/tee.s7i            0.042451            143
+seed7/lib/text.s7i           0.042778            135
+seed7/lib/tga.s7i            0.080166            676
+seed7/lib/tiff.s7i           0.242590           2771
+seed7/lib/time.s7i           0.099873           1191
+seed7/lib/tls.s7i            0.193961           2230
+seed7/lib/unicode.s7i        0.073624            575
+seed7/lib/unionfnd.s7i       0.043079            130
+seed7/lib/upper.s7i          0.042040            142
+seed7/lib/utf16.s7i          0.065467            540
+seed7/lib/utf8.s7i           0.047773            234
+seed7/lib/vecfont10.s7i      0.159408           1056
+seed7/lib/vecfont18.s7i      0.177591           1119
+seed7/lib/vector3d.s7i       0.050203            293
+seed7/lib/vectorfont.s7i     0.048896            239
+seed7/lib/wildcard.s7i       0.043074            140
+seed7/lib/window.s7i         0.058933            455
+seed7/lib/wrinum.s7i         0.047984            248
+seed7/lib/x509cert.s7i       0.115833           1243
+seed7/lib/xml_ent.s7i        0.040008             94
+seed7/lib/xmldom.s7i         0.052229            303
+seed7/lib/xz.s7i             0.062992            442
+seed7/lib/zip.s7i            0.230941           2792
+seed7/lib/zstd.s7i           0.117486           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.157734        |
++-----------+-----------------+
+| Minimum   | 0.036010        |
++-----------+-----------------+
+| Maximum   | 5.534053        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033834        | 0.032413        | 0.040304        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039011        | 0.035564        | 0.046597        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.088926        | 0.034377        | 2.502998        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.157734        | 0.036010        | 5.534053        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.291 | 00:00:57.635 | 00:01:09.927 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.987 | 00:01:06.523 | 00:01:21.510 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:35.859 | 00:02:32.383 | 00:03:08.243 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:00.881 | 00:04:29.602 | 00:05:30.483 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:10.171 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-16.1.rst
+++ b/reports/seed7mode-perf-16.1.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-29T20:02:33+0000 W27-1
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 16:13:36 local time
+:Generated on: 2026-06-29 20:24:51 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 211x95 chars
+:Window body: 211x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.033556            190
+seed7/prg/bas7.sd7           0.033565          11459
+seed7/prg/bifurk.sd7         0.032907             73
+seed7/prg/bigfiles.sd7       0.032698            129
+seed7/prg/brainf7.sd7        0.033531             86
+seed7/prg/calc7.sd7          0.032841            128
+seed7/prg/carddemo.sd7       0.033102            190
+seed7/prg/castle.sd7         0.035247           3148
+seed7/prg/cat.sd7            0.039638             82
+seed7/prg/cellauto.sd7       0.036653             85
+seed7/prg/celsius.sd7        0.033253             42
+seed7/prg/chk_all.sd7        0.033407            843
+seed7/prg/chkarr.sd7         0.033703           8367
+seed7/prg/chkbig.sd7         0.037345          29026
+seed7/prg/chkbin.sd7         0.033936           6469
+seed7/prg/chkbitdata.sd7     0.033600           6624
+seed7/prg/chkbool.sd7        0.033177           3157
+seed7/prg/chkbst.sd7         0.033389            722
+seed7/prg/chkchr.sd7         0.033274           2809
+seed7/prg/chkcmd.sd7         0.032831           1205
+seed7/prg/chkdb.sd7          0.033907           7454
+seed7/prg/chkdecl.sd7        0.032895            448
+seed7/prg/chkenum.sd7        0.032996           1230
+seed7/prg/chkerr.sd7         0.033245           4663
+seed7/prg/chkexc.sd7         0.032685           2627
+seed7/prg/chkfil.sd7         0.033227           1615
+seed7/prg/chkflt.sd7         0.036961          20620
+seed7/prg/chkhent.sd7        0.035521             54
+seed7/prg/chkhsh.sd7         0.035750           4548
+seed7/prg/chkidx.sd7         0.038878          19567
+seed7/prg/chkint.sd7         0.043345          38129
+seed7/prg/chkjson.sd7        0.035717           1764
+seed7/prg/chkovf.sd7         0.034432           8216
+seed7/prg/chkprc.sd7         0.033634          10111
+seed7/prg/chkscan.sd7        0.032801            714
+seed7/prg/chkset.sd7         0.034304          11974
+seed7/prg/chkstr.sd7         0.037204          26952
+seed7/prg/chktime.sd7        0.033633           2025
+seed7/prg/chktoml.sd7        0.034968           1656
+seed7/prg/clock.sd7          0.032603             47
+seed7/prg/clock2.sd7         0.033120             43
+seed7/prg/clock3.sd7         0.033302             95
+seed7/prg/cmpfil.sd7         0.032940             84
+seed7/prg/comanche.sd7       0.032921            180
+seed7/prg/confval.sd7        0.032947            175
+seed7/prg/db7.sd7            0.032950            417
+seed7/prg/diff7.sd7          0.033381            263
+seed7/prg/dirtst.sd7         0.033741             42
+seed7/prg/dirx.sd7           0.032894            152
+seed7/prg/dnafight.sd7       0.032966           1381
+seed7/prg/dragon.sd7         0.033034             73
+seed7/prg/echo.sd7           0.033102             39
+seed7/prg/eliza.sd7          0.032952            302
+seed7/prg/err.sd7            0.032867             96
+seed7/prg/fannkuch.sd7       0.032722            131
+seed7/prg/fib.sd7            0.032245             47
+seed7/prg/find7.sd7          0.032030            133
+seed7/prg/findchar.sd7       0.032283            149
+seed7/prg/fractree.sd7       0.032964             55
+seed7/prg/ftp7.sd7           0.032165            296
+seed7/prg/ftpserv.sd7        0.032387             74
+seed7/prg/gcd.sd7            0.033685            109
+seed7/prg/gkbd.sd7           0.033194            358
+seed7/prg/gtksvtst.sd7       0.033167             94
+seed7/prg/hal.sd7            0.033443            250
+seed7/prg/hamu.sd7           0.032852            573
+seed7/prg/hanoi.sd7          0.033276             55
+seed7/prg/hd.sd7             0.038877             79
+seed7/prg/hello.sd7          0.034560             32
+seed7/prg/hilbert.sd7        0.034197            108
+seed7/prg/ide7.sd7           0.033148            196
+seed7/prg/kbd.sd7            0.032883             49
+seed7/prg/klondike.sd7       0.034889            883
+seed7/prg/lander.sd7         0.033418           1551
+seed7/prg/lst80bas.sd7       0.035040            344
+seed7/prg/lst99bas.sd7       0.036568            401
+seed7/prg/lstgwbas.sd7       0.036592            577
+seed7/prg/mahjong.sd7        0.034221           1943
+seed7/prg/make7.sd7          0.033170            121
+seed7/prg/mandelbr.sd7       0.032923            237
+seed7/prg/mind.sd7           0.033068            443
+seed7/prg/mirror.sd7         0.033225            131
+seed7/prg/ms.sd7             0.033307            641
+seed7/prg/nicoma.sd7         0.032866            135
+seed7/prg/pac.sd7            0.032845            726
+seed7/prg/pairs.sd7          0.032992           2025
+seed7/prg/panic.sd7          0.032708           2634
+seed7/prg/percolation.sd7    0.033220            330
+seed7/prg/planets.sd7        0.032544           1486
+seed7/prg/portfwd7.sd7       0.033093            139
+seed7/prg/prime.sd7          0.032752             74
+seed7/prg/printpi1.sd7       0.036280             56
+seed7/prg/printpi2.sd7       0.033914             54
+seed7/prg/printpi3.sd7       0.033824             60
+seed7/prg/pv7.sd7            0.032872            337
+seed7/prg/queen.sd7          0.033149            149
+seed7/prg/rand.sd7           0.033109            121
+seed7/prg/raytrace.sd7       0.033259            538
+seed7/prg/rever.sd7          0.032937            816
+seed7/prg/roman.sd7          0.033120             38
+seed7/prg/s7c.sd7            0.033123           9060
+seed7/prg/s7check.sd7        0.033026             68
+seed7/prg/savehd7.sd7        0.032885           1110
+seed7/prg/self.sd7           0.033134             49
+seed7/prg/shisen.sd7         0.033012           1423
+seed7/prg/sl.sd7             0.033002           1029
+seed7/prg/snake.sd7          0.032946            615
+seed7/prg/sokoban.sd7        0.033373            891
+seed7/prg/spigotpi.sd7       0.033023             64
+seed7/prg/sql7.sd7           0.033552            278
+seed7/prg/startrek.sd7       0.033226            979
+seed7/prg/sudoku7.sd7        0.032923           2657
+seed7/prg/sydir7.sd7         0.032754            384
+seed7/prg/syntaxhl.sd7       0.033272            177
+seed7/prg/tak.sd7            0.032715             59
+seed7/prg/tar7.sd7           0.032767            121
+seed7/prg/tch.sd7            0.032879             55
+seed7/prg/testfont.sd7       0.032927             95
+seed7/prg/tet.sd7            0.032901            479
+seed7/prg/tetg.sd7           0.032237            501
+seed7/prg/toutf8.sd7         0.032417            240
+seed7/prg/tst_cli.sd7        0.033383             40
+seed7/prg/tst_srv.sd7        0.032646             47
+seed7/prg/wator.sd7          0.032486            651
+seed7/prg/which.sd7          0.033555             65
+seed7/prg/wiz.sd7            0.033244           2833
+seed7/prg/wordcnt.sd7        0.032935             54
+seed7/prg/wrinum.sd7         0.032905             43
+seed7/prg/wumpus.sd7         0.033048            372
+seed7/lib/aes.s7i            0.033362           1144
+seed7/lib/aes_gcm.s7i        0.033457            392
+seed7/lib/ar.s7i             0.032947           1532
+seed7/lib/arc4.s7i           0.032389            144
+seed7/lib/archive.s7i        0.033085            143
+seed7/lib/archive_base.s7i   0.033754            135
+seed7/lib/array.s7i          0.033065            610
+seed7/lib/asn1.s7i           0.033295            544
+seed7/lib/asn1oid.s7i        0.033067            157
+seed7/lib/basearray.s7i      0.033196            450
+seed7/lib/bigfile.s7i        0.032728            136
+seed7/lib/bigint.s7i         0.032893            824
+seed7/lib/bigrat.s7i         0.033005            784
+seed7/lib/bin16.s7i          0.032752            592
+seed7/lib/bin32.s7i          0.032900            490
+seed7/lib/bin64.s7i          0.033022            539
+seed7/lib/bitdata.s7i        0.033012           1330
+seed7/lib/bitmapfont.s7i     0.032792            215
+seed7/lib/bitset.s7i         0.032805            593
+seed7/lib/bitsetof.s7i       0.033354            431
+seed7/lib/blowfish.s7i       0.033006            383
+seed7/lib/bmp.s7i            0.033283            924
+seed7/lib/boolean.s7i        0.032859            403
+seed7/lib/browser.s7i        0.033057            280
+seed7/lib/bstring.s7i        0.032341            227
+seed7/lib/bytedata.s7i       0.032716            482
+seed7/lib/bzip2.s7i          0.032494            887
+seed7/lib/cards.s7i          0.033014           1342
+seed7/lib/category.s7i       0.035732            209
+seed7/lib/cc_conf.s7i        0.032986           1314
+seed7/lib/ccittfax.s7i       0.032964           1022
+seed7/lib/cgi.s7i            0.033097            109
+seed7/lib/cgidialog.s7i      0.033779           1118
+seed7/lib/char.s7i           0.033188            356
+seed7/lib/charsets.s7i       0.033607           2024
+seed7/lib/chartype.s7i       0.033701            121
+seed7/lib/cipher.s7i         0.033080            146
+seed7/lib/cli_cmds.s7i       0.033176           1360
+seed7/lib/clib_file.s7i      0.033280            301
+seed7/lib/color.s7i          0.033074            185
+seed7/lib/complex.s7i        0.032737            464
+seed7/lib/compress.s7i       0.033040            150
+seed7/lib/console.s7i        0.033048            188
+seed7/lib/cpio.s7i           0.033069           1708
+seed7/lib/crc32.s7i          0.033180            193
+seed7/lib/cronos16.s7i       0.033444           1173
+seed7/lib/cronos27.s7i       0.033506           1464
+seed7/lib/csv.s7i            0.033049            201
+seed7/lib/db_prop.s7i        0.033701            991
+seed7/lib/deflate.s7i        0.033456            740
+seed7/lib/des.s7i            0.033057            444
+seed7/lib/dialog.s7i         0.033189            311
+seed7/lib/dir.s7i            0.035684            163
+seed7/lib/draw.s7i           0.041376            854
+seed7/lib/duration.s7i       0.038299           1038
+seed7/lib/echo.s7i           0.038388            132
+seed7/lib/editline.s7i       0.036940            398
+seed7/lib/elf.s7i            0.037191           1560
+seed7/lib/elliptic.s7i       0.037702            649
+seed7/lib/enable_io.s7i      0.042259            312
+seed7/lib/encoding.s7i       0.037825            931
+seed7/lib/enumeration.s7i    0.038998            236
+seed7/lib/environment.s7i    0.037459            175
+seed7/lib/exif.s7i           0.038399            152
+seed7/lib/external_file.s7i  0.033223            340
+seed7/lib/field.s7i          0.034880            268
+seed7/lib/file.s7i           0.034597            372
+seed7/lib/filebits.s7i       0.032931             46
+seed7/lib/filesys.s7i        0.036363            601
+seed7/lib/fileutil.s7i       0.034686            144
+seed7/lib/fixarray.s7i       0.034599            307
+seed7/lib/float.s7i          0.033658            757
+seed7/lib/font.s7i           0.032838            196
+seed7/lib/font8x8.s7i        0.038842            998
+seed7/lib/forloop.s7i        0.039592            449
+seed7/lib/ftp.s7i            0.038400            969
+seed7/lib/ftpserv.s7i        0.036322            631
+seed7/lib/getf.s7i           0.033836            115
+seed7/lib/gethttp.s7i        0.036145             41
+seed7/lib/gethttps.s7i       0.038576             41
+seed7/lib/gif.s7i            0.038064            561
+seed7/lib/graph.s7i          0.041124            415
+seed7/lib/graph_file.s7i     0.043508            399
+seed7/lib/gtkserver.s7i      0.040651            161
+seed7/lib/gzip.s7i           0.039922            573
+seed7/lib/hash.s7i           0.037487            421
+seed7/lib/hashsetof.s7i      0.037789            499
+seed7/lib/hmac.s7i           0.036342            152
+seed7/lib/html.s7i           0.036590             83
+seed7/lib/html_ent.s7i       0.036653            476
+seed7/lib/htmldom.s7i        0.039326            286
+seed7/lib/http_request.s7i   0.039746            696
+seed7/lib/http_srv_resp.s7i  0.039972            380
+seed7/lib/https_request.s7i  0.039977            211
+seed7/lib/httpserv.s7i       0.036040            345
+seed7/lib/huffman.s7i        0.034876            644
+seed7/lib/ico.s7i            0.035978            221
+seed7/lib/idxarray.s7i       0.037255            232
+seed7/lib/image.s7i          0.039056            156
+seed7/lib/imagefile.s7i      0.036910            171
+seed7/lib/inflate.s7i        0.039605            411
+seed7/lib/inifile.s7i        0.040247            129
+seed7/lib/integer.s7i        0.039182            663
+seed7/lib/iobuffer.s7i       0.035917            289
+seed7/lib/jpeg.s7i           0.037371           1761
+seed7/lib/json.s7i           0.037810            891
+seed7/lib/json_serde.s7i     0.039943            783
+seed7/lib/keybd.s7i          0.041017            639
+seed7/lib/keydescr.s7i       0.035202            192
+seed7/lib/leb128.s7i         0.036496            218
+seed7/lib/line.s7i           0.036272            164
+seed7/lib/listener.s7i       0.035280            247
+seed7/lib/logfile.s7i        0.034634             73
+seed7/lib/lower.s7i          0.033538            142
+seed7/lib/lzma.s7i           0.033138            934
+seed7/lib/lzw.s7i            0.032304            861
+seed7/lib/magic.s7i          0.036297            403
+seed7/lib/mahjng32.s7i       0.036287           1500
+seed7/lib/make.s7i           0.034936            544
+seed7/lib/makedata.s7i       0.035972           1428
+seed7/lib/math.s7i           0.037438            201
+seed7/lib/mixarith.s7i       0.040915            249
+seed7/lib/modern27.s7i       0.040293           1099
+seed7/lib/more.s7i           0.037177            130
+seed7/lib/msgdigest.s7i      0.038220           1222
+seed7/lib/multiscr.s7i       0.033874             68
+seed7/lib/null_file.s7i      0.036120            345
+seed7/lib/osfiles.s7i        0.035514           1085
+seed7/lib/pbm.s7i            0.032988            230
+seed7/lib/pcx.s7i            0.033945            638
+seed7/lib/pem.s7i            0.033185            185
+seed7/lib/pgm.s7i            0.033000            238
+seed7/lib/pic16.s7i          0.034918           1037
+seed7/lib/pic32.s7i          0.035460           2060
+seed7/lib/pic_util.s7i       0.038118            144
+seed7/lib/pixelimage.s7i     0.038288            320
+seed7/lib/pixmap_file.s7i    0.033868            459
+seed7/lib/pixmapfont.s7i     0.032808            184
+seed7/lib/pkcs1.s7i          0.032746            543
+seed7/lib/png.s7i            0.034797           1064
+seed7/lib/poll.s7i           0.036984            313
+seed7/lib/ppm.s7i            0.034411            240
+seed7/lib/process.s7i        0.033157            541
+seed7/lib/progs.s7i          0.037727            789
+seed7/lib/propertyfile.s7i   0.039286            155
+seed7/lib/rational.s7i       0.039056            792
+seed7/lib/ref_list.s7i       0.039765            252
+seed7/lib/reference.s7i      0.039572            126
+seed7/lib/reverse.s7i        0.040640             94
+seed7/lib/rpm.s7i            0.041080           3487
+seed7/lib/rpmext.s7i         0.041114            318
+seed7/lib/scanfile.s7i       0.040919           1779
+seed7/lib/scanjson.s7i       0.040592            413
+seed7/lib/scanstri.s7i       0.037722           1814
+seed7/lib/scantoml.s7i       0.033015           1603
+seed7/lib/seed7_05.s7i       0.034525           1072
+seed7/lib/set.s7i            0.034420             57
+seed7/lib/shell.s7i          0.035128            615
+seed7/lib/showtls.s7i        0.033196            678
+seed7/lib/signature.s7i      0.033003            131
+seed7/lib/smtp.s7i           0.032866            261
+seed7/lib/sockbase.s7i       0.032772            217
+seed7/lib/socket.s7i         0.034927            326
+seed7/lib/sokoban1.s7i       0.033149           1519
+seed7/lib/sql_base.s7i       0.033013           1000
+seed7/lib/stars.s7i          0.033045           1705
+seed7/lib/stdfont10.s7i      0.032884           3347
+seed7/lib/stdfont12.s7i      0.032956           3928
+seed7/lib/stdfont14.s7i      0.032871           4510
+seed7/lib/stdfont16.s7i      0.033748           5092
+seed7/lib/stdfont18.s7i      0.033848           5868
+seed7/lib/stdfont20.s7i      0.033029           6449
+seed7/lib/stdfont24.s7i      0.033900           7421
+seed7/lib/stdfont8.s7i       0.032446           2960
+seed7/lib/stdfont9.s7i       0.032237           3152
+seed7/lib/stdio.s7i          0.032780            192
+seed7/lib/strifile.s7i       0.034861            345
+seed7/lib/string.s7i         0.032941            779
+seed7/lib/stritext.s7i       0.033059            352
+seed7/lib/struct.s7i         0.033557            266
+seed7/lib/struct_elem.s7i    0.039512            129
+seed7/lib/subfile.s7i        0.034219            174
+seed7/lib/subrange.s7i       0.034226             78
+seed7/lib/syntax.s7i         0.035181            294
+seed7/lib/tar.s7i            0.033849           1880
+seed7/lib/tar_cmds.s7i       0.032954            752
+seed7/lib/tdes.s7i           0.033375            143
+seed7/lib/tee.s7i            0.033061            143
+seed7/lib/text.s7i           0.032546            135
+seed7/lib/tga.s7i            0.033353            676
+seed7/lib/tiff.s7i           0.033286           2771
+seed7/lib/time.s7i           0.033034           1191
+seed7/lib/tls.s7i            0.033265           2230
+seed7/lib/unicode.s7i        0.032953            575
+seed7/lib/unionfnd.s7i       0.033027            130
+seed7/lib/upper.s7i          0.036366            142
+seed7/lib/utf16.s7i          0.038523            540
+seed7/lib/utf8.s7i           0.034014            234
+seed7/lib/vecfont10.s7i      0.036808           1056
+seed7/lib/vecfont18.s7i      0.040326           1119
+seed7/lib/vector3d.s7i       0.039168            293
+seed7/lib/vectorfont.s7i     0.032954            239
+seed7/lib/wildcard.s7i       0.032718            140
+seed7/lib/window.s7i         0.032927            455
+seed7/lib/wrinum.s7i         0.033848            248
+seed7/lib/x509cert.s7i       0.035682           1243
+seed7/lib/xml_ent.s7i        0.033531             94
+seed7/lib/xmldom.s7i         0.033848            303
+seed7/lib/xz.s7i             0.033002            442
+seed7/lib/zip.s7i            0.035279           2792
+seed7/lib/zstd.s7i           0.040179           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.034692        |
++-----------+-----------------+
+| Minimum   | 0.032030        |
++-----------+-----------------+
+| Maximum   | 0.043508        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.038963            190
+seed7/prg/bas7.sd7           0.040877          11459
+seed7/prg/bifurk.sd7         0.036077             73
+seed7/prg/bigfiles.sd7       0.037922            129
+seed7/prg/brainf7.sd7        0.037430             86
+seed7/prg/calc7.sd7          0.037518            128
+seed7/prg/carddemo.sd7       0.038945            190
+seed7/prg/castle.sd7         0.038674           3148
+seed7/prg/cat.sd7            0.037375             82
+seed7/prg/cellauto.sd7       0.036754             85
+seed7/prg/celsius.sd7        0.035301             42
+seed7/prg/chk_all.sd7        0.038713            843
+seed7/prg/chkarr.sd7         0.039034           8367
+seed7/prg/chkbig.sd7         0.044295          29026
+seed7/prg/chkbin.sd7         0.039503           6469
+seed7/prg/chkbitdata.sd7     0.039842           6624
+seed7/prg/chkbool.sd7        0.038432           3157
+seed7/prg/chkbst.sd7         0.038925            722
+seed7/prg/chkchr.sd7         0.039891           2809
+seed7/prg/chkcmd.sd7         0.038394           1205
+seed7/prg/chkdb.sd7          0.039108           7454
+seed7/prg/chkdecl.sd7        0.037843            448
+seed7/prg/chkenum.sd7        0.037906           1230
+seed7/prg/chkerr.sd7         0.038488           4663
+seed7/prg/chkexc.sd7         0.037381           2627
+seed7/prg/chkfil.sd7         0.040860           1615
+seed7/prg/chkflt.sd7         0.044387          20620
+seed7/prg/chkhent.sd7        0.035937             54
+seed7/prg/chkhsh.sd7         0.040255           4548
+seed7/prg/chkidx.sd7         0.041254          19567
+seed7/prg/chkint.sd7         0.046037          38129
+seed7/prg/chkjson.sd7        0.038659           1764
+seed7/prg/chkovf.sd7         0.038920           8216
+seed7/prg/chkprc.sd7         0.037541          10111
+seed7/prg/chkscan.sd7        0.038893            714
+seed7/prg/chkset.sd7         0.039874          11974
+seed7/prg/chkstr.sd7         0.043193          26952
+seed7/prg/chktime.sd7        0.039606           2025
+seed7/prg/chktoml.sd7        0.038310           1656
+seed7/prg/clock.sd7          0.035246             47
+seed7/prg/clock2.sd7         0.035489             43
+seed7/prg/clock3.sd7         0.038382             95
+seed7/prg/cmpfil.sd7         0.036128             84
+seed7/prg/comanche.sd7       0.038458            180
+seed7/prg/confval.sd7        0.039817            175
+seed7/prg/db7.sd7            0.038426            417
+seed7/prg/diff7.sd7          0.041326            263
+seed7/prg/dirtst.sd7         0.039986             42
+seed7/prg/dirx.sd7           0.045232            152
+seed7/prg/dnafight.sd7       0.045794           1381
+seed7/prg/dragon.sd7         0.043775             73
+seed7/prg/echo.sd7           0.043081             39
+seed7/prg/eliza.sd7          0.045477            302
+seed7/prg/err.sd7            0.041724             96
+seed7/prg/fannkuch.sd7       0.038982            131
+seed7/prg/fib.sd7            0.044230             47
+seed7/prg/find7.sd7          0.045337            133
+seed7/prg/findchar.sd7       0.046694            149
+seed7/prg/fractree.sd7       0.041293             55
+seed7/prg/ftp7.sd7           0.039645            296
+seed7/prg/ftpserv.sd7        0.039271             74
+seed7/prg/gcd.sd7            0.036877            109
+seed7/prg/gkbd.sd7           0.039923            358
+seed7/prg/gtksvtst.sd7       0.038878             94
+seed7/prg/hal.sd7            0.039253            250
+seed7/prg/hamu.sd7           0.042782            573
+seed7/prg/hanoi.sd7          0.036754             55
+seed7/prg/hd.sd7             0.042865             79
+seed7/prg/hello.sd7          0.042789             32
+seed7/prg/hilbert.sd7        0.040714            108
+seed7/prg/ide7.sd7           0.038461            196
+seed7/prg/kbd.sd7            0.035289             49
+seed7/prg/klondike.sd7       0.038083            883
+seed7/prg/lander.sd7         0.037929           1551
+seed7/prg/lst80bas.sd7       0.036665            344
+seed7/prg/lst99bas.sd7       0.038337            401
+seed7/prg/lstgwbas.sd7       0.038635            577
+seed7/prg/mahjong.sd7        0.039152           1943
+seed7/prg/make7.sd7          0.039075            121
+seed7/prg/mandelbr.sd7       0.038252            237
+seed7/prg/mind.sd7           0.037963            443
+seed7/prg/mirror.sd7         0.039577            131
+seed7/prg/ms.sd7             0.040445            641
+seed7/prg/nicoma.sd7         0.042567            135
+seed7/prg/pac.sd7            0.043022            726
+seed7/prg/pairs.sd7          0.042619           2025
+seed7/prg/panic.sd7          0.043814           2634
+seed7/prg/percolation.sd7    0.044086            330
+seed7/prg/planets.sd7        0.045204           1486
+seed7/prg/portfwd7.sd7       0.048937            139
+seed7/prg/prime.sd7          0.037109             74
+seed7/prg/printpi1.sd7       0.037512             56
+seed7/prg/printpi2.sd7       0.040508             54
+seed7/prg/printpi3.sd7       0.039895             60
+seed7/prg/pv7.sd7            0.043324            337
+seed7/prg/queen.sd7          0.043201            149
+seed7/prg/rand.sd7           0.042331            121
+seed7/prg/raytrace.sd7       0.043534            538
+seed7/prg/rever.sd7          0.041505            816
+seed7/prg/roman.sd7          0.036750             38
+seed7/prg/s7c.sd7            0.038588           9060
+seed7/prg/s7check.sd7        0.036931             68
+seed7/prg/savehd7.sd7        0.040180           1110
+seed7/prg/self.sd7           0.039797             49
+seed7/prg/shisen.sd7         0.040399           1423
+seed7/prg/sl.sd7             0.038705           1029
+seed7/prg/snake.sd7          0.038084            615
+seed7/prg/sokoban.sd7        0.038157            891
+seed7/prg/spigotpi.sd7       0.039266             64
+seed7/prg/sql7.sd7           0.042010            278
+seed7/prg/startrek.sd7       0.045245            979
+seed7/prg/sudoku7.sd7        0.039051           2657
+seed7/prg/sydir7.sd7         0.038082            384
+seed7/prg/syntaxhl.sd7       0.043100            177
+seed7/prg/tak.sd7            0.037762             59
+seed7/prg/tar7.sd7           0.043317            121
+seed7/prg/tch.sd7            0.037811             55
+seed7/prg/testfont.sd7       0.040062             95
+seed7/prg/tet.sd7            0.038615            479
+seed7/prg/tetg.sd7           0.038445            501
+seed7/prg/toutf8.sd7         0.041074            240
+seed7/prg/tst_cli.sd7        0.039406             40
+seed7/prg/tst_srv.sd7        0.036074             47
+seed7/prg/wator.sd7          0.038983            651
+seed7/prg/which.sd7          0.036375             65
+seed7/prg/wiz.sd7            0.037389           2833
+seed7/prg/wordcnt.sd7        0.035147             54
+seed7/prg/wrinum.sd7         0.034452             43
+seed7/prg/wumpus.sd7         0.037443            372
+seed7/lib/aes.s7i            0.040441           1144
+seed7/lib/aes_gcm.s7i        0.040886            392
+seed7/lib/ar.s7i             0.038965           1532
+seed7/lib/arc4.s7i           0.038295            144
+seed7/lib/archive.s7i        0.038036            143
+seed7/lib/archive_base.s7i   0.038326            135
+seed7/lib/array.s7i          0.038164            610
+seed7/lib/asn1.s7i           0.036690            544
+seed7/lib/asn1oid.s7i        0.042837            157
+seed7/lib/basearray.s7i      0.039188            450
+seed7/lib/bigfile.s7i        0.037991            136
+seed7/lib/bigint.s7i         0.040567            824
+seed7/lib/bigrat.s7i         0.041441            784
+seed7/lib/bin16.s7i          0.038038            592
+seed7/lib/bin32.s7i          0.038064            490
+seed7/lib/bin64.s7i          0.038342            539
+seed7/lib/bitdata.s7i        0.044587           1330
+seed7/lib/bitmapfont.s7i     0.039051            215
+seed7/lib/bitset.s7i         0.044393            593
+seed7/lib/bitsetof.s7i       0.043851            431
+seed7/lib/blowfish.s7i       0.044037            383
+seed7/lib/bmp.s7i            0.041749            924
+seed7/lib/boolean.s7i        0.039467            403
+seed7/lib/browser.s7i        0.037799            280
+seed7/lib/bstring.s7i        0.039866            227
+seed7/lib/bytedata.s7i       0.041905            482
+seed7/lib/bzip2.s7i          0.045192            887
+seed7/lib/cards.s7i          0.041536           1342
+seed7/lib/category.s7i       0.041604            209
+seed7/lib/cc_conf.s7i        0.039041           1314
+seed7/lib/ccittfax.s7i       0.038998           1022
+seed7/lib/cgi.s7i            0.037684            109
+seed7/lib/cgidialog.s7i      0.038461           1118
+seed7/lib/char.s7i           0.038080            356
+seed7/lib/charsets.s7i       0.038758           2024
+seed7/lib/chartype.s7i       0.041223            121
+seed7/lib/cipher.s7i         0.038088            146
+seed7/lib/cli_cmds.s7i       0.038500           1360
+seed7/lib/clib_file.s7i      0.037804            301
+seed7/lib/color.s7i          0.038623            185
+seed7/lib/complex.s7i        0.041180            464
+seed7/lib/compress.s7i       0.038280            150
+seed7/lib/console.s7i        0.037744            188
+seed7/lib/cpio.s7i           0.038389           1708
+seed7/lib/crc32.s7i          0.039081            193
+seed7/lib/cronos16.s7i       0.041629           1173
+seed7/lib/cronos27.s7i       0.045241           1464
+seed7/lib/csv.s7i            0.046131            201
+seed7/lib/db_prop.s7i        0.042907            991
+seed7/lib/deflate.s7i        0.038744            740
+seed7/lib/des.s7i            0.038046            444
+seed7/lib/dialog.s7i         0.038897            311
+seed7/lib/dir.s7i            0.038813            163
+seed7/lib/draw.s7i           0.039206            854
+seed7/lib/duration.s7i       0.044177           1038
+seed7/lib/echo.s7i           0.040992            132
+seed7/lib/editline.s7i       0.040755            398
+seed7/lib/elf.s7i            0.046287           1560
+seed7/lib/elliptic.s7i       0.038594            649
+seed7/lib/enable_io.s7i      0.038890            312
+seed7/lib/encoding.s7i       0.038425            931
+seed7/lib/enumeration.s7i    0.038375            236
+seed7/lib/environment.s7i    0.037396            175
+seed7/lib/exif.s7i           0.039772            152
+seed7/lib/external_file.s7i  0.037832            340
+seed7/lib/field.s7i          0.038078            268
+seed7/lib/file.s7i           0.038183            372
+seed7/lib/filebits.s7i       0.036123             46
+seed7/lib/filesys.s7i        0.037824            601
+seed7/lib/fileutil.s7i       0.038032            144
+seed7/lib/fixarray.s7i       0.039757            307
+seed7/lib/float.s7i          0.038131            757
+seed7/lib/font.s7i           0.037879            196
+seed7/lib/font8x8.s7i        0.037312            998
+seed7/lib/forloop.s7i        0.038802            449
+seed7/lib/ftp.s7i            0.037862            969
+seed7/lib/ftpserv.s7i        0.039349            631
+seed7/lib/getf.s7i           0.041788            115
+seed7/lib/gethttp.s7i        0.040696             41
+seed7/lib/gethttps.s7i       0.037543             41
+seed7/lib/gif.s7i            0.038908            561
+seed7/lib/graph.s7i          0.039866            415
+seed7/lib/graph_file.s7i     0.038437            399
+seed7/lib/gtkserver.s7i      0.037619            161
+seed7/lib/gzip.s7i           0.038494            573
+seed7/lib/hash.s7i           0.039958            421
+seed7/lib/hashsetof.s7i      0.040276            499
+seed7/lib/hmac.s7i           0.038047            152
+seed7/lib/html.s7i           0.037048             83
+seed7/lib/html_ent.s7i       0.038435            476
+seed7/lib/htmldom.s7i        0.037896            286
+seed7/lib/http_request.s7i   0.038737            696
+seed7/lib/http_srv_resp.s7i  0.039518            380
+seed7/lib/https_request.s7i  0.038032            211
+seed7/lib/httpserv.s7i       0.038019            345
+seed7/lib/huffman.s7i        0.038071            644
+seed7/lib/ico.s7i            0.038235            221
+seed7/lib/idxarray.s7i       0.038210            232
+seed7/lib/image.s7i          0.039797            156
+seed7/lib/imagefile.s7i      0.038794            171
+seed7/lib/inflate.s7i        0.039707            411
+seed7/lib/inifile.s7i        0.038332            129
+seed7/lib/integer.s7i        0.037358            663
+seed7/lib/iobuffer.s7i       0.038704            289
+seed7/lib/jpeg.s7i           0.038654           1761
+seed7/lib/json.s7i           0.038728            891
+seed7/lib/json_serde.s7i     0.039439            783
+seed7/lib/keybd.s7i          0.038497            639
+seed7/lib/keydescr.s7i       0.038633            192
+seed7/lib/leb128.s7i         0.037512            218
+seed7/lib/line.s7i           0.037546            164
+seed7/lib/listener.s7i       0.037695            247
+seed7/lib/logfile.s7i        0.036818             73
+seed7/lib/lower.s7i          0.040255            142
+seed7/lib/lzma.s7i           0.038718            934
+seed7/lib/lzw.s7i            0.040956            861
+seed7/lib/magic.s7i          0.046040            403
+seed7/lib/mahjng32.s7i       0.041244           1500
+seed7/lib/make.s7i           0.042695            544
+seed7/lib/makedata.s7i       0.040030           1428
+seed7/lib/math.s7i           0.040930            201
+seed7/lib/mixarith.s7i       0.042132            249
+seed7/lib/modern27.s7i       0.045107           1099
+seed7/lib/more.s7i           0.041877            130
+seed7/lib/msgdigest.s7i      0.039250           1222
+seed7/lib/multiscr.s7i       0.036169             68
+seed7/lib/null_file.s7i      0.037751            345
+seed7/lib/osfiles.s7i        0.039263           1085
+seed7/lib/pbm.s7i            0.038414            230
+seed7/lib/pcx.s7i            0.037591            638
+seed7/lib/pem.s7i            0.037342            185
+seed7/lib/pgm.s7i            0.041845            238
+seed7/lib/pic16.s7i          0.043980           1037
+seed7/lib/pic32.s7i          0.038139           2060
+seed7/lib/pic_util.s7i       0.040130            144
+seed7/lib/pixelimage.s7i     0.038503            320
+seed7/lib/pixmap_file.s7i    0.038105            459
+seed7/lib/pixmapfont.s7i     0.040353            184
+seed7/lib/pkcs1.s7i          0.043187            543
+seed7/lib/png.s7i            0.038804           1064
+seed7/lib/poll.s7i           0.038183            313
+seed7/lib/ppm.s7i            0.038272            240
+seed7/lib/process.s7i        0.038220            541
+seed7/lib/progs.s7i          0.038055            789
+seed7/lib/propertyfile.s7i   0.038297            155
+seed7/lib/rational.s7i       0.038462            792
+seed7/lib/ref_list.s7i       0.037952            252
+seed7/lib/reference.s7i      0.038173            126
+seed7/lib/reverse.s7i        0.037338             94
+seed7/lib/rpm.s7i            0.041552           3487
+seed7/lib/rpmext.s7i         0.043944            318
+seed7/lib/scanfile.s7i       0.042550           1779
+seed7/lib/scanjson.s7i       0.041742            413
+seed7/lib/scanstri.s7i       0.041353           1814
+seed7/lib/scantoml.s7i       0.040135           1603
+seed7/lib/seed7_05.s7i       0.039702           1072
+seed7/lib/set.s7i            0.039411             57
+seed7/lib/shell.s7i          0.043241            615
+seed7/lib/showtls.s7i        0.044382            678
+seed7/lib/signature.s7i      0.046668            131
+seed7/lib/smtp.s7i           0.042863            261
+seed7/lib/sockbase.s7i       0.043746            217
+seed7/lib/socket.s7i         0.042383            326
+seed7/lib/sokoban1.s7i       0.042565           1519
+seed7/lib/sql_base.s7i       0.042524           1000
+seed7/lib/stars.s7i          0.040993           1705
+seed7/lib/stdfont10.s7i      0.036925           3347
+seed7/lib/stdfont12.s7i      0.038584           3928
+seed7/lib/stdfont14.s7i      0.038038           4510
+seed7/lib/stdfont16.s7i      0.038796           5092
+seed7/lib/stdfont18.s7i      0.039915           5868
+seed7/lib/stdfont20.s7i      0.039539           6449
+seed7/lib/stdfont24.s7i      0.038200           7421
+seed7/lib/stdfont8.s7i       0.036697           2960
+seed7/lib/stdfont9.s7i       0.036869           3152
+seed7/lib/stdio.s7i          0.038962            192
+seed7/lib/strifile.s7i       0.039491            345
+seed7/lib/string.s7i         0.037829            779
+seed7/lib/stritext.s7i       0.039836            352
+seed7/lib/struct.s7i         0.040345            266
+seed7/lib/struct_elem.s7i    0.038230            129
+seed7/lib/subfile.s7i        0.038490            174
+seed7/lib/subrange.s7i       0.036411             78
+seed7/lib/syntax.s7i         0.038013            294
+seed7/lib/tar.s7i            0.038751           1880
+seed7/lib/tar_cmds.s7i       0.039076            752
+seed7/lib/tdes.s7i           0.038021            143
+seed7/lib/tee.s7i            0.038131            143
+seed7/lib/text.s7i           0.038128            135
+seed7/lib/tga.s7i            0.040208            676
+seed7/lib/tiff.s7i           0.040133           2771
+seed7/lib/time.s7i           0.038291           1191
+seed7/lib/tls.s7i            0.038293           2230
+seed7/lib/unicode.s7i        0.040042            575
+seed7/lib/unionfnd.s7i       0.037799            130
+seed7/lib/upper.s7i          0.042615            142
+seed7/lib/utf16.s7i          0.043276            540
+seed7/lib/utf8.s7i           0.039445            234
+seed7/lib/vecfont10.s7i      0.040847           1056
+seed7/lib/vecfont18.s7i      0.041452           1119
+seed7/lib/vector3d.s7i       0.038754            293
+seed7/lib/vectorfont.s7i     0.038239            239
+seed7/lib/wildcard.s7i       0.038261            140
+seed7/lib/window.s7i         0.038140            455
+seed7/lib/wrinum.s7i         0.038100            248
+seed7/lib/x509cert.s7i       0.038539           1243
+seed7/lib/xml_ent.s7i        0.037834             94
+seed7/lib/xmldom.s7i         0.037309            303
+seed7/lib/xz.s7i             0.038660            442
+seed7/lib/zip.s7i            0.037525           2792
+seed7/lib/zstd.s7i           0.037764           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039652        |
++-----------+-----------------+
+| Minimum   | 0.034452        |
++-----------+-----------------+
+| Maximum   | 0.048937        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.040322            190
+seed7/prg/bas7.sd7           0.334226          11459
+seed7/prg/bifurk.sd7         0.038471             73
+seed7/prg/bigfiles.sd7       0.039997            129
+seed7/prg/brainf7.sd7        0.037412             86
+seed7/prg/calc7.sd7          0.039819            128
+seed7/prg/carddemo.sd7       0.041123            190
+seed7/prg/castle.sd7         0.110600           3148
+seed7/prg/cat.sd7            0.037379             82
+seed7/prg/cellauto.sd7       0.038581             85
+seed7/prg/celsius.sd7        0.036415             42
+seed7/prg/chk_all.sd7        0.060575            843
+seed7/prg/chkarr.sd7         0.362974           8367
+seed7/prg/chkbig.sd7         2.088469          29026
+seed7/prg/chkbin.sd7         0.515330           6469
+seed7/prg/chkbitdata.sd7     0.622542           6624
+seed7/prg/chkbool.sd7        0.119621           3157
+seed7/prg/chkbst.sd7         0.066438            722
+seed7/prg/chkchr.sd7         0.226402           2809
+seed7/prg/chkcmd.sd7         0.069558           1205
+seed7/prg/chkdb.sd7          0.349846           7454
+seed7/prg/chkdecl.sd7        0.058746            448
+seed7/prg/chkenum.sd7        0.069841           1230
+seed7/prg/chkerr.sd7         0.195375           4663
+seed7/prg/chkexc.sd7         0.081779           2627
+seed7/prg/chkfil.sd7         0.074925           1615
+seed7/prg/chkflt.sd7         1.346800          20620
+seed7/prg/chkhent.sd7        0.035420             54
+seed7/prg/chkhsh.sd7         0.245926           4548
+seed7/prg/chkidx.sd7         1.340781          19567
+seed7/prg/chkint.sd7         2.573882          38129
+seed7/prg/chkjson.sd7        0.109186           1764
+seed7/prg/chkovf.sd7         0.566638           8216
+seed7/prg/chkprc.sd7         0.323634          10111
+seed7/prg/chkscan.sd7        0.061447            714
+seed7/prg/chkset.sd7         0.662534          11974
+seed7/prg/chkstr.sd7         1.441039          26952
+seed7/prg/chktime.sd7        0.136205           2025
+seed7/prg/chktoml.sd7        0.108730           1656
+seed7/prg/clock.sd7          0.035603             47
+seed7/prg/clock2.sd7         0.037470             43
+seed7/prg/clock3.sd7         0.039041             95
+seed7/prg/cmpfil.sd7         0.036244             84
+seed7/prg/comanche.sd7       0.039527            180
+seed7/prg/confval.sd7        0.041966            175
+seed7/prg/db7.sd7            0.046039            417
+seed7/prg/diff7.sd7          0.042509            263
+seed7/prg/dirtst.sd7         0.036759             42
+seed7/prg/dirx.sd7           0.037571            152
+seed7/prg/dnafight.sd7       0.065734           1381
+seed7/prg/dragon.sd7         0.035984             73
+seed7/prg/echo.sd7           0.035107             39
+seed7/prg/eliza.sd7          0.042152            302
+seed7/prg/err.sd7            0.039003             96
+seed7/prg/fannkuch.sd7       0.036831            131
+seed7/prg/fib.sd7            0.035035             47
+seed7/prg/find7.sd7          0.038011            133
+seed7/prg/findchar.sd7       0.038200            149
+seed7/prg/fractree.sd7       0.034891             55
+seed7/prg/ftp7.sd7           0.040702            296
+seed7/prg/ftpserv.sd7        0.036229             74
+seed7/prg/gcd.sd7            0.035447            109
+seed7/prg/gkbd.sd7           0.044155            358
+seed7/prg/gtksvtst.sd7       0.036218             94
+seed7/prg/hal.sd7            0.039291            250
+seed7/prg/hamu.sd7           0.047404            573
+seed7/prg/hanoi.sd7          0.035122             55
+seed7/prg/hd.sd7             0.035759             79
+seed7/prg/hello.sd7          0.034977             32
+seed7/prg/hilbert.sd7        0.036192            108
+seed7/prg/ide7.sd7           0.039324            196
+seed7/prg/kbd.sd7            0.035270             49
+seed7/prg/klondike.sd7       0.053700            883
+seed7/prg/lander.sd7         0.070858           1551
+seed7/prg/lst80bas.sd7       0.042908            344
+seed7/prg/lst99bas.sd7       0.044102            401
+seed7/prg/lstgwbas.sd7       0.049638            577
+seed7/prg/mahjong.sd7        0.079759           1943
+seed7/prg/make7.sd7          0.037400            121
+seed7/prg/mandelbr.sd7       0.040211            237
+seed7/prg/mind.sd7           0.044041            443
+seed7/prg/mirror.sd7         0.038161            131
+seed7/prg/ms.sd7             0.048270            641
+seed7/prg/nicoma.sd7         0.037226            135
+seed7/prg/pac.sd7            0.048201            726
+seed7/prg/pairs.sd7          0.080055           2025
+seed7/prg/panic.sd7          0.097547           2634
+seed7/prg/percolation.sd7    0.043685            330
+seed7/prg/planets.sd7        0.076328           1486
+seed7/prg/portfwd7.sd7       0.037776            139
+seed7/prg/prime.sd7          0.036570             74
+seed7/prg/printpi1.sd7       0.035365             56
+seed7/prg/printpi2.sd7       0.034970             54
+seed7/prg/printpi3.sd7       0.035479             60
+seed7/prg/pv7.sd7            0.043254            337
+seed7/prg/queen.sd7          0.037690            149
+seed7/prg/rand.sd7           0.036465            121
+seed7/prg/raytrace.sd7       0.047289            538
+seed7/prg/rever.sd7          0.053407            816
+seed7/prg/roman.sd7          0.034399             38
+seed7/prg/s7c.sd7            0.278603           9060
+seed7/prg/s7check.sd7        0.035547             68
+seed7/prg/savehd7.sd7        0.064447           1110
+seed7/prg/self.sd7           0.034631             49
+seed7/prg/shisen.sd7         0.069723           1423
+seed7/prg/sl.sd7             0.060067           1029
+seed7/prg/snake.sd7          0.045996            615
+seed7/prg/sokoban.sd7        0.053871            891
+seed7/prg/spigotpi.sd7       0.035253             64
+seed7/prg/sql7.sd7           0.040603            278
+seed7/prg/startrek.sd7       0.058230            979
+seed7/prg/sudoku7.sd7        0.100607           2657
+seed7/prg/sydir7.sd7         0.047478            384
+seed7/prg/syntaxhl.sd7       0.040525            177
+seed7/prg/tak.sd7            0.035107             59
+seed7/prg/tar7.sd7           0.040284            121
+seed7/prg/tch.sd7            0.042530             55
+seed7/prg/testfont.sd7       0.037163             95
+seed7/prg/tet.sd7            0.043794            479
+seed7/prg/tetg.sd7           0.044616            501
+seed7/prg/toutf8.sd7         0.041709            240
+seed7/prg/tst_cli.sd7        0.034670             40
+seed7/prg/tst_srv.sd7        0.039286             47
+seed7/prg/wator.sd7          0.059665            651
+seed7/prg/which.sd7          0.036619             65
+seed7/prg/wiz.sd7            0.102163           2833
+seed7/prg/wordcnt.sd7        0.034325             54
+seed7/prg/wrinum.sd7         0.035598             43
+seed7/prg/wumpus.sd7         0.041640            372
+seed7/lib/aes.s7i            0.108682           1144
+seed7/lib/aes_gcm.s7i        0.045177            392
+seed7/lib/ar.s7i             0.072495           1532
+seed7/lib/arc4.s7i           0.037303            144
+seed7/lib/archive.s7i        0.037642            143
+seed7/lib/archive_base.s7i   0.037838            135
+seed7/lib/array.s7i          0.052767            610
+seed7/lib/asn1.s7i           0.046604            544
+seed7/lib/asn1oid.s7i        0.041013            157
+seed7/lib/basearray.s7i      0.048437            450
+seed7/lib/bigfile.s7i        0.037290            136
+seed7/lib/bigint.s7i         0.054694            824
+seed7/lib/bigrat.s7i         0.052784            784
+seed7/lib/bin16.s7i          0.049739            592
+seed7/lib/bin32.s7i          0.046878            490
+seed7/lib/bin64.s7i          0.047991            539
+seed7/lib/bitdata.s7i        0.074547           1330
+seed7/lib/bitmapfont.s7i     0.038867            215
+seed7/lib/bitset.s7i         0.047762            593
+seed7/lib/bitsetof.s7i       0.047473            431
+seed7/lib/blowfish.s7i       0.055250            383
+seed7/lib/bmp.s7i            0.059416            924
+seed7/lib/boolean.s7i        0.043801            403
+seed7/lib/browser.s7i        0.041735            280
+seed7/lib/bstring.s7i        0.040383            227
+seed7/lib/bytedata.s7i       0.049260            482
+seed7/lib/bzip2.s7i          0.058074            887
+seed7/lib/cards.s7i          0.065717           1342
+seed7/lib/category.s7i       0.040111            209
+seed7/lib/cc_conf.s7i        0.077038           1314
+seed7/lib/ccittfax.s7i       0.064463           1022
+seed7/lib/cgi.s7i            0.036983            109
+seed7/lib/cgidialog.s7i      0.059138           1118
+seed7/lib/char.s7i           0.042366            356
+seed7/lib/charsets.s7i       0.079574           2024
+seed7/lib/chartype.s7i       0.038739            121
+seed7/lib/cipher.s7i         0.037009            146
+seed7/lib/cli_cmds.s7i       0.066295           1360
+seed7/lib/clib_file.s7i      0.042008            301
+seed7/lib/color.s7i          0.045586            185
+seed7/lib/complex.s7i        0.052213            464
+seed7/lib/compress.s7i       0.041353            150
+seed7/lib/console.s7i        0.038753            188
+seed7/lib/cpio.s7i           0.081761           1708
+seed7/lib/crc32.s7i          0.043183            193
+seed7/lib/cronos16.s7i       0.092038           1173
+seed7/lib/cronos27.s7i       0.116551           1464
+seed7/lib/csv.s7i            0.039716            201
+seed7/lib/db_prop.s7i        0.062323            991
+seed7/lib/deflate.s7i        0.054776            740
+seed7/lib/des.s7i            0.054874            444
+seed7/lib/dialog.s7i         0.042868            311
+seed7/lib/dir.s7i            0.037598            163
+seed7/lib/draw.s7i           0.055509            854
+seed7/lib/duration.s7i       0.059289           1038
+seed7/lib/echo.s7i           0.036962            132
+seed7/lib/editline.s7i       0.044547            398
+seed7/lib/elf.s7i            0.086276           1560
+seed7/lib/elliptic.s7i       0.053881            649
+seed7/lib/enable_io.s7i      0.045817            312
+seed7/lib/encoding.s7i       0.061172            931
+seed7/lib/enumeration.s7i    0.041642            236
+seed7/lib/environment.s7i    0.038509            175
+seed7/lib/exif.s7i           0.041622            152
+seed7/lib/external_file.s7i  0.047269            340
+seed7/lib/field.s7i          0.041234            268
+seed7/lib/file.s7i           0.043859            372
+seed7/lib/filebits.s7i       0.035778             46
+seed7/lib/filesys.s7i        0.048058            601
+seed7/lib/fileutil.s7i       0.037459            144
+seed7/lib/fixarray.s7i       0.042563            307
+seed7/lib/float.s7i          0.054658            757
+seed7/lib/font.s7i           0.038857            196
+seed7/lib/font8x8.s7i        0.047411            998
+seed7/lib/forloop.s7i        0.044667            449
+seed7/lib/ftp.s7i            0.056374            969
+seed7/lib/ftpserv.s7i        0.050777            631
+seed7/lib/getf.s7i           0.036485            115
+seed7/lib/gethttp.s7i        0.034781             41
+seed7/lib/gethttps.s7i       0.035605             41
+seed7/lib/gif.s7i            0.049321            561
+seed7/lib/graph.s7i          0.047992            415
+seed7/lib/graph_file.s7i     0.043699            399
+seed7/lib/gtkserver.s7i      0.037379            161
+seed7/lib/gzip.s7i           0.048281            573
+seed7/lib/hash.s7i           0.048745            421
+seed7/lib/hashsetof.s7i      0.048282            499
+seed7/lib/hmac.s7i           0.038372            152
+seed7/lib/html.s7i           0.036651             83
+seed7/lib/html_ent.s7i       0.046238            476
+seed7/lib/htmldom.s7i        0.042541            286
+seed7/lib/http_request.s7i   0.051303            696
+seed7/lib/http_srv_resp.s7i  0.044541            380
+seed7/lib/https_request.s7i  0.039420            211
+seed7/lib/httpserv.s7i       0.049678            345
+seed7/lib/huffman.s7i        0.054534            644
+seed7/lib/ico.s7i            0.040521            221
+seed7/lib/idxarray.s7i       0.041380            232
+seed7/lib/image.s7i          0.036704            156
+seed7/lib/imagefile.s7i      0.040160            171
+seed7/lib/inflate.s7i        0.046701            411
+seed7/lib/inifile.s7i        0.036695            129
+seed7/lib/integer.s7i        0.051247            663
+seed7/lib/iobuffer.s7i       0.043357            289
+seed7/lib/jpeg.s7i           0.083482           1761
+seed7/lib/json.s7i           0.055334            891
+seed7/lib/json_serde.s7i     0.052232            783
+seed7/lib/keybd.s7i          0.055129            639
+seed7/lib/keydescr.s7i       0.041046            192
+seed7/lib/leb128.s7i         0.039031            218
+seed7/lib/line.s7i           0.037983            164
+seed7/lib/listener.s7i       0.040992            247
+seed7/lib/logfile.s7i        0.035909             73
+seed7/lib/lower.s7i          0.037651            142
+seed7/lib/lzma.s7i           0.059492            934
+seed7/lib/lzw.s7i            0.058200            861
+seed7/lib/magic.s7i          0.047165            403
+seed7/lib/mahjng32.s7i       0.063887           1500
+seed7/lib/make.s7i           0.049727            544
+seed7/lib/makedata.s7i       0.068355           1428
+seed7/lib/math.s7i           0.042745            201
+seed7/lib/mixarith.s7i       0.038812            249
+seed7/lib/modern27.s7i       0.081881           1099
+seed7/lib/more.s7i           0.036658            130
+seed7/lib/msgdigest.s7i      0.081008           1222
+seed7/lib/multiscr.s7i       0.036686             68
+seed7/lib/null_file.s7i      0.041539            345
+seed7/lib/osfiles.s7i        0.067899           1085
+seed7/lib/pbm.s7i            0.045867            230
+seed7/lib/pcx.s7i            0.055015            638
+seed7/lib/pem.s7i            0.039611            185
+seed7/lib/pgm.s7i            0.040044            238
+seed7/lib/pic16.s7i          0.050227           1037
+seed7/lib/pic32.s7i          0.080631           2060
+seed7/lib/pic_util.s7i       0.037789            144
+seed7/lib/pixelimage.s7i     0.042006            320
+seed7/lib/pixmap_file.s7i    0.047540            459
+seed7/lib/pixmapfont.s7i     0.039862            184
+seed7/lib/pkcs1.s7i          0.058939            543
+seed7/lib/png.s7i            0.063557           1064
+seed7/lib/poll.s7i           0.042823            313
+seed7/lib/ppm.s7i            0.039117            240
+seed7/lib/process.s7i        0.047422            541
+seed7/lib/progs.s7i          0.055434            789
+seed7/lib/propertyfile.s7i   0.037474            155
+seed7/lib/rational.s7i       0.053567            792
+seed7/lib/ref_list.s7i       0.040953            252
+seed7/lib/reference.s7i      0.037768            126
+seed7/lib/reverse.s7i        0.036075             94
+seed7/lib/rpm.s7i            0.142877           3487
+seed7/lib/rpmext.s7i         0.052467            318
+seed7/lib/scanfile.s7i       0.079476           1779
+seed7/lib/scanjson.s7i       0.046211            413
+seed7/lib/scanstri.s7i       0.080071           1814
+seed7/lib/scantoml.s7i       0.070753           1603
+seed7/lib/seed7_05.s7i       0.065425           1072
+seed7/lib/set.s7i            0.035650             57
+seed7/lib/shell.s7i          0.052240            615
+seed7/lib/showtls.s7i        0.055769            678
+seed7/lib/signature.s7i      0.039400            131
+seed7/lib/smtp.s7i           0.039541            261
+seed7/lib/sockbase.s7i       0.041952            217
+seed7/lib/socket.s7i         0.042246            326
+seed7/lib/sokoban1.s7i       0.055563           1519
+seed7/lib/sql_base.s7i       0.068254           1000
+seed7/lib/stars.s7i          0.135421           1705
+seed7/lib/stdfont10.s7i      0.080438           3347
+seed7/lib/stdfont12.s7i      0.091522           3928
+seed7/lib/stdfont14.s7i      0.101933           4510
+seed7/lib/stdfont16.s7i      0.114551           5092
+seed7/lib/stdfont18.s7i      0.130792           5868
+seed7/lib/stdfont20.s7i      0.145012           6449
+seed7/lib/stdfont24.s7i      0.176523           7421
+seed7/lib/stdfont8.s7i       0.070728           2960
+seed7/lib/stdfont9.s7i       0.076036           3152
+seed7/lib/stdio.s7i          0.038608            192
+seed7/lib/strifile.s7i       0.042571            345
+seed7/lib/string.s7i         0.055069            779
+seed7/lib/stritext.s7i       0.042325            352
+seed7/lib/struct.s7i         0.043937            266
+seed7/lib/struct_elem.s7i    0.037155            129
+seed7/lib/subfile.s7i        0.038360            174
+seed7/lib/subrange.s7i       0.035969             78
+seed7/lib/syntax.s7i         0.045137            294
+seed7/lib/tar.s7i            0.081262           1880
+seed7/lib/tar_cmds.s7i       0.055510            752
+seed7/lib/tdes.s7i           0.038154            143
+seed7/lib/tee.s7i            0.037004            143
+seed7/lib/text.s7i           0.037125            135
+seed7/lib/tga.s7i            0.052728            676
+seed7/lib/tiff.s7i           0.120242           2771
+seed7/lib/time.s7i           0.060931           1191
+seed7/lib/tls.s7i            0.102226           2230
+seed7/lib/unicode.s7i        0.052986            575
+seed7/lib/unionfnd.s7i       0.037881            130
+seed7/lib/upper.s7i          0.037432            142
+seed7/lib/utf16.s7i          0.048707            540
+seed7/lib/utf8.s7i           0.040994            234
+seed7/lib/vecfont10.s7i      0.077882           1056
+seed7/lib/vecfont18.s7i      0.086500           1119
+seed7/lib/vector3d.s7i       0.040145            293
+seed7/lib/vectorfont.s7i     0.040395            239
+seed7/lib/wildcard.s7i       0.037306            140
+seed7/lib/window.s7i         0.044507            455
+seed7/lib/wrinum.s7i         0.040721            248
+seed7/lib/x509cert.s7i       0.070375           1243
+seed7/lib/xml_ent.s7i        0.036732             94
+seed7/lib/xmldom.s7i         0.040584            303
+seed7/lib/xz.s7i             0.045030            442
+seed7/lib/zip.s7i            0.126042           2792
+seed7/lib/zstd.s7i           0.067771           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.089476        |
++-----------+-----------------+
+| Minimum   | 0.034325        |
++-----------+-----------------+
+| Maximum   | 2.573882        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.044518            190
+seed7/prg/bas7.sd7           0.756074          11459
+seed7/prg/bifurk.sd7         0.037177             73
+seed7/prg/bigfiles.sd7       0.040351            129
+seed7/prg/brainf7.sd7        0.037314             86
+seed7/prg/calc7.sd7          0.039649            128
+seed7/prg/carddemo.sd7       0.045063            190
+seed7/prg/castle.sd7         0.209755           3148
+seed7/prg/cat.sd7            0.036877             82
+seed7/prg/cellauto.sd7       0.037063             85
+seed7/prg/celsius.sd7        0.036124             42
+seed7/prg/chk_all.sd7        0.081597            843
+seed7/prg/chkarr.sd7         0.859191           8367
+seed7/prg/chkbig.sd7         4.102016          29026
+seed7/prg/chkbin.sd7         1.029718           6469
+seed7/prg/chkbitdata.sd7     1.254468           6624
+seed7/prg/chkbool.sd7        0.229625           3157
+seed7/prg/chkbst.sd7         0.101942            722
+seed7/prg/chkchr.sd7         0.474652           2809
+seed7/prg/chkcmd.sd7         0.109558           1205
+seed7/prg/chkdb.sd7          0.758212           7454
+seed7/prg/chkdecl.sd7        0.091327            448
+seed7/prg/chkenum.sd7        0.120600           1230
+seed7/prg/chkerr.sd7         0.341925           4663
+seed7/prg/chkexc.sd7         0.147960           2627
+seed7/prg/chkfil.sd7         0.127552           1615
+seed7/prg/chkflt.sd7         2.818673          20620
+seed7/prg/chkhent.sd7        0.037193             54
+seed7/prg/chkhsh.sd7         0.502394           4548
+seed7/prg/chkidx.sd7         3.184617          19567
+seed7/prg/chkint.sd7         5.585167          38129
+seed7/prg/chkjson.sd7        0.186489           1764
+seed7/prg/chkovf.sd7         1.213033           8216
+seed7/prg/chkprc.sd7         0.705026          10111
+seed7/prg/chkscan.sd7        0.091685            714
+seed7/prg/chkset.sd7         1.753908          11974
+seed7/prg/chkstr.sd7         3.411852          26952
+seed7/prg/chktime.sd7        0.247392           2025
+seed7/prg/chktoml.sd7        0.199373           1656
+seed7/prg/clock.sd7          0.036021             47
+seed7/prg/clock2.sd7         0.035617             43
+seed7/prg/clock3.sd7         0.042856             95
+seed7/prg/cmpfil.sd7         0.041382             84
+seed7/prg/comanche.sd7       0.046696            180
+seed7/prg/confval.sd7        0.049997            175
+seed7/prg/db7.sd7            0.061932            417
+seed7/prg/diff7.sd7          0.050530            263
+seed7/prg/dirtst.sd7         0.035563             42
+seed7/prg/dirx.sd7           0.041560            152
+seed7/prg/dnafight.sd7       0.117630           1381
+seed7/prg/dragon.sd7         0.038430             73
+seed7/prg/echo.sd7           0.035858             39
+seed7/prg/eliza.sd7          0.056904            302
+seed7/prg/err.sd7            0.044777             96
+seed7/prg/fannkuch.sd7       0.040918            131
+seed7/prg/fib.sd7            0.036494             47
+seed7/prg/find7.sd7          0.041815            133
+seed7/prg/findchar.sd7       0.043092            149
+seed7/prg/fractree.sd7       0.036850             55
+seed7/prg/ftp7.sd7           0.052435            296
+seed7/prg/ftpserv.sd7        0.038395             74
+seed7/prg/gcd.sd7            0.040139            109
+seed7/prg/gkbd.sd7           0.064242            358
+seed7/prg/gtksvtst.sd7       0.038188             94
+seed7/prg/hal.sd7            0.047034            250
+seed7/prg/hamu.sd7           0.066034            573
+seed7/prg/hanoi.sd7          0.036673             55
+seed7/prg/hd.sd7             0.038313             79
+seed7/prg/hello.sd7          0.035671             32
+seed7/prg/hilbert.sd7        0.039764            108
+seed7/prg/ide7.sd7           0.046636            196
+seed7/prg/kbd.sd7            0.036046             49
+seed7/prg/klondike.sd7       0.086604            883
+seed7/prg/lander.sd7         0.132028           1551
+seed7/prg/lst80bas.sd7       0.054795            344
+seed7/prg/lst99bas.sd7       0.059044            401
+seed7/prg/lstgwbas.sd7       0.072642            577
+seed7/prg/mahjong.sd7        0.147296           1943
+seed7/prg/make7.sd7          0.041480            121
+seed7/prg/mandelbr.sd7       0.048406            237
+seed7/prg/mind.sd7           0.058776            443
+seed7/prg/mirror.sd7         0.043218            131
+seed7/prg/ms.sd7             0.070069            641
+seed7/prg/nicoma.sd7         0.041680            135
+seed7/prg/pac.sd7            0.069396            726
+seed7/prg/pairs.sd7          0.137245           2025
+seed7/prg/panic.sd7          0.191947           2634
+seed7/prg/percolation.sd7    0.054312            330
+seed7/prg/planets.sd7        0.138439           1486
+seed7/prg/portfwd7.sd7       0.043436            139
+seed7/prg/prime.sd7          0.037569             74
+seed7/prg/printpi1.sd7       0.037293             56
+seed7/prg/printpi2.sd7       0.036432             54
+seed7/prg/printpi3.sd7       0.038435             60
+seed7/prg/pv7.sd7            0.056904            337
+seed7/prg/queen.sd7          0.042470            149
+seed7/prg/rand.sd7           0.040549            121
+seed7/prg/raytrace.sd7       0.067421            538
+seed7/prg/rever.sd7          0.080337            816
+seed7/prg/roman.sd7          0.035835             38
+seed7/prg/s7c.sd7            0.626623           9060
+seed7/prg/s7check.sd7        0.038022             68
+seed7/prg/savehd7.sd7        0.111433           1110
+seed7/prg/self.sd7           0.036703             49
+seed7/prg/shisen.sd7         0.119856           1423
+seed7/prg/sl.sd7             0.099506           1029
+seed7/prg/snake.sd7          0.066818            615
+seed7/prg/sokoban.sd7        0.079709            891
+seed7/prg/spigotpi.sd7       0.038075             64
+seed7/prg/sql7.sd7           0.051745            278
+seed7/prg/startrek.sd7       0.092522            979
+seed7/prg/sudoku7.sd7        0.196223           2657
+seed7/prg/sydir7.sd7         0.059641            384
+seed7/prg/syntaxhl.sd7       0.047402            177
+seed7/prg/tak.sd7            0.037016             59
+seed7/prg/tar7.sd7           0.042084            121
+seed7/prg/tch.sd7            0.037149             55
+seed7/prg/testfont.sd7       0.040855             95
+seed7/prg/tet.sd7            0.059709            479
+seed7/prg/tetg.sd7           0.061357            501
+seed7/prg/toutf8.sd7         0.050403            240
+seed7/prg/tst_cli.sd7        0.036327             40
+seed7/prg/tst_srv.sd7        0.035855             47
+seed7/prg/wator.sd7          0.078361            651
+seed7/prg/which.sd7          0.037718             65
+seed7/prg/wiz.sd7            0.207527           2833
+seed7/prg/wordcnt.sd7        0.036503             54
+seed7/prg/wrinum.sd7         0.035562             43
+seed7/prg/wumpus.sd7         0.052978            372
+seed7/lib/aes.s7i            0.199350           1144
+seed7/lib/aes_gcm.s7i        0.060325            392
+seed7/lib/ar.s7i             0.123498           1532
+seed7/lib/arc4.s7i           0.042053            144
+seed7/lib/archive.s7i        0.042801            143
+seed7/lib/archive_base.s7i   0.042550            135
+seed7/lib/array.s7i          0.074682            610
+seed7/lib/asn1.s7i           0.062202            544
+seed7/lib/asn1oid.s7i        0.048216            157
+seed7/lib/basearray.s7i      0.061518            450
+seed7/lib/bigfile.s7i        0.040628            136
+seed7/lib/bigint.s7i         0.078581            824
+seed7/lib/bigrat.s7i         0.078349            784
+seed7/lib/bin16.s7i          0.066866            592
+seed7/lib/bin32.s7i          0.060413            490
+seed7/lib/bin64.s7i          0.062029            539
+seed7/lib/bitdata.s7i        0.122907           1330
+seed7/lib/bitmapfont.s7i     0.047119            215
+seed7/lib/bitset.s7i         0.063076            593
+seed7/lib/bitsetof.s7i       0.061372            431
+seed7/lib/blowfish.s7i       0.076605            383
+seed7/lib/bmp.s7i            0.100548            924
+seed7/lib/boolean.s7i        0.054271            403
+seed7/lib/browser.s7i        0.051548            280
+seed7/lib/bstring.s7i        0.045837            227
+seed7/lib/bytedata.s7i       0.064559            482
+seed7/lib/bzip2.s7i          0.088238            887
+seed7/lib/cards.s7i          0.101783           1342
+seed7/lib/category.s7i       0.048086            209
+seed7/lib/cc_conf.s7i        0.119596           1314
+seed7/lib/ccittfax.s7i       0.101805           1022
+seed7/lib/cgi.s7i            0.040058            109
+seed7/lib/cgidialog.s7i      0.099095           1118
+seed7/lib/char.s7i           0.050653            356
+seed7/lib/charsets.s7i       0.124852           2024
+seed7/lib/chartype.s7i       0.047237            121
+seed7/lib/cipher.s7i         0.041171            146
+seed7/lib/cli_cmds.s7i       0.110478           1360
+seed7/lib/clib_file.s7i      0.050349            301
+seed7/lib/color.s7i          0.044844            185
+seed7/lib/complex.s7i        0.057753            464
+seed7/lib/compress.s7i       0.044445            150
+seed7/lib/console.s7i        0.044602            188
+seed7/lib/cpio.s7i           0.147476           1708
+seed7/lib/crc32.s7i          0.053032            193
+seed7/lib/cronos16.s7i       0.193447           1173
+seed7/lib/cronos27.s7i       0.255776           1464
+seed7/lib/csv.s7i            0.047600            201
+seed7/lib/db_prop.s7i        0.102808            991
+seed7/lib/deflate.s7i        0.088781            740
+seed7/lib/des.s7i            0.077854            444
+seed7/lib/dialog.s7i         0.057169            311
+seed7/lib/dir.s7i            0.042025            163
+seed7/lib/draw.s7i           0.084454            854
+seed7/lib/duration.s7i       0.103395           1038
+seed7/lib/echo.s7i           0.041879            132
+seed7/lib/editline.s7i       0.059275            398
+seed7/lib/elf.s7i            0.159155           1560
+seed7/lib/elliptic.s7i       0.075772            649
+seed7/lib/enable_io.s7i      0.051693            312
+seed7/lib/encoding.s7i       0.096251            931
+seed7/lib/enumeration.s7i    0.048456            236
+seed7/lib/environment.s7i    0.042294            175
+seed7/lib/exif.s7i           0.044203            152
+seed7/lib/external_file.s7i  0.050220            340
+seed7/lib/field.s7i          0.049934            268
+seed7/lib/file.s7i           0.052267            372
+seed7/lib/filebits.s7i       0.037770             46
+seed7/lib/filesys.s7i        0.063415            601
+seed7/lib/fileutil.s7i       0.042341            144
+seed7/lib/fixarray.s7i       0.052473            307
+seed7/lib/float.s7i          0.072798            757
+seed7/lib/font.s7i           0.044275            196
+seed7/lib/font8x8.s7i        0.067331            998
+seed7/lib/forloop.s7i        0.058118            449
+seed7/lib/ftp.s7i            0.087586            969
+seed7/lib/ftpserv.s7i        0.076319            631
+seed7/lib/getf.s7i           0.040765            115
+seed7/lib/gethttp.s7i        0.037913             41
+seed7/lib/gethttps.s7i       0.036309             41
+seed7/lib/gif.s7i            0.069973            561
+seed7/lib/graph.s7i          0.063346            415
+seed7/lib/graph_file.s7i     0.056401            399
+seed7/lib/gtkserver.s7i      0.040084            161
+seed7/lib/gzip.s7i           0.065794            573
+seed7/lib/hash.s7i           0.064645            421
+seed7/lib/hashsetof.s7i      0.066098            499
+seed7/lib/hmac.s7i           0.043375            152
+seed7/lib/html.s7i           0.038309             83
+seed7/lib/html_ent.s7i       0.062230            476
+seed7/lib/htmldom.s7i        0.052719            286
+seed7/lib/http_request.s7i   0.076652            696
+seed7/lib/http_srv_resp.s7i  0.058841            380
+seed7/lib/https_request.s7i  0.047322            211
+seed7/lib/httpserv.s7i       0.058763            345
+seed7/lib/huffman.s7i        0.087858            644
+seed7/lib/ico.s7i            0.048529            221
+seed7/lib/idxarray.s7i       0.049849            232
+seed7/lib/image.s7i          0.041155            156
+seed7/lib/imagefile.s7i      0.044170            171
+seed7/lib/inflate.s7i        0.062134            411
+seed7/lib/inifile.s7i        0.040886            129
+seed7/lib/integer.s7i        0.066375            663
+seed7/lib/iobuffer.s7i       0.049247            289
+seed7/lib/jpeg.s7i           0.155846           1761
+seed7/lib/json.s7i           0.080282            891
+seed7/lib/json_serde.s7i     0.078098            783
+seed7/lib/keybd.s7i          0.079150            639
+seed7/lib/keydescr.s7i       0.049591            192
+seed7/lib/leb128.s7i         0.045931            218
+seed7/lib/line.s7i           0.042340            164
+seed7/lib/listener.s7i       0.048721            247
+seed7/lib/logfile.s7i        0.037741             73
+seed7/lib/lower.s7i          0.040985            142
+seed7/lib/lzma.s7i           0.096791            934
+seed7/lib/lzw.s7i            0.088648            861
+seed7/lib/magic.s7i          0.062416            403
+seed7/lib/mahjng32.s7i       0.090060           1500
+seed7/lib/make.s7i           0.067244            544
+seed7/lib/makedata.s7i       0.119761           1428
+seed7/lib/math.s7i           0.044832            201
+seed7/lib/mixarith.s7i       0.046041            249
+seed7/lib/modern27.s7i       0.170245           1099
+seed7/lib/more.s7i           0.041612            130
+seed7/lib/msgdigest.s7i      0.136896           1222
+seed7/lib/multiscr.s7i       0.037512             68
+seed7/lib/null_file.s7i      0.050190            345
+seed7/lib/osfiles.s7i        0.094195           1085
+seed7/lib/pbm.s7i            0.047701            230
+seed7/lib/pcx.s7i            0.076717            638
+seed7/lib/pem.s7i            0.043246            185
+seed7/lib/pgm.s7i            0.047174            238
+seed7/lib/pic16.s7i          0.065038           1037
+seed7/lib/pic32.s7i          0.119213           2060
+seed7/lib/pic_util.s7i       0.044368            144
+seed7/lib/pixelimage.s7i     0.052066            320
+seed7/lib/pixmap_file.s7i    0.061620            459
+seed7/lib/pixmapfont.s7i     0.046108            184
+seed7/lib/pkcs1.s7i          0.077271            543
+seed7/lib/png.s7i            0.109204           1064
+seed7/lib/poll.s7i           0.052430            313
+seed7/lib/ppm.s7i            0.048196            240
+seed7/lib/process.s7i        0.063927            541
+seed7/lib/progs.s7i          0.078153            789
+seed7/lib/propertyfile.s7i   0.043190            155
+seed7/lib/rational.s7i       0.078211            792
+seed7/lib/ref_list.s7i       0.048124            252
+seed7/lib/reference.s7i      0.040285            126
+seed7/lib/reverse.s7i        0.037929             94
+seed7/lib/rpm.s7i            0.288506           3487
+seed7/lib/rpmext.s7i         0.053674            318
+seed7/lib/scanfile.s7i       0.134893           1779
+seed7/lib/scanjson.s7i       0.060096            413
+seed7/lib/scanstri.s7i       0.142177           1814
+seed7/lib/scantoml.s7i       0.129804           1603
+seed7/lib/seed7_05.s7i       0.110089           1072
+seed7/lib/set.s7i            0.037412             57
+seed7/lib/shell.s7i          0.066920            615
+seed7/lib/showtls.s7i        0.090209            678
+seed7/lib/signature.s7i      0.041097            131
+seed7/lib/smtp.s7i           0.049060            261
+seed7/lib/sockbase.s7i       0.053112            217
+seed7/lib/socket.s7i         0.050684            326
+seed7/lib/sokoban1.s7i       0.079201           1519
+seed7/lib/sql_base.s7i       0.091992           1000
+seed7/lib/stars.s7i          0.230882           1705
+seed7/lib/stdfont10.s7i      0.141402           3347
+seed7/lib/stdfont12.s7i      0.165093           3928
+seed7/lib/stdfont14.s7i      0.184533           4510
+seed7/lib/stdfont16.s7i      0.212438           5092
+seed7/lib/stdfont18.s7i      0.244398           5868
+seed7/lib/stdfont20.s7i      0.272613           6449
+seed7/lib/stdfont24.s7i      0.323703           7421
+seed7/lib/stdfont8.s7i       0.126154           2960
+seed7/lib/stdfont9.s7i       0.133250           3152
+seed7/lib/stdio.s7i          0.043680            192
+seed7/lib/strifile.s7i       0.053118            345
+seed7/lib/string.s7i         0.074758            779
+seed7/lib/stritext.s7i       0.053988            352
+seed7/lib/struct.s7i         0.054549            266
+seed7/lib/struct_elem.s7i    0.041437            129
+seed7/lib/subfile.s7i        0.042486            174
+seed7/lib/subrange.s7i       0.038282             78
+seed7/lib/syntax.s7i         0.059495            294
+seed7/lib/tar.s7i            0.142948           1880
+seed7/lib/tar_cmds.s7i       0.082331            752
+seed7/lib/tdes.s7i           0.049977            143
+seed7/lib/tee.s7i            0.044080            143
+seed7/lib/text.s7i           0.041467            135
+seed7/lib/tga.s7i            0.078975            676
+seed7/lib/tiff.s7i           0.242037           2771
+seed7/lib/time.s7i           0.100769           1191
+seed7/lib/tls.s7i            0.196292           2230
+seed7/lib/unicode.s7i        0.072394            575
+seed7/lib/unionfnd.s7i       0.041518            130
+seed7/lib/upper.s7i          0.041440            142
+seed7/lib/utf16.s7i          0.063254            540
+seed7/lib/utf8.s7i           0.045882            234
+seed7/lib/vecfont10.s7i      0.158292           1056
+seed7/lib/vecfont18.s7i      0.178383           1119
+seed7/lib/vector3d.s7i       0.048923            293
+seed7/lib/vectorfont.s7i     0.047216            239
+seed7/lib/wildcard.s7i       0.042019            140
+seed7/lib/window.s7i         0.059826            455
+seed7/lib/wrinum.s7i         0.048908            248
+seed7/lib/x509cert.s7i       0.117082           1243
+seed7/lib/xml_ent.s7i        0.039369             94
+seed7/lib/xmldom.s7i         0.049724            303
+seed7/lib/xz.s7i             0.059304            442
+seed7/lib/zip.s7i            0.232942           2792
+seed7/lib/zstd.s7i           0.114939           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.158013        |
++-----------+-----------------+
+| Minimum   | 0.035562        |
++-----------+-----------------+
+| Maximum   | 5.585167        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.034692        | 0.032030        | 0.043508        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039652        | 0.034452        | 0.048937        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.089476        | 0.034325        | 2.573882        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.158013        | 0.035562        | 5.585167        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.148 | 00:00:59.110 | 00:01:11.259 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.899 | 00:01:07.619 | 00:01:22.519 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:36.981 | 00:02:33.298 | 00:03:10.280 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:00.829 | 00:04:30.094 | 00:05:30.924 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:14.989 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-16.2.rst
+++ b/reports/seed7mode-perf-16.2.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-30T03:26:24+0000 W27-2
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 05:55:28 local time
+:Generated on: 2026-06-30 10:06:44 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 211x95 chars
+:Window body: 211x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.034150            190
+seed7/prg/bas7.sd7           0.033867          11459
+seed7/prg/bifurk.sd7         0.033232             73
+seed7/prg/bigfiles.sd7       0.032924            129
+seed7/prg/brainf7.sd7        0.033095             86
+seed7/prg/calc7.sd7          0.033233            128
+seed7/prg/carddemo.sd7       0.033942            190
+seed7/prg/castle.sd7         0.033295           3148
+seed7/prg/cat.sd7            0.032717             82
+seed7/prg/cellauto.sd7       0.032422             85
+seed7/prg/celsius.sd7        0.032651             42
+seed7/prg/chk_all.sd7        0.033590            843
+seed7/prg/chkarr.sd7         0.033182           8367
+seed7/prg/chkbig.sd7         0.041434          29026
+seed7/prg/chkbin.sd7         0.034506           6469
+seed7/prg/chkbitdata.sd7     0.034570           6624
+seed7/prg/chkbool.sd7        0.034062           3157
+seed7/prg/chkbst.sd7         0.033210            722
+seed7/prg/chkchr.sd7         0.033748           2809
+seed7/prg/chkcmd.sd7         0.035041           1205
+seed7/prg/chkdb.sd7          0.034735           7454
+seed7/prg/chkdecl.sd7        0.033127            448
+seed7/prg/chkenum.sd7        0.033876           1230
+seed7/prg/chkerr.sd7         0.033690           4663
+seed7/prg/chkexc.sd7         0.033612           2627
+seed7/prg/chkfil.sd7         0.033295           1615
+seed7/prg/chkflt.sd7         0.036148          20620
+seed7/prg/chkhent.sd7        0.033803             54
+seed7/prg/chkhsh.sd7         0.033741           4548
+seed7/prg/chkidx.sd7         0.036578          19567
+seed7/prg/chkint.sd7         0.042053          38129
+seed7/prg/chkjson.sd7        0.034006           1764
+seed7/prg/chkovf.sd7         0.034129           8216
+seed7/prg/chkprc.sd7         0.033815          10111
+seed7/prg/chkscan.sd7        0.033350            714
+seed7/prg/chkset.sd7         0.034209          11974
+seed7/prg/chkstr.sd7         0.037977          26952
+seed7/prg/chktime.sd7        0.033152           2025
+seed7/prg/chktoml.sd7        0.033140           1656
+seed7/prg/clock.sd7          0.032450             47
+seed7/prg/clock2.sd7         0.033139             43
+seed7/prg/clock3.sd7         0.032634             95
+seed7/prg/cmpfil.sd7         0.032334             84
+seed7/prg/comanche.sd7       0.034104            180
+seed7/prg/confval.sd7        0.033200            175
+seed7/prg/db7.sd7            0.034557            417
+seed7/prg/diff7.sd7          0.033969            263
+seed7/prg/dirtst.sd7         0.033809             42
+seed7/prg/dirx.sd7           0.034082            152
+seed7/prg/dnafight.sd7       0.033699           1381
+seed7/prg/dragon.sd7         0.034066             73
+seed7/prg/echo.sd7           0.033440             39
+seed7/prg/eliza.sd7          0.033849            302
+seed7/prg/err.sd7            0.033757             96
+seed7/prg/fannkuch.sd7       0.035271            131
+seed7/prg/fib.sd7            0.034025             47
+seed7/prg/find7.sd7          0.033309            133
+seed7/prg/findchar.sd7       0.033505            149
+seed7/prg/fractree.sd7       0.033602             55
+seed7/prg/ftp7.sd7           0.033546            296
+seed7/prg/ftpserv.sd7        0.033506             74
+seed7/prg/gcd.sd7            0.034025            109
+seed7/prg/gkbd.sd7           0.034324            358
+seed7/prg/gtksvtst.sd7       0.033449             94
+seed7/prg/hal.sd7            0.033724            250
+seed7/prg/hamu.sd7           0.033016            573
+seed7/prg/hanoi.sd7          0.032947             55
+seed7/prg/hd.sd7             0.032353             79
+seed7/prg/hello.sd7          0.032821             32
+seed7/prg/hilbert.sd7        0.032620            108
+seed7/prg/ide7.sd7           0.032763            196
+seed7/prg/kbd.sd7            0.033754             49
+seed7/prg/klondike.sd7       0.032437            883
+seed7/prg/lander.sd7         0.034455           1551
+seed7/prg/lst80bas.sd7       0.033393            344
+seed7/prg/lst99bas.sd7       0.033422            401
+seed7/prg/lstgwbas.sd7       0.033984            577
+seed7/prg/mahjong.sd7        0.033930           1943
+seed7/prg/make7.sd7          0.033592            121
+seed7/prg/mandelbr.sd7       0.033944            237
+seed7/prg/mind.sd7           0.033262            443
+seed7/prg/mirror.sd7         0.033432            131
+seed7/prg/ms.sd7             0.033546            641
+seed7/prg/nicoma.sd7         0.033162            135
+seed7/prg/pac.sd7            0.033374            726
+seed7/prg/pairs.sd7          0.033144           2025
+seed7/prg/panic.sd7          0.033387           2634
+seed7/prg/percolation.sd7    0.033924            330
+seed7/prg/planets.sd7        0.033638           1486
+seed7/prg/portfwd7.sd7       0.033788            139
+seed7/prg/prime.sd7          0.034163             74
+seed7/prg/printpi1.sd7       0.034605             56
+seed7/prg/printpi2.sd7       0.033574             54
+seed7/prg/printpi3.sd7       0.033653             60
+seed7/prg/pv7.sd7            0.033733            337
+seed7/prg/queen.sd7          0.033548            149
+seed7/prg/rand.sd7           0.033383            121
+seed7/prg/raytrace.sd7       0.032348            538
+seed7/prg/rever.sd7          0.033396            816
+seed7/prg/roman.sd7          0.032710             38
+seed7/prg/s7c.sd7            0.033565           9060
+seed7/prg/s7check.sd7        0.033276             68
+seed7/prg/savehd7.sd7        0.033519           1110
+seed7/prg/self.sd7           0.033522             49
+seed7/prg/shisen.sd7         0.033963           1423
+seed7/prg/sl.sd7             0.034091           1029
+seed7/prg/snake.sd7          0.033269            615
+seed7/prg/sokoban.sd7        0.033042            891
+seed7/prg/spigotpi.sd7       0.034404             64
+seed7/prg/sql7.sd7           0.033601            278
+seed7/prg/startrek.sd7       0.038617            979
+seed7/prg/sudoku7.sd7        0.040220           2657
+seed7/prg/sydir7.sd7         0.033797            384
+seed7/prg/syntaxhl.sd7       0.034578            177
+seed7/prg/tak.sd7            0.033502             59
+seed7/prg/tar7.sd7           0.033930            121
+seed7/prg/tch.sd7            0.034152             55
+seed7/prg/testfont.sd7       0.034267             95
+seed7/prg/tet.sd7            0.033596            479
+seed7/prg/tetg.sd7           0.034030            501
+seed7/prg/toutf8.sd7         0.034412            240
+seed7/prg/tst_cli.sd7        0.033825             40
+seed7/prg/tst_srv.sd7        0.033931             47
+seed7/prg/wator.sd7          0.033597            651
+seed7/prg/which.sd7          0.034526             65
+seed7/prg/wiz.sd7            0.034474           2833
+seed7/prg/wordcnt.sd7        0.032957             54
+seed7/prg/wrinum.sd7         0.032587             43
+seed7/prg/wumpus.sd7         0.035007            372
+seed7/lib/aes.s7i            0.032979           1144
+seed7/lib/aes_gcm.s7i        0.033392            392
+seed7/lib/ar.s7i             0.033035           1532
+seed7/lib/arc4.s7i           0.033242            144
+seed7/lib/archive.s7i        0.032881            143
+seed7/lib/archive_base.s7i   0.034875            135
+seed7/lib/array.s7i          0.034078            610
+seed7/lib/asn1.s7i           0.033746            544
+seed7/lib/asn1oid.s7i        0.033512            157
+seed7/lib/basearray.s7i      0.033367            450
+seed7/lib/bigfile.s7i        0.033435            136
+seed7/lib/bigint.s7i         0.034580            824
+seed7/lib/bigrat.s7i         0.033704            784
+seed7/lib/bin16.s7i          0.033534            592
+seed7/lib/bin32.s7i          0.033750            490
+seed7/lib/bin64.s7i          0.033149            539
+seed7/lib/bitdata.s7i        0.033543           1330
+seed7/lib/bitmapfont.s7i     0.033547            215
+seed7/lib/bitset.s7i         0.033490            593
+seed7/lib/bitsetof.s7i       0.033373            431
+seed7/lib/blowfish.s7i       0.033638            383
+seed7/lib/bmp.s7i            0.033880            924
+seed7/lib/boolean.s7i        0.033349            403
+seed7/lib/browser.s7i        0.034938            280
+seed7/lib/bstring.s7i        0.033383            227
+seed7/lib/bytedata.s7i       0.033153            482
+seed7/lib/bzip2.s7i          0.033318            887
+seed7/lib/cards.s7i          0.033245           1342
+seed7/lib/category.s7i       0.032992            209
+seed7/lib/cc_conf.s7i        0.033410           1314
+seed7/lib/ccittfax.s7i       0.033236           1022
+seed7/lib/cgi.s7i            0.032281            109
+seed7/lib/cgidialog.s7i      0.032480           1118
+seed7/lib/char.s7i           0.033037            356
+seed7/lib/charsets.s7i       0.032869           2024
+seed7/lib/chartype.s7i       0.033678            121
+seed7/lib/cipher.s7i         0.034550            146
+seed7/lib/cli_cmds.s7i       0.034642           1360
+seed7/lib/clib_file.s7i      0.033502            301
+seed7/lib/color.s7i          0.033423            185
+seed7/lib/complex.s7i        0.033200            464
+seed7/lib/compress.s7i       0.032902            150
+seed7/lib/console.s7i        0.032353            188
+seed7/lib/cpio.s7i           0.032580           1708
+seed7/lib/crc32.s7i          0.032568            193
+seed7/lib/cronos16.s7i       0.032562           1173
+seed7/lib/cronos27.s7i       0.032763           1464
+seed7/lib/csv.s7i            0.032425            201
+seed7/lib/db_prop.s7i        0.032217            991
+seed7/lib/deflate.s7i        0.032282            740
+seed7/lib/des.s7i            0.034510            444
+seed7/lib/dialog.s7i         0.033595            311
+seed7/lib/dir.s7i            0.033930            163
+seed7/lib/draw.s7i           0.033319            854
+seed7/lib/duration.s7i       0.033622           1038
+seed7/lib/echo.s7i           0.033803            132
+seed7/lib/editline.s7i       0.033414            398
+seed7/lib/elf.s7i            0.034881           1560
+seed7/lib/elliptic.s7i       0.033893            649
+seed7/lib/enable_io.s7i      0.033222            312
+seed7/lib/encoding.s7i       0.033270            931
+seed7/lib/enumeration.s7i    0.033518            236
+seed7/lib/environment.s7i    0.033816            175
+seed7/lib/exif.s7i           0.032797            152
+seed7/lib/external_file.s7i  0.033463            340
+seed7/lib/field.s7i          0.033155            268
+seed7/lib/file.s7i           0.034004            372
+seed7/lib/filebits.s7i       0.033296             46
+seed7/lib/filesys.s7i        0.033744            601
+seed7/lib/fileutil.s7i       0.034821            144
+seed7/lib/fixarray.s7i       0.033099            307
+seed7/lib/float.s7i          0.034422            757
+seed7/lib/font.s7i           0.033326            196
+seed7/lib/font8x8.s7i        0.035512            998
+seed7/lib/forloop.s7i        0.033677            449
+seed7/lib/ftp.s7i            0.034391            969
+seed7/lib/ftpserv.s7i        0.033258            631
+seed7/lib/getf.s7i           0.034682            115
+seed7/lib/gethttp.s7i        0.033789             41
+seed7/lib/gethttps.s7i       0.033922             41
+seed7/lib/gif.s7i            0.034261            561
+seed7/lib/graph.s7i          0.033665            415
+seed7/lib/graph_file.s7i     0.033037            399
+seed7/lib/gtkserver.s7i      0.033616            161
+seed7/lib/gzip.s7i           0.033631            573
+seed7/lib/hash.s7i           0.033681            421
+seed7/lib/hashsetof.s7i      0.033396            499
+seed7/lib/hmac.s7i           0.033190            152
+seed7/lib/html.s7i           0.033331             83
+seed7/lib/html_ent.s7i       0.033269            476
+seed7/lib/htmldom.s7i        0.033122            286
+seed7/lib/http_request.s7i   0.033054            696
+seed7/lib/http_srv_resp.s7i  0.033626            380
+seed7/lib/https_request.s7i  0.032493            211
+seed7/lib/httpserv.s7i       0.032454            345
+seed7/lib/huffman.s7i        0.032665            644
+seed7/lib/ico.s7i            0.033053            221
+seed7/lib/idxarray.s7i       0.032781            232
+seed7/lib/image.s7i          0.033264            156
+seed7/lib/imagefile.s7i      0.034101            171
+seed7/lib/inflate.s7i        0.033933            411
+seed7/lib/inifile.s7i        0.034111            129
+seed7/lib/integer.s7i        0.033858            663
+seed7/lib/iobuffer.s7i       0.034010            289
+seed7/lib/jpeg.s7i           0.034548           1761
+seed7/lib/json.s7i           0.034754            891
+seed7/lib/json_serde.s7i     0.034152            783
+seed7/lib/keybd.s7i          0.033237            639
+seed7/lib/keydescr.s7i       0.033731            192
+seed7/lib/leb128.s7i         0.034372            218
+seed7/lib/line.s7i           0.033757            164
+seed7/lib/listener.s7i       0.034137            247
+seed7/lib/logfile.s7i        0.033615             73
+seed7/lib/lower.s7i          0.034075            142
+seed7/lib/lzma.s7i           0.034255            934
+seed7/lib/lzw.s7i            0.033520            861
+seed7/lib/magic.s7i          0.033976            403
+seed7/lib/mahjng32.s7i       0.034497           1500
+seed7/lib/make.s7i           0.033526            544
+seed7/lib/makedata.s7i       0.033249           1428
+seed7/lib/math.s7i           0.033130            201
+seed7/lib/mixarith.s7i       0.032944            249
+seed7/lib/modern27.s7i       0.033305           1099
+seed7/lib/more.s7i           0.032796            130
+seed7/lib/msgdigest.s7i      0.032611           1222
+seed7/lib/multiscr.s7i       0.032299             68
+seed7/lib/null_file.s7i      0.033110            345
+seed7/lib/osfiles.s7i        0.033148           1085
+seed7/lib/pbm.s7i            0.032739            230
+seed7/lib/pcx.s7i            0.035697            638
+seed7/lib/pem.s7i            0.033532            185
+seed7/lib/pgm.s7i            0.033833            238
+seed7/lib/pic16.s7i          0.034132           1037
+seed7/lib/pic32.s7i          0.033734           2060
+seed7/lib/pic_util.s7i       0.033236            144
+seed7/lib/pixelimage.s7i     0.033229            320
+seed7/lib/pixmap_file.s7i    0.033749            459
+seed7/lib/pixmapfont.s7i     0.033805            184
+seed7/lib/pkcs1.s7i          0.033940            543
+seed7/lib/png.s7i            0.034074           1064
+seed7/lib/poll.s7i           0.033559            313
+seed7/lib/ppm.s7i            0.034961            240
+seed7/lib/process.s7i        0.033380            541
+seed7/lib/progs.s7i          0.033759            789
+seed7/lib/propertyfile.s7i   0.033295            155
+seed7/lib/rational.s7i       0.034643            792
+seed7/lib/ref_list.s7i       0.033640            252
+seed7/lib/reference.s7i      0.034332            126
+seed7/lib/reverse.s7i        0.033430             94
+seed7/lib/rpm.s7i            0.033755           3487
+seed7/lib/rpmext.s7i         0.032845            318
+seed7/lib/scanfile.s7i       0.035114           1779
+seed7/lib/scanjson.s7i       0.034711            413
+seed7/lib/scanstri.s7i       0.033399           1814
+seed7/lib/scantoml.s7i       0.034406           1603
+seed7/lib/seed7_05.s7i       0.061562           1072
+seed7/lib/set.s7i            0.034919             57
+seed7/lib/shell.s7i          0.033528            615
+seed7/lib/showtls.s7i        0.033044            678
+seed7/lib/signature.s7i      0.032406            131
+seed7/lib/smtp.s7i           0.034386            261
+seed7/lib/sockbase.s7i       0.034090            217
+seed7/lib/socket.s7i         0.034118            326
+seed7/lib/sokoban1.s7i       0.033918           1519
+seed7/lib/sql_base.s7i       0.033936           1000
+seed7/lib/stars.s7i          0.033573           1705
+seed7/lib/stdfont10.s7i      0.036147           3347
+seed7/lib/stdfont12.s7i      0.034414           3928
+seed7/lib/stdfont14.s7i      0.034515           4510
+seed7/lib/stdfont16.s7i      0.037236           5092
+seed7/lib/stdfont18.s7i      0.033997           5868
+seed7/lib/stdfont20.s7i      0.034237           6449
+seed7/lib/stdfont24.s7i      0.034207           7421
+seed7/lib/stdfont8.s7i       0.034186           2960
+seed7/lib/stdfont9.s7i       0.034654           3152
+seed7/lib/stdio.s7i          0.034396            192
+seed7/lib/strifile.s7i       0.034061            345
+seed7/lib/string.s7i         0.034037            779
+seed7/lib/stritext.s7i       0.033476            352
+seed7/lib/struct.s7i         0.033575            266
+seed7/lib/struct_elem.s7i    0.035026            129
+seed7/lib/subfile.s7i        0.035616            174
+seed7/lib/subrange.s7i       0.033975             78
+seed7/lib/syntax.s7i         0.034145            294
+seed7/lib/tar.s7i            0.034152           1880
+seed7/lib/tar_cmds.s7i       0.033174            752
+seed7/lib/tdes.s7i           0.032663            143
+seed7/lib/tee.s7i            0.034645            143
+seed7/lib/text.s7i           0.032392            135
+seed7/lib/tga.s7i            0.032449            676
+seed7/lib/tiff.s7i           0.034509           2771
+seed7/lib/time.s7i           0.034054           1191
+seed7/lib/tls.s7i            0.034314           2230
+seed7/lib/unicode.s7i        0.033225            575
+seed7/lib/unionfnd.s7i       0.033713            130
+seed7/lib/upper.s7i          0.033213            142
+seed7/lib/utf16.s7i          0.033278            540
+seed7/lib/utf8.s7i           0.033534            234
+seed7/lib/vecfont10.s7i      0.034241           1056
+seed7/lib/vecfont18.s7i      0.033296           1119
+seed7/lib/vector3d.s7i       0.033397            293
+seed7/lib/vectorfont.s7i     0.033279            239
+seed7/lib/wildcard.s7i       0.033072            140
+seed7/lib/window.s7i         0.033249            455
+seed7/lib/wrinum.s7i         0.032968            248
+seed7/lib/x509cert.s7i       0.033184           1243
+seed7/lib/xml_ent.s7i        0.034433             94
+seed7/lib/xmldom.s7i         0.040294            303
+seed7/lib/xz.s7i             0.036377            442
+seed7/lib/zip.s7i            0.034716           2792
+seed7/lib/zstd.s7i           0.033489           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033866        |
++-----------+-----------------+
+| Minimum   | 0.032217        |
++-----------+-----------------+
+| Maximum   | 0.061562        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039316            190
+seed7/prg/bas7.sd7           0.041519          11459
+seed7/prg/bifurk.sd7         0.036591             73
+seed7/prg/bigfiles.sd7       0.038154            129
+seed7/prg/brainf7.sd7        0.037676             86
+seed7/prg/calc7.sd7          0.038930            128
+seed7/prg/carddemo.sd7       0.039365            190
+seed7/prg/castle.sd7         0.039374           3148
+seed7/prg/cat.sd7            0.038140             82
+seed7/prg/cellauto.sd7       0.037280             85
+seed7/prg/celsius.sd7        0.035248             42
+seed7/prg/chk_all.sd7        0.037893            843
+seed7/prg/chkarr.sd7         0.038083           8367
+seed7/prg/chkbig.sd7         0.042736          29026
+seed7/prg/chkbin.sd7         0.039668           6469
+seed7/prg/chkbitdata.sd7     0.040373           6624
+seed7/prg/chkbool.sd7        0.038704           3157
+seed7/prg/chkbst.sd7         0.039611            722
+seed7/prg/chkchr.sd7         0.040770           2809
+seed7/prg/chkcmd.sd7         0.039698           1205
+seed7/prg/chkdb.sd7          0.039752           7454
+seed7/prg/chkdecl.sd7        0.039876            448
+seed7/prg/chkenum.sd7        0.038814           1230
+seed7/prg/chkerr.sd7         0.039919           4663
+seed7/prg/chkexc.sd7         0.038943           2627
+seed7/prg/chkfil.sd7         0.042821           1615
+seed7/prg/chkflt.sd7         0.044244          20620
+seed7/prg/chkhent.sd7        0.036610             54
+seed7/prg/chkhsh.sd7         0.040293           4548
+seed7/prg/chkidx.sd7         0.043402          19567
+seed7/prg/chkint.sd7         0.048954          38129
+seed7/prg/chkjson.sd7        0.042149           1764
+seed7/prg/chkovf.sd7         0.039786           8216
+seed7/prg/chkprc.sd7         0.038216          10111
+seed7/prg/chkscan.sd7        0.038992            714
+seed7/prg/chkset.sd7         0.040396          11974
+seed7/prg/chkstr.sd7         0.042639          26952
+seed7/prg/chktime.sd7        0.038584           2025
+seed7/prg/chktoml.sd7        0.038300           1656
+seed7/prg/clock.sd7          0.035012             47
+seed7/prg/clock2.sd7         0.035781             43
+seed7/prg/clock3.sd7         0.039795             95
+seed7/prg/cmpfil.sd7         0.037263             84
+seed7/prg/comanche.sd7       0.039890            180
+seed7/prg/confval.sd7        0.039022            175
+seed7/prg/db7.sd7            0.037393            417
+seed7/prg/diff7.sd7          0.037844            263
+seed7/prg/dirtst.sd7         0.035706             42
+seed7/prg/dirx.sd7           0.037026            152
+seed7/prg/dnafight.sd7       0.037960           1381
+seed7/prg/dragon.sd7         0.035523             73
+seed7/prg/echo.sd7           0.034564             39
+seed7/prg/eliza.sd7          0.037584            302
+seed7/prg/err.sd7            0.042996             96
+seed7/prg/fannkuch.sd7       0.042092            131
+seed7/prg/fib.sd7            0.038389             47
+seed7/prg/find7.sd7          0.039415            133
+seed7/prg/findchar.sd7       0.039623            149
+seed7/prg/fractree.sd7       0.035920             55
+seed7/prg/ftp7.sd7           0.039181            296
+seed7/prg/ftpserv.sd7        0.037664             74
+seed7/prg/gcd.sd7            0.038123            109
+seed7/prg/gkbd.sd7           0.041224            358
+seed7/prg/gtksvtst.sd7       0.036981             94
+seed7/prg/hal.sd7            0.037363            250
+seed7/prg/hamu.sd7           0.037860            573
+seed7/prg/hanoi.sd7          0.036020             55
+seed7/prg/hd.sd7             0.036039             79
+seed7/prg/hello.sd7          0.035308             32
+seed7/prg/hilbert.sd7        0.039877            108
+seed7/prg/ide7.sd7           0.039703            196
+seed7/prg/kbd.sd7            0.036772             49
+seed7/prg/klondike.sd7       0.038846            883
+seed7/prg/lander.sd7         0.039591           1551
+seed7/prg/lst80bas.sd7       0.038185            344
+seed7/prg/lst99bas.sd7       0.039857            401
+seed7/prg/lstgwbas.sd7       0.039906            577
+seed7/prg/mahjong.sd7        0.039491           1943
+seed7/prg/make7.sd7          0.038918            121
+seed7/prg/mandelbr.sd7       0.039493            237
+seed7/prg/mind.sd7           0.040515            443
+seed7/prg/mirror.sd7         0.040444            131
+seed7/prg/ms.sd7             0.039366            641
+seed7/prg/nicoma.sd7         0.038360            135
+seed7/prg/pac.sd7            0.044095            726
+seed7/prg/pairs.sd7          0.042179           2025
+seed7/prg/panic.sd7          0.038368           2634
+seed7/prg/percolation.sd7    0.039156            330
+seed7/prg/planets.sd7        0.040140           1486
+seed7/prg/portfwd7.sd7       0.039091            139
+seed7/prg/prime.sd7          0.035704             74
+seed7/prg/printpi1.sd7       0.035531             56
+seed7/prg/printpi2.sd7       0.036756             54
+seed7/prg/printpi3.sd7       0.035874             60
+seed7/prg/pv7.sd7            0.038226            337
+seed7/prg/queen.sd7          0.038972            149
+seed7/prg/rand.sd7           0.038116            121
+seed7/prg/raytrace.sd7       0.038990            538
+seed7/prg/rever.sd7          0.039367            816
+seed7/prg/roman.sd7          0.035609             38
+seed7/prg/s7c.sd7            0.039308           9060
+seed7/prg/s7check.sd7        0.036932             68
+seed7/prg/savehd7.sd7        0.039499           1110
+seed7/prg/self.sd7           0.036853             49
+seed7/prg/shisen.sd7         0.038842           1423
+seed7/prg/sl.sd7             0.038499           1029
+seed7/prg/snake.sd7          0.038909            615
+seed7/prg/sokoban.sd7        0.038613            891
+seed7/prg/spigotpi.sd7       0.036779             64
+seed7/prg/sql7.sd7           0.038500            278
+seed7/prg/startrek.sd7       0.038666            979
+seed7/prg/sudoku7.sd7        0.039095           2657
+seed7/prg/sydir7.sd7         0.039083            384
+seed7/prg/syntaxhl.sd7       0.041520            177
+seed7/prg/tak.sd7            0.036523             59
+seed7/prg/tar7.sd7           0.038695            121
+seed7/prg/tch.sd7            0.035546             55
+seed7/prg/testfont.sd7       0.038415             95
+seed7/prg/tet.sd7            0.038714            479
+seed7/prg/tetg.sd7           0.037694            501
+seed7/prg/toutf8.sd7         0.039192            240
+seed7/prg/tst_cli.sd7        0.036386             40
+seed7/prg/tst_srv.sd7        0.036781             47
+seed7/prg/wator.sd7          0.038577            651
+seed7/prg/which.sd7          0.036637             65
+seed7/prg/wiz.sd7            0.038525           2833
+seed7/prg/wordcnt.sd7        0.038631             54
+seed7/prg/wrinum.sd7         0.039205             43
+seed7/prg/wumpus.sd7         0.041918            372
+seed7/lib/aes.s7i            0.042240           1144
+seed7/lib/aes_gcm.s7i        0.039956            392
+seed7/lib/ar.s7i             0.042562           1532
+seed7/lib/arc4.s7i           0.043424            144
+seed7/lib/archive.s7i        0.042709            143
+seed7/lib/archive_base.s7i   0.039073            135
+seed7/lib/array.s7i          0.038789            610
+seed7/lib/asn1.s7i           0.036947            544
+seed7/lib/asn1oid.s7i        0.044786            157
+seed7/lib/basearray.s7i      0.043638            450
+seed7/lib/bigfile.s7i        0.042774            136
+seed7/lib/bigint.s7i         0.043270            824
+seed7/lib/bigrat.s7i         0.042559            784
+seed7/lib/bin16.s7i          0.043061            592
+seed7/lib/bin32.s7i          0.041817            490
+seed7/lib/bin64.s7i          0.040219            539
+seed7/lib/bitdata.s7i        0.046454           1330
+seed7/lib/bitmapfont.s7i     0.042065            215
+seed7/lib/bitset.s7i         0.045472            593
+seed7/lib/bitsetof.s7i       0.045957            431
+seed7/lib/blowfish.s7i       0.045148            383
+seed7/lib/bmp.s7i            0.043564            924
+seed7/lib/boolean.s7i        0.042222            403
+seed7/lib/browser.s7i        0.043446            280
+seed7/lib/bstring.s7i        0.042036            227
+seed7/lib/bytedata.s7i       0.040567            482
+seed7/lib/bzip2.s7i          0.042541            887
+seed7/lib/cards.s7i          0.038400           1342
+seed7/lib/category.s7i       0.038915            209
+seed7/lib/cc_conf.s7i        0.038280           1314
+seed7/lib/ccittfax.s7i       0.039140           1022
+seed7/lib/cgi.s7i            0.038050            109
+seed7/lib/cgidialog.s7i      0.038679           1118
+seed7/lib/char.s7i           0.038679            356
+seed7/lib/charsets.s7i       0.039450           2024
+seed7/lib/chartype.s7i       0.045884            121
+seed7/lib/cipher.s7i         0.043779            146
+seed7/lib/cli_cmds.s7i       0.041514           1360
+seed7/lib/clib_file.s7i      0.038906            301
+seed7/lib/color.s7i          0.038272            185
+seed7/lib/complex.s7i        0.038484            464
+seed7/lib/compress.s7i       0.038285            150
+seed7/lib/console.s7i        0.037876            188
+seed7/lib/cpio.s7i           0.038679           1708
+seed7/lib/crc32.s7i          0.039496            193
+seed7/lib/cronos16.s7i       0.043867           1173
+seed7/lib/cronos27.s7i       0.046112           1464
+seed7/lib/csv.s7i            0.042542            201
+seed7/lib/db_prop.s7i        0.043515            991
+seed7/lib/deflate.s7i        0.043693            740
+seed7/lib/des.s7i            0.043022            444
+seed7/lib/dialog.s7i         0.042901            311
+seed7/lib/dir.s7i            0.040428            163
+seed7/lib/draw.s7i           0.041165            854
+seed7/lib/duration.s7i       0.042549           1038
+seed7/lib/echo.s7i           0.043772            132
+seed7/lib/editline.s7i       0.038772            398
+seed7/lib/elf.s7i            0.040486           1560
+seed7/lib/elliptic.s7i       0.038625            649
+seed7/lib/enable_io.s7i      0.038431            312
+seed7/lib/encoding.s7i       0.042701            931
+seed7/lib/enumeration.s7i    0.043752            236
+seed7/lib/environment.s7i    0.042698            175
+seed7/lib/exif.s7i           0.044405            152
+seed7/lib/external_file.s7i  0.041940            340
+seed7/lib/field.s7i          0.041894            268
+seed7/lib/file.s7i           0.039719            372
+seed7/lib/filebits.s7i       0.037722             46
+seed7/lib/filesys.s7i        0.037722            601
+seed7/lib/fileutil.s7i       0.037626            144
+seed7/lib/fixarray.s7i       0.044691            307
+seed7/lib/float.s7i          0.043632            757
+seed7/lib/font.s7i           0.039915            196
+seed7/lib/font8x8.s7i        0.040796            998
+seed7/lib/forloop.s7i        0.042839            449
+seed7/lib/ftp.s7i            0.039110            969
+seed7/lib/ftpserv.s7i        0.039385            631
+seed7/lib/getf.s7i           0.042995            115
+seed7/lib/gethttp.s7i        0.037791             41
+seed7/lib/gethttps.s7i       0.036798             41
+seed7/lib/gif.s7i            0.038994            561
+seed7/lib/graph.s7i          0.042204            415
+seed7/lib/graph_file.s7i     0.039321            399
+seed7/lib/gtkserver.s7i      0.039167            161
+seed7/lib/gzip.s7i           0.040021            573
+seed7/lib/hash.s7i           0.040650            421
+seed7/lib/hashsetof.s7i      0.041161            499
+seed7/lib/hmac.s7i           0.039435            152
+seed7/lib/html.s7i           0.038237             83
+seed7/lib/html_ent.s7i       0.039324            476
+seed7/lib/htmldom.s7i        0.040054            286
+seed7/lib/http_request.s7i   0.038483            696
+seed7/lib/http_srv_resp.s7i  0.038637            380
+seed7/lib/https_request.s7i  0.037709            211
+seed7/lib/httpserv.s7i       0.037655            345
+seed7/lib/huffman.s7i        0.039204            644
+seed7/lib/ico.s7i            0.040287            221
+seed7/lib/idxarray.s7i       0.039019            232
+seed7/lib/image.s7i          0.038098            156
+seed7/lib/imagefile.s7i      0.039147            171
+seed7/lib/inflate.s7i        0.038991            411
+seed7/lib/inifile.s7i        0.038933            129
+seed7/lib/integer.s7i        0.038994            663
+seed7/lib/iobuffer.s7i       0.039431            289
+seed7/lib/jpeg.s7i           0.039563           1761
+seed7/lib/json.s7i           0.039171            891
+seed7/lib/json_serde.s7i     0.039456            783
+seed7/lib/keybd.s7i          0.038274            639
+seed7/lib/keydescr.s7i       0.042221            192
+seed7/lib/leb128.s7i         0.039486            218
+seed7/lib/line.s7i           0.038933            164
+seed7/lib/listener.s7i       0.039549            247
+seed7/lib/logfile.s7i        0.037168             73
+seed7/lib/lower.s7i          0.038746            142
+seed7/lib/lzma.s7i           0.039720            934
+seed7/lib/lzw.s7i            0.039510            861
+seed7/lib/magic.s7i          0.042500            403
+seed7/lib/mahjng32.s7i       0.037498           1500
+seed7/lib/make.s7i           0.038154            544
+seed7/lib/makedata.s7i       0.037992           1428
+seed7/lib/math.s7i           0.037519            201
+seed7/lib/mixarith.s7i       0.039344            249
+seed7/lib/modern27.s7i       0.043467           1099
+seed7/lib/more.s7i           0.039292            130
+seed7/lib/msgdigest.s7i      0.040047           1222
+seed7/lib/multiscr.s7i       0.036950             68
+seed7/lib/null_file.s7i      0.038600            345
+seed7/lib/osfiles.s7i        0.040415           1085
+seed7/lib/pbm.s7i            0.039226            230
+seed7/lib/pcx.s7i            0.039271            638
+seed7/lib/pem.s7i            0.038519            185
+seed7/lib/pgm.s7i            0.038679            238
+seed7/lib/pic16.s7i          0.039243           1037
+seed7/lib/pic32.s7i          0.038129           2060
+seed7/lib/pic_util.s7i       0.039148            144
+seed7/lib/pixelimage.s7i     0.039285            320
+seed7/lib/pixmap_file.s7i    0.039750            459
+seed7/lib/pixmapfont.s7i     0.040235            184
+seed7/lib/pkcs1.s7i          0.044047            543
+seed7/lib/png.s7i            0.039775           1064
+seed7/lib/poll.s7i           0.039107            313
+seed7/lib/ppm.s7i            0.039673            240
+seed7/lib/process.s7i        0.038449            541
+seed7/lib/progs.s7i          0.037984            789
+seed7/lib/propertyfile.s7i   0.037726            155
+seed7/lib/rational.s7i       0.038406            792
+seed7/lib/ref_list.s7i       0.038215            252
+seed7/lib/reference.s7i      0.040472            126
+seed7/lib/reverse.s7i        0.037827             94
+seed7/lib/rpm.s7i            0.039399           3487
+seed7/lib/rpmext.s7i         0.039899            318
+seed7/lib/scanfile.s7i       0.039347           1779
+seed7/lib/scanjson.s7i       0.039942            413
+seed7/lib/scanstri.s7i       0.039159           1814
+seed7/lib/scantoml.s7i       0.040412           1603
+seed7/lib/seed7_05.s7i       0.041460           1072
+seed7/lib/set.s7i            0.037507             57
+seed7/lib/shell.s7i          0.040325            615
+seed7/lib/showtls.s7i        0.039631            678
+seed7/lib/signature.s7i      0.039432            131
+seed7/lib/smtp.s7i           0.039508            261
+seed7/lib/sockbase.s7i       0.041073            217
+seed7/lib/socket.s7i         0.039405            326
+seed7/lib/sokoban1.s7i       0.039469           1519
+seed7/lib/sql_base.s7i       0.039679           1000
+seed7/lib/stars.s7i          0.041672           1705
+seed7/lib/stdfont10.s7i      0.037503           3347
+seed7/lib/stdfont12.s7i      0.039281           3928
+seed7/lib/stdfont14.s7i      0.040088           4510
+seed7/lib/stdfont16.s7i      0.038008           5092
+seed7/lib/stdfont18.s7i      0.039714           5868
+seed7/lib/stdfont20.s7i      0.038071           6449
+seed7/lib/stdfont24.s7i      0.038646           7421
+seed7/lib/stdfont8.s7i       0.038427           2960
+seed7/lib/stdfont9.s7i       0.037623           3152
+seed7/lib/stdio.s7i          0.038594            192
+seed7/lib/strifile.s7i       0.038987            345
+seed7/lib/string.s7i         0.038643            779
+seed7/lib/stritext.s7i       0.039217            352
+seed7/lib/struct.s7i         0.040191            266
+seed7/lib/struct_elem.s7i    0.038131            129
+seed7/lib/subfile.s7i        0.038209            174
+seed7/lib/subrange.s7i       0.037417             78
+seed7/lib/syntax.s7i         0.039296            294
+seed7/lib/tar.s7i            0.039263           1880
+seed7/lib/tar_cmds.s7i       0.039226            752
+seed7/lib/tdes.s7i           0.038497            143
+seed7/lib/tee.s7i            0.038307            143
+seed7/lib/text.s7i           0.038915            135
+seed7/lib/tga.s7i            0.041043            676
+seed7/lib/tiff.s7i           0.041033           2771
+seed7/lib/time.s7i           0.039130           1191
+seed7/lib/tls.s7i            0.039409           2230
+seed7/lib/unicode.s7i        0.041442            575
+seed7/lib/unionfnd.s7i       0.038741            130
+seed7/lib/upper.s7i          0.038890            142
+seed7/lib/utf16.s7i          0.038125            540
+seed7/lib/utf8.s7i           0.039039            234
+seed7/lib/vecfont10.s7i      0.041110           1056
+seed7/lib/vecfont18.s7i      0.041134           1119
+seed7/lib/vector3d.s7i       0.039249            293
+seed7/lib/vectorfont.s7i     0.039206            239
+seed7/lib/wildcard.s7i       0.040575            140
+seed7/lib/window.s7i         0.038859            455
+seed7/lib/wrinum.s7i         0.042339            248
+seed7/lib/x509cert.s7i       0.040619           1243
+seed7/lib/xml_ent.s7i        0.038251             94
+seed7/lib/xmldom.s7i         0.038467            303
+seed7/lib/xz.s7i             0.039615            442
+seed7/lib/zip.s7i            0.039772           2792
+seed7/lib/zstd.s7i           0.040829           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039602        |
++-----------+-----------------+
+| Minimum   | 0.034564        |
++-----------+-----------------+
+| Maximum   | 0.048954        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.041893            190
+seed7/prg/bas7.sd7           0.328465          11459
+seed7/prg/bifurk.sd7         0.037808             73
+seed7/prg/bigfiles.sd7       0.039704            129
+seed7/prg/brainf7.sd7        0.038391             86
+seed7/prg/calc7.sd7          0.041786            128
+seed7/prg/carddemo.sd7       0.041063            190
+seed7/prg/castle.sd7         0.106669           3148
+seed7/prg/cat.sd7            0.038702             82
+seed7/prg/cellauto.sd7       0.049529             85
+seed7/prg/celsius.sd7        0.036274             42
+seed7/prg/chk_all.sd7        0.062137            843
+seed7/prg/chkarr.sd7         0.357908           8367
+seed7/prg/chkbig.sd7         2.059696          29026
+seed7/prg/chkbin.sd7         0.505256           6469
+seed7/prg/chkbitdata.sd7     0.605683           6624
+seed7/prg/chkbool.sd7        0.119160           3157
+seed7/prg/chkbst.sd7         0.062608            722
+seed7/prg/chkchr.sd7         0.216743           2809
+seed7/prg/chkcmd.sd7         0.064872           1205
+seed7/prg/chkdb.sd7          0.345043           7454
+seed7/prg/chkdecl.sd7        0.057459            448
+seed7/prg/chkenum.sd7        0.066789           1230
+seed7/prg/chkerr.sd7         0.191841           4663
+seed7/prg/chkexc.sd7         0.082331           2627
+seed7/prg/chkfil.sd7         0.075873           1615
+seed7/prg/chkflt.sd7         1.331720          20620
+seed7/prg/chkhent.sd7        0.037376             54
+seed7/prg/chkhsh.sd7         0.244449           4548
+seed7/prg/chkidx.sd7         1.304328          19567
+seed7/prg/chkint.sd7         2.502191          38129
+seed7/prg/chkjson.sd7        0.100377           1764
+seed7/prg/chkovf.sd7         0.570728           8216
+seed7/prg/chkprc.sd7         0.322333          10111
+seed7/prg/chkscan.sd7        0.054571            714
+seed7/prg/chkset.sd7         0.668381          11974
+seed7/prg/chkstr.sd7         1.410674          26952
+seed7/prg/chktime.sd7        0.134517           2025
+seed7/prg/chktoml.sd7        0.109705           1656
+seed7/prg/clock.sd7          0.035680             47
+seed7/prg/clock2.sd7         0.034963             43
+seed7/prg/clock3.sd7         0.037032             95
+seed7/prg/cmpfil.sd7         0.041605             84
+seed7/prg/comanche.sd7       0.044108            180
+seed7/prg/confval.sd7        0.042509            175
+seed7/prg/db7.sd7            0.046211            417
+seed7/prg/diff7.sd7          0.042167            263
+seed7/prg/dirtst.sd7         0.035212             42
+seed7/prg/dirx.sd7           0.038043            152
+seed7/prg/dnafight.sd7       0.069310           1381
+seed7/prg/dragon.sd7         0.037544             73
+seed7/prg/echo.sd7           0.035675             39
+seed7/prg/eliza.sd7          0.042808            302
+seed7/prg/err.sd7            0.042488             96
+seed7/prg/fannkuch.sd7       0.037841            131
+seed7/prg/fib.sd7            0.035599             47
+seed7/prg/find7.sd7          0.036712            133
+seed7/prg/findchar.sd7       0.037261            149
+seed7/prg/fractree.sd7       0.037166             55
+seed7/prg/ftp7.sd7           0.040970            296
+seed7/prg/ftpserv.sd7        0.035397             74
+seed7/prg/gcd.sd7            0.037904            109
+seed7/prg/gkbd.sd7           0.047844            358
+seed7/prg/gtksvtst.sd7       0.037719             94
+seed7/prg/hal.sd7            0.039603            250
+seed7/prg/hamu.sd7           0.048213            573
+seed7/prg/hanoi.sd7          0.035899             55
+seed7/prg/hd.sd7             0.036610             79
+seed7/prg/hello.sd7          0.035309             32
+seed7/prg/hilbert.sd7        0.038833            108
+seed7/prg/ide7.sd7           0.039664            196
+seed7/prg/kbd.sd7            0.035840             49
+seed7/prg/klondike.sd7       0.054915            883
+seed7/prg/lander.sd7         0.070843           1551
+seed7/prg/lst80bas.sd7       0.043732            344
+seed7/prg/lst99bas.sd7       0.044788            401
+seed7/prg/lstgwbas.sd7       0.050268            577
+seed7/prg/mahjong.sd7        0.081537           1943
+seed7/prg/make7.sd7          0.037815            121
+seed7/prg/mandelbr.sd7       0.039976            237
+seed7/prg/mind.sd7           0.044051            443
+seed7/prg/mirror.sd7         0.037719            131
+seed7/prg/ms.sd7             0.047556            641
+seed7/prg/nicoma.sd7         0.037044            135
+seed7/prg/pac.sd7            0.048365            726
+seed7/prg/pairs.sd7          0.086290           2025
+seed7/prg/panic.sd7          0.097290           2634
+seed7/prg/percolation.sd7    0.043044            330
+seed7/prg/planets.sd7        0.076196           1486
+seed7/prg/portfwd7.sd7       0.040517            139
+seed7/prg/prime.sd7          0.037421             74
+seed7/prg/printpi1.sd7       0.035810             56
+seed7/prg/printpi2.sd7       0.035863             54
+seed7/prg/printpi3.sd7       0.035704             60
+seed7/prg/pv7.sd7            0.042574            337
+seed7/prg/queen.sd7          0.036727            149
+seed7/prg/rand.sd7           0.036044            121
+seed7/prg/raytrace.sd7       0.046631            538
+seed7/prg/rever.sd7          0.052881            816
+seed7/prg/roman.sd7          0.035312             38
+seed7/prg/s7c.sd7            0.275420           9060
+seed7/prg/s7check.sd7        0.035739             68
+seed7/prg/savehd7.sd7        0.065653           1110
+seed7/prg/self.sd7           0.036995             49
+seed7/prg/shisen.sd7         0.072471           1423
+seed7/prg/sl.sd7             0.059561           1029
+seed7/prg/snake.sd7          0.046654            615
+seed7/prg/sokoban.sd7        0.053982            891
+seed7/prg/spigotpi.sd7       0.035721             64
+seed7/prg/sql7.sd7           0.040925            278
+seed7/prg/startrek.sd7       0.058506            979
+seed7/prg/sudoku7.sd7        0.099958           2657
+seed7/prg/sydir7.sd7         0.045500            384
+seed7/prg/syntaxhl.sd7       0.040635            177
+seed7/prg/tak.sd7            0.035586             59
+seed7/prg/tar7.sd7           0.037272            121
+seed7/prg/tch.sd7            0.035672             55
+seed7/prg/testfont.sd7       0.037193             95
+seed7/prg/tet.sd7            0.044887            479
+seed7/prg/tetg.sd7           0.045615            501
+seed7/prg/toutf8.sd7         0.041256            240
+seed7/prg/tst_cli.sd7        0.034137             40
+seed7/prg/tst_srv.sd7        0.034105             47
+seed7/prg/wator.sd7          0.050009            651
+seed7/prg/which.sd7          0.035523             65
+seed7/prg/wiz.sd7            0.106019           2833
+seed7/prg/wordcnt.sd7        0.035684             54
+seed7/prg/wrinum.sd7         0.035141             43
+seed7/prg/wumpus.sd7         0.042357            372
+seed7/lib/aes.s7i            0.108558           1144
+seed7/lib/aes_gcm.s7i        0.045754            392
+seed7/lib/ar.s7i             0.072401           1532
+seed7/lib/arc4.s7i           0.037990            144
+seed7/lib/archive.s7i        0.038297            143
+seed7/lib/archive_base.s7i   0.038179            135
+seed7/lib/array.s7i          0.053745            610
+seed7/lib/asn1.s7i           0.046812            544
+seed7/lib/asn1oid.s7i        0.041183            157
+seed7/lib/basearray.s7i      0.048286            450
+seed7/lib/bigfile.s7i        0.037911            136
+seed7/lib/bigint.s7i         0.055580            824
+seed7/lib/bigrat.s7i         0.052881            784
+seed7/lib/bin16.s7i          0.049045            592
+seed7/lib/bin32.s7i          0.046131            490
+seed7/lib/bin64.s7i          0.048426            539
+seed7/lib/bitdata.s7i        0.075585           1330
+seed7/lib/bitmapfont.s7i     0.040919            215
+seed7/lib/bitset.s7i         0.048587            593
+seed7/lib/bitsetof.s7i       0.049077            431
+seed7/lib/blowfish.s7i       0.055739            383
+seed7/lib/bmp.s7i            0.064170            924
+seed7/lib/boolean.s7i        0.044721            403
+seed7/lib/browser.s7i        0.042591            280
+seed7/lib/bstring.s7i        0.041427            227
+seed7/lib/bytedata.s7i       0.049826            482
+seed7/lib/bzip2.s7i          0.059068            887
+seed7/lib/cards.s7i          0.066704           1342
+seed7/lib/category.s7i       0.040872            209
+seed7/lib/cc_conf.s7i        0.077453           1314
+seed7/lib/ccittfax.s7i       0.064838           1022
+seed7/lib/cgi.s7i            0.037276            109
+seed7/lib/cgidialog.s7i      0.059431           1118
+seed7/lib/char.s7i           0.041806            356
+seed7/lib/charsets.s7i       0.079540           2024
+seed7/lib/chartype.s7i       0.040356            121
+seed7/lib/cipher.s7i         0.037310            146
+seed7/lib/cli_cmds.s7i       0.069863           1360
+seed7/lib/clib_file.s7i      0.043295            301
+seed7/lib/color.s7i          0.040412            185
+seed7/lib/complex.s7i        0.044993            464
+seed7/lib/compress.s7i       0.037931            150
+seed7/lib/console.s7i        0.039023            188
+seed7/lib/cpio.s7i           0.081637           1708
+seed7/lib/crc32.s7i          0.043533            193
+seed7/lib/cronos16.s7i       0.092634           1173
+seed7/lib/cronos27.s7i       0.116332           1464
+seed7/lib/csv.s7i            0.040243            201
+seed7/lib/db_prop.s7i        0.063362            991
+seed7/lib/deflate.s7i        0.055023            740
+seed7/lib/des.s7i            0.054605            444
+seed7/lib/dialog.s7i         0.044343            311
+seed7/lib/dir.s7i            0.037810            163
+seed7/lib/draw.s7i           0.054688            854
+seed7/lib/duration.s7i       0.058837           1038
+seed7/lib/echo.s7i           0.036990            132
+seed7/lib/editline.s7i       0.046273            398
+seed7/lib/elf.s7i            0.084075           1560
+seed7/lib/elliptic.s7i       0.051892            649
+seed7/lib/enable_io.s7i      0.043596            312
+seed7/lib/encoding.s7i       0.060755            931
+seed7/lib/enumeration.s7i    0.041146            236
+seed7/lib/environment.s7i    0.039149            175
+seed7/lib/exif.s7i           0.039060            152
+seed7/lib/external_file.s7i  0.044985            340
+seed7/lib/field.s7i          0.042721            268
+seed7/lib/file.s7i           0.043701            372
+seed7/lib/filebits.s7i       0.035885             46
+seed7/lib/filesys.s7i        0.048226            601
+seed7/lib/fileutil.s7i       0.037863            144
+seed7/lib/fixarray.s7i       0.043094            307
+seed7/lib/float.s7i          0.054710            757
+seed7/lib/font.s7i           0.039791            196
+seed7/lib/font8x8.s7i        0.048166            998
+seed7/lib/forloop.s7i        0.043956            449
+seed7/lib/ftp.s7i            0.055677            969
+seed7/lib/ftpserv.s7i        0.049701            631
+seed7/lib/getf.s7i           0.035748            115
+seed7/lib/gethttp.s7i        0.034559             41
+seed7/lib/gethttps.s7i       0.036671             41
+seed7/lib/gif.s7i            0.049707            561
+seed7/lib/graph.s7i          0.048894            415
+seed7/lib/graph_file.s7i     0.044215            399
+seed7/lib/gtkserver.s7i      0.038118            161
+seed7/lib/gzip.s7i           0.048532            573
+seed7/lib/hash.s7i           0.049186            421
+seed7/lib/hashsetof.s7i      0.048341            499
+seed7/lib/hmac.s7i           0.038850            152
+seed7/lib/html.s7i           0.036654             83
+seed7/lib/html_ent.s7i       0.046910            476
+seed7/lib/htmldom.s7i        0.043784            286
+seed7/lib/http_request.s7i   0.052452            696
+seed7/lib/http_srv_resp.s7i  0.046234            380
+seed7/lib/https_request.s7i  0.040032            211
+seed7/lib/httpserv.s7i       0.043500            345
+seed7/lib/huffman.s7i        0.052349            644
+seed7/lib/ico.s7i            0.041996            221
+seed7/lib/idxarray.s7i       0.042108            232
+seed7/lib/image.s7i          0.037173            156
+seed7/lib/imagefile.s7i      0.038511            171
+seed7/lib/inflate.s7i        0.045556            411
+seed7/lib/inifile.s7i        0.036614            129
+seed7/lib/integer.s7i        0.050541            663
+seed7/lib/iobuffer.s7i       0.041583            289
+seed7/lib/jpeg.s7i           0.083421           1761
+seed7/lib/json.s7i           0.055267            891
+seed7/lib/json_serde.s7i     0.052878            783
+seed7/lib/keybd.s7i          0.054941            639
+seed7/lib/keydescr.s7i       0.043036            192
+seed7/lib/leb128.s7i         0.039614            218
+seed7/lib/line.s7i           0.038723            164
+seed7/lib/listener.s7i       0.041012            247
+seed7/lib/logfile.s7i        0.036367             73
+seed7/lib/lower.s7i          0.037435            142
+seed7/lib/lzma.s7i           0.058508            934
+seed7/lib/lzw.s7i            0.058174            861
+seed7/lib/magic.s7i          0.047709            403
+seed7/lib/mahjng32.s7i       0.064348           1500
+seed7/lib/make.s7i           0.049932            544
+seed7/lib/makedata.s7i       0.069471           1428
+seed7/lib/math.s7i           0.038631            201
+seed7/lib/mixarith.s7i       0.038365            249
+seed7/lib/modern27.s7i       0.081727           1099
+seed7/lib/more.s7i           0.037561            130
+seed7/lib/msgdigest.s7i      0.078045           1222
+seed7/lib/multiscr.s7i       0.036529             68
+seed7/lib/null_file.s7i      0.042705            345
+seed7/lib/osfiles.s7i        0.064727           1085
+seed7/lib/pbm.s7i            0.040116            230
+seed7/lib/pcx.s7i            0.051504            638
+seed7/lib/pem.s7i            0.038211            185
+seed7/lib/pgm.s7i            0.039349            238
+seed7/lib/pic16.s7i          0.048034           1037
+seed7/lib/pic32.s7i          0.079140           2060
+seed7/lib/pic_util.s7i       0.037331            144
+seed7/lib/pixelimage.s7i     0.040920            320
+seed7/lib/pixmap_file.s7i    0.044133            459
+seed7/lib/pixmapfont.s7i     0.039500            184
+seed7/lib/pkcs1.s7i          0.063152            543
+seed7/lib/png.s7i            0.063927           1064
+seed7/lib/poll.s7i           0.042537            313
+seed7/lib/ppm.s7i            0.040878            240
+seed7/lib/process.s7i        0.049122            541
+seed7/lib/progs.s7i          0.055337            789
+seed7/lib/propertyfile.s7i   0.041477            155
+seed7/lib/rational.s7i       0.053143            792
+seed7/lib/ref_list.s7i       0.041860            252
+seed7/lib/reference.s7i      0.038072            126
+seed7/lib/reverse.s7i        0.036926             94
+seed7/lib/rpm.s7i            0.143058           3487
+seed7/lib/rpmext.s7i         0.044398            318
+seed7/lib/scanfile.s7i       0.080093           1779
+seed7/lib/scanjson.s7i       0.046791            413
+seed7/lib/scanstri.s7i       0.080897           1814
+seed7/lib/scantoml.s7i       0.071313           1603
+seed7/lib/seed7_05.s7i       0.066487           1072
+seed7/lib/set.s7i            0.035900             57
+seed7/lib/shell.s7i          0.052116            615
+seed7/lib/showtls.s7i        0.053870            678
+seed7/lib/signature.s7i      0.037998            131
+seed7/lib/smtp.s7i           0.039117            261
+seed7/lib/sockbase.s7i       0.040729            217
+seed7/lib/socket.s7i         0.044352            326
+seed7/lib/sokoban1.s7i       0.053935           1519
+seed7/lib/sql_base.s7i       0.063436           1000
+seed7/lib/stars.s7i          0.133388           1705
+seed7/lib/stdfont10.s7i      0.080646           3347
+seed7/lib/stdfont12.s7i      0.092178           3928
+seed7/lib/stdfont14.s7i      0.104897           4510
+seed7/lib/stdfont16.s7i      0.114199           5092
+seed7/lib/stdfont18.s7i      0.136016           5868
+seed7/lib/stdfont20.s7i      0.147318           6449
+seed7/lib/stdfont24.s7i      0.181782           7421
+seed7/lib/stdfont8.s7i       0.073114           2960
+seed7/lib/stdfont9.s7i       0.076043           3152
+seed7/lib/stdio.s7i          0.040694            192
+seed7/lib/strifile.s7i       0.043037            345
+seed7/lib/string.s7i         0.061169            779
+seed7/lib/stritext.s7i       0.050099            352
+seed7/lib/struct.s7i         0.058996            266
+seed7/lib/struct_elem.s7i    0.037863            129
+seed7/lib/subfile.s7i        0.037572            174
+seed7/lib/subrange.s7i       0.035857             78
+seed7/lib/syntax.s7i         0.044446            294
+seed7/lib/tar.s7i            0.079846           1880
+seed7/lib/tar_cmds.s7i       0.056678            752
+seed7/lib/tdes.s7i           0.037074            143
+seed7/lib/tee.s7i            0.037752            143
+seed7/lib/text.s7i           0.037561            135
+seed7/lib/tga.s7i            0.052902            676
+seed7/lib/tiff.s7i           0.119766           2771
+seed7/lib/time.s7i           0.063974           1191
+seed7/lib/tls.s7i            0.102760           2230
+seed7/lib/unicode.s7i        0.052024            575
+seed7/lib/unionfnd.s7i       0.037148            130
+seed7/lib/upper.s7i          0.036914            142
+seed7/lib/utf16.s7i          0.048463            540
+seed7/lib/utf8.s7i           0.039971            234
+seed7/lib/vecfont10.s7i      0.080460           1056
+seed7/lib/vecfont18.s7i      0.087177           1119
+seed7/lib/vector3d.s7i       0.040737            293
+seed7/lib/vectorfont.s7i     0.040527            239
+seed7/lib/wildcard.s7i       0.038924            140
+seed7/lib/window.s7i         0.045021            455
+seed7/lib/wrinum.s7i         0.040893            248
+seed7/lib/x509cert.s7i       0.071705           1243
+seed7/lib/xml_ent.s7i        0.036930             94
+seed7/lib/xmldom.s7i         0.039987            303
+seed7/lib/xz.s7i             0.044252            442
+seed7/lib/zip.s7i            0.116569           2792
+seed7/lib/zstd.s7i           0.069125           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.088911        |
++-----------+-----------------+
+| Minimum   | 0.034105        |
++-----------+-----------------+
+| Maximum   | 2.502191        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.047043            190
+seed7/prg/bas7.sd7           0.764153          11459
+seed7/prg/bifurk.sd7         0.038449             73
+seed7/prg/bigfiles.sd7       0.041350            129
+seed7/prg/brainf7.sd7        0.037391             86
+seed7/prg/calc7.sd7          0.047557            128
+seed7/prg/carddemo.sd7       0.049231            190
+seed7/prg/castle.sd7         0.219599           3148
+seed7/prg/cat.sd7            0.041339             82
+seed7/prg/cellauto.sd7       0.041174             85
+seed7/prg/celsius.sd7        0.038395             42
+seed7/prg/chk_all.sd7        0.085195            843
+seed7/prg/chkarr.sd7         0.872240           8367
+seed7/prg/chkbig.sd7         4.120094          29026
+seed7/prg/chkbin.sd7         1.030891           6469
+seed7/prg/chkbitdata.sd7     1.250768           6624
+seed7/prg/chkbool.sd7        0.239652           3157
+seed7/prg/chkbst.sd7         0.113847            722
+seed7/prg/chkchr.sd7         0.485496           2809
+seed7/prg/chkcmd.sd7         0.117475           1205
+seed7/prg/chkdb.sd7          0.758078           7454
+seed7/prg/chkdecl.sd7        0.093895            448
+seed7/prg/chkenum.sd7        0.119820           1230
+seed7/prg/chkerr.sd7         0.345272           4663
+seed7/prg/chkexc.sd7         0.148529           2627
+seed7/prg/chkfil.sd7         0.125234           1615
+seed7/prg/chkflt.sd7         2.794039          20620
+seed7/prg/chkhent.sd7        0.038098             54
+seed7/prg/chkhsh.sd7         0.493997           4548
+seed7/prg/chkidx.sd7         3.142457          19567
+seed7/prg/chkint.sd7         5.499677          38129
+seed7/prg/chkjson.sd7        0.186726           1764
+seed7/prg/chkovf.sd7         1.189432           8216
+seed7/prg/chkprc.sd7         0.695089          10111
+seed7/prg/chkscan.sd7        0.089334            714
+seed7/prg/chkset.sd7         1.724488          11974
+seed7/prg/chkstr.sd7         3.449540          26952
+seed7/prg/chktime.sd7        0.250791           2025
+seed7/prg/chktoml.sd7        0.201709           1656
+seed7/prg/clock.sd7          0.041845             47
+seed7/prg/clock2.sd7         0.039697             43
+seed7/prg/clock3.sd7         0.044926             95
+seed7/prg/cmpfil.sd7         0.040014             84
+seed7/prg/comanche.sd7       0.052159            180
+seed7/prg/confval.sd7        0.053863            175
+seed7/prg/db7.sd7            0.067289            417
+seed7/prg/diff7.sd7          0.056471            263
+seed7/prg/dirtst.sd7         0.039593             42
+seed7/prg/dirx.sd7           0.048989            152
+seed7/prg/dnafight.sd7       0.128308           1381
+seed7/prg/dragon.sd7         0.043509             73
+seed7/prg/echo.sd7           0.039681             39
+seed7/prg/eliza.sd7          0.055250            302
+seed7/prg/err.sd7            0.045689             96
+seed7/prg/fannkuch.sd7       0.048565            131
+seed7/prg/fib.sd7            0.042765             47
+seed7/prg/find7.sd7          0.047779            133
+seed7/prg/findchar.sd7       0.048914            149
+seed7/prg/fractree.sd7       0.039455             55
+seed7/prg/ftp7.sd7           0.056655            296
+seed7/prg/ftpserv.sd7        0.042979             74
+seed7/prg/gcd.sd7            0.044833            109
+seed7/prg/gkbd.sd7           0.064237            358
+seed7/prg/gtksvtst.sd7       0.042123             94
+seed7/prg/hal.sd7            0.051798            250
+seed7/prg/hamu.sd7           0.073659            573
+seed7/prg/hanoi.sd7          0.040378             55
+seed7/prg/hd.sd7             0.040851             79
+seed7/prg/hello.sd7          0.037708             32
+seed7/prg/hilbert.sd7        0.045908            108
+seed7/prg/ide7.sd7           0.052829            196
+seed7/prg/kbd.sd7            0.038688             49
+seed7/prg/klondike.sd7       0.097400            883
+seed7/prg/lander.sd7         0.142815           1551
+seed7/prg/lst80bas.sd7       0.068811            344
+seed7/prg/lst99bas.sd7       0.065201            401
+seed7/prg/lstgwbas.sd7       0.081294            577
+seed7/prg/mahjong.sd7        0.155152           1943
+seed7/prg/make7.sd7          0.049778            121
+seed7/prg/mandelbr.sd7       0.053198            237
+seed7/prg/mind.sd7           0.064775            443
+seed7/prg/mirror.sd7         0.051656            131
+seed7/prg/ms.sd7             0.081112            641
+seed7/prg/nicoma.sd7         0.057950            135
+seed7/prg/pac.sd7            0.089812            726
+seed7/prg/pairs.sd7          0.156255           2025
+seed7/prg/panic.sd7          0.207569           2634
+seed7/prg/percolation.sd7    0.060982            330
+seed7/prg/planets.sd7        0.143512           1486
+seed7/prg/portfwd7.sd7       0.048385            139
+seed7/prg/prime.sd7          0.041685             74
+seed7/prg/printpi1.sd7       0.044304             56
+seed7/prg/printpi2.sd7       0.045638             54
+seed7/prg/printpi3.sd7       0.045101             60
+seed7/prg/pv7.sd7            0.068709            337
+seed7/prg/queen.sd7          0.055762            149
+seed7/prg/rand.sd7           0.049570            121
+seed7/prg/raytrace.sd7       0.075675            538
+seed7/prg/rever.sd7          0.084656            816
+seed7/prg/roman.sd7          0.037707             38
+seed7/prg/s7c.sd7            0.622837           9060
+seed7/prg/s7check.sd7        0.043959             68
+seed7/prg/savehd7.sd7        0.112341           1110
+seed7/prg/self.sd7           0.042637             49
+seed7/prg/shisen.sd7         0.123702           1423
+seed7/prg/sl.sd7             0.104869           1029
+seed7/prg/snake.sd7          0.071663            615
+seed7/prg/sokoban.sd7        0.087120            891
+seed7/prg/spigotpi.sd7       0.040997             64
+seed7/prg/sql7.sd7           0.056869            278
+seed7/prg/startrek.sd7       0.100274            979
+seed7/prg/sudoku7.sd7        0.209327           2657
+seed7/prg/sydir7.sd7         0.065811            384
+seed7/prg/syntaxhl.sd7       0.053912            177
+seed7/prg/tak.sd7            0.041921             59
+seed7/prg/tar7.sd7           0.046420            121
+seed7/prg/tch.sd7            0.040597             55
+seed7/prg/testfont.sd7       0.046366             95
+seed7/prg/tet.sd7            0.067998            479
+seed7/prg/tetg.sd7           0.066574            501
+seed7/prg/toutf8.sd7         0.055064            240
+seed7/prg/tst_cli.sd7        0.045312             40
+seed7/prg/tst_srv.sd7        0.042954             47
+seed7/prg/wator.sd7          0.084577            651
+seed7/prg/which.sd7          0.041858             65
+seed7/prg/wiz.sd7            0.221157           2833
+seed7/prg/wordcnt.sd7        0.041690             54
+seed7/prg/wrinum.sd7         0.040682             43
+seed7/prg/wumpus.sd7         0.061333            372
+seed7/lib/aes.s7i            0.210803           1144
+seed7/lib/aes_gcm.s7i        0.065724            392
+seed7/lib/ar.s7i             0.134317           1532
+seed7/lib/arc4.s7i           0.048289            144
+seed7/lib/archive.s7i        0.046439            143
+seed7/lib/archive_base.s7i   0.046304            135
+seed7/lib/array.s7i          0.083466            610
+seed7/lib/asn1.s7i           0.072678            544
+seed7/lib/asn1oid.s7i        0.057608            157
+seed7/lib/basearray.s7i      0.071171            450
+seed7/lib/bigfile.s7i        0.047695            136
+seed7/lib/bigint.s7i         0.084789            824
+seed7/lib/bigrat.s7i         0.087342            784
+seed7/lib/bin16.s7i          0.076315            592
+seed7/lib/bin32.s7i          0.070444            490
+seed7/lib/bin64.s7i          0.071496            539
+seed7/lib/bitdata.s7i        0.131225           1330
+seed7/lib/bitmapfont.s7i     0.049358            215
+seed7/lib/bitset.s7i         0.067766            593
+seed7/lib/bitsetof.s7i       0.065962            431
+seed7/lib/blowfish.s7i       0.077036            383
+seed7/lib/bmp.s7i            0.098725            924
+seed7/lib/boolean.s7i        0.054670            403
+seed7/lib/browser.s7i        0.052742            280
+seed7/lib/bstring.s7i        0.046051            227
+seed7/lib/bytedata.s7i       0.064490            482
+seed7/lib/bzip2.s7i          0.086881            887
+seed7/lib/cards.s7i          0.101896           1342
+seed7/lib/category.s7i       0.048754            209
+seed7/lib/cc_conf.s7i        0.120477           1314
+seed7/lib/ccittfax.s7i       0.101400           1022
+seed7/lib/cgi.s7i            0.040603            109
+seed7/lib/cgidialog.s7i      0.096157           1118
+seed7/lib/char.s7i           0.051463            356
+seed7/lib/charsets.s7i       0.123001           2024
+seed7/lib/chartype.s7i       0.047414            121
+seed7/lib/cipher.s7i         0.042476            146
+seed7/lib/cli_cmds.s7i       0.111906           1360
+seed7/lib/clib_file.s7i      0.049767            301
+seed7/lib/color.s7i          0.044815            185
+seed7/lib/complex.s7i        0.057308            464
+seed7/lib/compress.s7i       0.041893            150
+seed7/lib/console.s7i        0.045850            188
+seed7/lib/cpio.s7i           0.143090           1708
+seed7/lib/crc32.s7i          0.053900            193
+seed7/lib/cronos16.s7i       0.191172           1173
+seed7/lib/cronos27.s7i       0.255816           1464
+seed7/lib/csv.s7i            0.048144            201
+seed7/lib/db_prop.s7i        0.100084            991
+seed7/lib/deflate.s7i        0.086955            740
+seed7/lib/des.s7i            0.077819            444
+seed7/lib/dialog.s7i         0.055107            311
+seed7/lib/dir.s7i            0.043725            163
+seed7/lib/draw.s7i           0.085140            854
+seed7/lib/duration.s7i       0.096273           1038
+seed7/lib/echo.s7i           0.043209            132
+seed7/lib/editline.s7i       0.059194            398
+seed7/lib/elf.s7i            0.152261           1560
+seed7/lib/elliptic.s7i       0.075393            649
+seed7/lib/enable_io.s7i      0.051073            312
+seed7/lib/encoding.s7i       0.096249            931
+seed7/lib/enumeration.s7i    0.049805            236
+seed7/lib/environment.s7i    0.043764            175
+seed7/lib/exif.s7i           0.045746            152
+seed7/lib/external_file.s7i  0.050397            340
+seed7/lib/field.s7i          0.050012            268
+seed7/lib/file.s7i           0.052278            372
+seed7/lib/filebits.s7i       0.036300             46
+seed7/lib/filesys.s7i        0.063428            601
+seed7/lib/fileutil.s7i       0.041842            144
+seed7/lib/fixarray.s7i       0.051776            307
+seed7/lib/float.s7i          0.071595            757
+seed7/lib/font.s7i           0.044077            196
+seed7/lib/font8x8.s7i        0.065888            998
+seed7/lib/forloop.s7i        0.058206            449
+seed7/lib/ftp.s7i            0.086337            969
+seed7/lib/ftpserv.s7i        0.075027            631
+seed7/lib/getf.s7i           0.040912            115
+seed7/lib/gethttp.s7i        0.038008             41
+seed7/lib/gethttps.s7i       0.037159             41
+seed7/lib/gif.s7i            0.071113            561
+seed7/lib/graph.s7i          0.063809            415
+seed7/lib/graph_file.s7i     0.057447            399
+seed7/lib/gtkserver.s7i      0.041256            161
+seed7/lib/gzip.s7i           0.065849            573
+seed7/lib/hash.s7i           0.065901            421
+seed7/lib/hashsetof.s7i      0.063921            499
+seed7/lib/hmac.s7i           0.044123            152
+seed7/lib/html.s7i           0.039182             83
+seed7/lib/html_ent.s7i       0.063487            476
+seed7/lib/htmldom.s7i        0.053072            286
+seed7/lib/http_request.s7i   0.076346            696
+seed7/lib/http_srv_resp.s7i  0.058471            380
+seed7/lib/https_request.s7i  0.047596            211
+seed7/lib/httpserv.s7i       0.054826            345
+seed7/lib/huffman.s7i        0.073821            644
+seed7/lib/ico.s7i            0.049116            221
+seed7/lib/idxarray.s7i       0.050812            232
+seed7/lib/image.s7i          0.041347            156
+seed7/lib/imagefile.s7i      0.044769            171
+seed7/lib/inflate.s7i        0.063394            411
+seed7/lib/inifile.s7i        0.042109            129
+seed7/lib/integer.s7i        0.067654            663
+seed7/lib/iobuffer.s7i       0.049243            289
+seed7/lib/jpeg.s7i           0.151885           1761
+seed7/lib/json.s7i           0.079129            891
+seed7/lib/json_serde.s7i     0.077625            783
+seed7/lib/keybd.s7i          0.078591            639
+seed7/lib/keydescr.s7i       0.049469            192
+seed7/lib/leb128.s7i         0.046823            218
+seed7/lib/line.s7i           0.042740            164
+seed7/lib/listener.s7i       0.048256            247
+seed7/lib/logfile.s7i        0.037914             73
+seed7/lib/lower.s7i          0.041465            142
+seed7/lib/lzma.s7i           0.097092            934
+seed7/lib/lzw.s7i            0.092185            861
+seed7/lib/magic.s7i          0.065970            403
+seed7/lib/mahjng32.s7i       0.091085           1500
+seed7/lib/make.s7i           0.066807            544
+seed7/lib/makedata.s7i       0.117987           1428
+seed7/lib/math.s7i           0.043571            201
+seed7/lib/mixarith.s7i       0.046465            249
+seed7/lib/modern27.s7i       0.168629           1099
+seed7/lib/more.s7i           0.042142            130
+seed7/lib/msgdigest.s7i      0.135399           1222
+seed7/lib/multiscr.s7i       0.038277             68
+seed7/lib/null_file.s7i      0.051034            345
+seed7/lib/osfiles.s7i        0.097564           1085
+seed7/lib/pbm.s7i            0.047807            230
+seed7/lib/pcx.s7i            0.076816            638
+seed7/lib/pem.s7i            0.045016            185
+seed7/lib/pgm.s7i            0.048606            238
+seed7/lib/pic16.s7i          0.065731           1037
+seed7/lib/pic32.s7i          0.118088           2060
+seed7/lib/pic_util.s7i       0.042143            144
+seed7/lib/pixelimage.s7i     0.050706            320
+seed7/lib/pixmap_file.s7i    0.061578            459
+seed7/lib/pixmapfont.s7i     0.046396            184
+seed7/lib/pkcs1.s7i          0.076855            543
+seed7/lib/png.s7i            0.105903           1064
+seed7/lib/poll.s7i           0.052351            313
+seed7/lib/ppm.s7i            0.051077            240
+seed7/lib/process.s7i        0.065991            541
+seed7/lib/progs.s7i          0.078479            789
+seed7/lib/propertyfile.s7i   0.044226            155
+seed7/lib/rational.s7i       0.077950            792
+seed7/lib/ref_list.s7i       0.047944            252
+seed7/lib/reference.s7i      0.041889            126
+seed7/lib/reverse.s7i        0.039223             94
+seed7/lib/rpm.s7i            0.280001           3487
+seed7/lib/rpmext.s7i         0.050240            318
+seed7/lib/scanfile.s7i       0.131567           1779
+seed7/lib/scanjson.s7i       0.060939            413
+seed7/lib/scanstri.s7i       0.135562           1814
+seed7/lib/scantoml.s7i       0.128478           1603
+seed7/lib/seed7_05.s7i       0.109282           1072
+seed7/lib/set.s7i            0.037733             57
+seed7/lib/shell.s7i          0.068432            615
+seed7/lib/showtls.s7i        0.083770            678
+seed7/lib/signature.s7i      0.041352            131
+seed7/lib/smtp.s7i           0.047363            261
+seed7/lib/sockbase.s7i       0.048918            217
+seed7/lib/socket.s7i         0.051318            326
+seed7/lib/sokoban1.s7i       0.079923           1519
+seed7/lib/sql_base.s7i       0.093062           1000
+seed7/lib/stars.s7i          0.232921           1705
+seed7/lib/stdfont10.s7i      0.141768           3347
+seed7/lib/stdfont12.s7i      0.163967           3928
+seed7/lib/stdfont14.s7i      0.185200           4510
+seed7/lib/stdfont16.s7i      0.208043           5092
+seed7/lib/stdfont18.s7i      0.242496           5868
+seed7/lib/stdfont20.s7i      0.270016           6449
+seed7/lib/stdfont24.s7i      0.324403           7421
+seed7/lib/stdfont8.s7i       0.123779           2960
+seed7/lib/stdfont9.s7i       0.131137           3152
+seed7/lib/stdio.s7i          0.044420            192
+seed7/lib/strifile.s7i       0.053299            345
+seed7/lib/string.s7i         0.075139            779
+seed7/lib/stritext.s7i       0.054432            352
+seed7/lib/struct.s7i         0.054477            266
+seed7/lib/struct_elem.s7i    0.041717            129
+seed7/lib/subfile.s7i        0.043382            174
+seed7/lib/subrange.s7i       0.038123             78
+seed7/lib/syntax.s7i         0.060009            294
+seed7/lib/tar.s7i            0.143046           1880
+seed7/lib/tar_cmds.s7i       0.083542            752
+seed7/lib/tdes.s7i           0.043203            143
+seed7/lib/tee.s7i            0.040813            143
+seed7/lib/text.s7i           0.040165            135
+seed7/lib/tga.s7i            0.078541            676
+seed7/lib/tiff.s7i           0.240355           2771
+seed7/lib/time.s7i           0.101474           1191
+seed7/lib/tls.s7i            0.193727           2230
+seed7/lib/unicode.s7i        0.073696            575
+seed7/lib/unionfnd.s7i       0.043028            130
+seed7/lib/upper.s7i          0.042079            142
+seed7/lib/utf16.s7i          0.064765            540
+seed7/lib/utf8.s7i           0.047135            234
+seed7/lib/vecfont10.s7i      0.156894           1056
+seed7/lib/vecfont18.s7i      0.173614           1119
+seed7/lib/vector3d.s7i       0.049023            293
+seed7/lib/vectorfont.s7i     0.048101            239
+seed7/lib/wildcard.s7i       0.042255            140
+seed7/lib/window.s7i         0.060235            455
+seed7/lib/wrinum.s7i         0.049296            248
+seed7/lib/x509cert.s7i       0.119084           1243
+seed7/lib/xml_ent.s7i        0.041384             94
+seed7/lib/xmldom.s7i         0.050963            303
+seed7/lib/xz.s7i             0.059750            442
+seed7/lib/zip.s7i            0.236822           2792
+seed7/lib/zstd.s7i           0.119275           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.159773        |
++-----------+-----------------+
+| Minimum   | 0.036300        |
++-----------+-----------------+
+| Maximum   | 5.499677        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033866        | 0.032217        | 0.061562        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039602        | 0.034564        | 0.048954        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.088911        | 0.034105        | 2.502191        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.159773        | 0.036300        | 5.499677        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.579 | 00:00:57.701 | 00:01:10.280 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.986 | 00:01:07.536 | 00:01:22.523 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:36.299 | 00:02:32.384 | 00:03:08.683 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:01.475 | 00:04:33.108 | 00:05:34.583 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:16.077 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-16.3.rst
+++ b/reports/seed7mode-perf-16.3.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-30T14:06:30+0000 W27-2
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 10:41:43 local time
+:Generated on: 2026-06-30 14:53:26 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 211x95 chars
+:Window body: 211x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.040885            190
+seed7/prg/bas7.sd7           0.041112          11459
+seed7/prg/bifurk.sd7         0.041173             73
+seed7/prg/bigfiles.sd7       0.040544            129
+seed7/prg/brainf7.sd7        0.039259             86
+seed7/prg/calc7.sd7          0.040114            128
+seed7/prg/carddemo.sd7       0.042236            190
+seed7/prg/castle.sd7         0.044821           3148
+seed7/prg/cat.sd7            0.044119             82
+seed7/prg/cellauto.sd7       0.038589             85
+seed7/prg/celsius.sd7        0.038676             42
+seed7/prg/chk_all.sd7        0.042777            843
+seed7/prg/chkarr.sd7         0.040937           8367
+seed7/prg/chkbig.sd7         0.046908          29026
+seed7/prg/chkbin.sd7         0.042976           6469
+seed7/prg/chkbitdata.sd7     0.043417           6624
+seed7/prg/chkbool.sd7        0.046039           3157
+seed7/prg/chkbst.sd7         0.041990            722
+seed7/prg/chkchr.sd7         0.044622           2809
+seed7/prg/chkcmd.sd7         0.042982           1205
+seed7/prg/chkdb.sd7          0.044422           7454
+seed7/prg/chkdecl.sd7        0.043182            448
+seed7/prg/chkenum.sd7        0.044246           1230
+seed7/prg/chkerr.sd7         0.044301           4663
+seed7/prg/chkexc.sd7         0.039144           2627
+seed7/prg/chkfil.sd7         0.039453           1615
+seed7/prg/chkflt.sd7         0.044043          20620
+seed7/prg/chkhent.sd7        0.042377             54
+seed7/prg/chkhsh.sd7         0.042580           4548
+seed7/prg/chkidx.sd7         0.045347          19567
+seed7/prg/chkint.sd7         0.050347          38129
+seed7/prg/chkjson.sd7        0.043324           1764
+seed7/prg/chkovf.sd7         0.043080           8216
+seed7/prg/chkprc.sd7         0.042131          10111
+seed7/prg/chkscan.sd7        0.039645            714
+seed7/prg/chkset.sd7         0.038332          11974
+seed7/prg/chkstr.sd7         0.042002          26952
+seed7/prg/chktime.sd7        0.034852           2025
+seed7/prg/chktoml.sd7        0.035774           1656
+seed7/prg/clock.sd7          0.034729             47
+seed7/prg/clock2.sd7         0.035971             43
+seed7/prg/clock3.sd7         0.034873             95
+seed7/prg/cmpfil.sd7         0.035627             84
+seed7/prg/comanche.sd7       0.035481            180
+seed7/prg/confval.sd7        0.035491            175
+seed7/prg/db7.sd7            0.034945            417
+seed7/prg/diff7.sd7          0.034710            263
+seed7/prg/dirtst.sd7         0.034844             42
+seed7/prg/dirx.sd7           0.035056            152
+seed7/prg/dnafight.sd7       0.036501           1381
+seed7/prg/dragon.sd7         0.036502             73
+seed7/prg/echo.sd7           0.036550             39
+seed7/prg/eliza.sd7          0.035170            302
+seed7/prg/err.sd7            0.037819             96
+seed7/prg/fannkuch.sd7       0.037908            131
+seed7/prg/fib.sd7            0.038590             47
+seed7/prg/find7.sd7          0.039796            133
+seed7/prg/findchar.sd7       0.040654            149
+seed7/prg/fractree.sd7       0.040943             55
+seed7/prg/ftp7.sd7           0.039715            296
+seed7/prg/ftpserv.sd7        0.038130             74
+seed7/prg/gcd.sd7            0.035630            109
+seed7/prg/gkbd.sd7           0.036425            358
+seed7/prg/gtksvtst.sd7       0.034049             94
+seed7/prg/hal.sd7            0.035123            250
+seed7/prg/hamu.sd7           0.035498            573
+seed7/prg/hanoi.sd7          0.035460             55
+seed7/prg/hd.sd7             0.034556             79
+seed7/prg/hello.sd7          0.034644             32
+seed7/prg/hilbert.sd7        0.034740            108
+seed7/prg/ide7.sd7           0.040102            196
+seed7/prg/kbd.sd7            0.036917             49
+seed7/prg/klondike.sd7       0.036452            883
+seed7/prg/lander.sd7         0.039779           1551
+seed7/prg/lst80bas.sd7       0.044000            344
+seed7/prg/lst99bas.sd7       0.043670            401
+seed7/prg/lstgwbas.sd7       0.041452            577
+seed7/prg/mahjong.sd7        0.036288           1943
+seed7/prg/make7.sd7          0.034621            121
+seed7/prg/mandelbr.sd7       0.038833            237
+seed7/prg/mind.sd7           0.037109            443
+seed7/prg/mirror.sd7         0.039538            131
+seed7/prg/ms.sd7             0.038694            641
+seed7/prg/nicoma.sd7         0.041883            135
+seed7/prg/pac.sd7            0.042526            726
+seed7/prg/pairs.sd7          0.040225           2025
+seed7/prg/panic.sd7          0.034778           2634
+seed7/prg/percolation.sd7    0.034197            330
+seed7/prg/planets.sd7        0.035200           1486
+seed7/prg/portfwd7.sd7       0.033993            139
+seed7/prg/prime.sd7          0.033599             74
+seed7/prg/printpi1.sd7       0.036833             56
+seed7/prg/printpi2.sd7       0.034974             54
+seed7/prg/printpi3.sd7       0.034748             60
+seed7/prg/pv7.sd7            0.035386            337
+seed7/prg/queen.sd7          0.034935            149
+seed7/prg/rand.sd7           0.036258            121
+seed7/prg/raytrace.sd7       0.040232            538
+seed7/prg/rever.sd7          0.035946            816
+seed7/prg/roman.sd7          0.035778             38
+seed7/prg/s7c.sd7            0.035635           9060
+seed7/prg/s7check.sd7        0.035286             68
+seed7/prg/savehd7.sd7        0.034668           1110
+seed7/prg/self.sd7           0.034917             49
+seed7/prg/shisen.sd7         0.036364           1423
+seed7/prg/sl.sd7             0.038104           1029
+seed7/prg/snake.sd7          0.039723            615
+seed7/prg/sokoban.sd7        0.039838            891
+seed7/prg/spigotpi.sd7       0.040415             64
+seed7/prg/sql7.sd7           0.038350            278
+seed7/prg/startrek.sd7       0.036405            979
+seed7/prg/sudoku7.sd7        0.036095           2657
+seed7/prg/sydir7.sd7         0.035561            384
+seed7/prg/syntaxhl.sd7       0.034148            177
+seed7/prg/tak.sd7            0.033884             59
+seed7/prg/tar7.sd7           0.034154            121
+seed7/prg/tch.sd7            0.035476             55
+seed7/prg/testfont.sd7       0.034084             95
+seed7/prg/tet.sd7            0.034165            479
+seed7/prg/tetg.sd7           0.034195            501
+seed7/prg/toutf8.sd7         0.034526            240
+seed7/prg/tst_cli.sd7        0.034731             40
+seed7/prg/tst_srv.sd7        0.034962             47
+seed7/prg/wator.sd7          0.034817            651
+seed7/prg/which.sd7          0.035021             65
+seed7/prg/wiz.sd7            0.035217           2833
+seed7/prg/wordcnt.sd7        0.034590             54
+seed7/prg/wrinum.sd7         0.034985             43
+seed7/prg/wumpus.sd7         0.035380            372
+seed7/lib/aes.s7i            0.037838           1144
+seed7/lib/aes_gcm.s7i        0.039555            392
+seed7/lib/ar.s7i             0.038245           1532
+seed7/lib/arc4.s7i           0.037143            144
+seed7/lib/archive.s7i        0.037259            143
+seed7/lib/archive_base.s7i   0.037361            135
+seed7/lib/array.s7i          0.034845            610
+seed7/lib/asn1.s7i           0.037987            544
+seed7/lib/asn1oid.s7i        0.038262            157
+seed7/lib/basearray.s7i      0.037093            450
+seed7/lib/bigfile.s7i        0.036596            136
+seed7/lib/bigint.s7i         0.035004            824
+seed7/lib/bigrat.s7i         0.035065            784
+seed7/lib/bin16.s7i          0.040240            592
+seed7/lib/bin32.s7i          0.042444            490
+seed7/lib/bin64.s7i          0.042314            539
+seed7/lib/bitdata.s7i        0.042524           1330
+seed7/lib/bitmapfont.s7i     0.041290            215
+seed7/lib/bitset.s7i         0.039766            593
+seed7/lib/bitsetof.s7i       0.038621            431
+seed7/lib/blowfish.s7i       0.040920            383
+seed7/lib/bmp.s7i            0.045399            924
+seed7/lib/boolean.s7i        0.038478            403
+seed7/lib/browser.s7i        0.043082            280
+seed7/lib/bstring.s7i        0.043061            227
+seed7/lib/bytedata.s7i       0.041335            482
+seed7/lib/bzip2.s7i          0.042467            887
+seed7/lib/cards.s7i          0.040986           1342
+seed7/lib/category.s7i       0.040515            209
+seed7/lib/cc_conf.s7i        0.037735           1314
+seed7/lib/ccittfax.s7i       0.038982           1022
+seed7/lib/cgi.s7i            0.036972            109
+seed7/lib/cgidialog.s7i      0.035890           1118
+seed7/lib/char.s7i           0.035449            356
+seed7/lib/charsets.s7i       0.040190           2024
+seed7/lib/chartype.s7i       0.041136            121
+seed7/lib/cipher.s7i         0.041763            146
+seed7/lib/cli_cmds.s7i       0.041604           1360
+seed7/lib/clib_file.s7i      0.036973            301
+seed7/lib/color.s7i          0.040244            185
+seed7/lib/complex.s7i        0.040763            464
+seed7/lib/compress.s7i       0.041384            150
+seed7/lib/console.s7i        0.040586            188
+seed7/lib/cpio.s7i           0.041378           1708
+seed7/lib/crc32.s7i          0.042797            193
+seed7/lib/cronos16.s7i       0.042113           1173
+seed7/lib/cronos27.s7i       0.040396           1464
+seed7/lib/csv.s7i            0.042561            201
+seed7/lib/db_prop.s7i        0.042428            991
+seed7/lib/deflate.s7i        0.041474            740
+seed7/lib/des.s7i            0.040920            444
+seed7/lib/dialog.s7i         0.043016            311
+seed7/lib/dir.s7i            0.041725            163
+seed7/lib/draw.s7i           0.039122            854
+seed7/lib/duration.s7i       0.039488           1038
+seed7/lib/echo.s7i           0.038622            132
+seed7/lib/editline.s7i       0.036259            398
+seed7/lib/elf.s7i            0.037583           1560
+seed7/lib/elliptic.s7i       0.039658            649
+seed7/lib/enable_io.s7i      0.040740            312
+seed7/lib/encoding.s7i       0.041878            931
+seed7/lib/enumeration.s7i    0.038387            236
+seed7/lib/environment.s7i    0.039587            175
+seed7/lib/exif.s7i           0.040499            152
+seed7/lib/external_file.s7i  0.042573            340
+seed7/lib/field.s7i          0.037160            268
+seed7/lib/file.s7i           0.040004            372
+seed7/lib/filebits.s7i       0.039781             46
+seed7/lib/filesys.s7i        0.034329            601
+seed7/lib/fileutil.s7i       0.034643            144
+seed7/lib/fixarray.s7i       0.034076            307
+seed7/lib/float.s7i          0.034863            757
+seed7/lib/font.s7i           0.035885            196
+seed7/lib/font8x8.s7i        0.034931            998
+seed7/lib/forloop.s7i        0.034953            449
+seed7/lib/ftp.s7i            0.035841            969
+seed7/lib/ftpserv.s7i        0.035855            631
+seed7/lib/getf.s7i           0.036242            115
+seed7/lib/gethttp.s7i        0.034631             41
+seed7/lib/gethttps.s7i       0.035126             41
+seed7/lib/gif.s7i            0.035248            561
+seed7/lib/graph.s7i          0.034976            415
+seed7/lib/graph_file.s7i     0.035089            399
+seed7/lib/gtkserver.s7i      0.035839            161
+seed7/lib/gzip.s7i           0.036817            573
+seed7/lib/hash.s7i           0.038482            421
+seed7/lib/hashsetof.s7i      0.041446            499
+seed7/lib/hmac.s7i           0.039350            152
+seed7/lib/html.s7i           0.036134             83
+seed7/lib/html_ent.s7i       0.035056            476
+seed7/lib/htmldom.s7i        0.034965            286
+seed7/lib/http_request.s7i   0.035187            696
+seed7/lib/http_srv_resp.s7i  0.034760            380
+seed7/lib/https_request.s7i  0.034949            211
+seed7/lib/httpserv.s7i       0.035384            345
+seed7/lib/huffman.s7i        0.035125            644
+seed7/lib/ico.s7i            0.033913            221
+seed7/lib/idxarray.s7i       0.033832            232
+seed7/lib/image.s7i          0.034089            156
+seed7/lib/imagefile.s7i      0.034544            171
+seed7/lib/inflate.s7i        0.036818            411
+seed7/lib/inifile.s7i        0.042578            129
+seed7/lib/integer.s7i        0.042551            663
+seed7/lib/iobuffer.s7i       0.040179            289
+seed7/lib/jpeg.s7i           0.037017           1761
+seed7/lib/json.s7i           0.036828            891
+seed7/lib/json_serde.s7i     0.040908            783
+seed7/lib/keybd.s7i          0.038604            639
+seed7/lib/keydescr.s7i       0.036004            192
+seed7/lib/leb128.s7i         0.035018            218
+seed7/lib/line.s7i           0.035895            164
+seed7/lib/listener.s7i       0.036756            247
+seed7/lib/logfile.s7i        0.035734             73
+seed7/lib/lower.s7i          0.035399            142
+seed7/lib/lzma.s7i           0.034932            934
+seed7/lib/lzw.s7i            0.035230            861
+seed7/lib/magic.s7i          0.035193            403
+seed7/lib/mahjng32.s7i       0.035278           1500
+seed7/lib/make.s7i           0.034738            544
+seed7/lib/makedata.s7i       0.035065           1428
+seed7/lib/math.s7i           0.035957            201
+seed7/lib/mixarith.s7i       0.042377            249
+seed7/lib/modern27.s7i       0.044305           1099
+seed7/lib/more.s7i           0.036656            130
+seed7/lib/msgdigest.s7i      0.035348           1222
+seed7/lib/multiscr.s7i       0.034934             68
+seed7/lib/null_file.s7i      0.034362            345
+seed7/lib/osfiles.s7i        0.033940           1085
+seed7/lib/pbm.s7i            0.033834            230
+seed7/lib/pcx.s7i            0.034174            638
+seed7/lib/pem.s7i            0.034982            185
+seed7/lib/pgm.s7i            0.035416            238
+seed7/lib/pic16.s7i          0.034751           1037
+seed7/lib/pic32.s7i          0.034719           2060
+seed7/lib/pic_util.s7i       0.035497            144
+seed7/lib/pixelimage.s7i     0.034815            320
+seed7/lib/pixmap_file.s7i    0.034892            459
+seed7/lib/pixmapfont.s7i     0.035239            184
+seed7/lib/pkcs1.s7i          0.034882            543
+seed7/lib/png.s7i            0.034832           1064
+seed7/lib/poll.s7i           0.035296            313
+seed7/lib/ppm.s7i            0.035092            240
+seed7/lib/process.s7i        0.034957            541
+seed7/lib/progs.s7i          0.034933            789
+seed7/lib/propertyfile.s7i   0.034901            155
+seed7/lib/rational.s7i       0.035027            792
+seed7/lib/ref_list.s7i       0.035452            252
+seed7/lib/reference.s7i      0.035136            126
+seed7/lib/reverse.s7i        0.035093             94
+seed7/lib/rpm.s7i            0.035323           3487
+seed7/lib/rpmext.s7i         0.034686            318
+seed7/lib/scanfile.s7i       0.036719           1779
+seed7/lib/scanjson.s7i       0.038030            413
+seed7/lib/scanstri.s7i       0.034863           1814
+seed7/lib/scantoml.s7i       0.034709           1603
+seed7/lib/seed7_05.s7i       0.034006           1072
+seed7/lib/set.s7i            0.033748             57
+seed7/lib/shell.s7i          0.034099            615
+seed7/lib/showtls.s7i        0.042979            678
+seed7/lib/signature.s7i      0.043985            131
+seed7/lib/smtp.s7i           0.042912            261
+seed7/lib/sockbase.s7i       0.040486            217
+seed7/lib/socket.s7i         0.036847            326
+seed7/lib/sokoban1.s7i       0.035330           1519
+seed7/lib/sql_base.s7i       0.036058           1000
+seed7/lib/stars.s7i          0.036018           1705
+seed7/lib/stdfont10.s7i      0.036788           3347
+seed7/lib/stdfont12.s7i      0.041240           3928
+seed7/lib/stdfont14.s7i      0.036903           4510
+seed7/lib/stdfont16.s7i      0.038278           5092
+seed7/lib/stdfont18.s7i      0.038802           5868
+seed7/lib/stdfont20.s7i      0.035754           6449
+seed7/lib/stdfont24.s7i      0.038139           7421
+seed7/lib/stdfont8.s7i       0.039619           2960
+seed7/lib/stdfont9.s7i       0.042495           3152
+seed7/lib/stdio.s7i          0.039060            192
+seed7/lib/strifile.s7i       0.038841            345
+seed7/lib/string.s7i         0.034873            779
+seed7/lib/stritext.s7i       0.036942            352
+seed7/lib/struct.s7i         0.036240            266
+seed7/lib/struct_elem.s7i    0.034651            129
+seed7/lib/subfile.s7i        0.034897            174
+seed7/lib/subrange.s7i       0.035734             78
+seed7/lib/syntax.s7i         0.035848            294
+seed7/lib/tar.s7i            0.037893           1880
+seed7/lib/tar_cmds.s7i       0.037747            752
+seed7/lib/tdes.s7i           0.034160            143
+seed7/lib/tee.s7i            0.034127            143
+seed7/lib/text.s7i           0.035948            135
+seed7/lib/tga.s7i            0.034526            676
+seed7/lib/tiff.s7i           0.035589           2771
+seed7/lib/time.s7i           0.035031           1191
+seed7/lib/tls.s7i            0.035415           2230
+seed7/lib/unicode.s7i        0.036499            575
+seed7/lib/unionfnd.s7i       0.040679            130
+seed7/lib/upper.s7i          0.042418            142
+seed7/lib/utf16.s7i          0.041029            540
+seed7/lib/utf8.s7i           0.042036            234
+seed7/lib/vecfont10.s7i      0.041889           1056
+seed7/lib/vecfont18.s7i      0.036614           1119
+seed7/lib/vector3d.s7i       0.040013            293
+seed7/lib/vectorfont.s7i     0.038221            239
+seed7/lib/wildcard.s7i       0.036918            140
+seed7/lib/window.s7i         0.039944            455
+seed7/lib/wrinum.s7i         0.039310            248
+seed7/lib/x509cert.s7i       0.039951           1243
+seed7/lib/xml_ent.s7i        0.035735             94
+seed7/lib/xmldom.s7i         0.036904            303
+seed7/lib/xz.s7i             0.036482            442
+seed7/lib/zip.s7i            0.035828           2792
+seed7/lib/zstd.s7i           0.034963           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.037853        |
++-----------+-----------------+
+| Minimum   | 0.033599        |
++-----------+-----------------+
+| Maximum   | 0.050347        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039712            190
+seed7/prg/bas7.sd7           0.042305          11459
+seed7/prg/bifurk.sd7         0.038437             73
+seed7/prg/bigfiles.sd7       0.044993            129
+seed7/prg/brainf7.sd7        0.044726             86
+seed7/prg/calc7.sd7          0.044658            128
+seed7/prg/carddemo.sd7       0.044959            190
+seed7/prg/castle.sd7         0.046801           3148
+seed7/prg/cat.sd7            0.040995             82
+seed7/prg/cellauto.sd7       0.039842             85
+seed7/prg/celsius.sd7        0.045414             42
+seed7/prg/chk_all.sd7        0.050084            843
+seed7/prg/chkarr.sd7         0.050251           8367
+seed7/prg/chkbig.sd7         0.051906          29026
+seed7/prg/chkbin.sd7         0.046452           6469
+seed7/prg/chkbitdata.sd7     0.042709           6624
+seed7/prg/chkbool.sd7        0.041844           3157
+seed7/prg/chkbst.sd7         0.040942            722
+seed7/prg/chkchr.sd7         0.044902           2809
+seed7/prg/chkcmd.sd7         0.044782           1205
+seed7/prg/chkdb.sd7          0.047413           7454
+seed7/prg/chkdecl.sd7        0.046754            448
+seed7/prg/chkenum.sd7        0.045107           1230
+seed7/prg/chkerr.sd7         0.047061           4663
+seed7/prg/chkexc.sd7         0.039987           2627
+seed7/prg/chkfil.sd7         0.042134           1615
+seed7/prg/chkflt.sd7         0.046303          20620
+seed7/prg/chkhent.sd7        0.044665             54
+seed7/prg/chkhsh.sd7         0.049183           4548
+seed7/prg/chkidx.sd7         0.046347          19567
+seed7/prg/chkint.sd7         0.048823          38129
+seed7/prg/chkjson.sd7        0.043314           1764
+seed7/prg/chkovf.sd7         0.042667           8216
+seed7/prg/chkprc.sd7         0.040957          10111
+seed7/prg/chkscan.sd7        0.042140            714
+seed7/prg/chkset.sd7         0.045057          11974
+seed7/prg/chkstr.sd7         0.048446          26952
+seed7/prg/chktime.sd7        0.041301           2025
+seed7/prg/chktoml.sd7        0.040929           1656
+seed7/prg/clock.sd7          0.037331             47
+seed7/prg/clock2.sd7         0.037455             43
+seed7/prg/clock3.sd7         0.040811             95
+seed7/prg/cmpfil.sd7         0.039783             84
+seed7/prg/comanche.sd7       0.042185            180
+seed7/prg/confval.sd7        0.045447            175
+seed7/prg/db7.sd7            0.044154            417
+seed7/prg/diff7.sd7          0.042533            263
+seed7/prg/dirtst.sd7         0.037210             42
+seed7/prg/dirx.sd7           0.039329            152
+seed7/prg/dnafight.sd7       0.040235           1381
+seed7/prg/dragon.sd7         0.038784             73
+seed7/prg/echo.sd7           0.037542             39
+seed7/prg/eliza.sd7          0.040163            302
+seed7/prg/err.sd7            0.047805             96
+seed7/prg/fannkuch.sd7       0.047998            131
+seed7/prg/fib.sd7            0.045710             47
+seed7/prg/find7.sd7          0.046622            133
+seed7/prg/findchar.sd7       0.040486            149
+seed7/prg/fractree.sd7       0.042581             55
+seed7/prg/ftp7.sd7           0.041309            296
+seed7/prg/ftpserv.sd7        0.040954             74
+seed7/prg/gcd.sd7            0.045707            109
+seed7/prg/gkbd.sd7           0.046639            358
+seed7/prg/gtksvtst.sd7       0.044364             94
+seed7/prg/hal.sd7            0.045894            250
+seed7/prg/hamu.sd7           0.045540            573
+seed7/prg/hanoi.sd7          0.042792             55
+seed7/prg/hd.sd7             0.039855             79
+seed7/prg/hello.sd7          0.037722             32
+seed7/prg/hilbert.sd7        0.041673            108
+seed7/prg/ide7.sd7           0.041663            196
+seed7/prg/kbd.sd7            0.036902             49
+seed7/prg/klondike.sd7       0.039486            883
+seed7/prg/lander.sd7         0.040538           1551
+seed7/prg/lst80bas.sd7       0.038573            344
+seed7/prg/lst99bas.sd7       0.043303            401
+seed7/prg/lstgwbas.sd7       0.046190            577
+seed7/prg/mahjong.sd7        0.046433           1943
+seed7/prg/make7.sd7          0.045340            121
+seed7/prg/mandelbr.sd7       0.041843            237
+seed7/prg/mind.sd7           0.040935            443
+seed7/prg/mirror.sd7         0.044127            131
+seed7/prg/ms.sd7             0.041814            641
+seed7/prg/nicoma.sd7         0.040616            135
+seed7/prg/pac.sd7            0.040560            726
+seed7/prg/pairs.sd7          0.039970           2025
+seed7/prg/panic.sd7          0.042444           2634
+seed7/prg/percolation.sd7    0.042039            330
+seed7/prg/planets.sd7        0.041727           1486
+seed7/prg/portfwd7.sd7       0.040107            139
+seed7/prg/prime.sd7          0.038148             74
+seed7/prg/printpi1.sd7       0.038142             56
+seed7/prg/printpi2.sd7       0.037590             54
+seed7/prg/printpi3.sd7       0.038399             60
+seed7/prg/pv7.sd7            0.040643            337
+seed7/prg/queen.sd7          0.040344            149
+seed7/prg/rand.sd7           0.039632            121
+seed7/prg/raytrace.sd7       0.039757            538
+seed7/prg/rever.sd7          0.041625            816
+seed7/prg/roman.sd7          0.037784             38
+seed7/prg/s7c.sd7            0.039966           9060
+seed7/prg/s7check.sd7        0.039376             68
+seed7/prg/savehd7.sd7        0.040836           1110
+seed7/prg/self.sd7           0.038511             49
+seed7/prg/shisen.sd7         0.045213           1423
+seed7/prg/sl.sd7             0.045680           1029
+seed7/prg/snake.sd7          0.044158            615
+seed7/prg/sokoban.sd7        0.043595            891
+seed7/prg/spigotpi.sd7       0.038676             64
+seed7/prg/sql7.sd7           0.042211            278
+seed7/prg/startrek.sd7       0.041131            979
+seed7/prg/sudoku7.sd7        0.041034           2657
+seed7/prg/sydir7.sd7         0.040086            384
+seed7/prg/syntaxhl.sd7       0.043630            177
+seed7/prg/tak.sd7            0.043316             59
+seed7/prg/tar7.sd7           0.044874            121
+seed7/prg/tch.sd7            0.042374             55
+seed7/prg/testfont.sd7       0.044530             95
+seed7/prg/tet.sd7            0.045788            479
+seed7/prg/tetg.sd7           0.046215            501
+seed7/prg/toutf8.sd7         0.045036            240
+seed7/prg/tst_cli.sd7        0.038684             40
+seed7/prg/tst_srv.sd7        0.040127             47
+seed7/prg/wator.sd7          0.047772            651
+seed7/prg/which.sd7          0.040977             65
+seed7/prg/wiz.sd7            0.048826           2833
+seed7/prg/wordcnt.sd7        0.043389             54
+seed7/prg/wrinum.sd7         0.041872             43
+seed7/prg/wumpus.sd7         0.044580            372
+seed7/lib/aes.s7i            0.048151           1144
+seed7/lib/aes_gcm.s7i        0.041393            392
+seed7/lib/ar.s7i             0.040500           1532
+seed7/lib/arc4.s7i           0.041121            144
+seed7/lib/archive.s7i        0.040369            143
+seed7/lib/archive_base.s7i   0.041268            135
+seed7/lib/array.s7i          0.040240            610
+seed7/lib/asn1.s7i           0.039474            544
+seed7/lib/asn1oid.s7i        0.044635            157
+seed7/lib/basearray.s7i      0.041668            450
+seed7/lib/bigfile.s7i        0.041137            136
+seed7/lib/bigint.s7i         0.040295            824
+seed7/lib/bigrat.s7i         0.040500            784
+seed7/lib/bin16.s7i          0.040993            592
+seed7/lib/bin32.s7i          0.041107            490
+seed7/lib/bin64.s7i          0.039971            539
+seed7/lib/bitdata.s7i        0.045677           1330
+seed7/lib/bitmapfont.s7i     0.039828            215
+seed7/lib/bitset.s7i         0.044585            593
+seed7/lib/bitsetof.s7i       0.044903            431
+seed7/lib/blowfish.s7i       0.046663            383
+seed7/lib/bmp.s7i            0.043628            924
+seed7/lib/boolean.s7i        0.040717            403
+seed7/lib/browser.s7i        0.041761            280
+seed7/lib/bstring.s7i        0.041652            227
+seed7/lib/bytedata.s7i       0.041032            482
+seed7/lib/bzip2.s7i          0.040684            887
+seed7/lib/cards.s7i          0.038764           1342
+seed7/lib/category.s7i       0.040523            209
+seed7/lib/cc_conf.s7i        0.040205           1314
+seed7/lib/ccittfax.s7i       0.040531           1022
+seed7/lib/cgi.s7i            0.039776            109
+seed7/lib/cgidialog.s7i      0.040895           1118
+seed7/lib/char.s7i           0.040368            356
+seed7/lib/charsets.s7i       0.041470           2024
+seed7/lib/chartype.s7i       0.043441            121
+seed7/lib/cipher.s7i         0.040179            146
+seed7/lib/cli_cmds.s7i       0.041837           1360
+seed7/lib/clib_file.s7i      0.040502            301
+seed7/lib/color.s7i          0.040252            185
+seed7/lib/complex.s7i        0.041040            464
+seed7/lib/compress.s7i       0.039496            150
+seed7/lib/console.s7i        0.038849            188
+seed7/lib/cpio.s7i           0.039992           1708
+seed7/lib/crc32.s7i          0.040083            193
+seed7/lib/cronos16.s7i       0.042860           1173
+seed7/lib/cronos27.s7i       0.045277           1464
+seed7/lib/csv.s7i            0.040361            201
+seed7/lib/db_prop.s7i        0.040854            991
+seed7/lib/deflate.s7i        0.041365            740
+seed7/lib/des.s7i            0.041370            444
+seed7/lib/dialog.s7i         0.042573            311
+seed7/lib/dir.s7i            0.043697            163
+seed7/lib/draw.s7i           0.041428            854
+seed7/lib/duration.s7i       0.042120           1038
+seed7/lib/echo.s7i           0.041818            132
+seed7/lib/editline.s7i       0.041412            398
+seed7/lib/elf.s7i            0.042779           1560
+seed7/lib/elliptic.s7i       0.040509            649
+seed7/lib/enable_io.s7i      0.040257            312
+seed7/lib/encoding.s7i       0.045921            931
+seed7/lib/enumeration.s7i    0.045253            236
+seed7/lib/environment.s7i    0.042419            175
+seed7/lib/exif.s7i           0.044657            152
+seed7/lib/external_file.s7i  0.043948            340
+seed7/lib/field.s7i          0.045939            268
+seed7/lib/file.s7i           0.043753            372
+seed7/lib/filebits.s7i       0.038574             46
+seed7/lib/filesys.s7i        0.041497            601
+seed7/lib/fileutil.s7i       0.044296            144
+seed7/lib/fixarray.s7i       0.046948            307
+seed7/lib/float.s7i          0.043941            757
+seed7/lib/font.s7i           0.040198            196
+seed7/lib/font8x8.s7i        0.043078            998
+seed7/lib/forloop.s7i        0.050571            449
+seed7/lib/ftp.s7i            0.045722            969
+seed7/lib/ftpserv.s7i        0.045637            631
+seed7/lib/getf.s7i           0.042052            115
+seed7/lib/gethttp.s7i        0.042278             41
+seed7/lib/gethttps.s7i       0.042382             41
+seed7/lib/gif.s7i            0.045960            561
+seed7/lib/graph.s7i          0.045842            415
+seed7/lib/graph_file.s7i     0.042249            399
+seed7/lib/gtkserver.s7i      0.043832            161
+seed7/lib/gzip.s7i           0.042833            573
+seed7/lib/hash.s7i           0.043063            421
+seed7/lib/hashsetof.s7i      0.043154            499
+seed7/lib/hmac.s7i           0.042460            152
+seed7/lib/html.s7i           0.044639             83
+seed7/lib/html_ent.s7i       0.045332            476
+seed7/lib/htmldom.s7i        0.044869            286
+seed7/lib/http_request.s7i   0.043819            696
+seed7/lib/http_srv_resp.s7i  0.043390            380
+seed7/lib/https_request.s7i  0.044676            211
+seed7/lib/httpserv.s7i       0.046046            345
+seed7/lib/huffman.s7i        0.047270            644
+seed7/lib/ico.s7i            0.046509            221
+seed7/lib/idxarray.s7i       0.045691            232
+seed7/lib/image.s7i          0.045930            156
+seed7/lib/imagefile.s7i      0.040779            171
+seed7/lib/inflate.s7i        0.040743            411
+seed7/lib/inifile.s7i        0.040588            129
+seed7/lib/integer.s7i        0.041150            663
+seed7/lib/iobuffer.s7i       0.041760            289
+seed7/lib/jpeg.s7i           0.041038           1761
+seed7/lib/json.s7i           0.040365            891
+seed7/lib/json_serde.s7i     0.044478            783
+seed7/lib/keybd.s7i          0.042376            639
+seed7/lib/keydescr.s7i       0.045310            192
+seed7/lib/leb128.s7i         0.043715            218
+seed7/lib/line.s7i           0.041063            164
+seed7/lib/listener.s7i       0.040429            247
+seed7/lib/logfile.s7i        0.043513             73
+seed7/lib/lower.s7i          0.044477            142
+seed7/lib/lzma.s7i           0.044153            934
+seed7/lib/lzw.s7i            0.046431            861
+seed7/lib/magic.s7i          0.046486            403
+seed7/lib/mahjng32.s7i       0.044289           1500
+seed7/lib/make.s7i           0.045907            544
+seed7/lib/makedata.s7i       0.044811           1428
+seed7/lib/math.s7i           0.043750            201
+seed7/lib/mixarith.s7i       0.041040            249
+seed7/lib/modern27.s7i       0.045035           1099
+seed7/lib/more.s7i           0.045825            130
+seed7/lib/msgdigest.s7i      0.045041           1222
+seed7/lib/multiscr.s7i       0.040106             68
+seed7/lib/null_file.s7i      0.045622            345
+seed7/lib/osfiles.s7i        0.048176           1085
+seed7/lib/pbm.s7i            0.044201            230
+seed7/lib/pcx.s7i            0.042567            638
+seed7/lib/pem.s7i            0.041347            185
+seed7/lib/pgm.s7i            0.047346            238
+seed7/lib/pic16.s7i          0.048796           1037
+seed7/lib/pic32.s7i          0.048095           2060
+seed7/lib/pic_util.s7i       0.048215            144
+seed7/lib/pixelimage.s7i     0.047677            320
+seed7/lib/pixmap_file.s7i    0.043342            459
+seed7/lib/pixmapfont.s7i     0.045753            184
+seed7/lib/pkcs1.s7i          0.052185            543
+seed7/lib/png.s7i            0.043657           1064
+seed7/lib/poll.s7i           0.041387            313
+seed7/lib/ppm.s7i            0.043080            240
+seed7/lib/process.s7i        0.047626            541
+seed7/lib/progs.s7i          0.048215            789
+seed7/lib/propertyfile.s7i   0.045734            155
+seed7/lib/rational.s7i       0.045304            792
+seed7/lib/ref_list.s7i       0.044602            252
+seed7/lib/reference.s7i      0.043649            126
+seed7/lib/reverse.s7i        0.042203             94
+seed7/lib/rpm.s7i            0.041243           3487
+seed7/lib/rpmext.s7i         0.040605            318
+seed7/lib/scanfile.s7i       0.042844           1779
+seed7/lib/scanjson.s7i       0.050898            413
+seed7/lib/scanstri.s7i       0.050028           1814
+seed7/lib/scantoml.s7i       0.050589           1603
+seed7/lib/seed7_05.s7i       0.045635           1072
+seed7/lib/set.s7i            0.038329             57
+seed7/lib/shell.s7i          0.040125            615
+seed7/lib/showtls.s7i        0.039596            678
+seed7/lib/signature.s7i      0.039479            131
+seed7/lib/smtp.s7i           0.040752            261
+seed7/lib/sockbase.s7i       0.040481            217
+seed7/lib/socket.s7i         0.042937            326
+seed7/lib/sokoban1.s7i       0.043800           1519
+seed7/lib/sql_base.s7i       0.045564           1000
+seed7/lib/stars.s7i          0.046374           1705
+seed7/lib/stdfont10.s7i      0.041693           3347
+seed7/lib/stdfont12.s7i      0.046616           3928
+seed7/lib/stdfont14.s7i      0.041455           4510
+seed7/lib/stdfont16.s7i      0.042024           5092
+seed7/lib/stdfont18.s7i      0.041913           5868
+seed7/lib/stdfont20.s7i      0.040441           6449
+seed7/lib/stdfont24.s7i      0.040390           7421
+seed7/lib/stdfont8.s7i       0.039169           2960
+seed7/lib/stdfont9.s7i       0.039320           3152
+seed7/lib/stdio.s7i          0.040978            192
+seed7/lib/strifile.s7i       0.039783            345
+seed7/lib/string.s7i         0.040287            779
+seed7/lib/stritext.s7i       0.040555            352
+seed7/lib/struct.s7i         0.041014            266
+seed7/lib/struct_elem.s7i    0.039556            129
+seed7/lib/subfile.s7i        0.039729            174
+seed7/lib/subrange.s7i       0.038425             78
+seed7/lib/syntax.s7i         0.039854            294
+seed7/lib/tar.s7i            0.039545           1880
+seed7/lib/tar_cmds.s7i       0.040014            752
+seed7/lib/tdes.s7i           0.042854            143
+seed7/lib/tee.s7i            0.040639            143
+seed7/lib/text.s7i           0.039123            135
+seed7/lib/tga.s7i            0.041910            676
+seed7/lib/tiff.s7i           0.041559           2771
+seed7/lib/time.s7i           0.041030           1191
+seed7/lib/tls.s7i            0.043262           2230
+seed7/lib/unicode.s7i        0.042998            575
+seed7/lib/unionfnd.s7i       0.040499            130
+seed7/lib/upper.s7i          0.040179            142
+seed7/lib/utf16.s7i          0.040711            540
+seed7/lib/utf8.s7i           0.041256            234
+seed7/lib/vecfont10.s7i      0.043108           1056
+seed7/lib/vecfont18.s7i      0.043873           1119
+seed7/lib/vector3d.s7i       0.040436            293
+seed7/lib/vectorfont.s7i     0.040544            239
+seed7/lib/wildcard.s7i       0.040313            140
+seed7/lib/window.s7i         0.040314            455
+seed7/lib/wrinum.s7i         0.040511            248
+seed7/lib/x509cert.s7i       0.040398           1243
+seed7/lib/xml_ent.s7i        0.040182             94
+seed7/lib/xmldom.s7i         0.040341            303
+seed7/lib/xz.s7i             0.040633            442
+seed7/lib/zip.s7i            0.040784           2792
+seed7/lib/zstd.s7i           0.042313           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.042717        |
++-----------+-----------------+
+| Minimum   | 0.036902        |
++-----------+-----------------+
+| Maximum   | 0.052185        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.043823            190
+seed7/prg/bas7.sd7           0.334746          11459
+seed7/prg/bifurk.sd7         0.037437             73
+seed7/prg/bigfiles.sd7       0.040565            129
+seed7/prg/brainf7.sd7        0.038971             86
+seed7/prg/calc7.sd7          0.039394            128
+seed7/prg/carddemo.sd7       0.040146            190
+seed7/prg/castle.sd7         0.111031           3148
+seed7/prg/cat.sd7            0.037621             82
+seed7/prg/cellauto.sd7       0.037896             85
+seed7/prg/celsius.sd7        0.036324             42
+seed7/prg/chk_all.sd7        0.060120            843
+seed7/prg/chkarr.sd7         0.365279           8367
+seed7/prg/chkbig.sd7         2.134157          29026
+seed7/prg/chkbin.sd7         0.530784           6469
+seed7/prg/chkbitdata.sd7     0.633632           6624
+seed7/prg/chkbool.sd7        0.119848           3157
+seed7/prg/chkbst.sd7         0.064416            722
+seed7/prg/chkchr.sd7         0.223741           2809
+seed7/prg/chkcmd.sd7         0.068776           1205
+seed7/prg/chkdb.sd7          0.361034           7454
+seed7/prg/chkdecl.sd7        0.063280            448
+seed7/prg/chkenum.sd7        0.070964           1230
+seed7/prg/chkerr.sd7         0.199000           4663
+seed7/prg/chkexc.sd7         0.084305           2627
+seed7/prg/chkfil.sd7         0.076335           1615
+seed7/prg/chkflt.sd7         1.378257          20620
+seed7/prg/chkhent.sd7        0.038506             54
+seed7/prg/chkhsh.sd7         0.256377           4548
+seed7/prg/chkidx.sd7         1.361515          19567
+seed7/prg/chkint.sd7         2.589570          38129
+seed7/prg/chkjson.sd7        0.103520           1764
+seed7/prg/chkovf.sd7         0.575172           8216
+seed7/prg/chkprc.sd7         0.328037          10111
+seed7/prg/chkscan.sd7        0.058515            714
+seed7/prg/chkset.sd7         0.677117          11974
+seed7/prg/chkstr.sd7         1.413889          26952
+seed7/prg/chktime.sd7        0.132004           2025
+seed7/prg/chktoml.sd7        0.109929           1656
+seed7/prg/clock.sd7          0.035866             47
+seed7/prg/clock2.sd7         0.035477             43
+seed7/prg/clock3.sd7         0.037905             95
+seed7/prg/cmpfil.sd7         0.036258             84
+seed7/prg/comanche.sd7       0.040343            180
+seed7/prg/confval.sd7        0.043073            175
+seed7/prg/db7.sd7            0.047910            417
+seed7/prg/diff7.sd7          0.043512            263
+seed7/prg/dirtst.sd7         0.036768             42
+seed7/prg/dirx.sd7           0.039834            152
+seed7/prg/dnafight.sd7       0.068582           1381
+seed7/prg/dragon.sd7         0.037640             73
+seed7/prg/echo.sd7           0.036288             39
+seed7/prg/eliza.sd7          0.043733            302
+seed7/prg/err.sd7            0.041068             96
+seed7/prg/fannkuch.sd7       0.038855            131
+seed7/prg/fib.sd7            0.036728             47
+seed7/prg/find7.sd7          0.039397            133
+seed7/prg/findchar.sd7       0.039749            149
+seed7/prg/fractree.sd7       0.037272             55
+seed7/prg/ftp7.sd7           0.043787            296
+seed7/prg/ftpserv.sd7        0.038624             74
+seed7/prg/gcd.sd7            0.037998            109
+seed7/prg/gkbd.sd7           0.046884            358
+seed7/prg/gtksvtst.sd7       0.037966             94
+seed7/prg/hal.sd7            0.040252            250
+seed7/prg/hamu.sd7           0.048826            573
+seed7/prg/hanoi.sd7          0.036422             55
+seed7/prg/hd.sd7             0.036685             79
+seed7/prg/hello.sd7          0.035298             32
+seed7/prg/hilbert.sd7        0.037178            108
+seed7/prg/ide7.sd7           0.041574            196
+seed7/prg/kbd.sd7            0.037033             49
+seed7/prg/klondike.sd7       0.055955            883
+seed7/prg/lander.sd7         0.073274           1551
+seed7/prg/lst80bas.sd7       0.044966            344
+seed7/prg/lst99bas.sd7       0.046139            401
+seed7/prg/lstgwbas.sd7       0.051929            577
+seed7/prg/mahjong.sd7        0.082188           1943
+seed7/prg/make7.sd7          0.039094            121
+seed7/prg/mandelbr.sd7       0.048331            237
+seed7/prg/mind.sd7           0.047494            443
+seed7/prg/mirror.sd7         0.040659            131
+seed7/prg/ms.sd7             0.050126            641
+seed7/prg/nicoma.sd7         0.039671            135
+seed7/prg/pac.sd7            0.050547            726
+seed7/prg/pairs.sd7          0.083483           2025
+seed7/prg/panic.sd7          0.098649           2634
+seed7/prg/percolation.sd7    0.042898            330
+seed7/prg/planets.sd7        0.077587           1486
+seed7/prg/portfwd7.sd7       0.039689            139
+seed7/prg/prime.sd7          0.037474             74
+seed7/prg/printpi1.sd7       0.037237             56
+seed7/prg/printpi2.sd7       0.037306             54
+seed7/prg/printpi3.sd7       0.040243             60
+seed7/prg/pv7.sd7            0.046613            337
+seed7/prg/queen.sd7          0.039325            149
+seed7/prg/rand.sd7           0.038727            121
+seed7/prg/raytrace.sd7       0.049654            538
+seed7/prg/rever.sd7          0.055043            816
+seed7/prg/roman.sd7          0.036502             38
+seed7/prg/s7c.sd7            0.286943           9060
+seed7/prg/s7check.sd7        0.036739             68
+seed7/prg/savehd7.sd7        0.067601           1110
+seed7/prg/self.sd7           0.036467             49
+seed7/prg/shisen.sd7         0.072005           1423
+seed7/prg/sl.sd7             0.061015           1029
+seed7/prg/snake.sd7          0.048233            615
+seed7/prg/sokoban.sd7        0.056424            891
+seed7/prg/spigotpi.sd7       0.037708             64
+seed7/prg/sql7.sd7           0.043064            278
+seed7/prg/startrek.sd7       0.060625            979
+seed7/prg/sudoku7.sd7        0.102504           2657
+seed7/prg/sydir7.sd7         0.046797            384
+seed7/prg/syntaxhl.sd7       0.042030            177
+seed7/prg/tak.sd7            0.037270             59
+seed7/prg/tar7.sd7           0.039276            121
+seed7/prg/tch.sd7            0.037186             55
+seed7/prg/testfont.sd7       0.038889             95
+seed7/prg/tet.sd7            0.045335            479
+seed7/prg/tetg.sd7           0.045558            501
+seed7/prg/toutf8.sd7         0.042933            240
+seed7/prg/tst_cli.sd7        0.035642             40
+seed7/prg/tst_srv.sd7        0.035796             47
+seed7/prg/wator.sd7          0.052247            651
+seed7/prg/which.sd7          0.036927             65
+seed7/prg/wiz.sd7            0.106648           2833
+seed7/prg/wordcnt.sd7        0.035976             54
+seed7/prg/wrinum.sd7         0.037248             43
+seed7/prg/wumpus.sd7         0.044510            372
+seed7/lib/aes.s7i            0.112506           1144
+seed7/lib/aes_gcm.s7i        0.048059            392
+seed7/lib/ar.s7i             0.075800           1532
+seed7/lib/arc4.s7i           0.039787            144
+seed7/lib/archive.s7i        0.039816            143
+seed7/lib/archive_base.s7i   0.039558            135
+seed7/lib/array.s7i          0.055381            610
+seed7/lib/asn1.s7i           0.048567            544
+seed7/lib/asn1oid.s7i        0.042887            157
+seed7/lib/basearray.s7i      0.049644            450
+seed7/lib/bigfile.s7i        0.039156            136
+seed7/lib/bigint.s7i         0.056708            824
+seed7/lib/bigrat.s7i         0.055286            784
+seed7/lib/bin16.s7i          0.051677            592
+seed7/lib/bin32.s7i          0.048392            490
+seed7/lib/bin64.s7i          0.049613            539
+seed7/lib/bitdata.s7i        0.077446           1330
+seed7/lib/bitmapfont.s7i     0.040235            215
+seed7/lib/bitset.s7i         0.050149            593
+seed7/lib/bitsetof.s7i       0.049001            431
+seed7/lib/blowfish.s7i       0.058044            383
+seed7/lib/bmp.s7i            0.063091            924
+seed7/lib/boolean.s7i        0.046075            403
+seed7/lib/browser.s7i        0.044048            280
+seed7/lib/bstring.s7i        0.042210            227
+seed7/lib/bytedata.s7i       0.051689            482
+seed7/lib/bzip2.s7i          0.060540            887
+seed7/lib/cards.s7i          0.067897           1342
+seed7/lib/category.s7i       0.042305            209
+seed7/lib/cc_conf.s7i        0.079695           1314
+seed7/lib/ccittfax.s7i       0.067861           1022
+seed7/lib/cgi.s7i            0.038706            109
+seed7/lib/cgidialog.s7i      0.061957           1118
+seed7/lib/char.s7i           0.043711            356
+seed7/lib/charsets.s7i       0.082317           2024
+seed7/lib/chartype.s7i       0.039920            121
+seed7/lib/cipher.s7i         0.037933            146
+seed7/lib/cli_cmds.s7i       0.070536           1360
+seed7/lib/clib_file.s7i      0.045010            301
+seed7/lib/color.s7i          0.041644            185
+seed7/lib/complex.s7i        0.047664            464
+seed7/lib/compress.s7i       0.047386            150
+seed7/lib/console.s7i        0.041702            188
+seed7/lib/cpio.s7i           0.087232           1708
+seed7/lib/crc32.s7i          0.044465            193
+seed7/lib/cronos16.s7i       0.098876           1173
+seed7/lib/cronos27.s7i       0.120374           1464
+seed7/lib/csv.s7i            0.045023            201
+seed7/lib/db_prop.s7i        0.068105            991
+seed7/lib/deflate.s7i        0.060379            740
+seed7/lib/des.s7i            0.056398            444
+seed7/lib/dialog.s7i         0.045486            311
+seed7/lib/dir.s7i            0.040999            163
+seed7/lib/draw.s7i           0.057909            854
+seed7/lib/duration.s7i       0.063891           1038
+seed7/lib/echo.s7i           0.041297            132
+seed7/lib/editline.s7i       0.048045            398
+seed7/lib/elf.s7i            0.090084           1560
+seed7/lib/elliptic.s7i       0.056462            649
+seed7/lib/enable_io.s7i      0.050287            312
+seed7/lib/encoding.s7i       0.065965            931
+seed7/lib/enumeration.s7i    0.044499            236
+seed7/lib/environment.s7i    0.040754            175
+seed7/lib/exif.s7i           0.040922            152
+seed7/lib/external_file.s7i  0.045596            340
+seed7/lib/field.s7i          0.044339            268
+seed7/lib/file.s7i           0.047585            372
+seed7/lib/filebits.s7i       0.038529             46
+seed7/lib/filesys.s7i        0.051480            601
+seed7/lib/fileutil.s7i       0.043479            144
+seed7/lib/fixarray.s7i       0.047538            307
+seed7/lib/float.s7i          0.057600            757
+seed7/lib/font.s7i           0.042641            196
+seed7/lib/font8x8.s7i        0.051122            998
+seed7/lib/forloop.s7i        0.047300            449
+seed7/lib/ftp.s7i            0.062291            969
+seed7/lib/ftpserv.s7i        0.054885            631
+seed7/lib/getf.s7i           0.039568            115
+seed7/lib/gethttp.s7i        0.039059             41
+seed7/lib/gethttps.s7i       0.038602             41
+seed7/lib/gif.s7i            0.052823            561
+seed7/lib/graph.s7i          0.052887            415
+seed7/lib/graph_file.s7i     0.047331            399
+seed7/lib/gtkserver.s7i      0.041156            161
+seed7/lib/gzip.s7i           0.050794            573
+seed7/lib/hash.s7i           0.051016            421
+seed7/lib/hashsetof.s7i      0.049690            499
+seed7/lib/hmac.s7i           0.040825            152
+seed7/lib/html.s7i           0.037341             83
+seed7/lib/html_ent.s7i       0.048423            476
+seed7/lib/htmldom.s7i        0.044709            286
+seed7/lib/http_request.s7i   0.053525            696
+seed7/lib/http_srv_resp.s7i  0.047675            380
+seed7/lib/https_request.s7i  0.040863            211
+seed7/lib/httpserv.s7i       0.044590            345
+seed7/lib/huffman.s7i        0.053181            644
+seed7/lib/ico.s7i            0.041664            221
+seed7/lib/idxarray.s7i       0.042388            232
+seed7/lib/image.s7i          0.038956            156
+seed7/lib/imagefile.s7i      0.040438            171
+seed7/lib/inflate.s7i        0.048377            411
+seed7/lib/inifile.s7i        0.039547            129
+seed7/lib/integer.s7i        0.054091            663
+seed7/lib/iobuffer.s7i       0.043039            289
+seed7/lib/jpeg.s7i           0.085624           1761
+seed7/lib/json.s7i           0.056929            891
+seed7/lib/json_serde.s7i     0.054340            783
+seed7/lib/keybd.s7i          0.056749            639
+seed7/lib/keydescr.s7i       0.041955            192
+seed7/lib/leb128.s7i         0.039877            218
+seed7/lib/line.s7i           0.038128            164
+seed7/lib/listener.s7i       0.041362            247
+seed7/lib/logfile.s7i        0.037169             73
+seed7/lib/lower.s7i          0.037994            142
+seed7/lib/lzma.s7i           0.060190            934
+seed7/lib/lzw.s7i            0.059681            861
+seed7/lib/magic.s7i          0.048711            403
+seed7/lib/mahjng32.s7i       0.064857           1500
+seed7/lib/make.s7i           0.050265            544
+seed7/lib/makedata.s7i       0.071192           1428
+seed7/lib/math.s7i           0.041684            201
+seed7/lib/mixarith.s7i       0.041633            249
+seed7/lib/modern27.s7i       0.087034           1099
+seed7/lib/more.s7i           0.039069            130
+seed7/lib/msgdigest.s7i      0.080535           1222
+seed7/lib/multiscr.s7i       0.037922             68
+seed7/lib/null_file.s7i      0.044425            345
+seed7/lib/osfiles.s7i        0.066842           1085
+seed7/lib/pbm.s7i            0.042206            230
+seed7/lib/pcx.s7i            0.053651            638
+seed7/lib/pem.s7i            0.040750            185
+seed7/lib/pgm.s7i            0.042311            238
+seed7/lib/pic16.s7i          0.049976           1037
+seed7/lib/pic32.s7i          0.082007           2060
+seed7/lib/pic_util.s7i       0.039152            144
+seed7/lib/pixelimage.s7i     0.042562            320
+seed7/lib/pixmap_file.s7i    0.046108            459
+seed7/lib/pixmapfont.s7i     0.040779            184
+seed7/lib/pkcs1.s7i          0.059653            543
+seed7/lib/png.s7i            0.066528           1064
+seed7/lib/poll.s7i           0.045382            313
+seed7/lib/ppm.s7i            0.041958            240
+seed7/lib/process.s7i        0.050226            541
+seed7/lib/progs.s7i          0.057624            789
+seed7/lib/propertyfile.s7i   0.039890            155
+seed7/lib/rational.s7i       0.055628            792
+seed7/lib/ref_list.s7i       0.042848            252
+seed7/lib/reference.s7i      0.039206            126
+seed7/lib/reverse.s7i        0.037502             94
+seed7/lib/rpm.s7i            0.147646           3487
+seed7/lib/rpmext.s7i         0.043838            318
+seed7/lib/scanfile.s7i       0.082973           1779
+seed7/lib/scanjson.s7i       0.048048            413
+seed7/lib/scanstri.s7i       0.082426           1814
+seed7/lib/scantoml.s7i       0.072745           1603
+seed7/lib/seed7_05.s7i       0.068169           1072
+seed7/lib/set.s7i            0.038413             57
+seed7/lib/shell.s7i          0.055451            615
+seed7/lib/showtls.s7i        0.055263            678
+seed7/lib/signature.s7i      0.038606            131
+seed7/lib/smtp.s7i           0.040951            261
+seed7/lib/sockbase.s7i       0.042374            217
+seed7/lib/socket.s7i         0.043343            326
+seed7/lib/sokoban1.s7i       0.054671           1519
+seed7/lib/sql_base.s7i       0.065304           1000
+seed7/lib/stars.s7i          0.139992           1705
+seed7/lib/stdfont10.s7i      0.087861           3347
+seed7/lib/stdfont12.s7i      0.099817           3928
+seed7/lib/stdfont14.s7i      0.106540           4510
+seed7/lib/stdfont16.s7i      0.122302           5092
+seed7/lib/stdfont18.s7i      0.136316           5868
+seed7/lib/stdfont20.s7i      0.151270           6449
+seed7/lib/stdfont24.s7i      0.185465           7421
+seed7/lib/stdfont8.s7i       0.074293           2960
+seed7/lib/stdfont9.s7i       0.079083           3152
+seed7/lib/stdio.s7i          0.040453            192
+seed7/lib/strifile.s7i       0.044555            345
+seed7/lib/string.s7i         0.056962            779
+seed7/lib/stritext.s7i       0.044498            352
+seed7/lib/struct.s7i         0.047057            266
+seed7/lib/struct_elem.s7i    0.039657            129
+seed7/lib/subfile.s7i        0.043020            174
+seed7/lib/subrange.s7i       0.039527             78
+seed7/lib/syntax.s7i         0.046989            294
+seed7/lib/tar.s7i            0.083361           1880
+seed7/lib/tar_cmds.s7i       0.056988            752
+seed7/lib/tdes.s7i           0.040671            143
+seed7/lib/tee.s7i            0.039003            143
+seed7/lib/text.s7i           0.039765            135
+seed7/lib/tga.s7i            0.055778            676
+seed7/lib/tiff.s7i           0.126984           2771
+seed7/lib/time.s7i           0.066042           1191
+seed7/lib/tls.s7i            0.110687           2230
+seed7/lib/unicode.s7i        0.057822            575
+seed7/lib/unionfnd.s7i       0.038912            130
+seed7/lib/upper.s7i          0.039024            142
+seed7/lib/utf16.s7i          0.050922            540
+seed7/lib/utf8.s7i           0.043333            234
+seed7/lib/vecfont10.s7i      0.082579           1056
+seed7/lib/vecfont18.s7i      0.090117           1119
+seed7/lib/vector3d.s7i       0.042174            293
+seed7/lib/vectorfont.s7i     0.040997            239
+seed7/lib/wildcard.s7i       0.038388            140
+seed7/lib/window.s7i         0.045897            455
+seed7/lib/wrinum.s7i         0.042889            248
+seed7/lib/x509cert.s7i       0.073143           1243
+seed7/lib/xml_ent.s7i        0.038722             94
+seed7/lib/xmldom.s7i         0.042575            303
+seed7/lib/xz.s7i             0.047140            442
+seed7/lib/zip.s7i            0.121658           2792
+seed7/lib/zstd.s7i           0.070952           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.091823        |
++-----------+-----------------+
+| Minimum   | 0.035298        |
++-----------+-----------------+
+| Maximum   | 2.589570        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.047025            190
+seed7/prg/bas7.sd7           0.786250          11459
+seed7/prg/bifurk.sd7         0.040518             73
+seed7/prg/bigfiles.sd7       0.044398            129
+seed7/prg/brainf7.sd7        0.041136             86
+seed7/prg/calc7.sd7          0.043279            128
+seed7/prg/carddemo.sd7       0.048482            190
+seed7/prg/castle.sd7         0.223259           3148
+seed7/prg/cat.sd7            0.039781             82
+seed7/prg/cellauto.sd7       0.039193             85
+seed7/prg/celsius.sd7        0.037113             42
+seed7/prg/chk_all.sd7        0.083560            843
+seed7/prg/chkarr.sd7         0.883872           8367
+seed7/prg/chkbig.sd7         4.239324          29026
+seed7/prg/chkbin.sd7         1.056140           6469
+seed7/prg/chkbitdata.sd7     1.282232           6624
+seed7/prg/chkbool.sd7        0.237671           3157
+seed7/prg/chkbst.sd7         0.104197            722
+seed7/prg/chkchr.sd7         0.493074           2809
+seed7/prg/chkcmd.sd7         0.113198           1205
+seed7/prg/chkdb.sd7          0.776126           7454
+seed7/prg/chkdecl.sd7        0.095062            448
+seed7/prg/chkenum.sd7        0.122685           1230
+seed7/prg/chkerr.sd7         0.347950           4663
+seed7/prg/chkexc.sd7         0.152197           2627
+seed7/prg/chkfil.sd7         0.132141           1615
+seed7/prg/chkflt.sd7         2.901358          20620
+seed7/prg/chkhent.sd7        0.039654             54
+seed7/prg/chkhsh.sd7         0.517281           4548
+seed7/prg/chkidx.sd7         3.265565          19567
+seed7/prg/chkint.sd7         5.721937          38129
+seed7/prg/chkjson.sd7        0.192809           1764
+seed7/prg/chkovf.sd7         1.240535           8216
+seed7/prg/chkprc.sd7         0.719138          10111
+seed7/prg/chkscan.sd7        0.092987            714
+seed7/prg/chkset.sd7         1.797017          11974
+seed7/prg/chkstr.sd7         3.511704          26952
+seed7/prg/chktime.sd7        0.252245           2025
+seed7/prg/chktoml.sd7        0.200505           1656
+seed7/prg/clock.sd7          0.037215             47
+seed7/prg/clock2.sd7         0.037140             43
+seed7/prg/clock3.sd7         0.043356             95
+seed7/prg/cmpfil.sd7         0.039916             84
+seed7/prg/comanche.sd7       0.048370            180
+seed7/prg/confval.sd7        0.052336            175
+seed7/prg/db7.sd7            0.064956            417
+seed7/prg/diff7.sd7          0.053470            263
+seed7/prg/dirtst.sd7         0.038044             42
+seed7/prg/dirx.sd7           0.044734            152
+seed7/prg/dnafight.sd7       0.121369           1381
+seed7/prg/dragon.sd7         0.039231             73
+seed7/prg/echo.sd7           0.038361             39
+seed7/prg/eliza.sd7          0.053742            302
+seed7/prg/err.sd7            0.046024             96
+seed7/prg/fannkuch.sd7       0.043128            131
+seed7/prg/fib.sd7            0.038039             47
+seed7/prg/find7.sd7          0.042866            133
+seed7/prg/findchar.sd7       0.045145            149
+seed7/prg/fractree.sd7       0.044103             55
+seed7/prg/ftp7.sd7           0.054485            296
+seed7/prg/ftpserv.sd7        0.040329             74
+seed7/prg/gcd.sd7            0.041730            109
+seed7/prg/gkbd.sd7           0.063671            358
+seed7/prg/gtksvtst.sd7       0.040292             94
+seed7/prg/hal.sd7            0.048150            250
+seed7/prg/hamu.sd7           0.068522            573
+seed7/prg/hanoi.sd7          0.038867             55
+seed7/prg/hd.sd7             0.040115             79
+seed7/prg/hello.sd7          0.037972             32
+seed7/prg/hilbert.sd7        0.042521            108
+seed7/prg/ide7.sd7           0.049424            196
+seed7/prg/kbd.sd7            0.037948             49
+seed7/prg/klondike.sd7       0.089517            883
+seed7/prg/lander.sd7         0.135595           1551
+seed7/prg/lst80bas.sd7       0.056523            344
+seed7/prg/lst99bas.sd7       0.060569            401
+seed7/prg/lstgwbas.sd7       0.073719            577
+seed7/prg/mahjong.sd7        0.153781           1943
+seed7/prg/make7.sd7          0.045002            121
+seed7/prg/mandelbr.sd7       0.052925            237
+seed7/prg/mind.sd7           0.064315            443
+seed7/prg/mirror.sd7         0.047588            131
+seed7/prg/ms.sd7             0.075117            641
+seed7/prg/nicoma.sd7         0.044589            135
+seed7/prg/pac.sd7            0.074523            726
+seed7/prg/pairs.sd7          0.150414           2025
+seed7/prg/panic.sd7          0.202525           2634
+seed7/prg/percolation.sd7    0.056839            330
+seed7/prg/planets.sd7        0.141729           1486
+seed7/prg/portfwd7.sd7       0.044420            139
+seed7/prg/prime.sd7          0.039509             74
+seed7/prg/printpi1.sd7       0.038929             56
+seed7/prg/printpi2.sd7       0.039340             54
+seed7/prg/printpi3.sd7       0.040355             60
+seed7/prg/pv7.sd7            0.059889            337
+seed7/prg/queen.sd7          0.044439            149
+seed7/prg/rand.sd7           0.042552            121
+seed7/prg/raytrace.sd7       0.071130            538
+seed7/prg/rever.sd7          0.084819            816
+seed7/prg/roman.sd7          0.038069             38
+seed7/prg/s7c.sd7            0.645648           9060
+seed7/prg/s7check.sd7        0.040163             68
+seed7/prg/savehd7.sd7        0.114457           1110
+seed7/prg/self.sd7           0.038972             49
+seed7/prg/shisen.sd7         0.123825           1423
+seed7/prg/sl.sd7             0.100077           1029
+seed7/prg/snake.sd7          0.067861            615
+seed7/prg/sokoban.sd7        0.086533            891
+seed7/prg/spigotpi.sd7       0.040291             64
+seed7/prg/sql7.sd7           0.053517            278
+seed7/prg/startrek.sd7       0.095634            979
+seed7/prg/sudoku7.sd7        0.204534           2657
+seed7/prg/sydir7.sd7         0.064890            384
+seed7/prg/syntaxhl.sd7       0.049317            177
+seed7/prg/tak.sd7            0.038714             59
+seed7/prg/tar7.sd7           0.043391            121
+seed7/prg/tch.sd7            0.038342             55
+seed7/prg/testfont.sd7       0.043220             95
+seed7/prg/tet.sd7            0.061927            479
+seed7/prg/tetg.sd7           0.063528            501
+seed7/prg/toutf8.sd7         0.052865            240
+seed7/prg/tst_cli.sd7        0.037732             40
+seed7/prg/tst_srv.sd7        0.038041             47
+seed7/prg/wator.sd7          0.080622            651
+seed7/prg/which.sd7          0.039099             65
+seed7/prg/wiz.sd7            0.215380           2833
+seed7/prg/wordcnt.sd7        0.038963             54
+seed7/prg/wrinum.sd7         0.037320             43
+seed7/prg/wumpus.sd7         0.054987            372
+seed7/lib/aes.s7i            0.204665           1144
+seed7/lib/aes_gcm.s7i        0.064346            392
+seed7/lib/ar.s7i             0.133214           1532
+seed7/lib/arc4.s7i           0.045098            144
+seed7/lib/archive.s7i        0.044834            143
+seed7/lib/archive_base.s7i   0.044526            135
+seed7/lib/array.s7i          0.077380            610
+seed7/lib/asn1.s7i           0.067133            544
+seed7/lib/asn1oid.s7i        0.052158            157
+seed7/lib/basearray.s7i      0.066139            450
+seed7/lib/bigfile.s7i        0.044143            136
+seed7/lib/bigint.s7i         0.078827            824
+seed7/lib/bigrat.s7i         0.080627            784
+seed7/lib/bin16.s7i          0.068341            592
+seed7/lib/bin32.s7i          0.063541            490
+seed7/lib/bin64.s7i          0.066497            539
+seed7/lib/bitdata.s7i        0.126849           1330
+seed7/lib/bitmapfont.s7i     0.048509            215
+seed7/lib/bitset.s7i         0.066201            593
+seed7/lib/bitsetof.s7i       0.062912            431
+seed7/lib/blowfish.s7i       0.079562            383
+seed7/lib/bmp.s7i            0.103453            924
+seed7/lib/boolean.s7i        0.056706            403
+seed7/lib/browser.s7i        0.055015            280
+seed7/lib/bstring.s7i        0.048886            227
+seed7/lib/bytedata.s7i       0.067170            482
+seed7/lib/bzip2.s7i          0.092031            887
+seed7/lib/cards.s7i          0.106826           1342
+seed7/lib/category.s7i       0.053330            209
+seed7/lib/cc_conf.s7i        0.127399           1314
+seed7/lib/ccittfax.s7i       0.108425           1022
+seed7/lib/cgi.s7i            0.046961            109
+seed7/lib/cgidialog.s7i      0.100034           1118
+seed7/lib/char.s7i           0.051412            356
+seed7/lib/charsets.s7i       0.127544           2024
+seed7/lib/chartype.s7i       0.048469            121
+seed7/lib/cipher.s7i         0.043788            146
+seed7/lib/cli_cmds.s7i       0.116560           1360
+seed7/lib/clib_file.s7i      0.052327            301
+seed7/lib/color.s7i          0.047502            185
+seed7/lib/complex.s7i        0.060620            464
+seed7/lib/compress.s7i       0.043882            150
+seed7/lib/console.s7i        0.047654            188
+seed7/lib/cpio.s7i           0.148865           1708
+seed7/lib/crc32.s7i          0.057183            193
+seed7/lib/cronos16.s7i       0.200691           1173
+seed7/lib/cronos27.s7i       0.265158           1464
+seed7/lib/csv.s7i            0.050075            201
+seed7/lib/db_prop.s7i        0.104546            991
+seed7/lib/deflate.s7i        0.087995            740
+seed7/lib/des.s7i            0.082161            444
+seed7/lib/dialog.s7i         0.057160            311
+seed7/lib/dir.s7i            0.044157            163
+seed7/lib/draw.s7i           0.086134            854
+seed7/lib/duration.s7i       0.100306           1038
+seed7/lib/echo.s7i           0.043363            132
+seed7/lib/editline.s7i       0.061252            398
+seed7/lib/elf.s7i            0.160571           1560
+seed7/lib/elliptic.s7i       0.079519            649
+seed7/lib/enable_io.s7i      0.054442            312
+seed7/lib/encoding.s7i       0.100560            931
+seed7/lib/enumeration.s7i    0.051558            236
+seed7/lib/environment.s7i    0.045584            175
+seed7/lib/exif.s7i           0.047831            152
+seed7/lib/external_file.s7i  0.052771            340
+seed7/lib/field.s7i          0.052281            268
+seed7/lib/file.s7i           0.054664            372
+seed7/lib/filebits.s7i       0.039071             46
+seed7/lib/filesys.s7i        0.066813            601
+seed7/lib/fileutil.s7i       0.045294            144
+seed7/lib/fixarray.s7i       0.056471            307
+seed7/lib/float.s7i          0.075749            757
+seed7/lib/font.s7i           0.047204            196
+seed7/lib/font8x8.s7i        0.069846            998
+seed7/lib/forloop.s7i        0.061681            449
+seed7/lib/ftp.s7i            0.090137            969
+seed7/lib/ftpserv.s7i        0.077283            631
+seed7/lib/getf.s7i           0.042642            115
+seed7/lib/gethttp.s7i        0.038633             41
+seed7/lib/gethttps.s7i       0.038353             41
+seed7/lib/gif.s7i            0.072722            561
+seed7/lib/graph.s7i          0.064649            415
+seed7/lib/graph_file.s7i     0.058637            399
+seed7/lib/gtkserver.s7i      0.041864            161
+seed7/lib/gzip.s7i           0.068619            573
+seed7/lib/hash.s7i           0.067559            421
+seed7/lib/hashsetof.s7i      0.067553            499
+seed7/lib/hmac.s7i           0.045648            152
+seed7/lib/html.s7i           0.040490             83
+seed7/lib/html_ent.s7i       0.065955            476
+seed7/lib/htmldom.s7i        0.055332            286
+seed7/lib/http_request.s7i   0.078163            696
+seed7/lib/http_srv_resp.s7i  0.059548            380
+seed7/lib/https_request.s7i  0.048141            211
+seed7/lib/httpserv.s7i       0.056116            345
+seed7/lib/huffman.s7i        0.077157            644
+seed7/lib/ico.s7i            0.050213            221
+seed7/lib/idxarray.s7i       0.057354            232
+seed7/lib/image.s7i          0.044269            156
+seed7/lib/imagefile.s7i      0.044876            171
+seed7/lib/inflate.s7i        0.064745            411
+seed7/lib/inifile.s7i        0.042520            129
+seed7/lib/integer.s7i        0.071161            663
+seed7/lib/iobuffer.s7i       0.052711            289
+seed7/lib/jpeg.s7i           0.159155           1761
+seed7/lib/json.s7i           0.083398            891
+seed7/lib/json_serde.s7i     0.080990            783
+seed7/lib/keybd.s7i          0.081569            639
+seed7/lib/keydescr.s7i       0.050915            192
+seed7/lib/leb128.s7i         0.047873            218
+seed7/lib/line.s7i           0.044517            164
+seed7/lib/listener.s7i       0.049785            247
+seed7/lib/logfile.s7i        0.039908             73
+seed7/lib/lower.s7i          0.043146            142
+seed7/lib/lzma.s7i           0.099061            934
+seed7/lib/lzw.s7i            0.090678            861
+seed7/lib/magic.s7i          0.064557            403
+seed7/lib/mahjng32.s7i       0.094577           1500
+seed7/lib/make.s7i           0.071052            544
+seed7/lib/makedata.s7i       0.124565           1428
+seed7/lib/math.s7i           0.046991            201
+seed7/lib/mixarith.s7i       0.048603            249
+seed7/lib/modern27.s7i       0.175596           1099
+seed7/lib/more.s7i           0.044407            130
+seed7/lib/msgdigest.s7i      0.141890           1222
+seed7/lib/multiscr.s7i       0.040375             68
+seed7/lib/null_file.s7i      0.053719            345
+seed7/lib/osfiles.s7i        0.096878           1085
+seed7/lib/pbm.s7i            0.048829            230
+seed7/lib/pcx.s7i            0.078473            638
+seed7/lib/pem.s7i            0.045408            185
+seed7/lib/pgm.s7i            0.052044            238
+seed7/lib/pic16.s7i          0.068859           1037
+seed7/lib/pic32.s7i          0.127328           2060
+seed7/lib/pic_util.s7i       0.045232            144
+seed7/lib/pixelimage.s7i     0.054613            320
+seed7/lib/pixmap_file.s7i    0.064772            459
+seed7/lib/pixmapfont.s7i     0.048791            184
+seed7/lib/pkcs1.s7i          0.080929            543
+seed7/lib/png.s7i            0.112081           1064
+seed7/lib/poll.s7i           0.054401            313
+seed7/lib/ppm.s7i            0.051398            240
+seed7/lib/process.s7i        0.065595            541
+seed7/lib/progs.s7i          0.081720            789
+seed7/lib/propertyfile.s7i   0.044468            155
+seed7/lib/rational.s7i       0.080048            792
+seed7/lib/ref_list.s7i       0.050268            252
+seed7/lib/reference.s7i      0.043476            126
+seed7/lib/reverse.s7i        0.041255             94
+seed7/lib/rpm.s7i            0.296422           3487
+seed7/lib/rpmext.s7i         0.054108            318
+seed7/lib/scanfile.s7i       0.137632           1779
+seed7/lib/scanjson.s7i       0.063462            413
+seed7/lib/scanstri.s7i       0.140766           1814
+seed7/lib/scantoml.s7i       0.134292           1603
+seed7/lib/seed7_05.s7i       0.113500           1072
+seed7/lib/set.s7i            0.039026             57
+seed7/lib/shell.s7i          0.073370            615
+seed7/lib/showtls.s7i        0.088824            678
+seed7/lib/signature.s7i      0.044029            131
+seed7/lib/smtp.s7i           0.050362            261
+seed7/lib/sockbase.s7i       0.052231            217
+seed7/lib/socket.s7i         0.055103            326
+seed7/lib/sokoban1.s7i       0.082623           1519
+seed7/lib/sql_base.s7i       0.097105           1000
+seed7/lib/stars.s7i          0.248115           1705
+seed7/lib/stdfont10.s7i      0.147369           3347
+seed7/lib/stdfont12.s7i      0.171003           3928
+seed7/lib/stdfont14.s7i      0.193706           4510
+seed7/lib/stdfont16.s7i      0.219174           5092
+seed7/lib/stdfont18.s7i      0.253837           5868
+seed7/lib/stdfont20.s7i      0.281272           6449
+seed7/lib/stdfont24.s7i      0.343009           7421
+seed7/lib/stdfont8.s7i       0.132220           2960
+seed7/lib/stdfont9.s7i       0.139834           3152
+seed7/lib/stdio.s7i          0.046061            192
+seed7/lib/strifile.s7i       0.057080            345
+seed7/lib/string.s7i         0.081203            779
+seed7/lib/stritext.s7i       0.057830            352
+seed7/lib/struct.s7i         0.055541            266
+seed7/lib/struct_elem.s7i    0.042435            129
+seed7/lib/subfile.s7i        0.044107            174
+seed7/lib/subrange.s7i       0.039587             78
+seed7/lib/syntax.s7i         0.064484            294
+seed7/lib/tar.s7i            0.151851           1880
+seed7/lib/tar_cmds.s7i       0.086797            752
+seed7/lib/tdes.s7i           0.044914            143
+seed7/lib/tee.s7i            0.043514            143
+seed7/lib/text.s7i           0.043809            135
+seed7/lib/tga.s7i            0.082903            676
+seed7/lib/tiff.s7i           0.250186           2771
+seed7/lib/time.s7i           0.105094           1191
+seed7/lib/tls.s7i            0.201578           2230
+seed7/lib/unicode.s7i        0.074458            575
+seed7/lib/unionfnd.s7i       0.043846            130
+seed7/lib/upper.s7i          0.042464            142
+seed7/lib/utf16.s7i          0.066934            540
+seed7/lib/utf8.s7i           0.048933            234
+seed7/lib/vecfont10.s7i      0.164659           1056
+seed7/lib/vecfont18.s7i      0.183824           1119
+seed7/lib/vector3d.s7i       0.050717            293
+seed7/lib/vectorfont.s7i     0.048469            239
+seed7/lib/wildcard.s7i       0.042878            140
+seed7/lib/window.s7i         0.062178            455
+seed7/lib/wrinum.s7i         0.049816            248
+seed7/lib/x509cert.s7i       0.120152           1243
+seed7/lib/xml_ent.s7i        0.040284             94
+seed7/lib/xmldom.s7i         0.051149            303
+seed7/lib/xz.s7i             0.062428            442
+seed7/lib/zip.s7i            0.240056           2792
+seed7/lib/zstd.s7i           0.120874           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.163300        |
++-----------+-----------------+
+| Minimum   | 0.037113        |
++-----------+-----------------+
+| Maximum   | 5.721937        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.037853        | 0.033599        | 0.050347        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.042717        | 0.036902        | 0.052185        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.091823        | 0.035298        | 2.589570        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.163300        | 0.037113        | 5.721937        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:13.583 | 00:01:04.489 | 00:01:18.072 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:15.669 | 00:01:12.845 | 00:01:28.514 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:37.182 | 00:02:37.298 | 00:03:14.480 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:02.911 | 00:04:39.056 | 00:05:41.968 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:43.041 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-16.4.rst
+++ b/reports/seed7mode-perf-16.4.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-30T15:25:53+0000 W27-2
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 11:27:47 local time
+:Generated on: 2026-06-30 15:39:14 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 211x95 chars
+:Window body: 211x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.037354            190
+seed7/prg/bas7.sd7           0.037081          11459
+seed7/prg/bifurk.sd7         0.034604             73
+seed7/prg/bigfiles.sd7       0.033830            129
+seed7/prg/brainf7.sd7        0.033348             86
+seed7/prg/calc7.sd7          0.033274            128
+seed7/prg/carddemo.sd7       0.033294            190
+seed7/prg/castle.sd7         0.033296           3148
+seed7/prg/cat.sd7            0.033745             82
+seed7/prg/cellauto.sd7       0.033576             85
+seed7/prg/celsius.sd7        0.033280             42
+seed7/prg/chk_all.sd7        0.033644            843
+seed7/prg/chkarr.sd7         0.034205           8367
+seed7/prg/chkbig.sd7         0.037696          29026
+seed7/prg/chkbin.sd7         0.034424           6469
+seed7/prg/chkbitdata.sd7     0.034262           6624
+seed7/prg/chkbool.sd7        0.033609           3157
+seed7/prg/chkbst.sd7         0.033462            722
+seed7/prg/chkchr.sd7         0.033989           2809
+seed7/prg/chkcmd.sd7         0.033787           1205
+seed7/prg/chkdb.sd7          0.034504           7454
+seed7/prg/chkdecl.sd7        0.033390            448
+seed7/prg/chkenum.sd7        0.033594           1230
+seed7/prg/chkerr.sd7         0.034435           4663
+seed7/prg/chkexc.sd7         0.033205           2627
+seed7/prg/chkfil.sd7         0.034497           1615
+seed7/prg/chkflt.sd7         0.036662          20620
+seed7/prg/chkhent.sd7        0.032648             54
+seed7/prg/chkhsh.sd7         0.032674           4548
+seed7/prg/chkidx.sd7         0.035104          19567
+seed7/prg/chkint.sd7         0.039313          38129
+seed7/prg/chkjson.sd7        0.033199           1764
+seed7/prg/chkovf.sd7         0.034033           8216
+seed7/prg/chkprc.sd7         0.035937          10111
+seed7/prg/chkscan.sd7        0.034243            714
+seed7/prg/chkset.sd7         0.034879          11974
+seed7/prg/chkstr.sd7         0.037597          26952
+seed7/prg/chktime.sd7        0.033752           2025
+seed7/prg/chktoml.sd7        0.033747           1656
+seed7/prg/clock.sd7          0.033312             47
+seed7/prg/clock2.sd7         0.033349             43
+seed7/prg/clock3.sd7         0.033382             95
+seed7/prg/cmpfil.sd7         0.033554             84
+seed7/prg/comanche.sd7       0.033247            180
+seed7/prg/confval.sd7        0.033211            175
+seed7/prg/db7.sd7            0.033260            417
+seed7/prg/diff7.sd7          0.033310            263
+seed7/prg/dirtst.sd7         0.033416             42
+seed7/prg/dirx.sd7           0.033291            152
+seed7/prg/dnafight.sd7       0.034037           1381
+seed7/prg/dragon.sd7         0.033551             73
+seed7/prg/echo.sd7           0.033814             39
+seed7/prg/eliza.sd7          0.033548            302
+seed7/prg/err.sd7            0.033341             96
+seed7/prg/fannkuch.sd7       0.033120            131
+seed7/prg/fib.sd7            0.033224             47
+seed7/prg/find7.sd7          0.033418            133
+seed7/prg/findchar.sd7       0.033515            149
+seed7/prg/fractree.sd7       0.032862             55
+seed7/prg/ftp7.sd7           0.032588            296
+seed7/prg/ftpserv.sd7        0.032446             74
+seed7/prg/gcd.sd7            0.033239            109
+seed7/prg/gkbd.sd7           0.032610            358
+seed7/prg/gtksvtst.sd7       0.032777             94
+seed7/prg/hal.sd7            0.033763            250
+seed7/prg/hamu.sd7           0.034529            573
+seed7/prg/hanoi.sd7          0.033300             55
+seed7/prg/hd.sd7             0.032954             79
+seed7/prg/hello.sd7          0.032838             32
+seed7/prg/hilbert.sd7        0.032721            108
+seed7/prg/ide7.sd7           0.032611            196
+seed7/prg/kbd.sd7            0.032418             49
+seed7/prg/klondike.sd7       0.032551            883
+seed7/prg/lander.sd7         0.032658           1551
+seed7/prg/lst80bas.sd7       0.032557            344
+seed7/prg/lst99bas.sd7       0.032638            401
+seed7/prg/lstgwbas.sd7       0.032947            577
+seed7/prg/mahjong.sd7        0.033589           1943
+seed7/prg/make7.sd7          0.033460            121
+seed7/prg/mandelbr.sd7       0.033547            237
+seed7/prg/mind.sd7           0.033360            443
+seed7/prg/mirror.sd7         0.033912            131
+seed7/prg/ms.sd7             0.033774            641
+seed7/prg/nicoma.sd7         0.033441            135
+seed7/prg/pac.sd7            0.035572            726
+seed7/prg/pairs.sd7          0.037250           2025
+seed7/prg/panic.sd7          0.033725           2634
+seed7/prg/percolation.sd7    0.033855            330
+seed7/prg/planets.sd7        0.033705           1486
+seed7/prg/portfwd7.sd7       0.033643            139
+seed7/prg/prime.sd7          0.032905             74
+seed7/prg/printpi1.sd7       0.032628             56
+seed7/prg/printpi2.sd7       0.032373             54
+seed7/prg/printpi3.sd7       0.032526             60
+seed7/prg/pv7.sd7            0.032668            337
+seed7/prg/queen.sd7          0.032426            149
+seed7/prg/rand.sd7           0.033450            121
+seed7/prg/raytrace.sd7       0.034290            538
+seed7/prg/rever.sd7          0.034286            816
+seed7/prg/roman.sd7          0.032867             38
+seed7/prg/s7c.sd7            0.033337           9060
+seed7/prg/s7check.sd7        0.032699             68
+seed7/prg/savehd7.sd7        0.032412           1110
+seed7/prg/self.sd7           0.032197             49
+seed7/prg/shisen.sd7         0.033442           1423
+seed7/prg/sl.sd7             0.033806           1029
+seed7/prg/snake.sd7          0.033430            615
+seed7/prg/sokoban.sd7        0.033463            891
+seed7/prg/spigotpi.sd7       0.033391             64
+seed7/prg/sql7.sd7           0.033302            278
+seed7/prg/startrek.sd7       0.033438            979
+seed7/prg/sudoku7.sd7        0.033676           2657
+seed7/prg/sydir7.sd7         0.033249            384
+seed7/prg/syntaxhl.sd7       0.034121            177
+seed7/prg/tak.sd7            0.033926             59
+seed7/prg/tar7.sd7           0.033713            121
+seed7/prg/tch.sd7            0.037301             55
+seed7/prg/testfont.sd7       0.039572             95
+seed7/prg/tet.sd7            0.035808            479
+seed7/prg/tetg.sd7           0.035461            501
+seed7/prg/toutf8.sd7         0.035262            240
+seed7/prg/tst_cli.sd7        0.034240             40
+seed7/prg/tst_srv.sd7        0.032988             47
+seed7/prg/wator.sd7          0.032482            651
+seed7/prg/which.sd7          0.033216             65
+seed7/prg/wiz.sd7            0.032815           2833
+seed7/prg/wordcnt.sd7        0.032379             54
+seed7/prg/wrinum.sd7         0.033883             43
+seed7/prg/wumpus.sd7         0.034158            372
+seed7/lib/aes.s7i            0.037850           1144
+seed7/lib/aes_gcm.s7i        0.037326            392
+seed7/lib/ar.s7i             0.034992           1532
+seed7/lib/arc4.s7i           0.033633            144
+seed7/lib/archive.s7i        0.033724            143
+seed7/lib/archive_base.s7i   0.033477            135
+seed7/lib/array.s7i          0.033942            610
+seed7/lib/asn1.s7i           0.034360            544
+seed7/lib/asn1oid.s7i        0.033405            157
+seed7/lib/basearray.s7i      0.033554            450
+seed7/lib/bigfile.s7i        0.033558            136
+seed7/lib/bigint.s7i         0.033543            824
+seed7/lib/bigrat.s7i         0.033251            784
+seed7/lib/bin16.s7i          0.033688            592
+seed7/lib/bin32.s7i          0.033745            490
+seed7/lib/bin64.s7i          0.033524            539
+seed7/lib/bitdata.s7i        0.033620           1330
+seed7/lib/bitmapfont.s7i     0.034349            215
+seed7/lib/bitset.s7i         0.033685            593
+seed7/lib/bitsetof.s7i       0.034237            431
+seed7/lib/blowfish.s7i       0.033560            383
+seed7/lib/bmp.s7i            0.033571            924
+seed7/lib/boolean.s7i        0.033488            403
+seed7/lib/browser.s7i        0.033975            280
+seed7/lib/bstring.s7i        0.033504            227
+seed7/lib/bytedata.s7i       0.032695            482
+seed7/lib/bzip2.s7i          0.032718            887
+seed7/lib/cards.s7i          0.032818           1342
+seed7/lib/category.s7i       0.033412            209
+seed7/lib/cc_conf.s7i        0.036591           1314
+seed7/lib/ccittfax.s7i       0.038271           1022
+seed7/lib/cgi.s7i            0.036475            109
+seed7/lib/cgidialog.s7i      0.034829           1118
+seed7/lib/char.s7i           0.033818            356
+seed7/lib/charsets.s7i       0.033703           2024
+seed7/lib/chartype.s7i       0.033566            121
+seed7/lib/cipher.s7i         0.033943            146
+seed7/lib/cli_cmds.s7i       0.033408           1360
+seed7/lib/clib_file.s7i      0.033481            301
+seed7/lib/color.s7i          0.033690            185
+seed7/lib/complex.s7i        0.033394            464
+seed7/lib/compress.s7i       0.033728            150
+seed7/lib/console.s7i        0.033627            188
+seed7/lib/cpio.s7i           0.033794           1708
+seed7/lib/crc32.s7i          0.033556            193
+seed7/lib/cronos16.s7i       0.033594           1173
+seed7/lib/cronos27.s7i       0.033601           1464
+seed7/lib/csv.s7i            0.034287            201
+seed7/lib/db_prop.s7i        0.035806            991
+seed7/lib/deflate.s7i        0.039198            740
+seed7/lib/des.s7i            0.034246            444
+seed7/lib/dialog.s7i         0.033699            311
+seed7/lib/dir.s7i            0.033902            163
+seed7/lib/draw.s7i           0.037368            854
+seed7/lib/duration.s7i       0.038507           1038
+seed7/lib/echo.s7i           0.033470            132
+seed7/lib/editline.s7i       0.032978            398
+seed7/lib/elf.s7i            0.032803           1560
+seed7/lib/elliptic.s7i       0.032706            649
+seed7/lib/enable_io.s7i      0.032679            312
+seed7/lib/encoding.s7i       0.032485            931
+seed7/lib/enumeration.s7i    0.034770            236
+seed7/lib/environment.s7i    0.034437            175
+seed7/lib/exif.s7i           0.033518            152
+seed7/lib/external_file.s7i  0.033651            340
+seed7/lib/field.s7i          0.033488            268
+seed7/lib/file.s7i           0.033564            372
+seed7/lib/filebits.s7i       0.034012             46
+seed7/lib/filesys.s7i        0.033452            601
+seed7/lib/fileutil.s7i       0.033631            144
+seed7/lib/fixarray.s7i       0.033620            307
+seed7/lib/float.s7i          0.033684            757
+seed7/lib/font.s7i           0.033632            196
+seed7/lib/font8x8.s7i        0.033827            998
+seed7/lib/forloop.s7i        0.033563            449
+seed7/lib/ftp.s7i            0.033350            969
+seed7/lib/ftpserv.s7i        0.033736            631
+seed7/lib/getf.s7i           0.033684            115
+seed7/lib/gethttp.s7i        0.033554             41
+seed7/lib/gethttps.s7i       0.033167             41
+seed7/lib/gif.s7i            0.033486            561
+seed7/lib/graph.s7i          0.033588            415
+seed7/lib/graph_file.s7i     0.033791            399
+seed7/lib/gtkserver.s7i      0.033254            161
+seed7/lib/gzip.s7i           0.033321            573
+seed7/lib/hash.s7i           0.033808            421
+seed7/lib/hashsetof.s7i      0.033058            499
+seed7/lib/hmac.s7i           0.032507            152
+seed7/lib/html.s7i           0.032608             83
+seed7/lib/html_ent.s7i       0.032754            476
+seed7/lib/htmldom.s7i        0.032588            286
+seed7/lib/http_request.s7i   0.032646            696
+seed7/lib/http_srv_resp.s7i  0.034369            380
+seed7/lib/https_request.s7i  0.033676            211
+seed7/lib/httpserv.s7i       0.033575            345
+seed7/lib/huffman.s7i        0.033797            644
+seed7/lib/ico.s7i            0.033516            221
+seed7/lib/idxarray.s7i       0.033414            232
+seed7/lib/image.s7i          0.033493            156
+seed7/lib/imagefile.s7i      0.033992            171
+seed7/lib/inflate.s7i        0.034053            411
+seed7/lib/inifile.s7i        0.033562            129
+seed7/lib/integer.s7i        0.033533            663
+seed7/lib/iobuffer.s7i       0.033552            289
+seed7/lib/jpeg.s7i           0.033776           1761
+seed7/lib/json.s7i           0.033178            891
+seed7/lib/json_serde.s7i     0.033544            783
+seed7/lib/keybd.s7i          0.033384            639
+seed7/lib/keydescr.s7i       0.033484            192
+seed7/lib/leb128.s7i         0.033961            218
+seed7/lib/line.s7i           0.033606            164
+seed7/lib/listener.s7i       0.033351            247
+seed7/lib/logfile.s7i        0.032827             73
+seed7/lib/lower.s7i          0.033968            142
+seed7/lib/lzma.s7i           0.033422            934
+seed7/lib/lzw.s7i            0.033814            861
+seed7/lib/magic.s7i          0.032739            403
+seed7/lib/mahjng32.s7i       0.033113           1500
+seed7/lib/make.s7i           0.032623            544
+seed7/lib/makedata.s7i       0.032549           1428
+seed7/lib/math.s7i           0.032612            201
+seed7/lib/mixarith.s7i       0.032284            249
+seed7/lib/modern27.s7i       0.033976           1099
+seed7/lib/more.s7i           0.033381            130
+seed7/lib/msgdigest.s7i      0.033364           1222
+seed7/lib/multiscr.s7i       0.033449             68
+seed7/lib/null_file.s7i      0.033497            345
+seed7/lib/osfiles.s7i        0.033465           1085
+seed7/lib/pbm.s7i            0.034209            230
+seed7/lib/pcx.s7i            0.033386            638
+seed7/lib/pem.s7i            0.033366            185
+seed7/lib/pgm.s7i            0.033601            238
+seed7/lib/pic16.s7i          0.033701           1037
+seed7/lib/pic32.s7i          0.033872           2060
+seed7/lib/pic_util.s7i       0.033647            144
+seed7/lib/pixelimage.s7i     0.033694            320
+seed7/lib/pixmap_file.s7i    0.033707            459
+seed7/lib/pixmapfont.s7i     0.033089            184
+seed7/lib/pkcs1.s7i          0.032825            543
+seed7/lib/png.s7i            0.032647           1064
+seed7/lib/poll.s7i           0.033161            313
+seed7/lib/ppm.s7i            0.032717            240
+seed7/lib/process.s7i        0.032335            541
+seed7/lib/progs.s7i          0.032935            789
+seed7/lib/propertyfile.s7i   0.032699            155
+seed7/lib/rational.s7i       0.032459            792
+seed7/lib/ref_list.s7i       0.033280            252
+seed7/lib/reference.s7i      0.032389            126
+seed7/lib/reverse.s7i        0.032701             94
+seed7/lib/rpm.s7i            0.033138           3487
+seed7/lib/rpmext.s7i         0.032350            318
+seed7/lib/scanfile.s7i       0.032771           1779
+seed7/lib/scanjson.s7i       0.034032            413
+seed7/lib/scanstri.s7i       0.034492           1814
+seed7/lib/scantoml.s7i       0.033499           1603
+seed7/lib/seed7_05.s7i       0.033389           1072
+seed7/lib/set.s7i            0.033532             57
+seed7/lib/shell.s7i          0.033464            615
+seed7/lib/showtls.s7i        0.033519            678
+seed7/lib/signature.s7i      0.033443            131
+seed7/lib/smtp.s7i           0.033295            261
+seed7/lib/sockbase.s7i       0.033508            217
+seed7/lib/socket.s7i         0.033833            326
+seed7/lib/sokoban1.s7i       0.033670           1519
+seed7/lib/sql_base.s7i       0.033791           1000
+seed7/lib/stars.s7i          0.034344           1705
+seed7/lib/stdfont10.s7i      0.033831           3347
+seed7/lib/stdfont12.s7i      0.033158           3928
+seed7/lib/stdfont14.s7i      0.034521           4510
+seed7/lib/stdfont16.s7i      0.033793           5092
+seed7/lib/stdfont18.s7i      0.034258           5868
+seed7/lib/stdfont20.s7i      0.034217           6449
+seed7/lib/stdfont24.s7i      0.034098           7421
+seed7/lib/stdfont8.s7i       0.034234           2960
+seed7/lib/stdfont9.s7i       0.033718           3152
+seed7/lib/stdio.s7i          0.033465            192
+seed7/lib/strifile.s7i       0.033683            345
+seed7/lib/string.s7i         0.033688            779
+seed7/lib/stritext.s7i       0.032623            352
+seed7/lib/struct.s7i         0.032915            266
+seed7/lib/struct_elem.s7i    0.032527            129
+seed7/lib/subfile.s7i        0.032557            174
+seed7/lib/subrange.s7i       0.032837             78
+seed7/lib/syntax.s7i         0.033535            294
+seed7/lib/tar.s7i            0.034406           1880
+seed7/lib/tar_cmds.s7i       0.033660            752
+seed7/lib/tdes.s7i           0.033513            143
+seed7/lib/tee.s7i            0.033633            143
+seed7/lib/text.s7i           0.033487            135
+seed7/lib/tga.s7i            0.033898            676
+seed7/lib/tiff.s7i           0.033756           2771
+seed7/lib/time.s7i           0.033405           1191
+seed7/lib/tls.s7i            0.033806           2230
+seed7/lib/unicode.s7i        0.033553            575
+seed7/lib/unionfnd.s7i       0.033596            130
+seed7/lib/upper.s7i          0.033450            142
+seed7/lib/utf16.s7i          0.033527            540
+seed7/lib/utf8.s7i           0.033553            234
+seed7/lib/vecfont10.s7i      0.033341           1056
+seed7/lib/vecfont18.s7i      0.033436           1119
+seed7/lib/vector3d.s7i       0.033505            293
+seed7/lib/vectorfont.s7i     0.033833            239
+seed7/lib/wildcard.s7i       0.032908            140
+seed7/lib/window.s7i         0.033448            455
+seed7/lib/wrinum.s7i         0.033300            248
+seed7/lib/x509cert.s7i       0.033748           1243
+seed7/lib/xml_ent.s7i        0.033608             94
+seed7/lib/xmldom.s7i         0.033512            303
+seed7/lib/xz.s7i             0.033636            442
+seed7/lib/zip.s7i            0.033438           2792
+seed7/lib/zstd.s7i           0.032813           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033710        |
++-----------+-----------------+
+| Minimum   | 0.032197        |
++-----------+-----------------+
+| Maximum   | 0.039572        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039235            190
+seed7/prg/bas7.sd7           0.039988          11459
+seed7/prg/bifurk.sd7         0.036120             73
+seed7/prg/bigfiles.sd7       0.037583            129
+seed7/prg/brainf7.sd7        0.037286             86
+seed7/prg/calc7.sd7          0.037202            128
+seed7/prg/carddemo.sd7       0.039313            190
+seed7/prg/castle.sd7         0.039809           3148
+seed7/prg/cat.sd7            0.037116             82
+seed7/prg/cellauto.sd7       0.036976             85
+seed7/prg/celsius.sd7        0.036579             42
+seed7/prg/chk_all.sd7        0.039247            843
+seed7/prg/chkarr.sd7         0.039374           8367
+seed7/prg/chkbig.sd7         0.044373          29026
+seed7/prg/chkbin.sd7         0.040942           6469
+seed7/prg/chkbitdata.sd7     0.040353           6624
+seed7/prg/chkbool.sd7        0.039160           3157
+seed7/prg/chkbst.sd7         0.039132            722
+seed7/prg/chkchr.sd7         0.040544           2809
+seed7/prg/chkcmd.sd7         0.038681           1205
+seed7/prg/chkdb.sd7          0.039848           7454
+seed7/prg/chkdecl.sd7        0.040797            448
+seed7/prg/chkenum.sd7        0.043655           1230
+seed7/prg/chkerr.sd7         0.045713           4663
+seed7/prg/chkexc.sd7         0.042197           2627
+seed7/prg/chkfil.sd7         0.039770           1615
+seed7/prg/chkflt.sd7         0.043506          20620
+seed7/prg/chkhent.sd7        0.036487             54
+seed7/prg/chkhsh.sd7         0.039679           4548
+seed7/prg/chkidx.sd7         0.046867          19567
+seed7/prg/chkint.sd7         0.048396          38129
+seed7/prg/chkjson.sd7        0.038315           1764
+seed7/prg/chkovf.sd7         0.040833           8216
+seed7/prg/chkprc.sd7         0.042741          10111
+seed7/prg/chkscan.sd7        0.039572            714
+seed7/prg/chkset.sd7         0.040740          11974
+seed7/prg/chkstr.sd7         0.043878          26952
+seed7/prg/chktime.sd7        0.040314           2025
+seed7/prg/chktoml.sd7        0.039826           1656
+seed7/prg/clock.sd7          0.037297             47
+seed7/prg/clock2.sd7         0.035888             43
+seed7/prg/clock3.sd7         0.039239             95
+seed7/prg/cmpfil.sd7         0.037595             84
+seed7/prg/comanche.sd7       0.039119            180
+seed7/prg/confval.sd7        0.040230            175
+seed7/prg/db7.sd7            0.039120            417
+seed7/prg/diff7.sd7          0.039207            263
+seed7/prg/dirtst.sd7         0.035950             42
+seed7/prg/dirx.sd7           0.039560            152
+seed7/prg/dnafight.sd7       0.039993           1381
+seed7/prg/dragon.sd7         0.036938             73
+seed7/prg/echo.sd7           0.036481             39
+seed7/prg/eliza.sd7          0.038645            302
+seed7/prg/err.sd7            0.041748             96
+seed7/prg/fannkuch.sd7       0.038697            131
+seed7/prg/fib.sd7            0.035342             47
+seed7/prg/find7.sd7          0.037554            133
+seed7/prg/findchar.sd7       0.037649            149
+seed7/prg/fractree.sd7       0.035435             55
+seed7/prg/ftp7.sd7           0.037880            296
+seed7/prg/ftpserv.sd7        0.038542             74
+seed7/prg/gcd.sd7            0.037503            109
+seed7/prg/gkbd.sd7           0.040748            358
+seed7/prg/gtksvtst.sd7       0.037451             94
+seed7/prg/hal.sd7            0.038601            250
+seed7/prg/hamu.sd7           0.038547            573
+seed7/prg/hanoi.sd7          0.036070             55
+seed7/prg/hd.sd7             0.037535             79
+seed7/prg/hello.sd7          0.035610             32
+seed7/prg/hilbert.sd7        0.037930            108
+seed7/prg/ide7.sd7           0.040505            196
+seed7/prg/kbd.sd7            0.037120             49
+seed7/prg/klondike.sd7       0.038612            883
+seed7/prg/lander.sd7         0.039084           1551
+seed7/prg/lst80bas.sd7       0.037990            344
+seed7/prg/lst99bas.sd7       0.039698            401
+seed7/prg/lstgwbas.sd7       0.040379            577
+seed7/prg/mahjong.sd7        0.039291           1943
+seed7/prg/make7.sd7          0.039249            121
+seed7/prg/mandelbr.sd7       0.038955            237
+seed7/prg/mind.sd7           0.038967            443
+seed7/prg/mirror.sd7         0.041959            131
+seed7/prg/ms.sd7             0.042140            641
+seed7/prg/nicoma.sd7         0.041621            135
+seed7/prg/pac.sd7            0.040943            726
+seed7/prg/pairs.sd7          0.041414           2025
+seed7/prg/panic.sd7          0.041411           2634
+seed7/prg/percolation.sd7    0.041073            330
+seed7/prg/planets.sd7        0.039957           1486
+seed7/prg/portfwd7.sd7       0.040827            139
+seed7/prg/prime.sd7          0.037964             74
+seed7/prg/printpi1.sd7       0.036796             56
+seed7/prg/printpi2.sd7       0.036398             54
+seed7/prg/printpi3.sd7       0.036612             60
+seed7/prg/pv7.sd7            0.040522            337
+seed7/prg/queen.sd7          0.040176            149
+seed7/prg/rand.sd7           0.039450            121
+seed7/prg/raytrace.sd7       0.039461            538
+seed7/prg/rever.sd7          0.039035            816
+seed7/prg/roman.sd7          0.037153             38
+seed7/prg/s7c.sd7            0.038957           9060
+seed7/prg/s7check.sd7        0.036879             68
+seed7/prg/savehd7.sd7        0.042324           1110
+seed7/prg/self.sd7           0.039101             49
+seed7/prg/shisen.sd7         0.039788           1423
+seed7/prg/sl.sd7             0.038845           1029
+seed7/prg/snake.sd7          0.039059            615
+seed7/prg/sokoban.sd7        0.038619            891
+seed7/prg/spigotpi.sd7       0.036882             64
+seed7/prg/sql7.sd7           0.038385            278
+seed7/prg/startrek.sd7       0.038652            979
+seed7/prg/sudoku7.sd7        0.038594           2657
+seed7/prg/sydir7.sd7         0.038010            384
+seed7/prg/syntaxhl.sd7       0.040244            177
+seed7/prg/tak.sd7            0.037170             59
+seed7/prg/tar7.sd7           0.039478            121
+seed7/prg/tch.sd7            0.036933             55
+seed7/prg/testfont.sd7       0.038869             95
+seed7/prg/tet.sd7            0.039121            479
+seed7/prg/tetg.sd7           0.038738            501
+seed7/prg/toutf8.sd7         0.040598            240
+seed7/prg/tst_cli.sd7        0.036208             40
+seed7/prg/tst_srv.sd7        0.036213             47
+seed7/prg/wator.sd7          0.039095            651
+seed7/prg/which.sd7          0.036637             65
+seed7/prg/wiz.sd7            0.038959           2833
+seed7/prg/wordcnt.sd7        0.036670             54
+seed7/prg/wrinum.sd7         0.036030             43
+seed7/prg/wumpus.sd7         0.038757            372
+seed7/lib/aes.s7i            0.042366           1144
+seed7/lib/aes_gcm.s7i        0.039158            392
+seed7/lib/ar.s7i             0.039145           1532
+seed7/lib/arc4.s7i           0.039129            144
+seed7/lib/archive.s7i        0.038806            143
+seed7/lib/archive_base.s7i   0.039042            135
+seed7/lib/array.s7i          0.038829            610
+seed7/lib/asn1.s7i           0.037569            544
+seed7/lib/asn1oid.s7i        0.041998            157
+seed7/lib/basearray.s7i      0.039048            450
+seed7/lib/bigfile.s7i        0.037665            136
+seed7/lib/bigint.s7i         0.037877            824
+seed7/lib/bigrat.s7i         0.037960            784
+seed7/lib/bin16.s7i          0.041202            592
+seed7/lib/bin32.s7i          0.039721            490
+seed7/lib/bin64.s7i          0.038638            539
+seed7/lib/bitdata.s7i        0.043861           1330
+seed7/lib/bitmapfont.s7i     0.039220            215
+seed7/lib/bitset.s7i         0.039034            593
+seed7/lib/bitsetof.s7i       0.040363            431
+seed7/lib/blowfish.s7i       0.043726            383
+seed7/lib/bmp.s7i            0.039730            924
+seed7/lib/boolean.s7i        0.038960            403
+seed7/lib/browser.s7i        0.039340            280
+seed7/lib/bstring.s7i        0.039108            227
+seed7/lib/bytedata.s7i       0.039275            482
+seed7/lib/bzip2.s7i          0.039358            887
+seed7/lib/cards.s7i          0.037273           1342
+seed7/lib/category.s7i       0.039011            209
+seed7/lib/cc_conf.s7i        0.038552           1314
+seed7/lib/ccittfax.s7i       0.039488           1022
+seed7/lib/cgi.s7i            0.038775            109
+seed7/lib/cgidialog.s7i      0.039216           1118
+seed7/lib/char.s7i           0.039560            356
+seed7/lib/charsets.s7i       0.039416           2024
+seed7/lib/chartype.s7i       0.040803            121
+seed7/lib/cipher.s7i         0.037732            146
+seed7/lib/cli_cmds.s7i       0.037886           1360
+seed7/lib/clib_file.s7i      0.037855            301
+seed7/lib/color.s7i          0.038270            185
+seed7/lib/complex.s7i        0.040314            464
+seed7/lib/compress.s7i       0.039374            150
+seed7/lib/console.s7i        0.038549            188
+seed7/lib/cpio.s7i           0.039474           1708
+seed7/lib/crc32.s7i          0.039321            193
+seed7/lib/cronos16.s7i       0.042424           1173
+seed7/lib/cronos27.s7i       0.042690           1464
+seed7/lib/csv.s7i            0.039199            201
+seed7/lib/db_prop.s7i        0.039195            991
+seed7/lib/deflate.s7i        0.039774            740
+seed7/lib/des.s7i            0.039898            444
+seed7/lib/dialog.s7i         0.039180            311
+seed7/lib/dir.s7i            0.039124            163
+seed7/lib/draw.s7i           0.038753            854
+seed7/lib/duration.s7i       0.038764           1038
+seed7/lib/echo.s7i           0.038630            132
+seed7/lib/editline.s7i       0.039597            398
+seed7/lib/elf.s7i            0.044204           1560
+seed7/lib/elliptic.s7i       0.039433            649
+seed7/lib/enable_io.s7i      0.038699            312
+seed7/lib/encoding.s7i       0.039342            931
+seed7/lib/enumeration.s7i    0.039027            236
+seed7/lib/environment.s7i    0.038079            175
+seed7/lib/exif.s7i           0.039214            152
+seed7/lib/external_file.s7i  0.037398            340
+seed7/lib/field.s7i          0.037488            268
+seed7/lib/file.s7i           0.038189            372
+seed7/lib/filebits.s7i       0.037198             46
+seed7/lib/filesys.s7i        0.038823            601
+seed7/lib/fileutil.s7i       0.037873            144
+seed7/lib/fixarray.s7i       0.039122            307
+seed7/lib/float.s7i          0.037681            757
+seed7/lib/font.s7i           0.037512            196
+seed7/lib/font8x8.s7i        0.037295            998
+seed7/lib/forloop.s7i        0.040009            449
+seed7/lib/ftp.s7i            0.038286            969
+seed7/lib/ftpserv.s7i        0.038344            631
+seed7/lib/getf.s7i           0.037687            115
+seed7/lib/gethttp.s7i        0.035902             41
+seed7/lib/gethttps.s7i       0.036151             41
+seed7/lib/gif.s7i            0.038795            561
+seed7/lib/graph.s7i          0.040501            415
+seed7/lib/graph_file.s7i     0.038891            399
+seed7/lib/gtkserver.s7i      0.038743            161
+seed7/lib/gzip.s7i           0.039263            573
+seed7/lib/hash.s7i           0.040806            421
+seed7/lib/hashsetof.s7i      0.040571            499
+seed7/lib/hmac.s7i           0.041152            152
+seed7/lib/html.s7i           0.043526             83
+seed7/lib/html_ent.s7i       0.043060            476
+seed7/lib/htmldom.s7i        0.038027            286
+seed7/lib/http_request.s7i   0.038065            696
+seed7/lib/http_srv_resp.s7i  0.038150            380
+seed7/lib/https_request.s7i  0.037925            211
+seed7/lib/httpserv.s7i       0.038104            345
+seed7/lib/huffman.s7i        0.039618            644
+seed7/lib/ico.s7i            0.039454            221
+seed7/lib/idxarray.s7i       0.038918            232
+seed7/lib/image.s7i          0.038421            156
+seed7/lib/imagefile.s7i      0.038875            171
+seed7/lib/inflate.s7i        0.039446            411
+seed7/lib/inifile.s7i        0.038958            129
+seed7/lib/integer.s7i        0.039070            663
+seed7/lib/iobuffer.s7i       0.039379            289
+seed7/lib/jpeg.s7i           0.039585           1761
+seed7/lib/json.s7i           0.038560            891
+seed7/lib/json_serde.s7i     0.038977            783
+seed7/lib/keybd.s7i          0.038600            639
+seed7/lib/keydescr.s7i       0.040210            192
+seed7/lib/leb128.s7i         0.039212            218
+seed7/lib/line.s7i           0.038879            164
+seed7/lib/listener.s7i       0.038083            247
+seed7/lib/logfile.s7i        0.037391             73
+seed7/lib/lower.s7i          0.037617            142
+seed7/lib/lzma.s7i           0.044040            934
+seed7/lib/lzw.s7i            0.038659            861
+seed7/lib/magic.s7i          0.039312            403
+seed7/lib/mahjng32.s7i       0.037329           1500
+seed7/lib/make.s7i           0.038137            544
+seed7/lib/makedata.s7i       0.038383           1428
+seed7/lib/math.s7i           0.038198            201
+seed7/lib/mixarith.s7i       0.038074            249
+seed7/lib/modern27.s7i       0.042478           1099
+seed7/lib/more.s7i           0.039114            130
+seed7/lib/msgdigest.s7i      0.039930           1222
+seed7/lib/multiscr.s7i       0.037561             68
+seed7/lib/null_file.s7i      0.038650            345
+seed7/lib/osfiles.s7i        0.039868           1085
+seed7/lib/pbm.s7i            0.039380            230
+seed7/lib/pcx.s7i            0.039654            638
+seed7/lib/pem.s7i            0.038859            185
+seed7/lib/pgm.s7i            0.039550            238
+seed7/lib/pic16.s7i          0.038749           1037
+seed7/lib/pic32.s7i          0.038416           2060
+seed7/lib/pic_util.s7i       0.039201            144
+seed7/lib/pixelimage.s7i     0.038940            320
+seed7/lib/pixmap_file.s7i    0.039154            459
+seed7/lib/pixmapfont.s7i     0.040653            184
+seed7/lib/pkcs1.s7i          0.044676            543
+seed7/lib/png.s7i            0.039961           1064
+seed7/lib/poll.s7i           0.038821            313
+seed7/lib/ppm.s7i            0.039391            240
+seed7/lib/process.s7i        0.039244            541
+seed7/lib/progs.s7i          0.039574            789
+seed7/lib/propertyfile.s7i   0.038304            155
+seed7/lib/rational.s7i       0.038058            792
+seed7/lib/ref_list.s7i       0.037840            252
+seed7/lib/reference.s7i      0.037987            126
+seed7/lib/reverse.s7i        0.036934             94
+seed7/lib/rpm.s7i            0.040491           3487
+seed7/lib/rpmext.s7i         0.039489            318
+seed7/lib/scanfile.s7i       0.039350           1779
+seed7/lib/scanjson.s7i       0.039383            413
+seed7/lib/scanstri.s7i       0.039154           1814
+seed7/lib/scantoml.s7i       0.039274           1603
+seed7/lib/seed7_05.s7i       0.041226           1072
+seed7/lib/set.s7i            0.037493             57
+seed7/lib/shell.s7i          0.039609            615
+seed7/lib/showtls.s7i        0.039068            678
+seed7/lib/signature.s7i      0.038598            131
+seed7/lib/smtp.s7i           0.038765            261
+seed7/lib/sockbase.s7i       0.039756            217
+seed7/lib/socket.s7i         0.039299            326
+seed7/lib/sokoban1.s7i       0.038729           1519
+seed7/lib/sql_base.s7i       0.038930           1000
+seed7/lib/stars.s7i          0.041692           1705
+seed7/lib/stdfont10.s7i      0.037632           3347
+seed7/lib/stdfont12.s7i      0.039257           3928
+seed7/lib/stdfont14.s7i      0.038941           4510
+seed7/lib/stdfont16.s7i      0.038561           5092
+seed7/lib/stdfont18.s7i      0.038742           5868
+seed7/lib/stdfont20.s7i      0.038785           6449
+seed7/lib/stdfont24.s7i      0.037940           7421
+seed7/lib/stdfont8.s7i       0.036397           2960
+seed7/lib/stdfont9.s7i       0.036344           3152
+seed7/lib/stdio.s7i          0.037335            192
+seed7/lib/strifile.s7i       0.038595            345
+seed7/lib/string.s7i         0.039673            779
+seed7/lib/stritext.s7i       0.039007            352
+seed7/lib/struct.s7i         0.040325            266
+seed7/lib/struct_elem.s7i    0.038502            129
+seed7/lib/subfile.s7i        0.039020            174
+seed7/lib/subrange.s7i       0.038174             78
+seed7/lib/syntax.s7i         0.039199            294
+seed7/lib/tar.s7i            0.039790           1880
+seed7/lib/tar_cmds.s7i       0.039141            752
+seed7/lib/tdes.s7i           0.038510            143
+seed7/lib/tee.s7i            0.039348            143
+seed7/lib/text.s7i           0.038880            135
+seed7/lib/tga.s7i            0.041089            676
+seed7/lib/tiff.s7i           0.041556           2771
+seed7/lib/time.s7i           0.039564           1191
+seed7/lib/tls.s7i            0.038857           2230
+seed7/lib/unicode.s7i        0.041715            575
+seed7/lib/unionfnd.s7i       0.039323            130
+seed7/lib/upper.s7i          0.038633            142
+seed7/lib/utf16.s7i          0.038838            540
+seed7/lib/utf8.s7i           0.039811            234
+seed7/lib/vecfont10.s7i      0.040977           1056
+seed7/lib/vecfont18.s7i      0.041117           1119
+seed7/lib/vector3d.s7i       0.038393            293
+seed7/lib/vectorfont.s7i     0.037534            239
+seed7/lib/wildcard.s7i       0.037481            140
+seed7/lib/window.s7i         0.039075            455
+seed7/lib/wrinum.s7i         0.039486            248
+seed7/lib/x509cert.s7i       0.039153           1243
+seed7/lib/xml_ent.s7i        0.038720             94
+seed7/lib/xmldom.s7i         0.038298            303
+seed7/lib/xz.s7i             0.038927            442
+seed7/lib/zip.s7i            0.039069           2792
+seed7/lib/zstd.s7i           0.039814           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.039158        |
++-----------+-----------------+
+| Minimum   | 0.035342        |
++-----------+-----------------+
+| Maximum   | 0.048396        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.041430            190
+seed7/prg/bas7.sd7           0.333643          11459
+seed7/prg/bifurk.sd7         0.038406             73
+seed7/prg/bigfiles.sd7       0.040161            129
+seed7/prg/brainf7.sd7        0.039217             86
+seed7/prg/calc7.sd7          0.040181            128
+seed7/prg/carddemo.sd7       0.041130            190
+seed7/prg/castle.sd7         0.112699           3148
+seed7/prg/cat.sd7            0.037965             82
+seed7/prg/cellauto.sd7       0.037464             85
+seed7/prg/celsius.sd7        0.038348             42
+seed7/prg/chk_all.sd7        0.064850            843
+seed7/prg/chkarr.sd7         0.369161           8367
+seed7/prg/chkbig.sd7         2.112991          29026
+seed7/prg/chkbin.sd7         0.529009           6469
+seed7/prg/chkbitdata.sd7     0.629600           6624
+seed7/prg/chkbool.sd7        0.119415           3157
+seed7/prg/chkbst.sd7         0.065248            722
+seed7/prg/chkchr.sd7         0.222829           2809
+seed7/prg/chkcmd.sd7         0.068212           1205
+seed7/prg/chkdb.sd7          0.358636           7454
+seed7/prg/chkdecl.sd7        0.058805            448
+seed7/prg/chkenum.sd7        0.070156           1230
+seed7/prg/chkerr.sd7         0.200294           4663
+seed7/prg/chkexc.sd7         0.085168           2627
+seed7/prg/chkfil.sd7         0.077486           1615
+seed7/prg/chkflt.sd7         1.378060          20620
+seed7/prg/chkhent.sd7        0.037519             54
+seed7/prg/chkhsh.sd7         0.253926           4548
+seed7/prg/chkidx.sd7         1.349764          19567
+seed7/prg/chkint.sd7         2.588956          38129
+seed7/prg/chkjson.sd7        0.101577           1764
+seed7/prg/chkovf.sd7         0.579146           8216
+seed7/prg/chkprc.sd7         0.327640          10111
+seed7/prg/chkscan.sd7        0.057591            714
+seed7/prg/chkset.sd7         0.680270          11974
+seed7/prg/chkstr.sd7         1.421703          26952
+seed7/prg/chktime.sd7        0.133340           2025
+seed7/prg/chktoml.sd7        0.110725           1656
+seed7/prg/clock.sd7          0.037529             47
+seed7/prg/clock2.sd7         0.037491             43
+seed7/prg/clock3.sd7         0.039607             95
+seed7/prg/cmpfil.sd7         0.037892             84
+seed7/prg/comanche.sd7       0.042725            180
+seed7/prg/confval.sd7        0.044808            175
+seed7/prg/db7.sd7            0.048988            417
+seed7/prg/diff7.sd7          0.044497            263
+seed7/prg/dirtst.sd7         0.037671             42
+seed7/prg/dirx.sd7           0.040261            152
+seed7/prg/dnafight.sd7       0.069929           1381
+seed7/prg/dragon.sd7         0.038326             73
+seed7/prg/echo.sd7           0.038250             39
+seed7/prg/eliza.sd7          0.044032            302
+seed7/prg/err.sd7            0.040223             96
+seed7/prg/fannkuch.sd7       0.038181            131
+seed7/prg/fib.sd7            0.035802             47
+seed7/prg/find7.sd7          0.038939            133
+seed7/prg/findchar.sd7       0.040635            149
+seed7/prg/fractree.sd7       0.038082             55
+seed7/prg/ftp7.sd7           0.043624            296
+seed7/prg/ftpserv.sd7        0.038382             74
+seed7/prg/gcd.sd7            0.038098            109
+seed7/prg/gkbd.sd7           0.047620            358
+seed7/prg/gtksvtst.sd7       0.038132             94
+seed7/prg/hal.sd7            0.041611            250
+seed7/prg/hamu.sd7           0.050435            573
+seed7/prg/hanoi.sd7          0.037426             55
+seed7/prg/hd.sd7             0.038433             79
+seed7/prg/hello.sd7          0.037455             32
+seed7/prg/hilbert.sd7        0.038653            108
+seed7/prg/ide7.sd7           0.042289            196
+seed7/prg/kbd.sd7            0.036898             49
+seed7/prg/klondike.sd7       0.056890            883
+seed7/prg/lander.sd7         0.074495           1551
+seed7/prg/lst80bas.sd7       0.045920            344
+seed7/prg/lst99bas.sd7       0.047210            401
+seed7/prg/lstgwbas.sd7       0.052763            577
+seed7/prg/mahjong.sd7        0.081340           1943
+seed7/prg/make7.sd7          0.038672            121
+seed7/prg/mandelbr.sd7       0.040702            237
+seed7/prg/mind.sd7           0.045292            443
+seed7/prg/mirror.sd7         0.040567            131
+seed7/prg/ms.sd7             0.050297            641
+seed7/prg/nicoma.sd7         0.039469            135
+seed7/prg/pac.sd7            0.051186            726
+seed7/prg/pairs.sd7          0.085074           2025
+seed7/prg/panic.sd7          0.101655           2634
+seed7/prg/percolation.sd7    0.045107            330
+seed7/prg/planets.sd7        0.079623           1486
+seed7/prg/portfwd7.sd7       0.040658            139
+seed7/prg/prime.sd7          0.037794             74
+seed7/prg/printpi1.sd7       0.037792             56
+seed7/prg/printpi2.sd7       0.037570             54
+seed7/prg/printpi3.sd7       0.037503             60
+seed7/prg/pv7.sd7            0.046064            337
+seed7/prg/queen.sd7          0.039594            149
+seed7/prg/rand.sd7           0.037809            121
+seed7/prg/raytrace.sd7       0.048843            538
+seed7/prg/rever.sd7          0.055204            816
+seed7/prg/roman.sd7          0.035842             38
+seed7/prg/s7c.sd7            0.285924           9060
+seed7/prg/s7check.sd7        0.038342             68
+seed7/prg/savehd7.sd7        0.068857           1110
+seed7/prg/self.sd7           0.038124             49
+seed7/prg/shisen.sd7         0.074702           1423
+seed7/prg/sl.sd7             0.061746           1029
+seed7/prg/snake.sd7          0.048706            615
+seed7/prg/sokoban.sd7        0.056681            891
+seed7/prg/spigotpi.sd7       0.038431             64
+seed7/prg/sql7.sd7           0.043297            278
+seed7/prg/startrek.sd7       0.061327            979
+seed7/prg/sudoku7.sd7        0.102484           2657
+seed7/prg/sydir7.sd7         0.045951            384
+seed7/prg/syntaxhl.sd7       0.041540            177
+seed7/prg/tak.sd7            0.036264             59
+seed7/prg/tar7.sd7           0.038828            121
+seed7/prg/tch.sd7            0.037508             55
+seed7/prg/testfont.sd7       0.039112             95
+seed7/prg/tet.sd7            0.046172            479
+seed7/prg/tetg.sd7           0.047537            501
+seed7/prg/toutf8.sd7         0.044096            240
+seed7/prg/tst_cli.sd7        0.036981             40
+seed7/prg/tst_srv.sd7        0.037636             47
+seed7/prg/wator.sd7          0.054992            651
+seed7/prg/which.sd7          0.037881             65
+seed7/prg/wiz.sd7            0.108257           2833
+seed7/prg/wordcnt.sd7        0.038130             54
+seed7/prg/wrinum.sd7         0.037308             43
+seed7/prg/wumpus.sd7         0.044369            372
+seed7/lib/aes.s7i            0.114361           1144
+seed7/lib/aes_gcm.s7i        0.048213            392
+seed7/lib/ar.s7i             0.075758           1532
+seed7/lib/arc4.s7i           0.041827            144
+seed7/lib/archive.s7i        0.040388            143
+seed7/lib/archive_base.s7i   0.039031            135
+seed7/lib/array.s7i          0.054583            610
+seed7/lib/asn1.s7i           0.049041            544
+seed7/lib/asn1oid.s7i        0.043645            157
+seed7/lib/basearray.s7i      0.050703            450
+seed7/lib/bigfile.s7i        0.040202            136
+seed7/lib/bigint.s7i         0.057535            824
+seed7/lib/bigrat.s7i         0.056037            784
+seed7/lib/bin16.s7i          0.052897            592
+seed7/lib/bin32.s7i          0.050201            490
+seed7/lib/bin64.s7i          0.051544            539
+seed7/lib/bitdata.s7i        0.079468           1330
+seed7/lib/bitmapfont.s7i     0.043229            215
+seed7/lib/bitset.s7i         0.050573            593
+seed7/lib/bitsetof.s7i       0.050177            431
+seed7/lib/blowfish.s7i       0.058167            383
+seed7/lib/bmp.s7i            0.062497            924
+seed7/lib/boolean.s7i        0.045852            403
+seed7/lib/browser.s7i        0.043394            280
+seed7/lib/bstring.s7i        0.041345            227
+seed7/lib/bytedata.s7i       0.051142            482
+seed7/lib/bzip2.s7i          0.060054            887
+seed7/lib/cards.s7i          0.067676           1342
+seed7/lib/category.s7i       0.043139            209
+seed7/lib/cc_conf.s7i        0.080281           1314
+seed7/lib/ccittfax.s7i       0.068316           1022
+seed7/lib/cgi.s7i            0.039752            109
+seed7/lib/cgidialog.s7i      0.061795           1118
+seed7/lib/char.s7i           0.044723            356
+seed7/lib/charsets.s7i       0.084987           2024
+seed7/lib/chartype.s7i       0.041875            121
+seed7/lib/cipher.s7i         0.039850            146
+seed7/lib/cli_cmds.s7i       0.071323           1360
+seed7/lib/clib_file.s7i      0.045243            301
+seed7/lib/color.s7i          0.041830            185
+seed7/lib/complex.s7i        0.047224            464
+seed7/lib/compress.s7i       0.040294            150
+seed7/lib/console.s7i        0.041048            188
+seed7/lib/cpio.s7i           0.083768           1708
+seed7/lib/crc32.s7i          0.044835            193
+seed7/lib/cronos16.s7i       0.094695           1173
+seed7/lib/cronos27.s7i       0.119487           1464
+seed7/lib/csv.s7i            0.042958            201
+seed7/lib/db_prop.s7i        0.065775            991
+seed7/lib/deflate.s7i        0.057578            740
+seed7/lib/des.s7i            0.057813            444
+seed7/lib/dialog.s7i         0.045261            311
+seed7/lib/dir.s7i            0.039714            163
+seed7/lib/draw.s7i           0.058119            854
+seed7/lib/duration.s7i       0.063030           1038
+seed7/lib/echo.s7i           0.040274            132
+seed7/lib/editline.s7i       0.046969            398
+seed7/lib/elf.s7i            0.088278           1560
+seed7/lib/elliptic.s7i       0.054622            649
+seed7/lib/enable_io.s7i      0.045419            312
+seed7/lib/encoding.s7i       0.062165            931
+seed7/lib/enumeration.s7i    0.041643            236
+seed7/lib/environment.s7i    0.040993            175
+seed7/lib/exif.s7i           0.040366            152
+seed7/lib/external_file.s7i  0.043778            340
+seed7/lib/field.s7i          0.045132            268
+seed7/lib/file.s7i           0.045939            372
+seed7/lib/filebits.s7i       0.037847             46
+seed7/lib/filesys.s7i        0.050721            601
+seed7/lib/fileutil.s7i       0.040288            144
+seed7/lib/fixarray.s7i       0.045599            307
+seed7/lib/float.s7i          0.057290            757
+seed7/lib/font.s7i           0.042081            196
+seed7/lib/font8x8.s7i        0.050798            998
+seed7/lib/forloop.s7i        0.048130            449
+seed7/lib/ftp.s7i            0.059366            969
+seed7/lib/ftpserv.s7i        0.052701            631
+seed7/lib/getf.s7i           0.040447            115
+seed7/lib/gethttp.s7i        0.037266             41
+seed7/lib/gethttps.s7i       0.038039             41
+seed7/lib/gif.s7i            0.052060            561
+seed7/lib/graph.s7i          0.050824            415
+seed7/lib/graph_file.s7i     0.045744            399
+seed7/lib/gtkserver.s7i      0.039612            161
+seed7/lib/gzip.s7i           0.050642            573
+seed7/lib/hash.s7i           0.049989            421
+seed7/lib/hashsetof.s7i      0.050291            499
+seed7/lib/hmac.s7i           0.041193            152
+seed7/lib/html.s7i           0.038754             83
+seed7/lib/html_ent.s7i       0.049276            476
+seed7/lib/htmldom.s7i        0.044691            286
+seed7/lib/http_request.s7i   0.053954            696
+seed7/lib/http_srv_resp.s7i  0.046936            380
+seed7/lib/https_request.s7i  0.041786            211
+seed7/lib/httpserv.s7i       0.046872            345
+seed7/lib/huffman.s7i        0.054639            644
+seed7/lib/ico.s7i            0.043479            221
+seed7/lib/idxarray.s7i       0.043979            232
+seed7/lib/image.s7i          0.039469            156
+seed7/lib/imagefile.s7i      0.041127            171
+seed7/lib/inflate.s7i        0.048443            411
+seed7/lib/inifile.s7i        0.039388            129
+seed7/lib/integer.s7i        0.054104            663
+seed7/lib/iobuffer.s7i       0.043865            289
+seed7/lib/jpeg.s7i           0.085901           1761
+seed7/lib/json.s7i           0.056180            891
+seed7/lib/json_serde.s7i     0.055052            783
+seed7/lib/keybd.s7i          0.056668            639
+seed7/lib/keydescr.s7i       0.048648            192
+seed7/lib/leb128.s7i         0.041757            218
+seed7/lib/line.s7i           0.040001            164
+seed7/lib/listener.s7i       0.042938            247
+seed7/lib/logfile.s7i        0.038254             73
+seed7/lib/lower.s7i          0.039957            142
+seed7/lib/lzma.s7i           0.061420            934
+seed7/lib/lzw.s7i            0.061112            861
+seed7/lib/magic.s7i          0.050140            403
+seed7/lib/mahjng32.s7i       0.066308           1500
+seed7/lib/make.s7i           0.051966            544
+seed7/lib/makedata.s7i       0.073024           1428
+seed7/lib/math.s7i           0.041693            201
+seed7/lib/mixarith.s7i       0.042439            249
+seed7/lib/modern27.s7i       0.088738           1099
+seed7/lib/more.s7i           0.040336            130
+seed7/lib/msgdigest.s7i      0.081133           1222
+seed7/lib/multiscr.s7i       0.038109             68
+seed7/lib/null_file.s7i      0.044356            345
+seed7/lib/osfiles.s7i        0.066026           1085
+seed7/lib/pbm.s7i            0.040762            230
+seed7/lib/pcx.s7i            0.054397            638
+seed7/lib/pem.s7i            0.041283            185
+seed7/lib/pgm.s7i            0.043089            238
+seed7/lib/pic16.s7i          0.051640           1037
+seed7/lib/pic32.s7i          0.083061           2060
+seed7/lib/pic_util.s7i       0.040933            144
+seed7/lib/pixelimage.s7i     0.044187            320
+seed7/lib/pixmap_file.s7i    0.047773            459
+seed7/lib/pixmapfont.s7i     0.041999            184
+seed7/lib/pkcs1.s7i          0.061709            543
+seed7/lib/png.s7i            0.066466           1064
+seed7/lib/poll.s7i           0.046018            313
+seed7/lib/ppm.s7i            0.042824            240
+seed7/lib/process.s7i        0.050710            541
+seed7/lib/progs.s7i          0.058308            789
+seed7/lib/propertyfile.s7i   0.040972            155
+seed7/lib/rational.s7i       0.054925            792
+seed7/lib/ref_list.s7i       0.042223            252
+seed7/lib/reference.s7i      0.038563            126
+seed7/lib/reverse.s7i        0.037082             94
+seed7/lib/rpm.s7i            0.148871           3487
+seed7/lib/rpmext.s7i         0.044568            318
+seed7/lib/scanfile.s7i       0.083412           1779
+seed7/lib/scanjson.s7i       0.048838            413
+seed7/lib/scanstri.s7i       0.082671           1814
+seed7/lib/scantoml.s7i       0.074497           1603
+seed7/lib/seed7_05.s7i       0.069129           1072
+seed7/lib/set.s7i            0.038125             57
+seed7/lib/shell.s7i          0.055764            615
+seed7/lib/showtls.s7i        0.056944            678
+seed7/lib/signature.s7i      0.040344            131
+seed7/lib/smtp.s7i           0.042805            261
+seed7/lib/sockbase.s7i       0.043959            217
+seed7/lib/socket.s7i         0.044733            326
+seed7/lib/sokoban1.s7i       0.055078           1519
+seed7/lib/sql_base.s7i       0.065049           1000
+seed7/lib/stars.s7i          0.139396           1705
+seed7/lib/stdfont10.s7i      0.083644           3347
+seed7/lib/stdfont12.s7i      0.094030           3928
+seed7/lib/stdfont14.s7i      0.106409           4510
+seed7/lib/stdfont16.s7i      0.119142           5092
+seed7/lib/stdfont18.s7i      0.136640           5868
+seed7/lib/stdfont20.s7i      0.155818           6449
+seed7/lib/stdfont24.s7i      0.184909           7421
+seed7/lib/stdfont8.s7i       0.074396           2960
+seed7/lib/stdfont9.s7i       0.077300           3152
+seed7/lib/stdio.s7i          0.039448            192
+seed7/lib/strifile.s7i       0.045677            345
+seed7/lib/string.s7i         0.057622            779
+seed7/lib/stritext.s7i       0.045559            352
+seed7/lib/struct.s7i         0.046626            266
+seed7/lib/struct_elem.s7i    0.040392            129
+seed7/lib/subfile.s7i        0.040082            174
+seed7/lib/subrange.s7i       0.041392             78
+seed7/lib/syntax.s7i         0.049197            294
+seed7/lib/tar.s7i            0.084072           1880
+seed7/lib/tar_cmds.s7i       0.057995            752
+seed7/lib/tdes.s7i           0.039899            143
+seed7/lib/tee.s7i            0.039569            143
+seed7/lib/text.s7i           0.038845            135
+seed7/lib/tga.s7i            0.055382            676
+seed7/lib/tiff.s7i           0.127652           2771
+seed7/lib/time.s7i           0.065041           1191
+seed7/lib/tls.s7i            0.106466           2230
+seed7/lib/unicode.s7i        0.053230            575
+seed7/lib/unionfnd.s7i       0.038303            130
+seed7/lib/upper.s7i          0.039941            142
+seed7/lib/utf16.s7i          0.051061            540
+seed7/lib/utf8.s7i           0.043369            234
+seed7/lib/vecfont10.s7i      0.081955           1056
+seed7/lib/vecfont18.s7i      0.091176           1119
+seed7/lib/vector3d.s7i       0.043121            293
+seed7/lib/vectorfont.s7i     0.042248            239
+seed7/lib/wildcard.s7i       0.040585            140
+seed7/lib/window.s7i         0.047876            455
+seed7/lib/wrinum.s7i         0.042286            248
+seed7/lib/x509cert.s7i       0.072694           1243
+seed7/lib/xml_ent.s7i        0.038138             94
+seed7/lib/xmldom.s7i         0.042634            303
+seed7/lib/xz.s7i             0.046614            442
+seed7/lib/zip.s7i            0.121657           2792
+seed7/lib/zstd.s7i           0.070217           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.091955        |
++-----------+-----------------+
+| Minimum   | 0.035802        |
++-----------+-----------------+
+| Maximum   | 2.588956        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.048830            190
+seed7/prg/bas7.sd7           0.788240          11459
+seed7/prg/bifurk.sd7         0.039507             73
+seed7/prg/bigfiles.sd7       0.042821            129
+seed7/prg/brainf7.sd7        0.040841             86
+seed7/prg/calc7.sd7          0.043419            128
+seed7/prg/carddemo.sd7       0.048498            190
+seed7/prg/castle.sd7         0.223079           3148
+seed7/prg/cat.sd7            0.039452             82
+seed7/prg/cellauto.sd7       0.039264             85
+seed7/prg/celsius.sd7        0.037647             42
+seed7/prg/chk_all.sd7        0.084248            843
+seed7/prg/chkarr.sd7         0.883027           8367
+seed7/prg/chkbig.sd7         4.232041          29026
+seed7/prg/chkbin.sd7         1.051963           6469
+seed7/prg/chkbitdata.sd7     1.277722           6624
+seed7/prg/chkbool.sd7        0.237807           3157
+seed7/prg/chkbst.sd7         0.103026            722
+seed7/prg/chkchr.sd7         0.496527           2809
+seed7/prg/chkcmd.sd7         0.113785           1205
+seed7/prg/chkdb.sd7          0.773719           7454
+seed7/prg/chkdecl.sd7        0.096442            448
+seed7/prg/chkenum.sd7        0.125030           1230
+seed7/prg/chkerr.sd7         0.348226           4663
+seed7/prg/chkexc.sd7         0.151700           2627
+seed7/prg/chkfil.sd7         0.130596           1615
+seed7/prg/chkflt.sd7         2.898160          20620
+seed7/prg/chkhent.sd7        0.039141             54
+seed7/prg/chkhsh.sd7         0.514200           4548
+seed7/prg/chkidx.sd7         3.265719          19567
+seed7/prg/chkint.sd7         5.699982          38129
+seed7/prg/chkjson.sd7        0.194125           1764
+seed7/prg/chkovf.sd7         1.238205           8216
+seed7/prg/chkprc.sd7         0.718989          10111
+seed7/prg/chkscan.sd7        0.092294            714
+seed7/prg/chkset.sd7         1.794186          11974
+seed7/prg/chkstr.sd7         3.510478          26952
+seed7/prg/chktime.sd7        0.254363           2025
+seed7/prg/chktoml.sd7        0.202626           1656
+seed7/prg/clock.sd7          0.039069             47
+seed7/prg/clock2.sd7         0.038067             43
+seed7/prg/clock3.sd7         0.043564             95
+seed7/prg/cmpfil.sd7         0.039971             84
+seed7/prg/comanche.sd7       0.054574            180
+seed7/prg/confval.sd7        0.054575            175
+seed7/prg/db7.sd7            0.063645            417
+seed7/prg/diff7.sd7          0.052644            263
+seed7/prg/dirtst.sd7         0.036808             42
+seed7/prg/dirx.sd7           0.043304            152
+seed7/prg/dnafight.sd7       0.123208           1381
+seed7/prg/dragon.sd7         0.039792             73
+seed7/prg/echo.sd7           0.037948             39
+seed7/prg/eliza.sd7          0.053504            302
+seed7/prg/err.sd7            0.046145             96
+seed7/prg/fannkuch.sd7       0.043903            131
+seed7/prg/fib.sd7            0.038635             47
+seed7/prg/find7.sd7          0.043741            133
+seed7/prg/findchar.sd7       0.045604            149
+seed7/prg/fractree.sd7       0.039186             55
+seed7/prg/ftp7.sd7           0.053799            296
+seed7/prg/ftpserv.sd7        0.039103             74
+seed7/prg/gcd.sd7            0.040818            109
+seed7/prg/gkbd.sd7           0.062604            358
+seed7/prg/gtksvtst.sd7       0.039777             94
+seed7/prg/hal.sd7            0.047377            250
+seed7/prg/hamu.sd7           0.067492            573
+seed7/prg/hanoi.sd7          0.038533             55
+seed7/prg/hd.sd7             0.039692             79
+seed7/prg/hello.sd7          0.037241             32
+seed7/prg/hilbert.sd7        0.042526            108
+seed7/prg/ide7.sd7           0.050216            196
+seed7/prg/kbd.sd7            0.038472             49
+seed7/prg/klondike.sd7       0.091483            883
+seed7/prg/lander.sd7         0.135813           1551
+seed7/prg/lst80bas.sd7       0.058353            344
+seed7/prg/lst99bas.sd7       0.061910            401
+seed7/prg/lstgwbas.sd7       0.076206            577
+seed7/prg/mahjong.sd7        0.152596           1943
+seed7/prg/make7.sd7          0.044057            121
+seed7/prg/mandelbr.sd7       0.051405            237
+seed7/prg/mind.sd7           0.060076            443
+seed7/prg/mirror.sd7         0.044349            131
+seed7/prg/ms.sd7             0.071519            641
+seed7/prg/nicoma.sd7         0.042731            135
+seed7/prg/pac.sd7            0.073850            726
+seed7/prg/pairs.sd7          0.144744           2025
+seed7/prg/panic.sd7          0.198533           2634
+seed7/prg/percolation.sd7    0.057106            330
+seed7/prg/planets.sd7        0.142237           1486
+seed7/prg/portfwd7.sd7       0.044450            139
+seed7/prg/prime.sd7          0.039192             74
+seed7/prg/printpi1.sd7       0.039732             56
+seed7/prg/printpi2.sd7       0.038874             54
+seed7/prg/printpi3.sd7       0.038943             60
+seed7/prg/pv7.sd7            0.058794            337
+seed7/prg/queen.sd7          0.042994            149
+seed7/prg/rand.sd7           0.041941            121
+seed7/prg/raytrace.sd7       0.069187            538
+seed7/prg/rever.sd7          0.083561            816
+seed7/prg/roman.sd7          0.038738             38
+seed7/prg/s7c.sd7            0.641590           9060
+seed7/prg/s7check.sd7        0.040742             68
+seed7/prg/savehd7.sd7        0.115065           1110
+seed7/prg/self.sd7           0.037667             49
+seed7/prg/shisen.sd7         0.121831           1423
+seed7/prg/sl.sd7             0.099281           1029
+seed7/prg/snake.sd7          0.070023            615
+seed7/prg/sokoban.sd7        0.085511            891
+seed7/prg/spigotpi.sd7       0.039303             64
+seed7/prg/sql7.sd7           0.053947            278
+seed7/prg/startrek.sd7       0.096197            979
+seed7/prg/sudoku7.sd7        0.202718           2657
+seed7/prg/sydir7.sd7         0.062420            384
+seed7/prg/syntaxhl.sd7       0.049280            177
+seed7/prg/tak.sd7            0.038915             59
+seed7/prg/tar7.sd7           0.044326            121
+seed7/prg/tch.sd7            0.039699             55
+seed7/prg/testfont.sd7       0.041915             95
+seed7/prg/tet.sd7            0.060461            479
+seed7/prg/tetg.sd7           0.062047            501
+seed7/prg/toutf8.sd7         0.052072            240
+seed7/prg/tst_cli.sd7        0.038637             40
+seed7/prg/tst_srv.sd7        0.038119             47
+seed7/prg/wator.sd7          0.081017            651
+seed7/prg/which.sd7          0.039974             65
+seed7/prg/wiz.sd7            0.215393           2833
+seed7/prg/wordcnt.sd7        0.039377             54
+seed7/prg/wrinum.sd7         0.037843             43
+seed7/prg/wumpus.sd7         0.055945            372
+seed7/lib/aes.s7i            0.202732           1144
+seed7/lib/aes_gcm.s7i        0.062945            392
+seed7/lib/ar.s7i             0.126371           1532
+seed7/lib/arc4.s7i           0.043509            144
+seed7/lib/archive.s7i        0.042923            143
+seed7/lib/archive_base.s7i   0.044194            135
+seed7/lib/array.s7i          0.078109            610
+seed7/lib/asn1.s7i           0.066608            544
+seed7/lib/asn1oid.s7i        0.051193            157
+seed7/lib/basearray.s7i      0.065103            450
+seed7/lib/bigfile.s7i        0.043365            136
+seed7/lib/bigint.s7i         0.080516            824
+seed7/lib/bigrat.s7i         0.081025            784
+seed7/lib/bin16.s7i          0.069321            592
+seed7/lib/bin32.s7i          0.064093            490
+seed7/lib/bin64.s7i          0.064873            539
+seed7/lib/bitdata.s7i        0.127127           1330
+seed7/lib/bitmapfont.s7i     0.047426            215
+seed7/lib/bitset.s7i         0.064481            593
+seed7/lib/bitsetof.s7i       0.062163            431
+seed7/lib/blowfish.s7i       0.078234            383
+seed7/lib/bmp.s7i            0.104902            924
+seed7/lib/boolean.s7i        0.057533            403
+seed7/lib/browser.s7i        0.055094            280
+seed7/lib/bstring.s7i        0.048687            227
+seed7/lib/bytedata.s7i       0.068887            482
+seed7/lib/bzip2.s7i          0.091185            887
+seed7/lib/cards.s7i          0.105819           1342
+seed7/lib/category.s7i       0.050430            209
+seed7/lib/cc_conf.s7i        0.124295           1314
+seed7/lib/ccittfax.s7i       0.107298           1022
+seed7/lib/cgi.s7i            0.041667            109
+seed7/lib/cgidialog.s7i      0.098561           1118
+seed7/lib/char.s7i           0.052991            356
+seed7/lib/charsets.s7i       0.129867           2024
+seed7/lib/chartype.s7i       0.055391            121
+seed7/lib/cipher.s7i         0.045445            146
+seed7/lib/cli_cmds.s7i       0.117141           1360
+seed7/lib/clib_file.s7i      0.060498            301
+seed7/lib/color.s7i          0.049347            185
+seed7/lib/complex.s7i        0.061094            464
+seed7/lib/compress.s7i       0.045973            150
+seed7/lib/console.s7i        0.047720            188
+seed7/lib/cpio.s7i           0.148614           1708
+seed7/lib/crc32.s7i          0.056299            193
+seed7/lib/cronos16.s7i       0.198931           1173
+seed7/lib/cronos27.s7i       0.262380           1464
+seed7/lib/csv.s7i            0.049572            201
+seed7/lib/db_prop.s7i        0.104530            991
+seed7/lib/deflate.s7i        0.088280            740
+seed7/lib/des.s7i            0.080431            444
+seed7/lib/dialog.s7i         0.057694            311
+seed7/lib/dir.s7i            0.043803            163
+seed7/lib/draw.s7i           0.086573            854
+seed7/lib/duration.s7i       0.100454           1038
+seed7/lib/echo.s7i           0.042493            132
+seed7/lib/editline.s7i       0.060090            398
+seed7/lib/elf.s7i            0.158336           1560
+seed7/lib/elliptic.s7i       0.079248            649
+seed7/lib/enable_io.s7i      0.055102            312
+seed7/lib/encoding.s7i       0.099844            931
+seed7/lib/enumeration.s7i    0.050852            236
+seed7/lib/environment.s7i    0.045763            175
+seed7/lib/exif.s7i           0.047796            152
+seed7/lib/external_file.s7i  0.053584            340
+seed7/lib/field.s7i          0.053467            268
+seed7/lib/file.s7i           0.056372            372
+seed7/lib/filebits.s7i       0.039619             46
+seed7/lib/filesys.s7i        0.066556            601
+seed7/lib/fileutil.s7i       0.044882            144
+seed7/lib/fixarray.s7i       0.054989            307
+seed7/lib/float.s7i          0.074362            757
+seed7/lib/font.s7i           0.046084            196
+seed7/lib/font8x8.s7i        0.068110            998
+seed7/lib/forloop.s7i        0.060778            449
+seed7/lib/ftp.s7i            0.089823            969
+seed7/lib/ftpserv.s7i        0.079069            631
+seed7/lib/getf.s7i           0.042388            115
+seed7/lib/gethttp.s7i        0.038435             41
+seed7/lib/gethttps.s7i       0.039216             41
+seed7/lib/gif.s7i            0.073191            561
+seed7/lib/graph.s7i          0.065988            415
+seed7/lib/graph_file.s7i     0.059558            399
+seed7/lib/gtkserver.s7i      0.043922            161
+seed7/lib/gzip.s7i           0.069767            573
+seed7/lib/hash.s7i           0.068083            421
+seed7/lib/hashsetof.s7i      0.068942            499
+seed7/lib/hmac.s7i           0.046113            152
+seed7/lib/html.s7i           0.039832             83
+seed7/lib/html_ent.s7i       0.065049            476
+seed7/lib/htmldom.s7i        0.054202            286
+seed7/lib/http_request.s7i   0.113096            696
+seed7/lib/http_srv_resp.s7i  0.074122            380
+seed7/lib/https_request.s7i  0.052009            211
+seed7/lib/httpserv.s7i       0.057863            345
+seed7/lib/huffman.s7i        0.078042            644
+seed7/lib/ico.s7i            0.052797            221
+seed7/lib/idxarray.s7i       0.052498            232
+seed7/lib/image.s7i          0.042696            156
+seed7/lib/imagefile.s7i      0.047307            171
+seed7/lib/inflate.s7i        0.066929            411
+seed7/lib/inifile.s7i        0.045721            129
+seed7/lib/integer.s7i        0.070628            663
+seed7/lib/iobuffer.s7i       0.053471            289
+seed7/lib/jpeg.s7i           0.160107           1761
+seed7/lib/json.s7i           0.083826            891
+seed7/lib/json_serde.s7i     0.081025            783
+seed7/lib/keybd.s7i          0.082100            639
+seed7/lib/keydescr.s7i       0.053538            192
+seed7/lib/leb128.s7i         0.048188            218
+seed7/lib/line.s7i           0.045739            164
+seed7/lib/listener.s7i       0.050680            247
+seed7/lib/logfile.s7i        0.040735             73
+seed7/lib/lower.s7i          0.043046            142
+seed7/lib/lzma.s7i           0.099131            934
+seed7/lib/lzw.s7i            0.092233            861
+seed7/lib/magic.s7i          0.065952            403
+seed7/lib/mahjng32.s7i       0.094660           1500
+seed7/lib/make.s7i           0.072238            544
+seed7/lib/makedata.s7i       0.126288           1428
+seed7/lib/math.s7i           0.047277            201
+seed7/lib/mixarith.s7i       0.049802            249
+seed7/lib/modern27.s7i       0.176854           1099
+seed7/lib/more.s7i           0.044699            130
+seed7/lib/msgdigest.s7i      0.141096           1222
+seed7/lib/multiscr.s7i       0.040988             68
+seed7/lib/null_file.s7i      0.053045            345
+seed7/lib/osfiles.s7i        0.098432           1085
+seed7/lib/pbm.s7i            0.050302            230
+seed7/lib/pcx.s7i            0.081294            638
+seed7/lib/pem.s7i            0.046954            185
+seed7/lib/pgm.s7i            0.051461            238
+seed7/lib/pic16.s7i          0.069998           1037
+seed7/lib/pic32.s7i          0.125508           2060
+seed7/lib/pic_util.s7i       0.045542            144
+seed7/lib/pixelimage.s7i     0.054567            320
+seed7/lib/pixmap_file.s7i    0.064356            459
+seed7/lib/pixmapfont.s7i     0.049736            184
+seed7/lib/pkcs1.s7i          0.081806            543
+seed7/lib/png.s7i            0.111793           1064
+seed7/lib/poll.s7i           0.054708            313
+seed7/lib/ppm.s7i            0.050644            240
+seed7/lib/process.s7i        0.066432            541
+seed7/lib/progs.s7i          0.082264            789
+seed7/lib/propertyfile.s7i   0.046265            155
+seed7/lib/rational.s7i       0.081969            792
+seed7/lib/ref_list.s7i       0.051852            252
+seed7/lib/reference.s7i      0.044113            126
+seed7/lib/reverse.s7i        0.041140             94
+seed7/lib/rpm.s7i            0.293445           3487
+seed7/lib/rpmext.s7i         0.054891            318
+seed7/lib/scanfile.s7i       0.138961           1779
+seed7/lib/scanjson.s7i       0.063761            413
+seed7/lib/scanstri.s7i       0.140783           1814
+seed7/lib/scantoml.s7i       0.134579           1603
+seed7/lib/seed7_05.s7i       0.115049           1072
+seed7/lib/set.s7i            0.039888             57
+seed7/lib/shell.s7i          0.071756            615
+seed7/lib/showtls.s7i        0.088414            678
+seed7/lib/signature.s7i      0.044744            131
+seed7/lib/smtp.s7i           0.051028            261
+seed7/lib/sockbase.s7i       0.052723            217
+seed7/lib/socket.s7i         0.059928            326
+seed7/lib/sokoban1.s7i       0.085371           1519
+seed7/lib/sql_base.s7i       0.097329           1000
+seed7/lib/stars.s7i          0.243433           1705
+seed7/lib/stdfont10.s7i      0.148543           3347
+seed7/lib/stdfont12.s7i      0.170748           3928
+seed7/lib/stdfont14.s7i      0.193951           4510
+seed7/lib/stdfont16.s7i      0.218637           5092
+seed7/lib/stdfont18.s7i      0.254266           5868
+seed7/lib/stdfont20.s7i      0.281342           6449
+seed7/lib/stdfont24.s7i      0.339683           7421
+seed7/lib/stdfont8.s7i       0.131382           2960
+seed7/lib/stdfont9.s7i       0.139078           3152
+seed7/lib/stdio.s7i          0.046442            192
+seed7/lib/strifile.s7i       0.060289            345
+seed7/lib/string.s7i         0.079589            779
+seed7/lib/stritext.s7i       0.057522            352
+seed7/lib/struct.s7i         0.058456            266
+seed7/lib/struct_elem.s7i    0.043539            129
+seed7/lib/subfile.s7i        0.052547            174
+seed7/lib/subrange.s7i       0.040636             78
+seed7/lib/syntax.s7i         0.064264            294
+seed7/lib/tar.s7i            0.149941           1880
+seed7/lib/tar_cmds.s7i       0.086931            752
+seed7/lib/tdes.s7i           0.045854            143
+seed7/lib/tee.s7i            0.043497            143
+seed7/lib/text.s7i           0.043483            135
+seed7/lib/tga.s7i            0.084068            676
+seed7/lib/tiff.s7i           0.251326           2771
+seed7/lib/time.s7i           0.105632           1191
+seed7/lib/tls.s7i            0.202223           2230
+seed7/lib/unicode.s7i        0.076169            575
+seed7/lib/unionfnd.s7i       0.044422            130
+seed7/lib/upper.s7i          0.043677            142
+seed7/lib/utf16.s7i          0.067374            540
+seed7/lib/utf8.s7i           0.050155            234
+seed7/lib/vecfont10.s7i      0.164457           1056
+seed7/lib/vecfont18.s7i      0.184176           1119
+seed7/lib/vector3d.s7i       0.052570            293
+seed7/lib/vectorfont.s7i     0.051178            239
+seed7/lib/wildcard.s7i       0.044330            140
+seed7/lib/window.s7i         0.062819            455
+seed7/lib/wrinum.s7i         0.050824            248
+seed7/lib/x509cert.s7i       0.121569           1243
+seed7/lib/xml_ent.s7i        0.044450             94
+seed7/lib/xmldom.s7i         0.052733            303
+seed7/lib/xz.s7i             0.062804            442
+seed7/lib/zip.s7i            0.237878           2792
+seed7/lib/zstd.s7i           0.121729           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.163413        |
++-----------+-----------------+
+| Minimum   | 0.036808        |
++-----------+-----------------+
+| Maximum   | 5.699982        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033710        | 0.032197        | 0.039572        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.039158        | 0.035342        | 0.048396        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.091955        | 0.035802        | 2.588956        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.163413        | 0.036808        | 5.699982        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.347 | 00:00:57.435 | 00:01:09.782 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.970 | 00:01:06.778 | 00:01:21.748 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:35.888 | 00:02:37.514 | 00:03:13.403 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:03.091 | 00:04:39.301 | 00:05:42.392 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:27.335 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/reports/seed7mode-perf-16.5.rst
+++ b/reports/seed7mode-perf-16.5.rst
@@ -1,0 +1,1534 @@
+=======================================================
+GC-Controlled Benchmark Report: Seed7 Mode — Four Modes
+=======================================================
+
+:Running with: seed7-mode 2026-06-30T16:45:51+0000 W27-2
+:Seed7 dir   : /Users/roup/my/dvo/seed7-repos/seed7/
+:Started at: 12:48:41 local time
+:Generated on: 2026-06-30 16:59:51 UTC
+:N Iterations: 5  (mean of N timed opens per file)
+:Window system: nil
+:Display graphic: nil
+:Frame size: 211x95 chars
+:Window body: 211x93 chars
+:GC @ testing: suppressed (gc-cons-threshold = most-positive-fixnum)
+:Warm-up info: yes (1 untimed pass per mode + garbage-collect before timing)
+:Modes planned: A B C D
+
+Mode Descriptions
+=================
+
+A:
+   Major-mode activation only. No window → jit-lock never fires.
+B:
+   Mode activation + initial visible jit-lock pass.
+C:
+   Mode activation + full-buffer fontification (font-lock-ensure).
+D:
+   Mode activation + full incremental jit-lock (scroll top→bottom).
+
+
+Mode A — Major-Mode Activation Only
+-----------------------------------
+
+No window created. Measures syntax-table setup and font-lock keyword compilation.
+
+File Load Times — Mode A (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.033279            190
+seed7/prg/bas7.sd7           0.034008          11459
+seed7/prg/bifurk.sd7         0.032740             73
+seed7/prg/bigfiles.sd7       0.034277            129
+seed7/prg/brainf7.sd7        0.034508             86
+seed7/prg/calc7.sd7          0.033678            128
+seed7/prg/carddemo.sd7       0.033858            190
+seed7/prg/castle.sd7         0.034761           3148
+seed7/prg/cat.sd7            0.033844             82
+seed7/prg/cellauto.sd7       0.033685             85
+seed7/prg/celsius.sd7        0.033862             42
+seed7/prg/chk_all.sd7        0.033643            843
+seed7/prg/chkarr.sd7         0.034499           8367
+seed7/prg/chkbig.sd7         0.038646          29026
+seed7/prg/chkbin.sd7         0.034432           6469
+seed7/prg/chkbitdata.sd7     0.034359           6624
+seed7/prg/chkbool.sd7        0.033916           3157
+seed7/prg/chkbst.sd7         0.033742            722
+seed7/prg/chkchr.sd7         0.033973           2809
+seed7/prg/chkcmd.sd7         0.033651           1205
+seed7/prg/chkdb.sd7          0.034725           7454
+seed7/prg/chkdecl.sd7        0.033645            448
+seed7/prg/chkenum.sd7        0.033580           1230
+seed7/prg/chkerr.sd7         0.034194           4663
+seed7/prg/chkexc.sd7         0.033469           2627
+seed7/prg/chkfil.sd7         0.033004           1615
+seed7/prg/chkflt.sd7         0.036848          20620
+seed7/prg/chkhent.sd7        0.033482             54
+seed7/prg/chkhsh.sd7         0.033773           4548
+seed7/prg/chkidx.sd7         0.034848          19567
+seed7/prg/chkint.sd7         0.039414          38129
+seed7/prg/chkjson.sd7        0.034446           1764
+seed7/prg/chkovf.sd7         0.033617           8216
+seed7/prg/chkprc.sd7         0.033164          10111
+seed7/prg/chkscan.sd7        0.036062            714
+seed7/prg/chkset.sd7         0.038868          11974
+seed7/prg/chkstr.sd7         0.038375          26952
+seed7/prg/chktime.sd7        0.033929           2025
+seed7/prg/chktoml.sd7        0.033882           1656
+seed7/prg/clock.sd7          0.033271             47
+seed7/prg/clock2.sd7         0.033577             43
+seed7/prg/clock3.sd7         0.033358             95
+seed7/prg/cmpfil.sd7         0.034007             84
+seed7/prg/comanche.sd7       0.033666            180
+seed7/prg/confval.sd7        0.033385            175
+seed7/prg/db7.sd7            0.033664            417
+seed7/prg/diff7.sd7          0.033997            263
+seed7/prg/dirtst.sd7         0.033560             42
+seed7/prg/dirx.sd7           0.033844            152
+seed7/prg/dnafight.sd7       0.033916           1381
+seed7/prg/dragon.sd7         0.033761             73
+seed7/prg/echo.sd7           0.033804             39
+seed7/prg/eliza.sd7          0.033931            302
+seed7/prg/err.sd7            0.033657             96
+seed7/prg/fannkuch.sd7       0.033722            131
+seed7/prg/fib.sd7            0.033737             47
+seed7/prg/find7.sd7          0.033609            133
+seed7/prg/findchar.sd7       0.033682            149
+seed7/prg/fractree.sd7       0.033770             55
+seed7/prg/ftp7.sd7           0.033615            296
+seed7/prg/ftpserv.sd7        0.032668             74
+seed7/prg/gcd.sd7            0.033366            109
+seed7/prg/gkbd.sd7           0.032721            358
+seed7/prg/gtksvtst.sd7       0.032737             94
+seed7/prg/hal.sd7            0.032864            250
+seed7/prg/hamu.sd7           0.033659            573
+seed7/prg/hanoi.sd7          0.034832             55
+seed7/prg/hd.sd7             0.034037             79
+seed7/prg/hello.sd7          0.033707             32
+seed7/prg/hilbert.sd7        0.033424            108
+seed7/prg/ide7.sd7           0.034145            196
+seed7/prg/kbd.sd7            0.033760             49
+seed7/prg/klondike.sd7       0.033873            883
+seed7/prg/lander.sd7         0.034029           1551
+seed7/prg/lst80bas.sd7       0.033879            344
+seed7/prg/lst99bas.sd7       0.033815            401
+seed7/prg/lstgwbas.sd7       0.033716            577
+seed7/prg/mahjong.sd7        0.033796           1943
+seed7/prg/make7.sd7          0.033454            121
+seed7/prg/mandelbr.sd7       0.033798            237
+seed7/prg/mind.sd7           0.033561            443
+seed7/prg/mirror.sd7         0.033508            131
+seed7/prg/ms.sd7             0.033850            641
+seed7/prg/nicoma.sd7         0.033408            135
+seed7/prg/pac.sd7            0.034080            726
+seed7/prg/pairs.sd7          0.033604           2025
+seed7/prg/panic.sd7          0.033730           2634
+seed7/prg/percolation.sd7    0.033595            330
+seed7/prg/planets.sd7        0.033802           1486
+seed7/prg/portfwd7.sd7       0.033760            139
+seed7/prg/prime.sd7          0.033710             74
+seed7/prg/printpi1.sd7       0.033242             56
+seed7/prg/printpi2.sd7       0.032765             54
+seed7/prg/printpi3.sd7       0.032694             60
+seed7/prg/pv7.sd7            0.032860            337
+seed7/prg/queen.sd7          0.032651            149
+seed7/prg/rand.sd7           0.032901            121
+seed7/prg/raytrace.sd7       0.033964            538
+seed7/prg/rever.sd7          0.033427            816
+seed7/prg/roman.sd7          0.032894             38
+seed7/prg/s7c.sd7            0.034156           9060
+seed7/prg/s7check.sd7        0.033409             68
+seed7/prg/savehd7.sd7        0.033906           1110
+seed7/prg/self.sd7           0.033669             49
+seed7/prg/shisen.sd7         0.033691           1423
+seed7/prg/sl.sd7             0.033872           1029
+seed7/prg/snake.sd7          0.033364            615
+seed7/prg/sokoban.sd7        0.034018            891
+seed7/prg/spigotpi.sd7       0.033609             64
+seed7/prg/sql7.sd7           0.033804            278
+seed7/prg/startrek.sd7       0.033814            979
+seed7/prg/sudoku7.sd7        0.033849           2657
+seed7/prg/sydir7.sd7         0.033795            384
+seed7/prg/syntaxhl.sd7       0.033611            177
+seed7/prg/tak.sd7            0.033680             59
+seed7/prg/tar7.sd7           0.033434            121
+seed7/prg/tch.sd7            0.033544             55
+seed7/prg/testfont.sd7       0.033707             95
+seed7/prg/tet.sd7            0.033705            479
+seed7/prg/tetg.sd7           0.033907            501
+seed7/prg/toutf8.sd7         0.033633            240
+seed7/prg/tst_cli.sd7        0.033493             40
+seed7/prg/tst_srv.sd7        0.033717             47
+seed7/prg/wator.sd7          0.035849            651
+seed7/prg/which.sd7          0.033363             65
+seed7/prg/wiz.sd7            0.033575           2833
+seed7/prg/wordcnt.sd7        0.032618             54
+seed7/prg/wrinum.sd7         0.032664             43
+seed7/prg/wumpus.sd7         0.032676            372
+seed7/lib/aes.s7i            0.035138           1144
+seed7/lib/aes_gcm.s7i        0.033925            392
+seed7/lib/ar.s7i             0.033540           1532
+seed7/lib/arc4.s7i           0.033803            144
+seed7/lib/archive.s7i        0.033804            143
+seed7/lib/archive_base.s7i   0.033703            135
+seed7/lib/array.s7i          0.033613            610
+seed7/lib/asn1.s7i           0.034118            544
+seed7/lib/asn1oid.s7i        0.033497            157
+seed7/lib/basearray.s7i      0.033795            450
+seed7/lib/bigfile.s7i        0.033856            136
+seed7/lib/bigint.s7i         0.033591            824
+seed7/lib/bigrat.s7i         0.033825            784
+seed7/lib/bin16.s7i          0.033441            592
+seed7/lib/bin32.s7i          0.033343            490
+seed7/lib/bin64.s7i          0.033840            539
+seed7/lib/bitdata.s7i        0.033721           1330
+seed7/lib/bitmapfont.s7i     0.032835            215
+seed7/lib/bitset.s7i         0.032748            593
+seed7/lib/bitsetof.s7i       0.032961            431
+seed7/lib/blowfish.s7i       0.032917            383
+seed7/lib/bmp.s7i            0.033144            924
+seed7/lib/boolean.s7i        0.032793            403
+seed7/lib/browser.s7i        0.033170            280
+seed7/lib/bstring.s7i        0.032846            227
+seed7/lib/bytedata.s7i       0.032770            482
+seed7/lib/bzip2.s7i          0.033011            887
+seed7/lib/cards.s7i          0.032769           1342
+seed7/lib/category.s7i       0.033227            209
+seed7/lib/cc_conf.s7i        0.032813           1314
+seed7/lib/ccittfax.s7i       0.032539           1022
+seed7/lib/cgi.s7i            0.033830            109
+seed7/lib/cgidialog.s7i      0.035156           1118
+seed7/lib/char.s7i           0.034037            356
+seed7/lib/charsets.s7i       0.034378           2024
+seed7/lib/chartype.s7i       0.033632            121
+seed7/lib/cipher.s7i         0.033867            146
+seed7/lib/cli_cmds.s7i       0.033899           1360
+seed7/lib/clib_file.s7i      0.033959            301
+seed7/lib/color.s7i          0.033891            185
+seed7/lib/complex.s7i        0.033638            464
+seed7/lib/compress.s7i       0.033535            150
+seed7/lib/console.s7i        0.033967            188
+seed7/lib/cpio.s7i           0.033660           1708
+seed7/lib/crc32.s7i          0.033774            193
+seed7/lib/cronos16.s7i       0.034104           1173
+seed7/lib/cronos27.s7i       0.033815           1464
+seed7/lib/csv.s7i            0.033703            201
+seed7/lib/db_prop.s7i        0.034512            991
+seed7/lib/deflate.s7i        0.033506            740
+seed7/lib/des.s7i            0.033986            444
+seed7/lib/dialog.s7i         0.034051            311
+seed7/lib/dir.s7i            0.033621            163
+seed7/lib/draw.s7i           0.033528            854
+seed7/lib/duration.s7i       0.033945           1038
+seed7/lib/echo.s7i           0.033763            132
+seed7/lib/editline.s7i       0.033759            398
+seed7/lib/elf.s7i            0.033286           1560
+seed7/lib/elliptic.s7i       0.032857            649
+seed7/lib/enable_io.s7i      0.032831            312
+seed7/lib/encoding.s7i       0.032645            931
+seed7/lib/enumeration.s7i    0.033017            236
+seed7/lib/environment.s7i    0.032737            175
+seed7/lib/exif.s7i           0.034320            152
+seed7/lib/external_file.s7i  0.033866            340
+seed7/lib/field.s7i          0.033623            268
+seed7/lib/file.s7i           0.033804            372
+seed7/lib/filebits.s7i       0.033641             46
+seed7/lib/filesys.s7i        0.033708            601
+seed7/lib/fileutil.s7i       0.033633            144
+seed7/lib/fixarray.s7i       0.033704            307
+seed7/lib/float.s7i          0.033609            757
+seed7/lib/font.s7i           0.034233            196
+seed7/lib/font8x8.s7i        0.033751            998
+seed7/lib/forloop.s7i        0.033770            449
+seed7/lib/ftp.s7i            0.033528            969
+seed7/lib/ftpserv.s7i        0.033130            631
+seed7/lib/getf.s7i           0.032512            115
+seed7/lib/gethttp.s7i        0.032866             41
+seed7/lib/gethttps.s7i       0.033007             41
+seed7/lib/gif.s7i            0.032423            561
+seed7/lib/graph.s7i          0.032770            415
+seed7/lib/graph_file.s7i     0.032777            399
+seed7/lib/gtkserver.s7i      0.032565            161
+seed7/lib/gzip.s7i           0.033333            573
+seed7/lib/hash.s7i           0.033734            421
+seed7/lib/hashsetof.s7i      0.033581            499
+seed7/lib/hmac.s7i           0.033833            152
+seed7/lib/html.s7i           0.033560             83
+seed7/lib/html_ent.s7i       0.033392            476
+seed7/lib/htmldom.s7i        0.032782            286
+seed7/lib/http_request.s7i   0.033189            696
+seed7/lib/http_srv_resp.s7i  0.032936            380
+seed7/lib/https_request.s7i  0.032933            211
+seed7/lib/httpserv.s7i       0.032770            345
+seed7/lib/huffman.s7i        0.034424            644
+seed7/lib/ico.s7i            0.034152            221
+seed7/lib/idxarray.s7i       0.033668            232
+seed7/lib/image.s7i          0.033784            156
+seed7/lib/imagefile.s7i      0.033924            171
+seed7/lib/inflate.s7i        0.033616            411
+seed7/lib/inifile.s7i        0.033829            129
+seed7/lib/integer.s7i        0.033624            663
+seed7/lib/iobuffer.s7i       0.033571            289
+seed7/lib/jpeg.s7i           0.033902           1761
+seed7/lib/json.s7i           0.033829            891
+seed7/lib/json_serde.s7i     0.033630            783
+seed7/lib/keybd.s7i          0.033771            639
+seed7/lib/keydescr.s7i       0.033929            192
+seed7/lib/leb128.s7i         0.033810            218
+seed7/lib/line.s7i           0.033781            164
+seed7/lib/listener.s7i       0.034244            247
+seed7/lib/logfile.s7i        0.033476             73
+seed7/lib/lower.s7i          0.033583            142
+seed7/lib/lzma.s7i           0.033453            934
+seed7/lib/lzw.s7i            0.033764            861
+seed7/lib/magic.s7i          0.033930            403
+seed7/lib/mahjng32.s7i       0.033831           1500
+seed7/lib/make.s7i           0.033667            544
+seed7/lib/makedata.s7i       0.033769           1428
+seed7/lib/math.s7i           0.033811            201
+seed7/lib/mixarith.s7i       0.032854            249
+seed7/lib/modern27.s7i       0.033296           1099
+seed7/lib/more.s7i           0.032621            130
+seed7/lib/msgdigest.s7i      0.032566           1222
+seed7/lib/multiscr.s7i       0.032626             68
+seed7/lib/null_file.s7i      0.032740            345
+seed7/lib/osfiles.s7i        0.035192           1085
+seed7/lib/pbm.s7i            0.034552            230
+seed7/lib/pcx.s7i            0.037061            638
+seed7/lib/pem.s7i            0.035313            185
+seed7/lib/pgm.s7i            0.033963            238
+seed7/lib/pic16.s7i          0.034046           1037
+seed7/lib/pic32.s7i          0.033745           2060
+seed7/lib/pic_util.s7i       0.034201            144
+seed7/lib/pixelimage.s7i     0.033888            320
+seed7/lib/pixmap_file.s7i    0.033741            459
+seed7/lib/pixmapfont.s7i     0.033854            184
+seed7/lib/pkcs1.s7i          0.033686            543
+seed7/lib/png.s7i            0.033985           1064
+seed7/lib/poll.s7i           0.033724            313
+seed7/lib/ppm.s7i            0.033583            240
+seed7/lib/process.s7i        0.033529            541
+seed7/lib/progs.s7i          0.034205            789
+seed7/lib/propertyfile.s7i   0.033849            155
+seed7/lib/rational.s7i       0.033825            792
+seed7/lib/ref_list.s7i       0.033856            252
+seed7/lib/reference.s7i      0.033909            126
+seed7/lib/reverse.s7i        0.032931             94
+seed7/lib/rpm.s7i            0.034210           3487
+seed7/lib/rpmext.s7i         0.033823            318
+seed7/lib/scanfile.s7i       0.033506           1779
+seed7/lib/scanjson.s7i       0.032939            413
+seed7/lib/scanstri.s7i       0.033106           1814
+seed7/lib/scantoml.s7i       0.033023           1603
+seed7/lib/seed7_05.s7i       0.032719           1072
+seed7/lib/set.s7i            0.032485             57
+seed7/lib/shell.s7i          0.032835            615
+seed7/lib/showtls.s7i        0.034871            678
+seed7/lib/signature.s7i      0.033847            131
+seed7/lib/smtp.s7i           0.033383            261
+seed7/lib/sockbase.s7i       0.033687            217
+seed7/lib/socket.s7i         0.034002            326
+seed7/lib/sokoban1.s7i       0.034066           1519
+seed7/lib/sql_base.s7i       0.033828           1000
+seed7/lib/stars.s7i          0.033616           1705
+seed7/lib/stdfont10.s7i      0.033673           3347
+seed7/lib/stdfont12.s7i      0.033930           3928
+seed7/lib/stdfont14.s7i      0.034043           4510
+seed7/lib/stdfont16.s7i      0.034001           5092
+seed7/lib/stdfont18.s7i      0.034069           5868
+seed7/lib/stdfont20.s7i      0.033999           6449
+seed7/lib/stdfont24.s7i      0.034204           7421
+seed7/lib/stdfont8.s7i       0.033727           2960
+seed7/lib/stdfont9.s7i       0.033679           3152
+seed7/lib/stdio.s7i          0.033879            192
+seed7/lib/strifile.s7i       0.033568            345
+seed7/lib/string.s7i         0.033712            779
+seed7/lib/stritext.s7i       0.034123            352
+seed7/lib/struct.s7i         0.033698            266
+seed7/lib/struct_elem.s7i    0.033720            129
+seed7/lib/subfile.s7i        0.033679            174
+seed7/lib/subrange.s7i       0.032576             78
+seed7/lib/syntax.s7i         0.032726            294
+seed7/lib/tar.s7i            0.032968           1880
+seed7/lib/tar_cmds.s7i       0.032903            752
+seed7/lib/tdes.s7i           0.032786            143
+seed7/lib/tee.s7i            0.033377            143
+seed7/lib/text.s7i           0.033765            135
+seed7/lib/tga.s7i            0.033701            676
+seed7/lib/tiff.s7i           0.034323           2771
+seed7/lib/time.s7i           0.033918           1191
+seed7/lib/tls.s7i            0.033623           2230
+seed7/lib/unicode.s7i        0.033633            575
+seed7/lib/unionfnd.s7i       0.033707            130
+seed7/lib/upper.s7i          0.033706            142
+seed7/lib/utf16.s7i          0.033577            540
+seed7/lib/utf8.s7i           0.033738            234
+seed7/lib/vecfont10.s7i      0.033824           1056
+seed7/lib/vecfont18.s7i      0.034159           1119
+seed7/lib/vector3d.s7i       0.033429            293
+seed7/lib/vectorfont.s7i     0.033813            239
+seed7/lib/wildcard.s7i       0.033973            140
+seed7/lib/window.s7i         0.033826            455
+seed7/lib/wrinum.s7i         0.033613            248
+seed7/lib/x509cert.s7i       0.033897           1243
+seed7/lib/xml_ent.s7i        0.033637             94
+seed7/lib/xmldom.s7i         0.033717            303
+seed7/lib/xz.s7i             0.033793            442
+seed7/lib/zip.s7i            0.033949           2792
+seed7/lib/zstd.s7i           0.033548           1263
+============================ ================= ================
+
+Statistical Summary — Mode A (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.033717        |
++-----------+-----------------+
+| Minimum   | 0.032423        |
++-----------+-----------------+
+| Maximum   | 0.039414        |
++-----------+-----------------+
+
+Mode B — Mode Activation + Initial Visible jit-lock Pass
+--------------------------------------------------------
+
+The buffer is displayed in a window, then `jit-lock-fontify-now` is called
+over `(window-start)` to `(window-end ... t)` to fontify the visible region.
+This avoids `sit-for 0`, which can process queued terminal input events.
+
+File Load Times — Mode B (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039774            190
+seed7/prg/bas7.sd7           0.041561          11459
+seed7/prg/bifurk.sd7         0.035641             73
+seed7/prg/bigfiles.sd7       0.037792            129
+seed7/prg/brainf7.sd7        0.036725             86
+seed7/prg/calc7.sd7          0.037036            128
+seed7/prg/carddemo.sd7       0.037686            190
+seed7/prg/castle.sd7         0.040464           3148
+seed7/prg/cat.sd7            0.037737             82
+seed7/prg/cellauto.sd7       0.037580             85
+seed7/prg/celsius.sd7        0.036339             42
+seed7/prg/chk_all.sd7        0.039364            843
+seed7/prg/chkarr.sd7         0.039472           8367
+seed7/prg/chkbig.sd7         0.044594          29026
+seed7/prg/chkbin.sd7         0.040601           6469
+seed7/prg/chkbitdata.sd7     0.040655           6624
+seed7/prg/chkbool.sd7        0.039029           3157
+seed7/prg/chkbst.sd7         0.039412            722
+seed7/prg/chkchr.sd7         0.041214           2809
+seed7/prg/chkcmd.sd7         0.038822           1205
+seed7/prg/chkdb.sd7          0.040152           7454
+seed7/prg/chkdecl.sd7        0.039375            448
+seed7/prg/chkenum.sd7        0.038147           1230
+seed7/prg/chkerr.sd7         0.040119           4663
+seed7/prg/chkexc.sd7         0.038954           2627
+seed7/prg/chkfil.sd7         0.038833           1615
+seed7/prg/chkflt.sd7         0.042943          20620
+seed7/prg/chkhent.sd7        0.036667             54
+seed7/prg/chkhsh.sd7         0.040656           4548
+seed7/prg/chkidx.sd7         0.040204          19567
+seed7/prg/chkint.sd7         0.044760          38129
+seed7/prg/chkjson.sd7        0.038212           1764
+seed7/prg/chkovf.sd7         0.038342           8216
+seed7/prg/chkprc.sd7         0.036903          10111
+seed7/prg/chkscan.sd7        0.039634            714
+seed7/prg/chkset.sd7         0.040667          11974
+seed7/prg/chkstr.sd7         0.043823          26952
+seed7/prg/chktime.sd7        0.040168           2025
+seed7/prg/chktoml.sd7        0.039455           1656
+seed7/prg/clock.sd7          0.036244             47
+seed7/prg/clock2.sd7         0.035931             43
+seed7/prg/clock3.sd7         0.038861             95
+seed7/prg/cmpfil.sd7         0.037276             84
+seed7/prg/comanche.sd7       0.039976            180
+seed7/prg/confval.sd7        0.039845            175
+seed7/prg/db7.sd7            0.038673            417
+seed7/prg/diff7.sd7          0.039508            263
+seed7/prg/dirtst.sd7         0.035832             42
+seed7/prg/dirx.sd7           0.039148            152
+seed7/prg/dnafight.sd7       0.039256           1381
+seed7/prg/dragon.sd7         0.037084             73
+seed7/prg/echo.sd7           0.035840             39
+seed7/prg/eliza.sd7          0.038480            302
+seed7/prg/err.sd7            0.041497             96
+seed7/prg/fannkuch.sd7       0.038850            131
+seed7/prg/fib.sd7            0.036270             47
+seed7/prg/find7.sd7          0.038128            133
+seed7/prg/findchar.sd7       0.037644            149
+seed7/prg/fractree.sd7       0.036008             55
+seed7/prg/ftp7.sd7           0.038263            296
+seed7/prg/ftpserv.sd7        0.036636             74
+seed7/prg/gcd.sd7            0.036600            109
+seed7/prg/gkbd.sd7           0.041739            358
+seed7/prg/gtksvtst.sd7       0.037901             94
+seed7/prg/hal.sd7            0.038748            250
+seed7/prg/hamu.sd7           0.039044            573
+seed7/prg/hanoi.sd7          0.036748             55
+seed7/prg/hd.sd7             0.037358             79
+seed7/prg/hello.sd7          0.035914             32
+seed7/prg/hilbert.sd7        0.038002            108
+seed7/prg/ide7.sd7           0.039122            196
+seed7/prg/kbd.sd7            0.036309             49
+seed7/prg/klondike.sd7       0.038791            883
+seed7/prg/lander.sd7         0.039758           1551
+seed7/prg/lst80bas.sd7       0.038239            344
+seed7/prg/lst99bas.sd7       0.040226            401
+seed7/prg/lstgwbas.sd7       0.040155            577
+seed7/prg/mahjong.sd7        0.039242           1943
+seed7/prg/make7.sd7          0.039133            121
+seed7/prg/mandelbr.sd7       0.038886            237
+seed7/prg/mind.sd7           0.039333            443
+seed7/prg/mirror.sd7         0.039784            131
+seed7/prg/ms.sd7             0.038915            641
+seed7/prg/nicoma.sd7         0.037802            135
+seed7/prg/pac.sd7            0.037655            726
+seed7/prg/pairs.sd7          0.038169           2025
+seed7/prg/panic.sd7          0.038258           2634
+seed7/prg/percolation.sd7    0.037776            330
+seed7/prg/planets.sd7        0.039702           1486
+seed7/prg/portfwd7.sd7       0.038787            139
+seed7/prg/prime.sd7          0.037227             74
+seed7/prg/printpi1.sd7       0.036577             56
+seed7/prg/printpi2.sd7       0.036592             54
+seed7/prg/printpi3.sd7       0.037002             60
+seed7/prg/pv7.sd7            0.038872            337
+seed7/prg/queen.sd7          0.038992            149
+seed7/prg/rand.sd7           0.038755            121
+seed7/prg/raytrace.sd7       0.039390            538
+seed7/prg/rever.sd7          0.039329            816
+seed7/prg/roman.sd7          0.036689             38
+seed7/prg/s7c.sd7            0.039531           9060
+seed7/prg/s7check.sd7        0.037286             68
+seed7/prg/savehd7.sd7        0.039173           1110
+seed7/prg/self.sd7           0.036279             49
+seed7/prg/shisen.sd7         0.041451           1423
+seed7/prg/sl.sd7             0.039802           1029
+seed7/prg/snake.sd7          0.039184            615
+seed7/prg/sokoban.sd7        0.038652            891
+seed7/prg/spigotpi.sd7       0.036779             64
+seed7/prg/sql7.sd7           0.038799            278
+seed7/prg/startrek.sd7       0.039054            979
+seed7/prg/sudoku7.sd7        0.038012           2657
+seed7/prg/sydir7.sd7         0.037755            384
+seed7/prg/syntaxhl.sd7       0.040387            177
+seed7/prg/tak.sd7            0.035933             59
+seed7/prg/tar7.sd7           0.037935            121
+seed7/prg/tch.sd7            0.038407             55
+seed7/prg/testfont.sd7       0.039394             95
+seed7/prg/tet.sd7            0.039365            479
+seed7/prg/tetg.sd7           0.039147            501
+seed7/prg/toutf8.sd7         0.043206            240
+seed7/prg/tst_cli.sd7        0.037136             40
+seed7/prg/tst_srv.sd7        0.037197             47
+seed7/prg/wator.sd7          0.039185            651
+seed7/prg/which.sd7          0.037278             65
+seed7/prg/wiz.sd7            0.039058           2833
+seed7/prg/wordcnt.sd7        0.036434             54
+seed7/prg/wrinum.sd7         0.036001             43
+seed7/prg/wumpus.sd7         0.038856            372
+seed7/lib/aes.s7i            0.044037           1144
+seed7/lib/aes_gcm.s7i        0.045484            392
+seed7/lib/ar.s7i             0.040273           1532
+seed7/lib/arc4.s7i           0.039581            144
+seed7/lib/archive.s7i        0.038679            143
+seed7/lib/archive_base.s7i   0.038855            135
+seed7/lib/array.s7i          0.039184            610
+seed7/lib/asn1.s7i           0.037684            544
+seed7/lib/asn1oid.s7i        0.043004            157
+seed7/lib/basearray.s7i      0.039132            450
+seed7/lib/bigfile.s7i        0.037736            136
+seed7/lib/bigint.s7i         0.037570            824
+seed7/lib/bigrat.s7i         0.037910            784
+seed7/lib/bin16.s7i          0.038039            592
+seed7/lib/bin32.s7i          0.039379            490
+seed7/lib/bin64.s7i          0.039304            539
+seed7/lib/bitdata.s7i        0.044821           1330
+seed7/lib/bitmapfont.s7i     0.039013            215
+seed7/lib/bitset.s7i         0.039150            593
+seed7/lib/bitsetof.s7i       0.040467            431
+seed7/lib/blowfish.s7i       0.042518            383
+seed7/lib/bmp.s7i            0.039929            924
+seed7/lib/boolean.s7i        0.038943            403
+seed7/lib/browser.s7i        0.039189            280
+seed7/lib/bstring.s7i        0.038695            227
+seed7/lib/bytedata.s7i       0.038719            482
+seed7/lib/bzip2.s7i          0.038890            887
+seed7/lib/cards.s7i          0.037032           1342
+seed7/lib/category.s7i       0.039605            209
+seed7/lib/cc_conf.s7i        0.038793           1314
+seed7/lib/ccittfax.s7i       0.039048           1022
+seed7/lib/cgi.s7i            0.038259            109
+seed7/lib/cgidialog.s7i      0.038783           1118
+seed7/lib/char.s7i           0.038832            356
+seed7/lib/charsets.s7i       0.039404           2024
+seed7/lib/chartype.s7i       0.042110            121
+seed7/lib/cipher.s7i         0.037894            146
+seed7/lib/cli_cmds.s7i       0.038095           1360
+seed7/lib/clib_file.s7i      0.037972            301
+seed7/lib/color.s7i          0.038189            185
+seed7/lib/complex.s7i        0.037927            464
+seed7/lib/compress.s7i       0.038967            150
+seed7/lib/console.s7i        0.038586            188
+seed7/lib/cpio.s7i           0.039126           1708
+seed7/lib/crc32.s7i          0.039847            193
+seed7/lib/cronos16.s7i       0.042624           1173
+seed7/lib/cronos27.s7i       0.043017           1464
+seed7/lib/csv.s7i            0.038764            201
+seed7/lib/db_prop.s7i        0.038943            991
+seed7/lib/deflate.s7i        0.039921            740
+seed7/lib/des.s7i            0.039876            444
+seed7/lib/dialog.s7i         0.043154            311
+seed7/lib/dir.s7i            0.040432            163
+seed7/lib/draw.s7i           0.039447            854
+seed7/lib/duration.s7i       0.039535           1038
+seed7/lib/echo.s7i           0.038721            132
+seed7/lib/editline.s7i       0.038663            398
+seed7/lib/elf.s7i            0.040300           1560
+seed7/lib/elliptic.s7i       0.039393            649
+seed7/lib/enable_io.s7i      0.038666            312
+seed7/lib/encoding.s7i       0.039629            931
+seed7/lib/enumeration.s7i    0.038916            236
+seed7/lib/environment.s7i    0.038345            175
+seed7/lib/exif.s7i           0.039074            152
+seed7/lib/external_file.s7i  0.038012            340
+seed7/lib/field.s7i          0.037730            268
+seed7/lib/file.s7i           0.037527            372
+seed7/lib/filebits.s7i       0.035778             46
+seed7/lib/filesys.s7i        0.038809            601
+seed7/lib/fileutil.s7i       0.039257            144
+seed7/lib/fixarray.s7i       0.040092            307
+seed7/lib/float.s7i          0.039137            757
+seed7/lib/font.s7i           0.038333            196
+seed7/lib/font8x8.s7i        0.038187            998
+seed7/lib/forloop.s7i        0.040117            449
+seed7/lib/ftp.s7i            0.039164            969
+seed7/lib/ftpserv.s7i        0.038804            631
+seed7/lib/getf.s7i           0.038319            115
+seed7/lib/gethttp.s7i        0.036483             41
+seed7/lib/gethttps.s7i       0.036397             41
+seed7/lib/gif.s7i            0.038927            561
+seed7/lib/graph.s7i          0.040682            415
+seed7/lib/graph_file.s7i     0.039152            399
+seed7/lib/gtkserver.s7i      0.038087            161
+seed7/lib/gzip.s7i           0.039364            573
+seed7/lib/hash.s7i           0.040428            421
+seed7/lib/hashsetof.s7i      0.040849            499
+seed7/lib/hmac.s7i           0.038760            152
+seed7/lib/html.s7i           0.037693             83
+seed7/lib/html_ent.s7i       0.039261            476
+seed7/lib/htmldom.s7i        0.038975            286
+seed7/lib/http_request.s7i   0.038077            696
+seed7/lib/http_srv_resp.s7i  0.037646            380
+seed7/lib/https_request.s7i  0.037782            211
+seed7/lib/httpserv.s7i       0.037696            345
+seed7/lib/huffman.s7i        0.038374            644
+seed7/lib/ico.s7i            0.040660            221
+seed7/lib/idxarray.s7i       0.039035            232
+seed7/lib/image.s7i          0.038434            156
+seed7/lib/imagefile.s7i      0.038713            171
+seed7/lib/inflate.s7i        0.039263            411
+seed7/lib/inifile.s7i        0.038966            129
+seed7/lib/integer.s7i        0.039413            663
+seed7/lib/iobuffer.s7i       0.039328            289
+seed7/lib/jpeg.s7i           0.038971           1761
+seed7/lib/json.s7i           0.038197            891
+seed7/lib/json_serde.s7i     0.037541            783
+seed7/lib/keybd.s7i          0.037865            639
+seed7/lib/keydescr.s7i       0.038864            192
+seed7/lib/leb128.s7i         0.038285            218
+seed7/lib/line.s7i           0.038413            164
+seed7/lib/listener.s7i       0.037865            247
+seed7/lib/logfile.s7i        0.036157             73
+seed7/lib/lower.s7i          0.037313            142
+seed7/lib/lzma.s7i           0.039597            934
+seed7/lib/lzw.s7i            0.039198            861
+seed7/lib/magic.s7i          0.040863            403
+seed7/lib/mahjng32.s7i       0.038591           1500
+seed7/lib/make.s7i           0.038324            544
+seed7/lib/makedata.s7i       0.038025           1428
+seed7/lib/math.s7i           0.037805            201
+seed7/lib/mixarith.s7i       0.037575            249
+seed7/lib/modern27.s7i       0.041605           1099
+seed7/lib/more.s7i           0.038535            130
+seed7/lib/msgdigest.s7i      0.040005           1222
+seed7/lib/multiscr.s7i       0.037520             68
+seed7/lib/null_file.s7i      0.040045            345
+seed7/lib/osfiles.s7i        0.042140           1085
+seed7/lib/pbm.s7i            0.039315            230
+seed7/lib/pcx.s7i            0.039171            638
+seed7/lib/pem.s7i            0.038904            185
+seed7/lib/pgm.s7i            0.039126            238
+seed7/lib/pic16.s7i          0.038242           1037
+seed7/lib/pic32.s7i          0.037978           2060
+seed7/lib/pic_util.s7i       0.038954            144
+seed7/lib/pixelimage.s7i     0.038694            320
+seed7/lib/pixmap_file.s7i    0.038637            459
+seed7/lib/pixmapfont.s7i     0.040179            184
+seed7/lib/pkcs1.s7i          0.044232            543
+seed7/lib/png.s7i            0.038902           1064
+seed7/lib/poll.s7i           0.038938            313
+seed7/lib/ppm.s7i            0.039158            240
+seed7/lib/process.s7i        0.040314            541
+seed7/lib/progs.s7i          0.038894            789
+seed7/lib/propertyfile.s7i   0.039390            155
+seed7/lib/rational.s7i       0.042018            792
+seed7/lib/ref_list.s7i       0.040787            252
+seed7/lib/reference.s7i      0.038228            126
+seed7/lib/reverse.s7i        0.036747             94
+seed7/lib/rpm.s7i            0.038481           3487
+seed7/lib/rpmext.s7i         0.039237            318
+seed7/lib/scanfile.s7i       0.039193           1779
+seed7/lib/scanjson.s7i       0.039907            413
+seed7/lib/scanstri.s7i       0.039103           1814
+seed7/lib/scantoml.s7i       0.039246           1603
+seed7/lib/seed7_05.s7i       0.041095           1072
+seed7/lib/set.s7i            0.037119             57
+seed7/lib/shell.s7i          0.039097            615
+seed7/lib/showtls.s7i        0.039545            678
+seed7/lib/signature.s7i      0.039005            131
+seed7/lib/smtp.s7i           0.038895            261
+seed7/lib/sockbase.s7i       0.040442            217
+seed7/lib/socket.s7i         0.039332            326
+seed7/lib/sokoban1.s7i       0.038295           1519
+seed7/lib/sql_base.s7i       0.038787           1000
+seed7/lib/stars.s7i          0.041030           1705
+seed7/lib/stdfont10.s7i      0.038041           3347
+seed7/lib/stdfont12.s7i      0.039161           3928
+seed7/lib/stdfont14.s7i      0.038599           4510
+seed7/lib/stdfont16.s7i      0.038797           5092
+seed7/lib/stdfont18.s7i      0.038951           5868
+seed7/lib/stdfont20.s7i      0.039115           6449
+seed7/lib/stdfont24.s7i      0.038375           7421
+seed7/lib/stdfont8.s7i       0.036639           2960
+seed7/lib/stdfont9.s7i       0.036451           3152
+seed7/lib/stdio.s7i          0.037405            192
+seed7/lib/strifile.s7i       0.037843            345
+seed7/lib/string.s7i         0.037351            779
+seed7/lib/stritext.s7i       0.040396            352
+seed7/lib/struct.s7i         0.040734            266
+seed7/lib/struct_elem.s7i    0.038995            129
+seed7/lib/subfile.s7i        0.039065            174
+seed7/lib/subrange.s7i       0.037966             78
+seed7/lib/syntax.s7i         0.040230            294
+seed7/lib/tar.s7i            0.039777           1880
+seed7/lib/tar_cmds.s7i       0.038976            752
+seed7/lib/tdes.s7i           0.038527            143
+seed7/lib/tee.s7i            0.038779            143
+seed7/lib/text.s7i           0.038676            135
+seed7/lib/tga.s7i            0.040912            676
+seed7/lib/tiff.s7i           0.041532           2771
+seed7/lib/time.s7i           0.039273           1191
+seed7/lib/tls.s7i            0.039132           2230
+seed7/lib/unicode.s7i        0.041026            575
+seed7/lib/unionfnd.s7i       0.038884            130
+seed7/lib/upper.s7i          0.038653            142
+seed7/lib/utf16.s7i          0.038445            540
+seed7/lib/utf8.s7i           0.040103            234
+seed7/lib/vecfont10.s7i      0.042395           1056
+seed7/lib/vecfont18.s7i      0.042223           1119
+seed7/lib/vector3d.s7i       0.038405            293
+seed7/lib/vectorfont.s7i     0.038146            239
+seed7/lib/wildcard.s7i       0.037743            140
+seed7/lib/window.s7i         0.037648            455
+seed7/lib/wrinum.s7i         0.038481            248
+seed7/lib/x509cert.s7i       0.040673           1243
+seed7/lib/xml_ent.s7i        0.038899             94
+seed7/lib/xmldom.s7i         0.038764            303
+seed7/lib/xz.s7i             0.038953            442
+seed7/lib/zip.s7i            0.039001           2792
+seed7/lib/zstd.s7i           0.039218           1263
+============================ ================= ================
+
+Statistical Summary — Mode B (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.038971        |
++-----------+-----------------+
+| Minimum   | 0.035641        |
++-----------+-----------------+
+| Maximum   | 0.045484        |
++-----------+-----------------+
+
+Mode C — Mode Activation + Full-Buffer Fontification (font-lock-ensure)
+-----------------------------------------------------------------------
+
+Full-buffer fontification stress test.
+
+File Load Times — Mode C (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.039796            190
+seed7/prg/bas7.sd7           0.320540          11459
+seed7/prg/bifurk.sd7         0.036679             73
+seed7/prg/bigfiles.sd7       0.037522            129
+seed7/prg/brainf7.sd7        0.036581             86
+seed7/prg/calc7.sd7          0.037928            128
+seed7/prg/carddemo.sd7       0.039091            190
+seed7/prg/castle.sd7         0.107687           3148
+seed7/prg/cat.sd7            0.036489             82
+seed7/prg/cellauto.sd7       0.036197             85
+seed7/prg/celsius.sd7        0.035504             42
+seed7/prg/chk_all.sd7        0.058226            843
+seed7/prg/chkarr.sd7         0.347293           8367
+seed7/prg/chkbig.sd7         2.038781          29026
+seed7/prg/chkbin.sd7         0.508225           6469
+seed7/prg/chkbitdata.sd7     0.606488           6624
+seed7/prg/chkbool.sd7        0.114479           3157
+seed7/prg/chkbst.sd7         0.062669            722
+seed7/prg/chkchr.sd7         0.214260           2809
+seed7/prg/chkcmd.sd7         0.066601           1205
+seed7/prg/chkdb.sd7          0.345706           7454
+seed7/prg/chkdecl.sd7        0.056302            448
+seed7/prg/chkenum.sd7        0.065252           1230
+seed7/prg/chkerr.sd7         0.192562           4663
+seed7/prg/chkexc.sd7         0.081920           2627
+seed7/prg/chkfil.sd7         0.074546           1615
+seed7/prg/chkflt.sd7         1.324083          20620
+seed7/prg/chkhent.sd7        0.036826             54
+seed7/prg/chkhsh.sd7         0.243302           4548
+seed7/prg/chkidx.sd7         1.303414          19567
+seed7/prg/chkint.sd7         2.496033          38129
+seed7/prg/chkjson.sd7        0.099312           1764
+seed7/prg/chkovf.sd7         0.552164           8216
+seed7/prg/chkprc.sd7         0.318298          10111
+seed7/prg/chkscan.sd7        0.058276            714
+seed7/prg/chkset.sd7         0.645921          11974
+seed7/prg/chkstr.sd7         1.360840          26952
+seed7/prg/chktime.sd7        0.128465           2025
+seed7/prg/chktoml.sd7        0.108550           1656
+seed7/prg/clock.sd7          0.036140             47
+seed7/prg/clock2.sd7         0.035350             43
+seed7/prg/clock3.sd7         0.037091             95
+seed7/prg/cmpfil.sd7         0.036180             84
+seed7/prg/comanche.sd7       0.039797            180
+seed7/prg/confval.sd7        0.042068            175
+seed7/prg/db7.sd7            0.045966            417
+seed7/prg/diff7.sd7          0.041202            263
+seed7/prg/dirtst.sd7         0.034234             42
+seed7/prg/dirx.sd7           0.036620            152
+seed7/prg/dnafight.sd7       0.065114           1381
+seed7/prg/dragon.sd7         0.036770             73
+seed7/prg/echo.sd7           0.035572             39
+seed7/prg/eliza.sd7          0.042800            302
+seed7/prg/err.sd7            0.040573             96
+seed7/prg/fannkuch.sd7       0.037142            131
+seed7/prg/fib.sd7            0.035300             47
+seed7/prg/find7.sd7          0.037657            133
+seed7/prg/findchar.sd7       0.038359            149
+seed7/prg/fractree.sd7       0.035888             55
+seed7/prg/ftp7.sd7           0.043128            296
+seed7/prg/ftpserv.sd7        0.036898             74
+seed7/prg/gcd.sd7            0.035564            109
+seed7/prg/gkbd.sd7           0.044293            358
+seed7/prg/gtksvtst.sd7       0.035856             94
+seed7/prg/hal.sd7            0.037986            250
+seed7/prg/hamu.sd7           0.047022            573
+seed7/prg/hanoi.sd7          0.035226             55
+seed7/prg/hd.sd7             0.034972             79
+seed7/prg/hello.sd7          0.033986             32
+seed7/prg/hilbert.sd7        0.036744            108
+seed7/prg/ide7.sd7           0.039325            196
+seed7/prg/kbd.sd7            0.034888             49
+seed7/prg/klondike.sd7       0.052704            883
+seed7/prg/lander.sd7         0.069187           1551
+seed7/prg/lst80bas.sd7       0.042145            344
+seed7/prg/lst99bas.sd7       0.043484            401
+seed7/prg/lstgwbas.sd7       0.051199            577
+seed7/prg/mahjong.sd7        0.079705           1943
+seed7/prg/make7.sd7          0.037710            121
+seed7/prg/mandelbr.sd7       0.041419            237
+seed7/prg/mind.sd7           0.044932            443
+seed7/prg/mirror.sd7         0.038521            131
+seed7/prg/ms.sd7             0.048547            641
+seed7/prg/nicoma.sd7         0.037695            135
+seed7/prg/pac.sd7            0.049233            726
+seed7/prg/pairs.sd7          0.081833           2025
+seed7/prg/panic.sd7          0.096885           2634
+seed7/prg/percolation.sd7    0.042350            330
+seed7/prg/planets.sd7        0.075766           1486
+seed7/prg/portfwd7.sd7       0.038566            139
+seed7/prg/prime.sd7          0.035249             74
+seed7/prg/printpi1.sd7       0.037763             56
+seed7/prg/printpi2.sd7       0.036366             54
+seed7/prg/printpi3.sd7       0.035089             60
+seed7/prg/pv7.sd7            0.042598            337
+seed7/prg/queen.sd7          0.037680            149
+seed7/prg/rand.sd7           0.038126            121
+seed7/prg/raytrace.sd7       0.048133            538
+seed7/prg/rever.sd7          0.053295            816
+seed7/prg/roman.sd7          0.035340             38
+seed7/prg/s7c.sd7            0.277142           9060
+seed7/prg/s7check.sd7        0.037158             68
+seed7/prg/savehd7.sd7        0.067762           1110
+seed7/prg/self.sd7           0.036094             49
+seed7/prg/shisen.sd7         0.071455           1423
+seed7/prg/sl.sd7             0.061365           1029
+seed7/prg/snake.sd7          0.046939            615
+seed7/prg/sokoban.sd7        0.052899            891
+seed7/prg/spigotpi.sd7       0.035280             64
+seed7/prg/sql7.sd7           0.040000            278
+seed7/prg/startrek.sd7       0.056921            979
+seed7/prg/sudoku7.sd7        0.099315           2657
+seed7/prg/sydir7.sd7         0.045437            384
+seed7/prg/syntaxhl.sd7       0.041217            177
+seed7/prg/tak.sd7            0.035753             59
+seed7/prg/tar7.sd7           0.037391            121
+seed7/prg/tch.sd7            0.035758             55
+seed7/prg/testfont.sd7       0.036976             95
+seed7/prg/tet.sd7            0.044078            479
+seed7/prg/tetg.sd7           0.045988            501
+seed7/prg/toutf8.sd7         0.042684            240
+seed7/prg/tst_cli.sd7        0.035061             40
+seed7/prg/tst_srv.sd7        0.035117             47
+seed7/prg/wator.sd7          0.051669            651
+seed7/prg/which.sd7          0.036033             65
+seed7/prg/wiz.sd7            0.103900           2833
+seed7/prg/wordcnt.sd7        0.035800             54
+seed7/prg/wrinum.sd7         0.035815             43
+seed7/prg/wumpus.sd7         0.042048            372
+seed7/lib/aes.s7i            0.107429           1144
+seed7/lib/aes_gcm.s7i        0.045456            392
+seed7/lib/ar.s7i             0.070887           1532
+seed7/lib/arc4.s7i           0.036908            144
+seed7/lib/archive.s7i        0.038833            143
+seed7/lib/archive_base.s7i   0.038153            135
+seed7/lib/array.s7i          0.055528            610
+seed7/lib/asn1.s7i           0.051307            544
+seed7/lib/asn1oid.s7i        0.042126            157
+seed7/lib/basearray.s7i      0.048249            450
+seed7/lib/bigfile.s7i        0.038358            136
+seed7/lib/bigint.s7i         0.055344            824
+seed7/lib/bigrat.s7i         0.053664            784
+seed7/lib/bin16.s7i          0.050713            592
+seed7/lib/bin32.s7i          0.048206            490
+seed7/lib/bin64.s7i          0.049547            539
+seed7/lib/bitdata.s7i        0.076242           1330
+seed7/lib/bitmapfont.s7i     0.039798            215
+seed7/lib/bitset.s7i         0.048801            593
+seed7/lib/bitsetof.s7i       0.047479            431
+seed7/lib/blowfish.s7i       0.055327            383
+seed7/lib/bmp.s7i            0.058149            924
+seed7/lib/boolean.s7i        0.043013            403
+seed7/lib/browser.s7i        0.041473            280
+seed7/lib/bstring.s7i        0.039423            227
+seed7/lib/bytedata.s7i       0.050196            482
+seed7/lib/bzip2.s7i          0.058401            887
+seed7/lib/cards.s7i          0.066276           1342
+seed7/lib/category.s7i       0.041142            209
+seed7/lib/cc_conf.s7i        0.078009           1314
+seed7/lib/ccittfax.s7i       0.065417           1022
+seed7/lib/cgi.s7i            0.038393            109
+seed7/lib/cgidialog.s7i      0.060381           1118
+seed7/lib/char.s7i           0.043687            356
+seed7/lib/charsets.s7i       0.081323           2024
+seed7/lib/chartype.s7i       0.039794            121
+seed7/lib/cipher.s7i         0.037943            146
+seed7/lib/cli_cmds.s7i       0.068563           1360
+seed7/lib/clib_file.s7i      0.043429            301
+seed7/lib/color.s7i          0.040815            185
+seed7/lib/complex.s7i        0.045176            464
+seed7/lib/compress.s7i       0.037106            150
+seed7/lib/console.s7i        0.038076            188
+seed7/lib/cpio.s7i           0.079210           1708
+seed7/lib/crc32.s7i          0.042018            193
+seed7/lib/cronos16.s7i       0.093756           1173
+seed7/lib/cronos27.s7i       0.116094           1464
+seed7/lib/csv.s7i            0.041097            201
+seed7/lib/db_prop.s7i        0.062947            991
+seed7/lib/deflate.s7i        0.055592            740
+seed7/lib/des.s7i            0.055298            444
+seed7/lib/dialog.s7i         0.043716            311
+seed7/lib/dir.s7i            0.038807            163
+seed7/lib/draw.s7i           0.056065            854
+seed7/lib/duration.s7i       0.061209           1038
+seed7/lib/echo.s7i           0.037800            132
+seed7/lib/editline.s7i       0.045321            398
+seed7/lib/elf.s7i            0.085055           1560
+seed7/lib/elliptic.s7i       0.052262            649
+seed7/lib/enable_io.s7i      0.042328            312
+seed7/lib/encoding.s7i       0.059165            931
+seed7/lib/enumeration.s7i    0.040140            236
+seed7/lib/environment.s7i    0.037755            175
+seed7/lib/exif.s7i           0.038658            152
+seed7/lib/external_file.s7i  0.044355            340
+seed7/lib/field.s7i          0.042342            268
+seed7/lib/file.s7i           0.044704            372
+seed7/lib/filebits.s7i       0.036638             46
+seed7/lib/filesys.s7i        0.048498            601
+seed7/lib/fileutil.s7i       0.038253            144
+seed7/lib/fixarray.s7i       0.043482            307
+seed7/lib/float.s7i          0.054847            757
+seed7/lib/font.s7i           0.039342            196
+seed7/lib/font8x8.s7i        0.048092            998
+seed7/lib/forloop.s7i        0.044878            449
+seed7/lib/ftp.s7i            0.057552            969
+seed7/lib/ftpserv.s7i        0.051207            631
+seed7/lib/getf.s7i           0.037326            115
+seed7/lib/gethttp.s7i        0.074253             41
+seed7/lib/gethttps.s7i       0.044141             41
+seed7/lib/gif.s7i            0.054107            561
+seed7/lib/graph.s7i          0.050681            415
+seed7/lib/graph_file.s7i     0.043524            399
+seed7/lib/gtkserver.s7i      0.038838            161
+seed7/lib/gzip.s7i           0.049967            573
+seed7/lib/hash.s7i           0.049338            421
+seed7/lib/hashsetof.s7i      0.049146            499
+seed7/lib/hmac.s7i           0.039053            152
+seed7/lib/html.s7i           0.037622             83
+seed7/lib/html_ent.s7i       0.047020            476
+seed7/lib/htmldom.s7i        0.044149            286
+seed7/lib/http_request.s7i   0.052089            696
+seed7/lib/http_srv_resp.s7i  0.045850            380
+seed7/lib/https_request.s7i  0.040680            211
+seed7/lib/httpserv.s7i       0.043889            345
+seed7/lib/huffman.s7i        0.053024            644
+seed7/lib/ico.s7i            0.040776            221
+seed7/lib/idxarray.s7i       0.043989            232
+seed7/lib/image.s7i          0.037887            156
+seed7/lib/imagefile.s7i      0.039373            171
+seed7/lib/inflate.s7i        0.046893            411
+seed7/lib/inifile.s7i        0.037710            129
+seed7/lib/integer.s7i        0.051963            663
+seed7/lib/iobuffer.s7i       0.041593            289
+seed7/lib/jpeg.s7i           0.082191           1761
+seed7/lib/json.s7i           0.054836            891
+seed7/lib/json_serde.s7i     0.052223            783
+seed7/lib/keybd.s7i          0.054415            639
+seed7/lib/keydescr.s7i       0.043224            192
+seed7/lib/leb128.s7i         0.041221            218
+seed7/lib/line.s7i           0.039093            164
+seed7/lib/listener.s7i       0.041499            247
+seed7/lib/logfile.s7i        0.037016             73
+seed7/lib/lower.s7i          0.038169            142
+seed7/lib/lzma.s7i           0.059898            934
+seed7/lib/lzw.s7i            0.058933            861
+seed7/lib/magic.s7i          0.048613            403
+seed7/lib/mahjng32.s7i       0.064028           1500
+seed7/lib/make.s7i           0.049502            544
+seed7/lib/makedata.s7i       0.070665           1428
+seed7/lib/math.s7i           0.040481            201
+seed7/lib/mixarith.s7i       0.041120            249
+seed7/lib/modern27.s7i       0.087749           1099
+seed7/lib/more.s7i           0.040495            130
+seed7/lib/msgdigest.s7i      0.077597           1222
+seed7/lib/multiscr.s7i       0.036406             68
+seed7/lib/null_file.s7i      0.044404            345
+seed7/lib/osfiles.s7i        0.063739           1085
+seed7/lib/pbm.s7i            0.041052            230
+seed7/lib/pcx.s7i            0.053431            638
+seed7/lib/pem.s7i            0.040178            185
+seed7/lib/pgm.s7i            0.041286            238
+seed7/lib/pic16.s7i          0.048992           1037
+seed7/lib/pic32.s7i          0.081059           2060
+seed7/lib/pic_util.s7i       0.039200            144
+seed7/lib/pixelimage.s7i     0.042997            320
+seed7/lib/pixmap_file.s7i    0.046046            459
+seed7/lib/pixmapfont.s7i     0.040507            184
+seed7/lib/pkcs1.s7i          0.059790            543
+seed7/lib/png.s7i            0.064677           1064
+seed7/lib/poll.s7i           0.044522            313
+seed7/lib/ppm.s7i            0.041074            240
+seed7/lib/process.s7i        0.049504            541
+seed7/lib/progs.s7i          0.056945            789
+seed7/lib/propertyfile.s7i   0.039087            155
+seed7/lib/rational.s7i       0.053072            792
+seed7/lib/ref_list.s7i       0.041052            252
+seed7/lib/reference.s7i      0.038676            126
+seed7/lib/reverse.s7i        0.036335             94
+seed7/lib/rpm.s7i            0.144171           3487
+seed7/lib/rpmext.s7i         0.043455            318
+seed7/lib/scanfile.s7i       0.084821           1779
+seed7/lib/scanjson.s7i       0.047865            413
+seed7/lib/scanstri.s7i       0.081274           1814
+seed7/lib/scantoml.s7i       0.072039           1603
+seed7/lib/seed7_05.s7i       0.067258           1072
+seed7/lib/set.s7i            0.037693             57
+seed7/lib/shell.s7i          0.053395            615
+seed7/lib/showtls.s7i        0.055429            678
+seed7/lib/signature.s7i      0.039270            131
+seed7/lib/smtp.s7i           0.041841            261
+seed7/lib/sockbase.s7i       0.043532            217
+seed7/lib/socket.s7i         0.043721            326
+seed7/lib/sokoban1.s7i       0.054266           1519
+seed7/lib/sql_base.s7i       0.062512           1000
+seed7/lib/stars.s7i          0.133873           1705
+seed7/lib/stdfont10.s7i      0.080080           3347
+seed7/lib/stdfont12.s7i      0.093340           3928
+seed7/lib/stdfont14.s7i      0.102736           4510
+seed7/lib/stdfont16.s7i      0.114913           5092
+seed7/lib/stdfont18.s7i      0.130979           5868
+seed7/lib/stdfont20.s7i      0.148573           6449
+seed7/lib/stdfont24.s7i      0.178800           7421
+seed7/lib/stdfont8.s7i       0.071740           2960
+seed7/lib/stdfont9.s7i       0.075489           3152
+seed7/lib/stdio.s7i          0.039184            192
+seed7/lib/strifile.s7i       0.044836            345
+seed7/lib/string.s7i         0.055210            779
+seed7/lib/stritext.s7i       0.044840            352
+seed7/lib/struct.s7i         0.044527            266
+seed7/lib/struct_elem.s7i    0.038457            129
+seed7/lib/subfile.s7i        0.038901            174
+seed7/lib/subrange.s7i       0.037209             78
+seed7/lib/syntax.s7i         0.046661            294
+seed7/lib/tar.s7i            0.083853           1880
+seed7/lib/tar_cmds.s7i       0.059596            752
+seed7/lib/tdes.s7i           0.039494            143
+seed7/lib/tee.s7i            0.038002            143
+seed7/lib/text.s7i           0.038067            135
+seed7/lib/tga.s7i            0.053158            676
+seed7/lib/tiff.s7i           0.120446           2771
+seed7/lib/time.s7i           0.062372           1191
+seed7/lib/tls.s7i            0.104350           2230
+seed7/lib/unicode.s7i        0.051193            575
+seed7/lib/unionfnd.s7i       0.037838            130
+seed7/lib/upper.s7i          0.037580            142
+seed7/lib/utf16.s7i          0.050691            540
+seed7/lib/utf8.s7i           0.041116            234
+seed7/lib/vecfont10.s7i      0.080263           1056
+seed7/lib/vecfont18.s7i      0.087671           1119
+seed7/lib/vector3d.s7i       0.042013            293
+seed7/lib/vectorfont.s7i     0.041037            239
+seed7/lib/wildcard.s7i       0.038596            140
+seed7/lib/window.s7i         0.045785            455
+seed7/lib/wrinum.s7i         0.041784            248
+seed7/lib/x509cert.s7i       0.071620           1243
+seed7/lib/xml_ent.s7i        0.037650             94
+seed7/lib/xmldom.s7i         0.041874            303
+seed7/lib/xz.s7i             0.045608            442
+seed7/lib/zip.s7i            0.118712           2792
+seed7/lib/zstd.s7i           0.069493           1263
+============================ ================= ================
+
+Statistical Summary — Mode C (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.088590        |
++-----------+-----------------+
+| Minimum   | 0.033986        |
++-----------+-----------------+
+| Maximum   | 2.496033        |
++-----------+-----------------+
+
+Mode D — Mode Activation + Full Incremental jit-lock (Scroll Pass)
+------------------------------------------------------------------
+
+The buffer is displayed and scrolled from top to bottom. After each screenful,
+`jit-lock-fontify-now` is called over the currently visible window region.
+This models incremental visible-region fontification without using `sit-for 0`.
+
+File Load Times — Mode D (mean, GC-free)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================ ================= ================
+File Name                    Mean Time (s)     Line count
+============================ ================= ================
+seed7/prg/addup.sd7          0.046340            190
+seed7/prg/bas7.sd7           0.758885          11459
+seed7/prg/bifurk.sd7         0.039392             73
+seed7/prg/bigfiles.sd7       0.043517            129
+seed7/prg/brainf7.sd7        0.039539             86
+seed7/prg/calc7.sd7          0.043399            128
+seed7/prg/carddemo.sd7       0.048539            190
+seed7/prg/castle.sd7         0.214801           3148
+seed7/prg/cat.sd7            0.038890             82
+seed7/prg/cellauto.sd7       0.039413             85
+seed7/prg/celsius.sd7        0.037417             42
+seed7/prg/chk_all.sd7        0.081593            843
+seed7/prg/chkarr.sd7         0.857720           8367
+seed7/prg/chkbig.sd7         4.114234          29026
+seed7/prg/chkbin.sd7         1.027267           6469
+seed7/prg/chkbitdata.sd7     1.248920           6624
+seed7/prg/chkbool.sd7        0.229338           3157
+seed7/prg/chkbst.sd7         0.099723            722
+seed7/prg/chkchr.sd7         0.478684           2809
+seed7/prg/chkcmd.sd7         0.111210           1205
+seed7/prg/chkdb.sd7          0.746527           7454
+seed7/prg/chkdecl.sd7        0.093475            448
+seed7/prg/chkenum.sd7        0.121017           1230
+seed7/prg/chkerr.sd7         0.338976           4663
+seed7/prg/chkexc.sd7         0.147894           2627
+seed7/prg/chkfil.sd7         0.126709           1615
+seed7/prg/chkflt.sd7         2.798344          20620
+seed7/prg/chkhent.sd7        0.039813             54
+seed7/prg/chkhsh.sd7         0.494333           4548
+seed7/prg/chkidx.sd7         3.160179          19567
+seed7/prg/chkint.sd7         5.536954          38129
+seed7/prg/chkjson.sd7        0.185116           1764
+seed7/prg/chkovf.sd7         1.190923           8216
+seed7/prg/chkprc.sd7         0.688980          10111
+seed7/prg/chkscan.sd7        0.089044            714
+seed7/prg/chkset.sd7         1.721742          11974
+seed7/prg/chkstr.sd7         3.391772          26952
+seed7/prg/chktime.sd7        0.245947           2025
+seed7/prg/chktoml.sd7        0.194536           1656
+seed7/prg/clock.sd7          0.036317             47
+seed7/prg/clock2.sd7         0.036157             43
+seed7/prg/clock3.sd7         0.041640             95
+seed7/prg/cmpfil.sd7         0.038497             84
+seed7/prg/comanche.sd7       0.046228            180
+seed7/prg/confval.sd7        0.050141            175
+seed7/prg/db7.sd7            0.062062            417
+seed7/prg/diff7.sd7          0.051003            263
+seed7/prg/dirtst.sd7         0.036780             42
+seed7/prg/dirx.sd7           0.043694            152
+seed7/prg/dnafight.sd7       0.116318           1381
+seed7/prg/dragon.sd7         0.037373             73
+seed7/prg/echo.sd7           0.036003             39
+seed7/prg/eliza.sd7          0.051019            302
+seed7/prg/err.sd7            0.043875             96
+seed7/prg/fannkuch.sd7       0.042901            131
+seed7/prg/fib.sd7            0.036327             47
+seed7/prg/find7.sd7          0.042010            133
+seed7/prg/findchar.sd7       0.047237            149
+seed7/prg/fractree.sd7       0.042626             55
+seed7/prg/ftp7.sd7           0.053331            296
+seed7/prg/ftpserv.sd7        0.038752             74
+seed7/prg/gcd.sd7            0.040571            109
+seed7/prg/gkbd.sd7           0.061315            358
+seed7/prg/gtksvtst.sd7       0.039292             94
+seed7/prg/hal.sd7            0.047538            250
+seed7/prg/hamu.sd7           0.066304            573
+seed7/prg/hanoi.sd7          0.037027             55
+seed7/prg/hd.sd7             0.039186             79
+seed7/prg/hello.sd7          0.035893             32
+seed7/prg/hilbert.sd7        0.041206            108
+seed7/prg/ide7.sd7           0.047524            196
+seed7/prg/kbd.sd7            0.038309             49
+seed7/prg/klondike.sd7       0.086112            883
+seed7/prg/lander.sd7         0.129955           1551
+seed7/prg/lst80bas.sd7       0.055141            344
+seed7/prg/lst99bas.sd7       0.058997            401
+seed7/prg/lstgwbas.sd7       0.071995            577
+seed7/prg/mahjong.sd7        0.145280           1943
+seed7/prg/make7.sd7          0.041830            121
+seed7/prg/mandelbr.sd7       0.048170            237
+seed7/prg/mind.sd7           0.058889            443
+seed7/prg/mirror.sd7         0.043537            131
+seed7/prg/ms.sd7             0.068958            641
+seed7/prg/nicoma.sd7         0.041884            135
+seed7/prg/pac.sd7            0.070866            726
+seed7/prg/pairs.sd7          0.140105           2025
+seed7/prg/panic.sd7          0.195755           2634
+seed7/prg/percolation.sd7    0.055525            330
+seed7/prg/planets.sd7        0.136212           1486
+seed7/prg/portfwd7.sd7       0.043652            139
+seed7/prg/prime.sd7          0.037526             74
+seed7/prg/printpi1.sd7       0.037698             56
+seed7/prg/printpi2.sd7       0.037301             54
+seed7/prg/printpi3.sd7       0.037449             60
+seed7/prg/pv7.sd7            0.057814            337
+seed7/prg/queen.sd7          0.042121            149
+seed7/prg/rand.sd7           0.040568            121
+seed7/prg/raytrace.sd7       0.066954            538
+seed7/prg/rever.sd7          0.081001            816
+seed7/prg/roman.sd7          0.036325             38
+seed7/prg/s7c.sd7            0.615748           9060
+seed7/prg/s7check.sd7        0.038177             68
+seed7/prg/savehd7.sd7        0.109057           1110
+seed7/prg/self.sd7           0.036586             49
+seed7/prg/shisen.sd7         0.117880           1423
+seed7/prg/sl.sd7             0.095041           1029
+seed7/prg/snake.sd7          0.064859            615
+seed7/prg/sokoban.sd7        0.081556            891
+seed7/prg/spigotpi.sd7       0.037468             64
+seed7/prg/sql7.sd7           0.051605            278
+seed7/prg/startrek.sd7       0.092839            979
+seed7/prg/sudoku7.sd7        0.196682           2657
+seed7/prg/sydir7.sd7         0.059600            384
+seed7/prg/syntaxhl.sd7       0.048460            177
+seed7/prg/tak.sd7            0.037425             59
+seed7/prg/tar7.sd7           0.042055            121
+seed7/prg/tch.sd7            0.036896             55
+seed7/prg/testfont.sd7       0.041145             95
+seed7/prg/tet.sd7            0.061727            479
+seed7/prg/tetg.sd7           0.061796            501
+seed7/prg/toutf8.sd7         0.050789            240
+seed7/prg/tst_cli.sd7        0.036144             40
+seed7/prg/tst_srv.sd7        0.036799             47
+seed7/prg/wator.sd7          0.078735            651
+seed7/prg/which.sd7          0.037989             65
+seed7/prg/wiz.sd7            0.209747           2833
+seed7/prg/wordcnt.sd7        0.038398             54
+seed7/prg/wrinum.sd7         0.039209             43
+seed7/prg/wumpus.sd7         0.054071            372
+seed7/lib/aes.s7i            0.195561           1144
+seed7/lib/aes_gcm.s7i        0.062301            392
+seed7/lib/ar.s7i             0.123157           1532
+seed7/lib/arc4.s7i           0.042686            144
+seed7/lib/archive.s7i        0.042806            143
+seed7/lib/archive_base.s7i   0.042701            135
+seed7/lib/array.s7i          0.074586            610
+seed7/lib/asn1.s7i           0.063570            544
+seed7/lib/asn1oid.s7i        0.057710            157
+seed7/lib/basearray.s7i      0.066424            450
+seed7/lib/bigfile.s7i        0.042483            136
+seed7/lib/bigint.s7i         0.078641            824
+seed7/lib/bigrat.s7i         0.080119            784
+seed7/lib/bin16.s7i          0.068554            592
+seed7/lib/bin32.s7i          0.061917            490
+seed7/lib/bin64.s7i          0.063835            539
+seed7/lib/bitdata.s7i        0.121342           1330
+seed7/lib/bitmapfont.s7i     0.046849            215
+seed7/lib/bitset.s7i         0.063025            593
+seed7/lib/bitsetof.s7i       0.060935            431
+seed7/lib/blowfish.s7i       0.076722            383
+seed7/lib/bmp.s7i            0.099080            924
+seed7/lib/boolean.s7i        0.055243            403
+seed7/lib/browser.s7i        0.052980            280
+seed7/lib/bstring.s7i        0.049358            227
+seed7/lib/bytedata.s7i       0.066928            482
+seed7/lib/bzip2.s7i          0.089468            887
+seed7/lib/cards.s7i          0.108827           1342
+seed7/lib/category.s7i       0.050105            209
+seed7/lib/cc_conf.s7i        0.120532           1314
+seed7/lib/ccittfax.s7i       0.101381           1022
+seed7/lib/cgi.s7i            0.042180            109
+seed7/lib/cgidialog.s7i      0.098231           1118
+seed7/lib/char.s7i           0.051794            356
+seed7/lib/charsets.s7i       0.122067           2024
+seed7/lib/chartype.s7i       0.047935            121
+seed7/lib/cipher.s7i         0.042575            146
+seed7/lib/cli_cmds.s7i       0.114421           1360
+seed7/lib/clib_file.s7i      0.052799            301
+seed7/lib/color.s7i          0.046434            185
+seed7/lib/complex.s7i        0.058505            464
+seed7/lib/compress.s7i       0.043489            150
+seed7/lib/console.s7i        0.048165            188
+seed7/lib/cpio.s7i           0.142536           1708
+seed7/lib/crc32.s7i          0.054968            193
+seed7/lib/cronos16.s7i       0.193676           1173
+seed7/lib/cronos27.s7i       0.253084           1464
+seed7/lib/csv.s7i            0.047399            201
+seed7/lib/db_prop.s7i        0.101690            991
+seed7/lib/deflate.s7i        0.087900            740
+seed7/lib/des.s7i            0.080182            444
+seed7/lib/dialog.s7i         0.057342            311
+seed7/lib/dir.s7i            0.043479            163
+seed7/lib/draw.s7i           0.085536            854
+seed7/lib/duration.s7i       0.097572           1038
+seed7/lib/echo.s7i           0.043027            132
+seed7/lib/editline.s7i       0.059490            398
+seed7/lib/elf.s7i            0.154635           1560
+seed7/lib/elliptic.s7i       0.075267            649
+seed7/lib/enable_io.s7i      0.051381            312
+seed7/lib/encoding.s7i       0.095882            931
+seed7/lib/enumeration.s7i    0.048889            236
+seed7/lib/environment.s7i    0.046128            175
+seed7/lib/exif.s7i           0.046451            152
+seed7/lib/external_file.s7i  0.052909            340
+seed7/lib/field.s7i          0.052075            268
+seed7/lib/file.s7i           0.054146            372
+seed7/lib/filebits.s7i       0.038184             46
+seed7/lib/filesys.s7i        0.064750            601
+seed7/lib/fileutil.s7i       0.043615            144
+seed7/lib/fixarray.s7i       0.053668            307
+seed7/lib/float.s7i          0.083119            757
+seed7/lib/font.s7i           0.046220            196
+seed7/lib/font8x8.s7i        0.067405            998
+seed7/lib/forloop.s7i        0.065892            449
+seed7/lib/ftp.s7i            0.087179            969
+seed7/lib/ftpserv.s7i        0.079323            631
+seed7/lib/getf.s7i           0.053113            115
+seed7/lib/gethttp.s7i        0.046899             41
+seed7/lib/gethttps.s7i       0.041465             41
+seed7/lib/gif.s7i            0.074600            561
+seed7/lib/graph.s7i          0.063803            415
+seed7/lib/graph_file.s7i     0.058985            399
+seed7/lib/gtkserver.s7i      0.041358            161
+seed7/lib/gzip.s7i           0.075833            573
+seed7/lib/hash.s7i           0.065140            421
+seed7/lib/hashsetof.s7i      0.066879            499
+seed7/lib/hmac.s7i           0.045266            152
+seed7/lib/html.s7i           0.039519             83
+seed7/lib/html_ent.s7i       0.064881            476
+seed7/lib/htmldom.s7i        0.053450            286
+seed7/lib/http_request.s7i   0.077598            696
+seed7/lib/http_srv_resp.s7i  0.058567            380
+seed7/lib/https_request.s7i  0.048825            211
+seed7/lib/httpserv.s7i       0.058368            345
+seed7/lib/huffman.s7i        0.075382            644
+seed7/lib/ico.s7i            0.058891            221
+seed7/lib/idxarray.s7i       0.052069            232
+seed7/lib/image.s7i          0.041958            156
+seed7/lib/imagefile.s7i      0.045184            171
+seed7/lib/inflate.s7i        0.064272            411
+seed7/lib/inifile.s7i        0.043525            129
+seed7/lib/integer.s7i        0.068765            663
+seed7/lib/iobuffer.s7i       0.051485            289
+seed7/lib/jpeg.s7i           0.153822           1761
+seed7/lib/json.s7i           0.080672            891
+seed7/lib/json_serde.s7i     0.079814            783
+seed7/lib/keybd.s7i          0.079714            639
+seed7/lib/keydescr.s7i       0.050522            192
+seed7/lib/leb128.s7i         0.046092            218
+seed7/lib/line.s7i           0.042726            164
+seed7/lib/listener.s7i       0.047857            247
+seed7/lib/logfile.s7i        0.037935             73
+seed7/lib/lower.s7i          0.041274            142
+seed7/lib/lzma.s7i           0.098342            934
+seed7/lib/lzw.s7i            0.089035            861
+seed7/lib/magic.s7i          0.064783            403
+seed7/lib/mahjng32.s7i       0.093281           1500
+seed7/lib/make.s7i           0.070056            544
+seed7/lib/makedata.s7i       0.123006           1428
+seed7/lib/math.s7i           0.045392            201
+seed7/lib/mixarith.s7i       0.047547            249
+seed7/lib/modern27.s7i       0.170420           1099
+seed7/lib/more.s7i           0.043325            130
+seed7/lib/msgdigest.s7i      0.135405           1222
+seed7/lib/multiscr.s7i       0.038788             68
+seed7/lib/null_file.s7i      0.050355            345
+seed7/lib/osfiles.s7i        0.096699           1085
+seed7/lib/pbm.s7i            0.047975            230
+seed7/lib/pcx.s7i            0.078046            638
+seed7/lib/pem.s7i            0.046356            185
+seed7/lib/pgm.s7i            0.048944            238
+seed7/lib/pic16.s7i          0.069586           1037
+seed7/lib/pic32.s7i          0.122559           2060
+seed7/lib/pic_util.s7i       0.044829            144
+seed7/lib/pixelimage.s7i     0.053440            320
+seed7/lib/pixmap_file.s7i    0.065570            459
+seed7/lib/pixmapfont.s7i     0.048137            184
+seed7/lib/pkcs1.s7i          0.078468            543
+seed7/lib/png.s7i            0.106595           1064
+seed7/lib/poll.s7i           0.051854            313
+seed7/lib/ppm.s7i            0.049102            240
+seed7/lib/process.s7i        0.063729            541
+seed7/lib/progs.s7i          0.080543            789
+seed7/lib/propertyfile.s7i   0.044850            155
+seed7/lib/rational.s7i       0.079689            792
+seed7/lib/ref_list.s7i       0.049383            252
+seed7/lib/reference.s7i      0.042511            126
+seed7/lib/reverse.s7i        0.039642             94
+seed7/lib/rpm.s7i            0.285525           3487
+seed7/lib/rpmext.s7i         0.053163            318
+seed7/lib/scanfile.s7i       0.132552           1779
+seed7/lib/scanjson.s7i       0.060522            413
+seed7/lib/scanstri.s7i       0.134436           1814
+seed7/lib/scantoml.s7i       0.129987           1603
+seed7/lib/seed7_05.s7i       0.111653           1072
+seed7/lib/set.s7i            0.038757             57
+seed7/lib/shell.s7i          0.069626            615
+seed7/lib/showtls.s7i        0.085531            678
+seed7/lib/signature.s7i      0.043732            131
+seed7/lib/smtp.s7i           0.049627            261
+seed7/lib/sockbase.s7i       0.050549            217
+seed7/lib/socket.s7i         0.052563            326
+seed7/lib/sokoban1.s7i       0.081149           1519
+seed7/lib/sql_base.s7i       0.094541           1000
+seed7/lib/stars.s7i          0.237244           1705
+seed7/lib/stdfont10.s7i      0.146785           3347
+seed7/lib/stdfont12.s7i      0.166860           3928
+seed7/lib/stdfont14.s7i      0.187840           4510
+seed7/lib/stdfont16.s7i      0.212033           5092
+seed7/lib/stdfont18.s7i      0.243762           5868
+seed7/lib/stdfont20.s7i      0.270123           6449
+seed7/lib/stdfont24.s7i      0.330330           7421
+seed7/lib/stdfont8.s7i       0.127143           2960
+seed7/lib/stdfont9.s7i       0.133914           3152
+seed7/lib/stdio.s7i          0.044623            192
+seed7/lib/strifile.s7i       0.054980            345
+seed7/lib/string.s7i         0.075415            779
+seed7/lib/stritext.s7i       0.054569            352
+seed7/lib/struct.s7i         0.054063            266
+seed7/lib/struct_elem.s7i    0.041491            129
+seed7/lib/subfile.s7i        0.043724            174
+seed7/lib/subrange.s7i       0.040125             78
+seed7/lib/syntax.s7i         0.060599            294
+seed7/lib/tar.s7i            0.146005           1880
+seed7/lib/tar_cmds.s7i       0.085048            752
+seed7/lib/tdes.s7i           0.043823            143
+seed7/lib/tee.s7i            0.042326            143
+seed7/lib/text.s7i           0.042927            135
+seed7/lib/tga.s7i            0.080610            676
+seed7/lib/tiff.s7i           0.245623           2771
+seed7/lib/time.s7i           0.102027           1191
+seed7/lib/tls.s7i            0.193588           2230
+seed7/lib/unicode.s7i        0.073958            575
+seed7/lib/unionfnd.s7i       0.044623            130
+seed7/lib/upper.s7i          0.041954            142
+seed7/lib/utf16.s7i          0.065809            540
+seed7/lib/utf8.s7i           0.048400            234
+seed7/lib/vecfont10.s7i      0.159930           1056
+seed7/lib/vecfont18.s7i      0.180332           1119
+seed7/lib/vector3d.s7i       0.049991            293
+seed7/lib/vectorfont.s7i     0.048568            239
+seed7/lib/wildcard.s7i       0.042993            140
+seed7/lib/window.s7i         0.059905            455
+seed7/lib/wrinum.s7i         0.049815            248
+seed7/lib/x509cert.s7i       0.116278           1243
+seed7/lib/xml_ent.s7i        0.040189             94
+seed7/lib/xmldom.s7i         0.051537            303
+seed7/lib/xz.s7i             0.061031            442
+seed7/lib/zip.s7i            0.232629           2792
+seed7/lib/zstd.s7i           0.117666           1263
+============================ ================= ================
+
+Statistical Summary — Mode D (GC-free, mean-of-N)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------+-----------------+
+| Metric    | Mean Time (s)   |
++===========+=================+
+| Average   | 0.158256        |
++-----------+-----------------+
+| Minimum   | 0.035893        |
++-----------+-----------------+
+| Maximum   | 5.536954        |
++-----------+-----------------+
+
+Cross-Mode Comparison
+=====================
+
++------+-----------------+-----------------+-----------------+
+| Mode | Average (s)     | Minimum (s)     | Maximum (s)     |
++======+=================+=================+=================+
+| A    | 0.033717        | 0.032423        | 0.039414        |
++------+-----------------+-----------------+-----------------+
+| B    | 0.038971        | 0.035641        | 0.045484        |
++------+-----------------+-----------------+-----------------+
+| C    | 0.088590        | 0.033986        | 2.496033        |
++------+-----------------+-----------------+-----------------+
+| D    | 0.158256        | 0.035893        | 5.536954        |
++------+-----------------+-----------------+-----------------+
+
+Phase Timing Summary
+====================
+
+Wall-clock times include warm-up work and GC performed by the warm-up helper.
+
++----------+--------------+--------------+--------------+
+| Phase    | Warm-up      | Timed pass   | Mode total   |
++==========+==============+==============+==============+
+| Mode A   | 00:00:12.362 | 00:00:57.433 | 00:01:09.795 |
++----------+--------------+--------------+--------------+
+| Mode B   | 00:00:14.988 | 00:01:06.450 | 00:01:21.439 |
++----------+--------------+--------------+--------------+
+| Mode C   | 00:00:35.868 | 00:02:31.767 | 00:03:07.635 |
++----------+--------------+--------------+--------------+
+| Mode D   | 00:01:00.478 | 00:04:30.467 | 00:05:30.945 |
++----------+--------------+--------------+--------------+
+| Total    |              |              | 00:11:09.823 |
++----------+--------------+--------------+--------------+
+
+
+.. ---------------------------------------------------------------------------

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260630.1125
+;; Package-Version: 20260630.1245
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-30T15:25:53+0000 W27-2"
+(defconst seed7-mode-version-timestamp "2026-06-30T16:45:51+0000 W27-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5671,11 +5671,7 @@ N is: - :previous-non-empty for the previous non-empty line,
     (seed7-to-block-forward :dont-push-mark)
     (point))
    ;;
-   ((string= header "exception")
-    (seed7-to-next-line-starts-with "end block")
-    (point))
-   ;;
-   ((member header '("catch " "catch\t"))
+   ((member header '("exception" "catch " "catch\t"))
     (seed7-to-next-line-starts-with "end block")
     (point))
    ;;

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260629.1554
+;; Package-Version: 20260629.1602
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-29T19:54:51+0000 W27-1"
+(defconst seed7-mode-version-timestamp "2026-06-29T20:02:33+0000 W27-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6103,7 +6103,7 @@ If a block is found, return a list of 5 elements:
            ;; Fast path: if current-line cache is valid: use it
            (seed7--cached-block-spec-current-line))
       ;;
-      ;; Cache miss or cached block is outside requested lower bound.
+      ;; Cache miss
       (let ((spec (seed7-line-inside-a-block
                    n dont-skip-comment-start beg-bound)))
         (when (and (eq n 0) spec)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260630.1006
+;; Package-Version: 20260630.1125
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-30T14:06:30+0000 W27-2"
+(defconst seed7-mode-version-timestamp "2026-06-30T15:25:53+0000 W27-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5640,56 +5640,46 @@ N is: - :previous-non-empty for the previous non-empty line,
       - A negative number for previous lines: -1 previous, -2 line before..."
   (seed7-line-starts-with n seed7-block-end-regexp dont-skip-comment-start))
 
-(defconst seed7--block-end-kind-by-header
-  (let ((table (make-hash-table :test #'equal)))
-    ;; Headers whose end can be found with `seed7-to-block-forward'.
-    (dolist (header '("const proc: "
-                      "const func "
-                      "const type: "
-                      "local"
-                      "repeat"
-                      "begin"
-                      "block"
-                      "global"
-                      "else"
-                      "result"
-                      "if "
-                      "elsif "
-                      "while "
-                      "for "
-                      "case "
-                      ;; Also support tabs when caller did not normalize them.
-                      "const proc:\t"
-                      "const func\t"
-                      "const type:\t"
-                      "if\t"
-                      "elsif\t"
-                      "while\t"
-                      "for\t"
-                      "case\t"))
-      (puthash header 'block-forward table))
-    ;; Headers whose end is the `end block` line.
-    (puthash "exception" 'end-block table)
-    (puthash "catch " 'end-block table)
-    (puthash "catch\t" 'end-block table)
-    table)
-  "Map a Seed7 block header string to the strategy used to locate its end.")
-
 (defun seed7--block-end-pos-for (header)
   "Return position of end of block starting with HEADER.
-Move point."
-  (let ((val (gethash header seed7--block-end-kind-by-header)))
-    (cond
-     ;;
-     ((eq val 'block-forward)
-      (seed7-to-block-forward :dont-push-mark)
-      (point))
-     ;;
-     ((eq val 'end-block)
-      (seed7-to-next-line-starts-with "end block")
-      (point))
-     ;;
-     (t (error "Unsupported block header: %s" header)))))
+ Move point."
+  (cond
+   ((member header '("const proc: "
+                     "const func "
+                     "const type: "
+                     "local"
+                     "repeat"
+                     "begin"
+                     "block"
+                     "global"
+                     "else"
+                     "result"
+                     "if "
+                     "elsif "
+                     "while "
+                     "for "
+                     "case "
+                     ;; ... also support tabs when caller did not normalize them.
+                     "const proc:\t"
+                     "const func\t"
+                     "const type:\t"
+                     "if\t"
+                     "elsif\t"
+                     "while\t"
+                     "for\t"
+                     "case\t"))
+    (seed7-to-block-forward :dont-push-mark)
+    (point))
+   ;;
+   ((string= header "exception")
+    (seed7-to-next-line-starts-with "end block")
+    (point))
+   ;;
+   ((member header '("catch " "catch\t"))
+    (seed7-to-next-line-starts-with "end block")
+    (point))
+   ;;
+   (t (error "Unsupported block header: %s" header))))
 
 (defun seed7--indent-offset-for (header first-text)
   "Return indentation offset (in columns) for the inside of a block.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260629.2326
+;; Package-Version: 20260630.1006
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-30T03:26:24+0000 W27-2"
+(defconst seed7-mode-version-timestamp "2026-06-30T14:06:30+0000 W27-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5640,46 +5640,56 @@ N is: - :previous-non-empty for the previous non-empty line,
       - A negative number for previous lines: -1 previous, -2 line before..."
   (seed7-line-starts-with n seed7-block-end-regexp dont-skip-comment-start))
 
+(defconst seed7--block-end-kind-by-header
+  (let ((table (make-hash-table :test #'equal)))
+    ;; Headers whose end can be found with `seed7-to-block-forward'.
+    (dolist (header '("const proc: "
+                      "const func "
+                      "const type: "
+                      "local"
+                      "repeat"
+                      "begin"
+                      "block"
+                      "global"
+                      "else"
+                      "result"
+                      "if "
+                      "elsif "
+                      "while "
+                      "for "
+                      "case "
+                      ;; Also support tabs when caller did not normalize them.
+                      "const proc:\t"
+                      "const func\t"
+                      "const type:\t"
+                      "if\t"
+                      "elsif\t"
+                      "while\t"
+                      "for\t"
+                      "case\t"))
+      (puthash header 'block-forward table))
+    ;; Headers whose end is the `end block` line.
+    (puthash "exception" 'end-block table)
+    (puthash "catch " 'end-block table)
+    (puthash "catch\t" 'end-block table)
+    table)
+  "Map a Seed7 block header string to the strategy used to locate its end.")
+
 (defun seed7--block-end-pos-for (header)
   "Return position of end of block starting with HEADER.
 Move point."
-  (cond
-   ((member header '("const proc: "
-                     "const func "
-                     "const type: "
-                     "local"
-                     "repeat"
-                     "begin"
-                     "block"
-                     "global"
-                     "else"
-                     "result"
-                     "if "
-                     "elsif "
-                     "while "
-                     "for "
-                     "case "
-                     ;; ... also support tabs when caller did not normalize them.
-                     "const proc:\t"
-                     "const func\t"
-                     "const type:\t"
-                     "if\t"
-                     "elsif\t"
-                     "while\t"
-                     "for\t"
-                     "case\t"))
-    (seed7-to-block-forward :dont-push-mark)
-    (point))
-   ;;
-   ((string= header "exception")
-    (seed7-to-next-line-starts-with "end block")
-    (point))
-   ;;
-   ((member header '("catch " "catch\t"))
-    (seed7-to-next-line-starts-with "end block")
-    (point))
-   ;;
-   (t (error "Unsupported block header: %s" header))))
+  (let ((val (gethash header seed7--block-end-kind-by-header)))
+    (cond
+     ;;
+     ((eq val 'block-forward)
+      (seed7-to-block-forward :dont-push-mark)
+      (point))
+     ;;
+     ((eq val 'end-block)
+      (seed7-to-next-line-starts-with "end block")
+      (point))
+     ;;
+     (t (error "Unsupported block header: %s" header)))))
 
 (defun seed7--indent-offset-for (header first-text)
   "Return indentation offset (in columns) for the inside of a block.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260629.1527
+;; Package-Version: 20260629.1554
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-29T19:27:22+0000 W27-1"
+(defconst seed7-mode-version-timestamp "2026-06-29T19:54:51+0000 W27-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6097,21 +6097,13 @@ If a block is found, return a list of 5 elements:
 - 2: block start position (the beginning of the start keyword line),
 - 3: enclosing block end position,
 - 4: indent column of the block start line."
-  (let ((cached-spec
-         (and (eq n 0)
-              (not dont-skip-comment-start)
-              (not beg-bound)
-              (seed7--cached-block-spec-current-line))))
-    (cond
-     ;; Fast path: cached spec is still valid for current line, and if a
-     ;; lower bound is supplied, the cached block still starts at or after it.
-     ((and cached-spec
-           (or (not beg-bound)
-               (<= beg-bound (nth 2 cached-spec))))
-      cached-spec)
-     ;;
-     ;; Cache miss or cached block is outside requested lower bound.
-     (t
+  (or (and (eq n 0)
+           (not dont-skip-comment-start)
+           (not beg-bound)
+           ;; Fast path: if current-line cache is valid: use it
+           (seed7--cached-block-spec-current-line))
+      ;;
+      ;; Cache miss or cached block is outside requested lower bound.
       (let ((spec (seed7-line-inside-a-block
                    n dont-skip-comment-start beg-bound)))
         (when (and (eq n 0) spec)
@@ -6122,7 +6114,7 @@ If a block is found, return a list of 5 elements:
           (setq seed7--indent-block-bounds
                 (cons (nth 2 seed7--indent-last-block-spec)
                       (nth 3 seed7--indent-last-block-spec))))
-        spec)))))
+        spec)))
 
 ;; ---------------------------------------------------------------------------
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260629.1139
+;; Package-Version: 20260629.1527
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-29T15:39:17+0000 W27-1"
+(defconst seed7-mode-version-timestamp "2026-06-29T19:27:22+0000 W27-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5951,17 +5951,17 @@ If it finds something it returns a list that holds the following information:
                           (let ((bounds (seed7--safe-enclosing-block-bounds match-text)))
                             (when bounds
                               (setq enclosing-block-start-pos (car bounds)
-                                    enclosing-block-end-pos (cdr bounds)))
-                            (when (<= block-start-pos current-pos enclosing-block-end-pos)
-                              (setq keep-searching nil
-                                    result (list (+ block-start-indent-column
-                                                    (seed7--indent-offset-for
-                                                     match-text
-                                                     line-n-first-text))
-                                                 match-text
-                                                 block-start-pos
-                                                 enclosing-block-end-pos
-                                                 block-start-indent-column))))))
+                                    enclosing-block-end-pos (cdr bounds))
+                              (when (<= block-start-pos current-pos enclosing-block-end-pos)
+                                (setq keep-searching nil
+                                      result (list (+ block-start-indent-column
+                                                      (seed7--indent-offset-for
+                                                       match-text
+                                                       line-n-first-text))
+                                                   match-text
+                                                   block-start-pos
+                                                   enclosing-block-end-pos
+                                                   block-start-indent-column)))))))
                        ;;
                        ;; Case 3: point is on a line that is not on the block start,
                        ;;         but between the block start and the block end.
@@ -7447,10 +7447,17 @@ otherwise leave point over the same character."
   "Indent the block enclosing point.  Do not move point."
   (interactive)
   (save-excursion
-    (seed7-to-block-forward :dont-push-mark)
-    (set-mark (point))
-    (seed7-to-block-backward :at-beginning-of-line :dont-push-mark)
-    (seed7-indent-region)))
+    (let ((start (save-excursion
+                   (unless (seed7-to-block-backward
+                            :at-beginning-of-line
+                            :dont-push-mark)
+                     (user-error "No enclosing block start found"))
+                   (point)))
+          (end (save-excursion
+                 (unless (seed7-to-block-forward :dont-push-mark)
+                   (user-error "No enclosing block end found"))
+                 (point))))
+      (seed7-indent-region start end))))
 
 (defun seed7-fill ()
   "Refill/justify comment or string paragraph, or re-indent current code block."
@@ -8000,9 +8007,13 @@ and \\[tempo-backward-mark] to move to previous one."
   (delete-char n))
 
 (defun seed7-complete-statement-or-indent ()
-  "Adjust indentation of current line or block.
-Expand statement if point follows specific keyword located at the beginning of
-a code line.  The supported keywords are:
+  "Adjust indentation of current line or marked block.
+
+If a block is marked, indent it.  Otherwise, if point follows specific
+keyword located at the beginning of a code line expands it.  If there's
+no keyword, just indent the line
+
+The supported keywords are:
 
 ============ =========================================================
 Keyword      Expansion
@@ -8042,155 +8053,155 @@ enum         enum type definition
 struct       struct type definition
 ============ ========================================================="
   (interactive "*")
-  (let ((keyword nil)
-        (col-at-keyword-beg nil)
-        (in-indent nil))
-    (save-excursion
-      (backward-word)
-      (setq col-at-keyword-beg (current-column)
-            in-indent (seed7-inside-line-indent-p)
-            keyword (thing-at-point 'word :no-properties)))
-    ;; expand only if there's 1 word at the beginning of a line of code,
-    ;; with nothing after and only for specified predefined keywords
-    ;; or inside parens, just before the closing parens
-    (if (and (not (use-region-p))
-             keyword
-             (not (seed7-inside-comment-p))
-             (not (seed7-inside-string-p))
-             (or (and (or in-indent
-                          (eq col-at-keyword-beg 0))
-                      (or (looking-at-p "\n")
-                          (eobp))
-                      (member keyword '("inc"
-                                        "const" "var"
-                                        "enum" "struct"
-                                        "proc"
-                                        "func" "funcs"
-                                        "if" "ife" "ifei" "ifeie"
-                                        "case"
-                                        "for"   "foru"
-                                        "fors"
-                                        "fore"  "foreu"
-                                        "forek" "foreku"
-                                        "fork"  "forku"
-                                        "repeat"
-                                        "while"
-                                        "bl"
-                                        "gl")))
-                 (and (looking-at-p " ?)")
-                      (member keyword '("in"
-                                        "invar"
-                                        "inout"
-                                        "ref"
-                                        "val"
-                                        "callbn")))))
-        (progn
-          (when seed7-template-expansion-disables-overwrite-mode
-            (overwrite-mode 0))
-          (cond
-           ((string= keyword "if")
-            (seed7--delete-backward 2)
-            (seed7-insert-if-statement))
-           ((string= keyword "ife")
-            (seed7--delete-backward 3)
-            (seed7-insert-if-else-statement))
-           ((string= keyword "ifei")
-            (seed7--delete-backward 4)
-            (seed7-insert-if-elsif-statement))
-           ((string= keyword "ifeie")
-            (seed7--delete-backward 5)
-            (seed7-insert-if-elsif-else-statement))
-           ((string= keyword "case")
-            (seed7--delete-backward 4)
-            (seed7-insert-case-statement))
-           ((string= keyword "for")
-            (seed7--delete-backward 3)
-            (seed7-insert-for))
-           ((string= keyword "foru")
-            (seed7--delete-backward 4)
-            (seed7-insert-for-until))
-           ((string= keyword "fors")
-            (seed7--delete-backward 4)
-            (seed7-insert-for-step))
-           ((string= keyword "fore")
-            (seed7--delete-backward 4)
-            (seed7-insert-for-each))
-           ((string= keyword "foreu")
-            (seed7--delete-backward 5)
-            (seed7-insert-for-each-until))
-           ((string= keyword "forek")
-            (seed7--delete-backward 5)
-            (seed7-insert-for-each-key))
-           ((string= keyword "foreku")
-            (seed7--delete-backward 6)
-            (seed7-insert-for-each-key-until))
-           ((string= keyword "fork")
-            (seed7--delete-backward 4)
-            (seed7-insert-for-key))
-           ((string= keyword "forku")
-            (seed7--delete-backward 5)
-            (seed7-insert-for-key-until))
-           ((string= keyword "repeat")
-            (seed7--delete-backward 6)
-            (seed7-insert-repeat))
-           ((string= keyword "while")
-            (seed7--delete-backward 5)
-            (seed7-insert-while))
-           ((string= keyword "bl")
-            (seed7--delete-backward 2)
-            (seed7-insert-block))
-           ((string= keyword "gl")
-            (seed7--delete-backward 2)
-            (seed7-insert-global))
+  (if (use-region-p)
+      (seed7-indent-region)
+    (let ((keyword nil)
+          (col-at-keyword-beg nil)
+          (in-indent nil))
+      (save-excursion
+        (backward-word)
+        (setq col-at-keyword-beg (current-column)
+              in-indent (seed7-inside-line-indent-p)
+              keyword (thing-at-point 'word :no-properties)))
+      ;; expand only if there's 1 word at the beginning of a line of code,
+      ;; with nothing after and only for specified predefined keywords
+      ;; or inside parens, just before the closing parens
+      (if (and (not (use-region-p))
+               keyword
+               (not (seed7-inside-comment-p))
+               (not (seed7-inside-string-p))
+               (or (and (or in-indent
+                            (eq col-at-keyword-beg 0))
+                        (or (looking-at-p "\n")
+                            (eobp))
+                        (member keyword '("inc"
+                                          "const" "var"
+                                          "enum" "struct"
+                                          "proc"
+                                          "func" "funcs"
+                                          "if" "ife" "ifei" "ifeie"
+                                          "case"
+                                          "for"   "foru"
+                                          "fors"
+                                          "fore"  "foreu"
+                                          "forek" "foreku"
+                                          "fork"  "forku"
+                                          "repeat"
+                                          "while"
+                                          "bl"
+                                          "gl")))
+                   (and (looking-at-p " ?)")
+                        (member keyword '("in"
+                                          "invar"
+                                          "inout"
+                                          "ref"
+                                          "val"
+                                          "callbn")))))
+          (progn
+            (when seed7-template-expansion-disables-overwrite-mode
+              (overwrite-mode 0))
+            (cond
+             ((string= keyword "if")
+              (seed7--delete-backward 2)
+              (seed7-insert-if-statement))
+             ((string= keyword "ife")
+              (seed7--delete-backward 3)
+              (seed7-insert-if-else-statement))
+             ((string= keyword "ifei")
+              (seed7--delete-backward 4)
+              (seed7-insert-if-elsif-statement))
+             ((string= keyword "ifeie")
+              (seed7--delete-backward 5)
+              (seed7-insert-if-elsif-else-statement))
+             ((string= keyword "case")
+              (seed7--delete-backward 4)
+              (seed7-insert-case-statement))
+             ((string= keyword "for")
+              (seed7--delete-backward 3)
+              (seed7-insert-for))
+             ((string= keyword "foru")
+              (seed7--delete-backward 4)
+              (seed7-insert-for-until))
+             ((string= keyword "fors")
+              (seed7--delete-backward 4)
+              (seed7-insert-for-step))
+             ((string= keyword "fore")
+              (seed7--delete-backward 4)
+              (seed7-insert-for-each))
+             ((string= keyword "foreu")
+              (seed7--delete-backward 5)
+              (seed7-insert-for-each-until))
+             ((string= keyword "forek")
+              (seed7--delete-backward 5)
+              (seed7-insert-for-each-key))
+             ((string= keyword "foreku")
+              (seed7--delete-backward 6)
+              (seed7-insert-for-each-key-until))
+             ((string= keyword "fork")
+              (seed7--delete-backward 4)
+              (seed7-insert-for-key))
+             ((string= keyword "forku")
+              (seed7--delete-backward 5)
+              (seed7-insert-for-key-until))
+             ((string= keyword "repeat")
+              (seed7--delete-backward 6)
+              (seed7-insert-repeat))
+             ((string= keyword "while")
+              (seed7--delete-backward 5)
+              (seed7-insert-while))
+             ((string= keyword "bl")
+              (seed7--delete-backward 2)
+              (seed7-insert-block))
+             ((string= keyword "gl")
+              (seed7--delete-backward 2)
+              (seed7-insert-global))
 
-           ((string= keyword "proc")
-            (seed7--delete-backward 4)
-            (seed7-insert-procedure-declaration))
-           ((string= keyword "func")
-            (seed7--delete-backward 4)
-            (seed7-insert-func-declaration))
-           ((string= keyword "funcs")
-            (seed7--delete-backward 5)
-            (seed7-insert-short-function-declaration))
+             ((string= keyword "proc")
+              (seed7--delete-backward 4)
+              (seed7-insert-procedure-declaration))
+             ((string= keyword "func")
+              (seed7--delete-backward 4)
+              (seed7-insert-func-declaration))
+             ((string= keyword "funcs")
+              (seed7--delete-backward 5)
+              (seed7-insert-short-function-declaration))
 
-           ((string= keyword "var")
-            (seed7--delete-backward 3)
-            (seed7-insert-var-declaration))
-           ((string= keyword "const")
-            (seed7--delete-backward 5)
-            (seed7-insert-const-declaration))
-           ((string= keyword "in")
-            (seed7--delete-backward 2)
-            (seed7-insert-in-parameter))
-           ((string= keyword "invar")
-            (seed7--delete-backward 5)
-            (seed7-insert-invar-parameter))
-           ((string= keyword "inout")
-            (seed7--delete-backward 5)
-            (seed7-insert-inout-parameter))
-           ((string= keyword "ref")
-            (seed7--delete-backward 3)
-            (seed7-insert-reference-parameter))
-           ((string= keyword "val")
-            (seed7--delete-backward 3)
-            (seed7-insert-value-parameter))
-           ((string= keyword "callbn")
-            (seed7--delete-backward 6)
-            (seed7-insert-call-by-name-parameter))
+             ((string= keyword "var")
+              (seed7--delete-backward 3)
+              (seed7-insert-var-declaration))
+             ((string= keyword "const")
+              (seed7--delete-backward 5)
+              (seed7-insert-const-declaration))
+             ((string= keyword "in")
+              (seed7--delete-backward 2)
+              (seed7-insert-in-parameter))
+             ((string= keyword "invar")
+              (seed7--delete-backward 5)
+              (seed7-insert-invar-parameter))
+             ((string= keyword "inout")
+              (seed7--delete-backward 5)
+              (seed7-insert-inout-parameter))
+             ((string= keyword "ref")
+              (seed7--delete-backward 3)
+              (seed7-insert-reference-parameter))
+             ((string= keyword "val")
+              (seed7--delete-backward 3)
+              (seed7-insert-value-parameter))
+             ((string= keyword "callbn")
+              (seed7--delete-backward 6)
+              (seed7-insert-call-by-name-parameter))
 
-           ((string= keyword "inc")
-            (seed7--delete-backward 3)
-            (seed7-insert-include))
-           ((string= keyword "enum")
-            (seed7--delete-backward 4)
-            (seed7-insert-enumeration-type-declaration))
-           ((string= keyword "struct")
-            (seed7--delete-backward 6)
-            (seed7-insert-struct-type-declaration))))
-
-      ;; not on keyword; just indent
-      (if (use-region-p)
-          (seed7-indent-region)
+             ((string= keyword "inc")
+              (seed7--delete-backward 3)
+              (seed7-insert-include))
+             ((string= keyword "enum")
+              (seed7--delete-backward 4)
+              (seed7-insert-enumeration-type-declaration))
+             ((string= keyword "struct")
+              (seed7--delete-backward 6)
+              (seed7-insert-struct-type-declaration))))
+        ;;
+        ;; point is not on keyword; just indent the line
         (seed7-indent-line)))))
 
 ;; ---------------------------------------------------------------------------

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260629.2303
+;; Package-Version: 20260629.2326
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-30T03:03:44+0000 W27-2"
+(defconst seed7-mode-version-timestamp "2026-06-30T03:26:24+0000 W27-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -4476,6 +4476,15 @@ NO match.  From %d, at point %d, nesting=%d, line %d  for: %S"
           (seed7-to-indent)))
       (point))))
 
+(defun seed7--safe-to-block-backward (&optional at-beginning-of-line)
+  "Move to enclosing block start, or return nil on block-match failure.
+
+ This is intended for navigation-time probing where falling back to
+ `scan-sexps' is preferable to aborting the command."
+  (condition-case nil
+      (seed7-to-block-backward at-beginning-of-line :dont-push-mark)
+    (user-error nil)))
+
 (defvar-local seed7--sexp-dispatch-active nil
   "Non-nil while `seed7--forward-sexp-function' is dispatching to a Seed7 helper.
 This prevents re-entry when those helpers internally invoke `backward-sexp' or
@@ -4626,7 +4635,9 @@ navigation command."
                  (save-excursion
                    (seed7-to-indent)
                    (looking-at-p seed7-block-end-regexp)))
-            (seed7-to-block-backward nil :dont-push-mark))
+            (or (seed7--safe-to-block-backward)
+                (goto-char (or (scan-sexps (point) -1)
+                               (buffer-end arg)))))
            ;;
            ;; Backward: current line ends with ); — may be end of a
            ;; const/var array definition block.
@@ -4635,12 +4646,16 @@ navigation command."
            ;; `seed7--array-definition-start-regexp' at the destination indent
            ;; position.
            ((seed7--at-array-definition-end-line-p)
-            (seed7-to-block-backward nil :dont-push-mark))
+            (or (seed7--safe-to-block-backward)
+                (goto-char (or (scan-sexps (point) -1)
+                               (buffer-end arg)))))
            ;;
            ;; Backward: current line ends with }; — may be end of a
            ;; const/var set definition block.
            ((seed7--at-set-definition-end-line-p)
-            (seed7-to-block-backward nil :dont-push-mark))
+            (or (seed7--safe-to-block-backward)
+                (goto-char (or (scan-sexps (point) -1)
+                               (buffer-end arg)))))
            ;;
            ;; Backward: current line is the return statement of a short
            ;; function (matches `seed7-short-func-end-regexp'), or point is
@@ -6798,13 +6813,11 @@ Return nil when no such previous line exists."
         (skip-chars-forward " \t")
         (current-column)))))
 
-
 (defun seed7-line-is-procfunc-beg-of-decl (n &optional dont-skip-comment-start)
   "Return indent column when line N is a procedure or function declaration.
 Skip comment start unless DONT-SKIP-COMMENT-START is non-nil."
   (seed7-line-starts-with n seed7-procfunc-beg-of-decl-nc-re
                           dont-skip-comment-start))
-
 
 (defun seed7--safe-current-line-defun-start-indent ()
    "Return indent of enclosing defun start for current line, or nil.
@@ -7453,16 +7466,17 @@ otherwise leave point over the same character."
   "Indent the block enclosing point.  Do not move point."
   (interactive)
   (save-excursion
-    (let ((start (save-excursion
-                   (unless (seed7-to-block-backward
-                            :at-beginning-of-line
-                            :dont-push-mark)
-                     (user-error "No enclosing block start found"))
-                   (point)))
-          (end (save-excursion
-                 (unless (seed7-to-block-forward :dont-push-mark)
-                   (user-error "No enclosing block end found"))
-                 (point))))
+    (let* ((start (save-excursion
+                    (unless (seed7-to-block-backward
+                             :at-beginning-of-line
+                             :dont-push-mark)
+                      (user-error "No enclosing block start found"))
+                    (point)))
+           (end (save-excursion
+                  (goto-char start)
+                  (unless (seed7-to-block-forward :dont-push-mark)
+                    (user-error "No enclosing block end found"))
+                  (point))))
       (seed7-indent-region start end))))
 
 (defun seed7-fill ()

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260629.1602
+;; Package-Version: 20260629.2303
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-29T20:02:33+0000 W27-1"
+(defconst seed7-mode-version-timestamp "2026-06-30T03:03:44+0000 W27-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6805,6 +6805,18 @@ Skip comment start unless DONT-SKIP-COMMENT-START is non-nil."
   (seed7-line-starts-with n seed7-procfunc-beg-of-decl-nc-re
                           dont-skip-comment-start))
 
+
+(defun seed7--safe-current-line-defun-start-indent ()
+   "Return indent of enclosing defun start for current line, or nil.
+ This is a defensive indentation-time probe.  If
+ `seed7-to-block-backward' cannot match a corresponding callable start,
+ do not abort indentation; return nil so callers can try other logic."
+   (condition-case nil
+       (save-excursion
+         (seed7-to-block-backward nil :dont-push-mark)
+         (seed7-current-line-indent))
+     (user-error nil)))
+
 (defun seed7-line-is-defun-end (n &optional dont-skip-comment-start)
   "Return the defining-line indentation when line N ends a definition.
 Recognizes func, proc, struct, enum, forward, and native/action declaration
@@ -6826,26 +6838,28 @@ N is: - :previous-non-empty for the previous non-empty line,
           nil)
 
          ;; Handle line that is an end func, struct or enum.
-         ((seed7-line-starts-with-any
-           0
-           (list
-            "end[[:blank:]]+?func[[:blank:]]*?;"
-            "end[[:blank:]]+?struct[[:blank:]]*?;"
-            "end[[:blank:]]+?enum[[:blank:]]*?;"))
-          (seed7-to-block-backward nil :dont-push-mark)
-          (seed7-current-line-indent))
+         ((seed7--set (and (seed7-line-starts-with-any
+                            0
+                            (list
+                             "end[[:blank:]]+?func[[:blank:]]*?;"
+                             "end[[:blank:]]+?struct[[:blank:]]*?;"
+                             "end[[:blank:]]+?enum[[:blank:]]*?;")
+                            nil
+                            end-pos)
+                           (seed7--safe-current-line-defun-start-indent))
+                      previous-defun-column)
+          previous-defun-column)
 
          ;; Handle forward and native/action declarations of func and proc.
-         ((seed7--set
-           (seed7-line-starts-with-any
-            0
-            (list
-             seed7-func-forward-or-action-declaration-nc-re
-             seed7---inner-callables-4
-             seed7-proc-forward-or-action-declaration-re)
-            nil
-            end-pos)
-           previous-defun-column)
+         ((seed7--set (seed7-line-starts-with-any
+                       0
+                       (list
+                        seed7-func-forward-or-action-declaration-nc-re
+                        seed7---inner-callables-4
+                        seed7-proc-forward-or-action-declaration-re)
+                       nil
+                       end-pos)
+                      previous-defun-column)
           previous-defun-column)
 
          ;; Fallback only for plausible lines, not for every ordinary code line.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260625.2209
+;; Package-Version: 20260629.1139
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -362,6 +362,7 @@
 ;;       . `seed7--indent-last-block-spec'
 ;;       . `seed7--indent-block-bounds'
 ;;       . `seed7-line-inside-a-block'
+;;         . `seed7--safe-enclosing-block-bounds'
 ;;         . `seed7--block-end-pos-for'
 ;;         . `seed7--indent-offset-for'
 ;;         . `seed7--on-lineof'
@@ -398,17 +399,18 @@
 ;;     . `seed7-bol-position'
 ;;   - Seed7 Indentation Calculator Function
 ;;     o `seed7-complete-statement-or-indent'
-;;       * `seed7-indent-line'
+;;       * `seed7-indent-region'
+;;         . `seed7-indent-region'
 ;;         . `seed7-calc-indent'
 ;;           . `seed7--cached-block-bounds'
 ;;           . `seed7--indent-one-line'
 ;;       * `seed7-fill'
 ;;         * `seed7-indent-block'
-;;           o `seed7-indent-line'
+;;           o `seed7-indent-region'
 ;; - Seed7 Code Template Expansion
 ;;   * `seed7-complete-statement-or-indent'
 ;;     . `seed7--delete-backward'
-;;     o `seed7-indent-line'
+;;     o `seed7-indent-region'
 ;;     . `seed7-insert-if-statement'
 ;;     . `seed7-insert-if-else-statement'
 ;;     . `seed7-insert-if-elsif-statement'
@@ -540,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-06-26T02:09:26+0000 W26-5"
+(defconst seed7-mode-version-timestamp "2026-06-29T15:39:17+0000 W27-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5231,7 +5233,7 @@ Return nil otherwise."
 (defvar-local seed7--indent-search-boundary-cache nil
   "Sequential indentation cache for `seed7--indent-search-boundary'.
 
-Used only during one `seed7-indent-line' invocation or one region-indentation
+Used only during one `seed7-indent-region' invocation or one region-indentation
 pass.  Value is a plist with keys:
 - :line-beg    beginning position of the line the cache was computed for,
 - :target-col  indentation column used for the lookup,
@@ -5815,6 +5817,21 @@ Move point."
       (save-excursion (goto-char start-pos)
                       (line-end-position))))
 
+(defun seed7--safe-enclosing-block-bounds (match-text)
+  "Return (START . END) for block described by MATCH-TEXT, or nil.
+
+This is a defensive wrapper for indentation-time probing.  Some candidate
+matches found by `seed7-block-line-start-regexp' are not valid enclosing
+blocks for the current point.  In that case, do not abort indentation;
+just return nil so the caller can continue searching farther upward."
+  (condition-case nil
+      (save-excursion
+        (let ((end-pos   (seed7--block-end-pos-for match-text))
+              (start-pos (seed7-to-block-backward nil :dont-push-mark)))
+          (when (and start-pos end-pos)
+            (cons start-pos end-pos))))
+    (user-error nil)))
+
 (defun seed7-line-inside-a-block (n &optional dont-skip-comment-start beg-bound)
   "Check if line N is inside a Seed7 block.
 N is: - :previous-non-empty for the previous non-empty line,
@@ -5862,81 +5879,93 @@ If it finds something it returns a list that holds the following information:
                 (skip-chars-forward " \t")
                 (setq block-start-indent-column (current-column))
                 ;; Identify the end position and start position of the currently
-                ;; enclosing block
-                (save-excursion
-                  (setq enclosing-block-end-pos (seed7--block-end-pos-for match-text))
-                  ;; Identify the beginning of the enclosing top-level block
-                  (setq enclosing-block-start-pos
-                        (seed7-to-block-backward nil :dont-push-mark)))
-                (when (<= block-start-pos current-pos enclosing-block-end-pos)
-                  ;; It's a real and valid block: 3 cases are possible:
-                  (cond
-                   ;; Case 1: point is on the start line of a top level block.
-                   ((and (seed7--on-lineof block-start-pos current-pos)
-                         (member match-text '("const proc: "
-                                              "const func "
-                                              "const type: ")))
-                    ;; In that case the enclosing block start should be the same as
-                    ;; the block start.  If it's not the case there's a logic error.
-                    (when (eq enclosing-block-start-pos block-start-pos)
-                      ;; When at the line of top-level enclosing block, use the
-                      ;; `seed7-calc-indent' to get the indentation of the line just
-                      ;; above the current line, as if the previous line was a noop
-                      ;; statement.  Simulate the noop statement by temporary
-                      ;; inserting it in the above line.  This way it will be
-                      ;; possible to handle the case where the statement is inside
-                      ;; the first line of another block statement like an if
-                      ;; statement.
-                      ;; Note that calling `seed7-calc-indent' means recursing into
-                      ;; it since it's `seed7-calc-indent' that calls
-                      ;; `seed7-line-inside-a-block'.  But doing it this way we use
-                      ;; all the logic necessary to compute the indentation for this
-                      ;; case.
-                      ;; Allow modification of a read-only buffer and ensure that
-                      ;; the undo history is not modified by the insertion and
-                      ;; removal operations.
-                      (let ((inhibit-read-only t))
-                        (with-silent-modifications
-                          (setq keep-searching nil
-                                result (list
-                                        (save-excursion
-                                          (forward-line 0)
-                                          (let ((noop-start (point))
-                                                (noop-end nil))
-                                            (insert " noop;\n")
-                                            (setq noop-end (point))
-                                            (forward-line -1)
-                                            (unwind-protect
-                                                ;; compute indentation with noop
-                                                (seed7-calc-indent)
-                                              ;; always delete inserted noop
-                                              (delete-region noop-start noop-end))))
-                                        match-text
-                                        enclosing-block-start-pos
-                                        enclosing-block-end-pos
-                                        block-start-indent-column))))))
-                   ;;
-                   ;; Case 2: point is on an internal block start line.
-                   ((seed7--on-lineof block-start-pos current-pos)
-                    ;; Look for the previous block and use info from it.
-                    (goto-char block-start-pos)
-                    (when (seed7-re-search-backward
-                           seed7-block-line-start-regexp beg-bound)
-                      (setq match-text (replace-regexp-in-string
-                                        "[[:blank:]]+$" " "
-                                        (substring-no-properties (match-string 1))))
-                      (setq block-start-pos (point))
-                      (skip-chars-forward " \t")
-                      (setq block-start-indent-column (current-column))
-                      ;; Identify the end position and start position of the
-                      ;; currently enclosing block
-                      (save-excursion
-                        (setq enclosing-block-end-pos
-                              (seed7--block-end-pos-for match-text))
-                        ;; Identify the beginning of the enclosing top-level block
-                        (setq enclosing-block-start-pos
-                              (seed7-to-block-backward nil :dont-push-mark)))
-                      (when (<= block-start-pos current-pos enclosing-block-end-pos)
+                ;; enclosing block.  If this candidate is not a valid enclosing
+                ;; block, just keep searching farther upward.
+                (let ((bounds (seed7--safe-enclosing-block-bounds match-text)))
+                  (when bounds
+                    (setq enclosing-block-start-pos (car bounds)
+                          enclosing-block-end-pos   (cdr bounds))
+
+                    (when (<= block-start-pos current-pos enclosing-block-end-pos)
+                      ;; It's a real and valid block: 3 cases are possible:
+                      (cond
+                       ;; Case 1: point is on the start line of a top level block.
+                       ((and (seed7--on-lineof block-start-pos current-pos)
+                             (member match-text '("const proc: "
+                                                  "const func "
+                                                  "const type: ")))
+                        ;; In that case the enclosing block start should be the same as
+                        ;; the block start.  If it's not the case there's a logic error.
+                        (when (eq enclosing-block-start-pos block-start-pos)
+                          ;; When at the line of top-level enclosing block, use the
+                          ;; `seed7-calc-indent' to get the indentation of the line just
+                          ;; above the current line, as if the previous line was a noop
+                          ;; statement.  Simulate the noop statement by temporary
+                          ;; inserting it in the above line.  This way it will be
+                          ;; possible to handle the case where the statement is inside
+                          ;; the first line of another block statement like an if
+                          ;; statement.
+                          ;; Note that calling `seed7-calc-indent' means recursing into
+                          ;; it since it's `seed7-calc-indent' that calls
+                          ;; `seed7-line-inside-a-block'.  But doing it this way we use
+                          ;; all the logic necessary to compute the indentation for this
+                          ;; case.
+                          ;; Allow modification of a read-only buffer and ensure that
+                          ;; the undo history is not modified by the insertion and
+                          ;; removal operations.
+                          (let ((inhibit-read-only t))
+                            (with-silent-modifications
+                              (setq keep-searching nil
+                                    result (list
+                                            (save-excursion
+                                              (forward-line 0)
+                                              (let ((noop-start (point))
+                                                    (noop-end nil))
+                                                (insert " noop;\n")
+                                                (setq noop-end (point))
+                                                (forward-line -1)
+                                                (unwind-protect
+                                                    ;; compute indentation with noop
+                                                    (seed7-calc-indent)
+                                                  ;; always delete inserted noop
+                                                  (delete-region noop-start noop-end))))
+                                            match-text
+                                            enclosing-block-start-pos
+                                            enclosing-block-end-pos
+                                            block-start-indent-column))))))
+                       ;;
+                       ;; Case 2: point is on an internal block start line.
+                       ((seed7--on-lineof block-start-pos current-pos)
+                        ;; Look for the previous block and use info from it.
+                        (goto-char block-start-pos)
+                        (when (seed7-re-search-backward
+                               seed7-block-line-start-regexp beg-bound)
+                          (setq match-text (replace-regexp-in-string
+                                            "[[:blank:]]+$" " "
+                                            (substring-no-properties (match-string 1))))
+                          (setq block-start-pos (point))
+                          (skip-chars-forward " \t")
+                          (setq block-start-indent-column (current-column))
+                          ;; Identify the end position and start position of the
+                          ;; currently enclosing block
+                          (let ((bounds (seed7--safe-enclosing-block-bounds match-text)))
+                            (when bounds
+                              (setq enclosing-block-start-pos (car bounds)
+                                    enclosing-block-end-pos (cdr bounds)))
+                            (when (<= block-start-pos current-pos enclosing-block-end-pos)
+                              (setq keep-searching nil
+                                    result (list (+ block-start-indent-column
+                                                    (seed7--indent-offset-for
+                                                     match-text
+                                                     line-n-first-text))
+                                                 match-text
+                                                 block-start-pos
+                                                 enclosing-block-end-pos
+                                                 block-start-indent-column))))))
+                       ;;
+                       ;; Case 3: point is on a line that is not on the block start,
+                       ;;         but between the block start and the block end.
+                       (t
                         (setq keep-searching nil
                               result (list (+ block-start-indent-column
                                               (seed7--indent-offset-for
@@ -5945,20 +5974,7 @@ If it finds something it returns a list that holds the following information:
                                            match-text
                                            block-start-pos
                                            enclosing-block-end-pos
-                                           block-start-indent-column)))))
-                   ;;
-                   ;; Case 3: point is on a line that is not on the block start,
-                   ;;         but between the block start and the block end.
-                   (t
-                    (setq keep-searching nil
-                          result (list (+ block-start-indent-column
-                                          (seed7--indent-offset-for
-                                           match-text
-                                           line-n-first-text))
-                                       match-text
-                                       block-start-pos
-                                       enclosing-block-end-pos
-                                       block-start-indent-column)))))
+                                           block-start-indent-column)))))))
                 (when keep-searching
                   ;; Found something that looks like a block, but either not
                   ;; a real block or not the block that holds the line.
@@ -5983,7 +5999,7 @@ Used by `seed7--cached-block-spec-current-line' to avoid recomputation
 when the current line is still inside the same block.
 
 During normal indentation this variable is dynamically rebound by
-`seed7-indent-line', so the cache lifetime is one indentation command
+`seed7-indent-region', so the cache lifetime is one indentation command
 or one region-indentation pass.  Direct callers of `seed7-calc-indent'
 may use the buffer-local value.")
 
@@ -5997,7 +6013,7 @@ Used by `seed7--cached-block-bounds' to provide O(1) begin/end lookup
 without returning or allocating the full block spec.
 
 During normal indentation this variable is dynamically rebound by
-`seed7-indent-line', so the cache lifetime is one indentation command
+`seed7-indent-region', so the cache lifetime is one indentation command
 or one region-indentation pass.  Direct callers of `seed7-calc-indent'
 may use the buffer-local value.")
 
@@ -6084,6 +6100,7 @@ If a block is found, return a list of 5 elements:
   (let ((cached-spec
          (and (eq n 0)
               (not dont-skip-comment-start)
+              (not beg-bound)
               (seed7--cached-block-spec-current-line))))
     (cond
      ;; Fast path: cached spec is still valid for current line, and if a
@@ -7388,32 +7405,41 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
       (unless (eq indent 0)
         (indent-to indent)))))
 
+(defun seed7-indent-region (&optional start end)
+  "Indent Seed7 code from START to END using one shared cache pass.
+When START and END are nil, use the active region."
+  (interactive "r")
+  (setq start (or start
+                  (and (use-region-p) (region-beginning))
+                  (user-error "No active region to indent")))
+  (setq end   (or end
+                  (and (use-region-p) (region-end))
+                  (user-error "No active region to indent")))
+  (save-excursion
+    (let ((end-marker (copy-marker end))
+          ;; Keep only this cache across the whole region pass.
+          (seed7--indent-search-boundary-cache nil))
+      (goto-char start)
+      (forward-line 0)
+      (while (< (point) end-marker)
+        ;; cache indent info per-line, not per-region
+        (let ((seed7--indent-last-block-spec nil)
+              (seed7--indent-block-bounds nil))
+            (seed7--indent-one-line))
+        (forward-line 1))
+      (set-marker end-marker nil))))
+
 (defun seed7-indent-line ()
-  "Indent the current Seed7 line of code or all marked lines.
+  "Indent the current Seed7 line of code.
 If point was inside the indentation space move it to first non-whitespace,
-otherwise leave point over the same character.
-If a region is marked, use it to identify the lines that must be indented,
-then deactivates it (to prevent the area to limit searches)."
+otherwise leave point over the same character."
   (interactive "*")
   (let ((move-point (seed7-inside-line-indent-p))
-        ;; clear both caches; code below repopulates them per line via the
-        ;; call to `seed7--indent-one-line' --> `seed7-calc-indent'.
         (seed7--indent-last-block-spec nil)
-        (seed7--indent-block-bounds    nil)
-        ;; Cache consecutive `seed7--indent-search-boundary' lookups during one
-        ;; indentation command / region pass.
+        (seed7--indent-block-bounds nil)
         (seed7--indent-search-boundary-cache nil))
     (save-excursion
-      (if (use-region-p)
-          ;; region active: indent complete region
-          (let ((line-count (count-lines (region-beginning) (region-end))))
-            (goto-char (region-beginning))
-            (deactivate-mark)
-            (dotimes (_ line-count)
-              (seed7--indent-one-line)
-              (forward-line 1)))
-        ;; no region: indent current line
-        (seed7--indent-one-line)))
+      (seed7--indent-one-line))
     (when move-point
       (seed7-to-indent))))
 
@@ -7424,7 +7450,7 @@ then deactivates it (to prevent the area to limit searches)."
     (seed7-to-block-forward :dont-push-mark)
     (set-mark (point))
     (seed7-to-block-backward :at-beginning-of-line :dont-push-mark)
-    (seed7-indent-line)))
+    (seed7-indent-region)))
 
 (defun seed7-fill ()
   "Refill/justify comment or string paragraph, or re-indent current code block."
@@ -8163,7 +8189,9 @@ struct       struct type definition
             (seed7-insert-struct-type-declaration))))
 
       ;; not on keyword; just indent
-      (seed7-indent-line))))
+      (if (use-region-p)
+          (seed7-indent-region)
+        (seed7-indent-line)))))
 
 ;; ---------------------------------------------------------------------------
 ;;* Seed7 Compilation
@@ -10300,7 +10328,8 @@ compilation requires a working installation of Seed7.
 
   ;; Seed7 Indentation
   (when seed7-auto-indent
-    (setq-local indent-line-function #'seed7-indent-line))
+    (setq-local indent-line-function   #'seed7-indent-line)
+    (setq-local indent-region-function #'seed7-indent-region))
 
   (when seed7-support-abbrev-mode
     ;; Seed7 Abbreviation Support


### PR DESCRIPTION
This version of seed7-mode is slower than previous versions (as of 11.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/regen Seed7 Mode performance benchmark reports for four fontification modes (A–D), including run metadata, per-file mean load times, cross-mode comparisons, and phase timing breakdowns.
* **New Features**
  * Added region-aware indentation via a dedicated region indentation entry point; when a region is active, statement completion now indents that region.
* **Bug Fixes**
  * Hardened block/enclosure detection and defun-end probing to prevent premature aborts during indentation and navigation.
* **Refactor**
  * Made line indentation operate only on the current line, and delegated block indentation through the shared region flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->