### PR TITLE
Adding Emacs profiler capabilities to sd7-indent-perf

### DIFF
--- a/reports/18.1/bas7.sd7-perf-cpu.txt
+++ b/reports/18.1/bas7.sd7-perf-cpu.txt
@@ -1,0 +1,1565 @@
+           0   0%   ...
+           1   0% + mode-local-post-major-mode-change
+          14   0% + timer-event-handler
+        1319   0% + redisplay_internal (C function)
+       13471   3%   Automatic GC
+      322932  95% - command-execute
+      322932  95%  - call-interactively
+      322932  95%   - apply
+      322932  95%    - call-interactively@ido-cr+-record-current-command
+      322932  95%     - #<primitive-function call-interactively>
+      322932  95%      - funcall-interactively
+         195   0%       - smex
+           5   0%        - smex-detect-new-commands
+           5   0%         - #<byte-code-function 48E>
+           5   0%          - commandp
+           1   0%           - interactive-form
+           1   0%            - oclosure-interactive-form
+           1   0%               oclosure-type
+           9   0%        - smex-update
+           9   0%         - smex-rebuild-cache
+           2   0%            #<native-comp-function smex-sorting-rules>
+           6   0%          - #<byte-code-function 4EA>
+           1   0%             commandp
+         181   0%        - smex-read-and-run
+           2   0%           execute-extended-command
+         179   0%         - smex-completing-read
+         179   0%          - ido-completing-read
+         179   0%           - apply
+         179   0%            - ido-completing-read@ido-cr+-replace
+         179   0%             - #<native-comp-function ido-completing-read>
+         179   0%              - ido-read-internal
+         179   0%               - apply
+         179   0%                - ad-Advice-ido-read-internal
+         179   0%                 - #<native-comp-function ido-read-internal>
+         179   0%                  - read-from-minibuffer
+          61   0%                   - redisplay_internal (C function)
+           1   0%                    - redisplay--pre-redisplay-functions
+           1   0%                       window-buffer
+          99   0%                   - ido-exhibit
+          99   0%                    - apply
+          99   0%                     - #<native-comp-function ido-exhibit>
+           3   0%                      - ido-set-common-completion
+           3   0%                       - ido-find-common-substring
+           3   0%                          ido-word-matching-substring
+           6   0%                      - ido-completions
+           6   0%                       - apply
+           6   0%                        - ido-grid--completions
+           4   0%                         - ido-grid--grid-ensure-visible
+           4   0%                          - ido-grid--grid
+           1   0%                           - ido-final-slash
+           1   0%                              ido-is-tramp-root
+           1   0%                             string-match
+           1   0%                             move-to-column
+          90   0%                      - ido-set-matches
+          90   0%                       - apply
+          90   0%                        - ido-grid--set-matches
+           1   0%                         - ido-grid--same-matches
+           1   0%                            ido-grid--matches-differ-from
+          89   0%                         - apply
+          89   0%                          - #<native-comp-function ido-set-matches>
+          88   0%                           - ido-set-matches-1
+          88   0%                            - apply
+          88   0%                             - ad-Advice-ido-set-matches-1
+          88   0%                              - flx-ido-match
+           4   0%                               - flx-ido-narrowed
+           2   0%                                - flx-ido-undecorate
+           2   0%                                   flx-ido-decorate
+          84   0%                               - flx-ido-match-internal
+          11   0%                                - flx-flex-match
+          11   0%                                 - #<byte-code-function 854>
+           8   0%                                    string-match
+          46   0%                                - flx-score
+          10   0%                                 - flx-find-best-match
+           3   0%                                    puthash
+           6   0%                                  - flx-find-best-match
+           5   0%                                   - flx-find-best-match
+           2   0%                                      gethash
+           3   0%                                    - flx-find-best-match
+           2   0%                                     - flx-find-best-match
+           2   0%                                      - flx-find-best-match
+           1   0%                                         puthash
+      322737  95%       - seed7-complete-statement-or-indent
+      322736  95%        - seed7-indent-region
+      322735  95%         - seed7--indent-one-line
+           1   0%          - undo-auto--undoable-change
+           1   0%             undo-auto--boundary-ensure-timer
+           1   0%            seed7-to-indent
+           1   0%          - delete-horizontal-space
+           1   0%             delete-space--internal
+           1   0%            syntax-ppss-flush-cache
+           9   0%          - jit-lock-after-change
+           5   0%             font-lock-extend-jit-lock-region-after-change
+      322635  95%          - seed7-calc-indent
+           1   0%             seed7-blank-line-p
+           2   0%           - seed7-position-of-end-of-statement
+           2   0%            - seed7-line-code-ends-with
+           2   0%             - seed7-re-search-backward
+           2   0%              - run-with-timer
+           2   0%               - run-at-time
+           2   0%                - timer-set-time
+           2   0%                   timer--time-setter
+           2   0%           - seed7-line-ends-with
+           2   0%            - seed7-move-to-line
+           2   0%             - seed7-to-previous-non-empty-line
+           2   0%              - seed7-inside-comment-p
+           2   0%               - syntax-ppss
+           2   0%                  parse-partial-sexp
+           2   0%           - seed7-line-at-endof-set-definition-block
+           1   0%            - backward-sexp
+           1   0%             - forward-sexp
+           1   0%              - seed7--forward-sexp-function
+           1   0%               - seed7--at-set-definition-end-line-p
+           1   0%                - seed7-line-code-ends-with
+           1   0%                 - seed7-re-search-backward
+           1   0%                  - seed7-inside-comment-p
+           1   0%                   - syntax-ppss
+           1   0%                      parse-partial-sexp
+           1   0%            - seed7-move-to-line
+           1   0%             - seed7-to-previous-non-empty-line
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           6   0%           - seed7-line-isa-string
+           5   0%            - seed7-line-starts-with
+           3   0%               seed7-move-to-line
+           6   0%           - seed7-line-at-endof-array-definition-block
+           1   0%            - seed7-move-to-line
+           1   0%             - seed7-to-previous-non-empty-line
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           5   0%            - backward-sexp
+           5   0%             - forward-sexp
+           5   0%              - seed7--forward-sexp-function
+           5   0%               - seed7-beg-of-defun
+           5   0%                - seed7-re-search-backward-closest
+           5   0%                 - seed7-re-search-backward
+           5   0%                    re-search-backward
+           8   0%           - seed7-line-starts-with
+           5   0%            - seed7-move-to-line
+           4   0%             - seed7-to-previous-non-empty-line
+           4   0%              - seed7-inside-comment-p
+           4   0%               - syntax-ppss
+           4   0%                  parse-partial-sexp
+          10   0%           - seed7-line-indent-step
+           9   0%            - seed7-move-to-line
+           9   0%             - seed7-to-previous-non-empty-line
+           7   0%              - seed7-inside-comment-p
+           7   0%               - syntax-ppss
+           2   0%                - syntax-propertize
+           2   0%                   seed7-mode-syntax-propertize
+           5   0%                  parse-partial-sexp
+          25   0%           - seed7-current-line-start-inside-comment-p
+           1   0%              seed7-to-indent
+          24   0%            - seed7-inside-comment-p
+          24   0%             - syntax-ppss
+           1   0%                syntax-propertize
+          23   0%                parse-partial-sexp
+         107   0%           - seed7-line-after-func-return-logic-operator-column
+          91   0%            - seed7-move-to-line
+          90   0%             - seed7-to-previous-non-empty-line
+          61   0%              - seed7-inside-comment-p
+          57   0%               - syntax-ppss
+          55   0%                  parse-partial-sexp
+         202   0%           - seed7-line-inside-logic-check-expression
+          11   0%            - seed7--current-line-nth-word
+           6   0%             - thing-at-point
+           6   0%              - bounds-of-thing-at-point
+           1   0%               - #<byte-code-function E84>
+           1   0%                - forward-thing
+           1   0%                   forward-word
+           2   0%                 re-search-forward
+           3   0%               - #<byte-code-function FD3>
+           3   0%                - forward-thing
+           1   0%                   intern-soft
+           2   0%                   forward-word
+          20   0%            - seed7-re-search-forward
+           8   0%             - seed7-inside-string-p
+           8   0%              - syntax-ppss
+           8   0%                 parse-partial-sexp
+          11   0%             - seed7-inside-comment-p
+          11   0%              - syntax-ppss
+           1   0%                 make-closure
+          10   0%                 parse-partial-sexp
+         170   0%            - seed7-to-previous-line-starts-with
+         170   0%             - seed7-re-search-backward
+           5   0%              - seed7-inside-string-p
+           5   0%               - syntax-ppss
+           5   0%                  parse-partial-sexp
+          43   0%              - seed7-inside-comment-p
+          41   0%               - syntax-ppss
+           1   0%                  set-syntax-table
+          40   0%                  parse-partial-sexp
+          59   0%                re-search-backward
+          63   0%              - run-with-timer
+          63   0%               - run-at-time
+           6   0%                  timer-relative-time
+          22   0%                - timer-set-time
+          22   0%                   timer--time-setter
+          35   0%                - timer-activate
+          35   0%                 - timer--activate
+          35   0%                    timer--time-less-p
+         222   0%           - seed7--current-line-nth-word
+         221   0%            - thing-at-point
+         221   0%             - bounds-of-thing-at-point
+           1   0%                re-search-forward
+           1   0%                make-closure
+           2   0%                seq-some
+           3   0%              - #<byte-code-function 045>
+           3   0%               - forward-thing
+           3   0%                  forward-word
+         214   0%              - #<byte-code-function B99>
+         214   0%               - forward-thing
+           1   0%                  format
+         213   0%                - forward-word
+         210   0%                 - internal--syntax-propertize
+         210   0%                  - syntax-propertize
+           2   0%                     #<byte-code-function FDF>
+         199   0%                     seed7-mode-syntax-propertize
+         232   0%           - seed7-line-inside-until-logic-expression
+           2   0%              seed7-move-to-line
+           8   0%            - seed7-line-code-ends-with
+           1   0%               seed7-move-to-line
+           7   0%             - seed7-re-search-backward
+           1   0%                re-search-backward
+           6   0%              - run-with-timer
+           6   0%               - run-at-time
+           1   0%                  timer-relative-time
+           1   0%                - timer-set-time
+           1   0%                   timer--time-setter
+           4   0%                - timer-activate
+           4   0%                 - timer--activate
+           4   0%                    timer--time-less-p
+         222   0%            - seed7-re-search-backward
+           5   0%             - seed7-inside-comment-p
+           5   0%              - syntax-ppss
+           5   0%                 parse-partial-sexp
+          64   0%             - run-with-timer
+          64   0%              - run-at-time
+           5   0%                 timer-relative-time
+          19   0%               - timer-set-time
+          19   0%                  timer--time-setter
+          40   0%               - timer-activate
+          40   0%                - timer--activate
+          40   0%                 - timer--time-less-p
+           2   0%                    timer--time
+         153   0%               re-search-backward
+         344   0%           - seed7-line-inside-func-return-statement
+         343   0%            - seed7-re-search-backward
+          70   0%             - run-with-timer
+          70   0%              - run-at-time
+          10   0%                 timer-relative-time
+          18   0%               - timer-set-time
+          18   0%                - timer--time-setter
+           1   0%                   timerp
+          42   0%               - timer-activate
+          42   0%                - timer--activate
+          42   0%                   timer--time-less-p
+         273   0%               re-search-backward
+         389   0%           - seed7-line-inside-assign-statement-continuation
+           9   0%            - seed7-statement-end-pos
+           8   0%             - seed7-forward-char-pos
+           8   0%              - seed7-re-search-forward
+           1   0%                 seed7-inside-string-p
+           3   0%               - seed7-inside-comment-p
+           3   0%                - syntax-ppss
+           3   0%                   parse-partial-sexp
+         379   0%            - seed7-assign-op-pos
+         379   0%             - seed7-re-search-backward
+           5   0%              - seed7-inside-string-p
+           3   0%               - syntax-ppss
+           1   0%                  make-closure
+           1   0%                  syntax-ppss--update-stats
+           1   0%                  parse-partial-sexp
+          23   0%                re-search-backward
+          69   0%              - run-with-timer
+          69   0%               - run-at-time
+           1   0%                  timer-create
+          11   0%                  timer-relative-time
+          27   0%                - timer-set-time
+          27   0%                   timer--time-setter
+          30   0%                - timer-activate
+          30   0%                 - timer--activate
+          30   0%                    timer--time-less-p
+         282   0%              - seed7-inside-comment-p
+         282   0%               - syntax-ppss
+         282   0%                  parse-partial-sexp
+         421   0%           - seed7-line-inside-argument-list-section
+           1   0%            - forward-sexp
+           1   0%               seed7--forward-sexp-function
+           1   0%              seed7-to-indent
+          17   0%            - seed7-line-is-procfunc-beg-of-decl
+          17   0%             - seed7-line-starts-with
+           1   0%                seed7-move-to-line
+         398   0%            - seed7-re-search-backward
+          66   0%             - run-with-timer
+          66   0%              - run-at-time
+           6   0%                 timer-relative-time
+          17   0%               - timer-set-time
+          17   0%                  timer--time-setter
+          43   0%               - timer-activate
+          43   0%                - timer--activate
+          42   0%                 - timer--time-less-p
+           2   0%                    timer--time
+         329   0%               re-search-backward
+         927   0%           - seed7-comment-column
+           2   0%            - seed7-line-starts-with
+           2   0%               seed7-move-to-line
+          10   0%            - seed7-line-inside-a-block
+           5   0%             - seed7-re-search-backward
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           4   0%                re-search-backward
+           5   0%             - seed7--safe-enclosing-block-bounds
+           1   0%              - seed7-to-block-backward
+           1   0%               - seed7-re-search-backward
+           1   0%                  re-search-backward
+           4   0%              - seed7--block-end-pos-for
+           4   0%               - seed7-to-block-forward
+           4   0%                - seed7-re-search-forward
+           2   0%                 - seed7-inside-comment-p
+           2   0%                  - syntax-ppss
+           2   0%                     parse-partial-sexp
+          15   0%            - seed7-line-code-ends-with
+           1   0%             - seed7-re-search-backward
+           1   0%              - run-with-timer
+           1   0%               - run-at-time
+           1   0%                - timer-activate
+           1   0%                 - timer--activate
+           1   0%                    timer--time-less-p
+          14   0%             - seed7-move-to-line
+          14   0%              - seed7-to-previous-non-empty-line
+          13   0%               - seed7-inside-comment-p
+          13   0%                - syntax-ppss
+          12   0%                   parse-partial-sexp
+         900   0%            - seed7-calc-indent
+           1   0%             - seed7-line-inside-logic-check-expression
+           1   0%              - seed7--current-line-nth-word
+           1   0%               - thing-at-point
+           1   0%                - bounds-of-thing-at-point
+           1   0%                 - #<byte-code-function 716>
+           1   0%                  - forward-thing
+           1   0%                     forward-word
+           1   0%             - seed7-current-line-start-inside-comment-p
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  make-closure
+           2   0%             - seed7-line-inside-argument-list-section
+           2   0%              - seed7-re-search-backward
+           1   0%                 re-search-backward
+           1   0%               - run-with-timer
+           1   0%                - run-at-time
+           1   0%                 - timer-set-time
+           1   0%                    timer--time-setter
+           3   0%             - seed7-line-inside-until-logic-expression
+           3   0%              - seed7-re-search-backward
+           3   0%               - run-with-timer
+           3   0%                - run-at-time
+           1   0%                   timer-relative-time
+           2   0%                 - timer-activate
+           2   0%                  - timer--activate
+           2   0%                     timer--time-less-p
+           4   0%             - seed7-line-inside-assign-statement-continuation
+           4   0%              - seed7-assign-op-pos
+           4   0%               - seed7-re-search-backward
+           4   0%                - seed7-inside-comment-p
+           4   0%                 - syntax-ppss
+           4   0%                    parse-partial-sexp
+          14   0%             - seed7-line-after-func-return-logic-operator-column
+          14   0%              - seed7-move-to-line
+          14   0%               - seed7-to-previous-non-empty-line
+          14   0%                - seed7-inside-comment-p
+          14   0%                 - syntax-ppss
+          14   0%                    parse-partial-sexp
+          15   0%             - seed7-line-at-endof-array-definition-block
+          15   0%              - seed7-move-to-line
+          15   0%               - seed7-to-previous-non-empty-line
+          14   0%                - seed7-inside-comment-p
+          13   0%                 - syntax-ppss
+           1   0%                  - #<byte-code-function 82F>
+           1   0%                     set-syntax-table
+           2   0%                    make-closure
+          10   0%                    parse-partial-sexp
+          16   0%             - seed7-line-at-endof-set-definition-block
+          16   0%              - seed7-move-to-line
+          16   0%               - seed7-to-previous-non-empty-line
+          14   0%                - seed7-inside-comment-p
+          13   0%                 - syntax-ppss
+           1   0%                    make-closure
+          12   0%                    parse-partial-sexp
+          18   0%             - seed7-line-starts-with-open-paren-after-logic-operator
+          18   0%              - seed7-move-to-line
+          18   0%               - seed7-to-previous-non-empty-line
+          16   0%                - seed7-inside-comment-p
+          15   0%                 - syntax-ppss
+           4   0%                    make-closure
+          11   0%                    parse-partial-sexp
+          39   0%             - seed7-line-inside-parens-pair-column
+          39   0%              - seed7-line-inside-parens-pair
+           1   0%               - forward-sexp
+           1   0%                  seed7--forward-sexp-function
+           2   0%               - seed7-line-inside-syntax-parens-pair
+           2   0%                - syntax-ppss
+           2   0%                   parse-partial-sexp
+          35   0%               - seed7-re-search-backward
+           1   0%                  re-search-backward
+           3   0%                - run-with-timer
+           3   0%                 - run-at-time
+           3   0%                  - timer-activate
+           3   0%                   - timer--activate
+           3   0%                      timer--time-less-p
+          30   0%                - seed7-inside-comment-p
+          29   0%                 - syntax-ppss
+           1   0%                    syntax-ppss-toplevel-pos
+           1   0%                    syntax-ppss--data
+           1   0%                    make-closure
+          26   0%                    parse-partial-sexp
+          61   0%             - seed7-line-inside-a-block-cached
+          61   0%              - seed7-line-inside-a-block
+          15   0%               - seed7-re-search-backward
+           1   0%                  re-search-backward
+           4   0%                - run-with-timer
+           4   0%                 - run-at-time
+           2   0%                  - timer-set-time
+           1   0%                     timer--time-setter
+           2   0%                  - timer-activate
+           2   0%                   - timer--activate
+           2   0%                      timer--time-less-p
+          10   0%                - seed7-inside-comment-p
+          10   0%                 - syntax-ppss
+          10   0%                    parse-partial-sexp
+          46   0%               - seed7--safe-enclosing-block-bounds
+          13   0%                - seed7--block-end-pos-for
+          13   0%                 - seed7-to-block-forward
+           1   0%                  - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+           1   0%                   - seed7-inside-comment-p
+           1   0%                    - syntax-ppss
+           1   0%                       parse-partial-sexp
+           1   0%                  - seed7-inside-comment-p
+           1   0%                   - syntax-ppss
+           1   0%                      parse-partial-sexp
+           2   0%                  - seed7--current-line-nth-word
+           2   0%                   - thing-at-point
+           1   0%                    - bounds-of-thing-at-point
+           1   0%                       re-search-forward
+           9   0%                  - seed7-re-search-forward
+           1   0%                   - seed7-inside-string-p
+           1   0%                    - syntax-ppss
+           1   0%                       parse-partial-sexp
+           7   0%                   - seed7-inside-comment-p
+           7   0%                    - syntax-ppss
+           7   0%                       parse-partial-sexp
+          33   0%                - seed7-to-block-backward
+           3   0%                 - seed7-inside-comment-p
+           3   0%                  - syntax-ppss
+           3   0%                     parse-partial-sexp
+          30   0%                 - seed7-re-search-backward
+           3   0%                  - seed7-inside-string-p
+           3   0%                   - syntax-ppss
+           3   0%                      parse-partial-sexp
+           6   0%                    re-search-backward
+           8   0%                  - run-with-timer
+           8   0%                   - run-at-time
+           1   0%                    - timer-set-time
+           1   0%                       timer--time-setter
+           7   0%                    - timer-activate
+           7   0%                     - timer--activate
+           7   0%                        timer--time-less-p
+          12   0%                  - seed7-inside-comment-p
+          12   0%                   - syntax-ppss
+          12   0%                      parse-partial-sexp
+          91   0%             - seed7--indent-search-boundary
+          91   0%              - seed7--indent-search-boundary-uncached
+           1   0%                 seed7-to-indent
+          78   0%               - syntax-ppss
+           1   0%                  syntax-table
+          77   0%                  parse-partial-sexp
+         184   0%             - seed7-line-inside-set-definition-block
+         184   0%              - seed7-re-search-backward
+           3   0%               - seed7-inside-comment-p
+           3   0%                - syntax-ppss
+           3   0%                   parse-partial-sexp
+         181   0%                 re-search-backward
+         192   0%             - seed7-line-is-defun-end
+           1   0%              - seed7--safe-current-line-defun-start-indent
+           1   0%               - seed7-to-block-backward
+           1   0%                - seed7-re-search-backward
+           1   0%                   re-search-backward
+           1   0%              - seed7--current-line-nth-word
+           1   0%               - thing-at-point
+           1   0%                - bounds-of-thing-at-point
+           1   0%                 - #<byte-code-function 63B>
+           1   0%                  - forward-thing
+           1   0%                     forward-word
+          12   0%              - seed7-move-to-line
+          12   0%               - seed7-to-previous-non-empty-line
+          12   0%                - seed7-inside-comment-p
+          11   0%                 - syntax-ppss
+           2   0%                    make-closure
+           9   0%                    parse-partial-sexp
+          20   0%              - seed7-beg-of-defun
+           2   0%               - seed7-re-search-backward
+           2   0%                  re-search-backward
+          18   0%               - seed7-re-search-backward-closest
+          18   0%                - seed7-re-search-backward
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+          17   0%                   re-search-backward
+         158   0%              - seed7-end-of-defun
+           1   0%               - seed7-re-search-backward
+           1   0%                  re-search-backward
+          42   0%                 seed7-re-search-forward
+         115   0%               - seed7-top-block-name
+         115   0%                - seed7--to-top
+         112   0%                 - seed7-re-search-backward
+           7   0%                    re-search-backward
+          13   0%                  - run-with-timer
+          13   0%                   - run-at-time
+           1   0%                      timer-relative-time
+           2   0%                    - timer-set-time
+           2   0%                       timer--time-setter
+          10   0%                    - timer-activate
+          10   0%                     - timer--activate
+          10   0%                        timer--time-less-p
+          92   0%                  - seed7-inside-comment-p
+          92   0%                   - syntax-ppss
+           3   0%                    - syntax-propertize
+           3   0%                       seed7-mode-syntax-propertize
+          89   0%                      parse-partial-sexp
+         259   0%             - seed7-line-inside-array-definition-block
+         259   0%              - seed7-re-search-backward
+           2   0%               - seed7-inside-comment-p
+           2   0%                - syntax-ppss
+           2   0%                   parse-partial-sexp
+         257   0%                 re-search-backward
+       11330   3%           - seed7-line-inside-parens-pair-column
+       11330   3%            - seed7-line-inside-parens-pair
+          89   0%             - seed7-line-inside-syntax-parens-pair
+           3   0%                seed7-move-to-line
+          85   0%              - syntax-ppss
+          84   0%                 parse-partial-sexp
+         143   0%             - forward-sexp
+         141   0%              - seed7--forward-sexp-function
+           1   0%                 seed7--at-line-comment-start-p
+       10047   2%             - seed7-re-search-backward
+           4   0%                make-closure
+           7   0%              - #<byte-code-function 916>
+           7   0%                 cancel-timer
+          82   0%              - seed7-inside-string-p
+           4   0%               - #<byte-code-function 829>
+           1   0%                  set-match-data
+          67   0%               - syntax-ppss
+           1   0%                  set-syntax-table
+           1   0%                  syntax-propertize
+           2   0%                - #<byte-code-function A15>
+           1   0%                   set-syntax-table
+           5   0%                  syntax-ppss--data
+           6   0%                  make-closure
+          46   0%                  parse-partial-sexp
+         133   0%                re-search-backward
+        2766   0%              - run-with-timer
+        2765   0%               - run-at-time
+           2   0%                  timer-set-function
+           5   0%                  timer-create
+         280   0%                  timer-relative-time
+         930   0%                - timer-set-time
+         927   0%                 - timer--time-setter
+           1   0%                    timerp
+        1543   0%                - timer-activate
+        1541   0%                 - timer--activate
+        1538   0%                  - timer--time-less-p
+          14   0%                     timer--time
+        7035   2%              - seed7-inside-comment-p
+        7029   2%               - syntax-ppss
+           2   0%                  syntax-propertize
+           2   0%                  syntax-ppss--data
+           2   0%                  syntax-ppss--update-stats
+           3   0%                  syntax-ppss-toplevel-pos
+           3   0%                  syntax-table
+           5   0%                  #<byte-code-function BC8>
+           7   0%                  make-closure
+        6986   2%                  parse-partial-sexp
+       25833   7%           - seed7-line-inside-set-definition-block
+          26   0%            - forward-sexp
+          26   0%               seed7--forward-sexp-function
+       25797   7%            - seed7-re-search-backward
+           1   0%             - #<byte-code-function 2AE>
+           1   0%                cancel-timer
+           4   0%             - seed7-inside-string-p
+           1   0%              - #<byte-code-function 465>
+           1   0%                 set-match-data
+           2   0%              - syntax-ppss
+           2   0%                 parse-partial-sexp
+          84   0%             - run-with-timer
+          84   0%              - run-at-time
+          12   0%                 timer-relative-time
+          29   0%               - timer-set-time
+          28   0%                  timer--time-setter
+          43   0%               - timer-activate
+          43   0%                - timer--activate
+          43   0%                 - timer--time-less-p
+           1   0%                    timer--time
+         459   0%             - seed7-inside-comment-p
+         458   0%              - syntax-ppss
+         457   0%                 parse-partial-sexp
+       25247   7%               re-search-backward
+       27414   8%           - seed7-line-inside-array-definition-block
+          14   0%            - forward-sexp
+          14   0%               seed7--forward-sexp-function
+       27390   8%            - seed7-re-search-backward
+           1   0%               #<byte-code-function C72>
+           3   0%             - seed7-inside-string-p
+           1   0%              - syntax-ppss
+           1   0%                 parse-partial-sexp
+          47   0%             - run-with-timer
+          47   0%              - run-at-time
+           6   0%               - timer-set-time
+           6   0%                  timer--time-setter
+           6   0%                 timer-relative-time
+          35   0%               - timer-activate
+          35   0%                - timer--activate
+          35   0%                   timer--time-less-p
+         505   0%             - seed7-inside-comment-p
+         505   0%              - syntax-ppss
+         503   0%                 parse-partial-sexp
+       26833   7%               re-search-backward
+       34989  10%           - seed7--indent-search-boundary
+       34984  10%            - seed7--indent-search-boundary-uncached
+         146   0%               seed7-to-indent
+       31814   9%             - syntax-ppss
+           5   0%                syntax-propertize
+           6   0%                set-syntax-table
+           6   0%                syntax-ppss--data
+           8   0%                syntax-ppss-toplevel-pos
+          10   0%                syntax-ppss--update-stats
+          10   0%                syntax-table
+          26   0%              - #<byte-code-function 790>
+           6   0%                 set-syntax-table
+          36   0%                make-closure
+       31632   9%                parse-partial-sexp
+      101023  29%           - seed7-line-is-defun-end
+           3   0%              line-end-position
+          16   0%            - seed7-line-starts-with-any
+          16   0%               seed7-line-starts-with
+          29   0%            - seed7--current-line-nth-word
+          24   0%             - thing-at-point
+          21   0%              - bounds-of-thing-at-point
+           1   0%                 re-search-forward
+           2   0%               - #<byte-code-function B3E>
+           2   0%                - forward-thing
+           1   0%                   format
+           1   0%                   forward-word
+           2   0%               - seq-some
+           2   0%                  make-closure
+           5   0%               - #<byte-code-function D84>
+           5   0%                - forward-thing
+           1   0%                   format
+           4   0%                   forward-word
+           8   0%                 make-closure
+          92   0%            - seed7--safe-current-line-defun-start-indent
+           2   0%               seed7-current-line-indent
+          90   0%             - seed7-to-block-backward
+           1   0%              - seed7--current-line-nth-word
+           1   0%               - thing-at-point
+           1   0%                - bounds-of-thing-at-point
+           1   0%                 - #<byte-code-function F0C>
+           1   0%                  - forward-thing
+           1   0%                     forward-word
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+          88   0%              - seed7-re-search-backward
+           1   0%               - seed7-inside-string-p
+           1   0%                - syntax-ppss
+           1   0%                   parse-partial-sexp
+           4   0%               - run-with-timer
+           4   0%                - run-at-time
+           1   0%                 - timer-set-time
+           1   0%                    timer--time-setter
+           3   0%                 - timer-activate
+           3   0%                  - timer--activate
+           3   0%                     timer--time-less-p
+          14   0%               - seed7-inside-comment-p
+          14   0%                - syntax-ppss
+          14   0%                   parse-partial-sexp
+          69   0%                 re-search-backward
+         107   0%            - seed7-move-to-line
+         106   0%             - seed7-to-previous-non-empty-line
+          74   0%              - seed7-inside-comment-p
+          74   0%               - syntax-ppss
+           1   0%                  #<byte-code-function 332>
+           1   0%                  syntax-ppss-toplevel-pos
+          72   0%                  parse-partial-sexp
+       23287   6%            - seed7-beg-of-defun
+           1   0%               match-string-no-properties
+           6   0%               match-string
+        5767   1%             - seed7-re-search-backward
+           2   0%                make-closure
+          20   0%              - seed7-inside-string-p
+           2   0%               - #<byte-code-function 5C5>
+           2   0%                  set-match-data
+          13   0%               - syntax-ppss
+           1   0%                - #<byte-code-function E8C>
+           1   0%                   set-syntax-table
+           1   0%                  syntax-ppss--data
+           1   0%                  make-closure
+           7   0%                  parse-partial-sexp
+         449   0%              - run-with-timer
+         449   0%               - run-at-time
+          39   0%                  timer-relative-time
+         134   0%                - timer-set-time
+         134   0%                 - timer--time-setter
+           1   0%                    timerp
+         275   0%                - timer-activate
+         275   0%                 - timer--activate
+         275   0%                    timer--time-less-p
+        1448   0%              - seed7-inside-comment-p
+        1448   0%               - syntax-ppss
+           1   0%                  #<byte-code-function 2A0>
+        1444   0%                  parse-partial-sexp
+        3842   1%                re-search-backward
+        6355   1%             - seed7-top-block-name
+         123   0%              - seed7--block-name
+         123   0%               - seed7-re-search-forward
+           2   0%                - seed7-inside-string-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           4   0%                - seed7-inside-comment-p
+           4   0%                 - syntax-ppss
+           4   0%                    parse-partial-sexp
+        6232   1%              - seed7--to-top
+          23   0%               - run-with-timer
+          23   0%                - run-at-time
+           1   0%                   timer-create
+           4   0%                   timer-relative-time
+           8   0%                 - timer-activate
+           8   0%                  - timer--activate
+           8   0%                   - timer--time-less-p
+           1   0%                      timer--time
+          10   0%                 - timer-set-time
+          10   0%                    timer--time-setter
+          24   0%                 seed7-to-indent
+        5918   1%               - seed7-re-search-backward
+           1   0%                - #<byte-code-function 21E>
+           1   0%                   cancel-timer
+           5   0%                  make-closure
+          46   0%                - seed7-inside-string-p
+           3   0%                 - #<byte-code-function 3DE>
+           1   0%                    set-match-data
+          28   0%                 - syntax-ppss
+           1   0%                    syntax-ppss--update-stats
+           5   0%                    make-closure
+          21   0%                    parse-partial-sexp
+         794   0%                  re-search-backward
+        1514   0%                - run-with-timer
+        1511   0%                 - run-at-time
+           2   0%                    timer-create
+          83   0%                    timer-relative-time
+         415   0%                  - timer-set-time
+         413   0%                   - timer--time-setter
+           1   0%                      timerp
+        1010   0%                  - timer-activate
+        1010   0%                   - timer--activate
+           1   0%                      timerp
+        1006   0%                    - timer--time-less-p
+           9   0%                       timer--time
+        3548   1%                - seed7-inside-comment-p
+        3546   1%                 - syntax-ppss
+           1   0%                    syntax-propertize
+           1   0%                    syntax-ppss-toplevel-pos
+           1   0%                    syntax-table
+           1   0%                    set-syntax-table
+           2   0%                    syntax-ppss--data
+           2   0%                  - #<byte-code-function 1BB>
+           1   0%                     set-syntax-table
+           4   0%                    make-closure
+        3518   1%                    parse-partial-sexp
+       11112   3%             - seed7-re-search-backward-closest
+           5   0%              - seq-filter
+           1   0%                 make-symbol
+           4   0%               - seq-map
+           3   0%                - apply
+           2   0%                 - #<byte-code-function D07>
+           2   0%                  - mapcar
+           1   0%                   - #<byte-code-function 5F5>
+           1   0%                      identity
+       11105   3%              - seed7-re-search-backward
+           2   0%               - seed7-inside-string-p
+           1   0%                  #<byte-code-function 623>
+          40   0%               - run-with-timer
+          40   0%                - run-at-time
+           2   0%                   timer-relative-time
+          14   0%                 - timer-set-time
+          14   0%                    timer--time-setter
+          24   0%                 - timer-activate
+          24   0%                  - timer--activate
+          24   0%                     timer--time-less-p
+         215   0%               - seed7-inside-comment-p
+         215   0%                - syntax-ppss
+           1   0%                   make-closure
+         213   0%                   parse-partial-sexp
+       10847   3%                 re-search-backward
+       77485  22%            - seed7-end-of-defun
+           1   0%               seed7--move-and-mark
+           3   0%               match-string-no-properties
+           4   0%               match-string
+         451   0%             - seed7-re-search-backward
+           1   0%              - seed7-inside-string-p
+           1   0%                 syntax-ppss
+          73   0%              - run-with-timer
+          73   0%               - run-at-time
+           8   0%                  timer-relative-time
+          22   0%                - timer-set-time
+          22   0%                 - timer--time-setter
+           1   0%                    timerp
+          43   0%                - timer-activate
+          43   0%                 - timer--activate
+          41   0%                    timer--time-less-p
+         129   0%              - seed7-inside-comment-p
+         128   0%               - syntax-ppss
+         127   0%                  parse-partial-sexp
+         247   0%                re-search-backward
+       23205   6%             - seed7-re-search-forward
+         442   0%              - seed7-inside-string-p
+         432   0%               - syntax-ppss
+           1   0%                  make-closure
+           1   0%                  syntax-propertize
+           1   0%                  set-syntax-table
+           2   0%                  #<byte-code-function CE1>
+         423   0%                  parse-partial-sexp
+        2008   0%              - seed7-inside-comment-p
+        2006   0%               - syntax-ppss
+           2   0%                  #<byte-code-function BA4>
+           5   0%                  make-closure
+         479   0%                - syntax-propertize
+           1   0%                   #<byte-code-function 68D>
+           2   0%                 - syntax-ppss-flush-cache
+           1   0%                    syntax-propertize--in-process-p
+           8   0%                 - #<byte-code-function A55>
+           5   0%                  - syntax-propertize-wholelines
+           3   0%                     syntax--lbp
+         442   0%                 - seed7-mode-syntax-propertize
+           1   0%                    #<byte-code-function B64>
+           1   0%                    #<byte-code-function 34E>
+        1512   0%                  parse-partial-sexp
+       53790  15%             - seed7-top-block-name
+         139   0%              - seed7--block-name
+           2   0%                 match-string
+         136   0%               - seed7-re-search-forward
+          12   0%                - seed7-inside-string-p
+           8   0%                 - syntax-ppss
+           1   0%                    #<byte-code-function 050>
+           7   0%                    parse-partial-sexp
+          78   0%                - seed7-inside-comment-p
+          78   0%                 - syntax-ppss
+          78   0%                    parse-partial-sexp
+       53649  15%              - seed7--to-top
+          69   0%               - run-with-timer
+          69   0%                - run-at-time
+           9   0%                   timer-relative-time
+          21   0%                 - timer-set-time
+          21   0%                    timer--time-setter
+          39   0%                 - timer-activate
+          39   0%                  - timer--activate
+          39   0%                     timer--time-less-p
+         117   0%                 seed7-to-indent
+       52332  15%               - seed7-re-search-backward
+          10   0%                  make-closure
+          10   0%                - #<byte-code-function 9E1>
+           8   0%                 - cancel-timer
+           1   0%                    timerp
+         283   0%                - seed7-inside-string-p
+          21   0%                 - #<byte-code-function 799>
+          15   0%                    set-match-data
+         180   0%                 - syntax-ppss
+           2   0%                    syntax-ppss--data
+           3   0%                    set-syntax-table
+           4   0%                    syntax-table
+           5   0%                    syntax-propertize
+           7   0%                    syntax-ppss--update-stats
+          10   0%                  - #<byte-code-function 982>
+           2   0%                     set-syntax-table
+          18   0%                    make-closure
+         107   0%                  - parse-partial-sexp
+          26   0%                   - internal--syntax-propertize
+          25   0%                    - syntax-propertize
+          17   0%                       seed7-mode-syntax-propertize
+        4185   1%                  re-search-backward
+        9687   2%                - run-with-timer
+        9682   2%                 - run-at-time
+           9   0%                  - timer-set-function
+           3   0%                     timerp
+          21   0%                    timer-create
+         660   0%                    timer-relative-time
+        2625   0%                  - timer-set-time
+        2622   0%                   - timer--time-setter
+           2   0%                      timerp
+        6357   1%                  - timer-activate
+        6355   1%                   - timer--activate
+           4   0%                      timerp
+        6331   1%                    - timer--time-less-p
+          38   0%                       timer--time
+       38045  11%                - seed7-inside-comment-p
+       38028  11%                 - syntax-ppss
+           1   0%                    set-syntax-table
+           3   0%                    syntax-ppss--data
+           4   0%                    syntax-ppss--update-stats
+           4   0%                    syntax-ppss-toplevel-pos
+           4   0%                    syntax-table
+          14   0%                    make-closure
+          16   0%                  - #<byte-code-function ED6>
+           1   0%                     set-syntax-table
+        1446   0%                  - syntax-propertize
+        1438   0%                     seed7-mode-syntax-propertize
+       36471  10%                    parse-partial-sexp
+      119139  35%           - seed7-line-inside-a-block-cached
+           1   0%              seed7--cache-block-spec
+      119137  35%            - seed7-line-inside-a-block
+           1   0%               seed7--indent-offset-for
+           3   0%               seed7--on-lineof
+           6   0%               match-string
+          16   0%               replace-regexp-in-string
+        4021   1%             - seed7-re-search-backward
+           1   0%              - #<byte-code-function 617>
+           1   0%                 cancel-timer
+           1   0%                make-closure
+          48   0%              - seed7-inside-string-p
+           4   0%               - #<byte-code-function AB7>
+           3   0%                  set-match-data
+          36   0%               - syntax-ppss
+           1   0%                  make-closure
+          34   0%                  parse-partial-sexp
+         858   0%              - run-with-timer
+         857   0%               - run-at-time
+           1   0%                  timer-create
+          72   0%                  timer-relative-time
+         301   0%                - timer-set-time
+         301   0%                 - timer--time-setter
+           1   0%                    timerp
+         483   0%                - timer-activate
+         483   0%                 - timer--activate
+         483   0%                  - timer--time-less-p
+           5   0%                     timer--time
+        1444   0%              - seed7-inside-comment-p
+        1441   0%               - syntax-ppss
+           1   0%                  make-closure
+           2   0%                  #<byte-code-function 9B9>
+           2   0%                  syntax-ppss--data
+        1428   0%                  parse-partial-sexp
+        1660   0%                re-search-backward
+        6091   1%             - seed7-calc-indent
+           1   0%              - seed7-line-inside-assign-statement-continuation
+           1   0%               - seed7-assign-op-pos
+           1   0%                - seed7-re-search-backward
+           1   0%                 - run-with-timer
+           1   0%                  - run-at-time
+           1   0%                   - timer-activate
+           1   0%                    - timer--activate
+           1   0%                       timer--time-less-p
+           1   0%              - seed7-line-at-endof-set-definition-block
+           1   0%               - seed7-line-code-ends-with
+           1   0%                - seed7-re-search-backward
+           1   0%                   re-search-backward
+           1   0%              - seed7-line-indent-step
+           1   0%               - seed7-move-to-line
+           1   0%                - seed7-to-previous-non-empty-line
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           2   0%              - seed7-line-at-endof-array-definition-block
+           2   0%               - seed7-line-code-ends-with
+           2   0%                - seed7-re-search-backward
+           1   0%                 - run-with-timer
+           1   0%                  - run-at-time
+           1   0%                   - timer-activate
+           1   0%                    - timer--activate
+           1   0%                       timer--time-less-p
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           8   0%              - seed7-line-inside-set-definition-block
+           8   0%               - seed7-re-search-backward
+           1   0%                - run-with-timer
+           1   0%                 - run-at-time
+           1   0%                  - timer-set-time
+           1   0%                     timer--time-setter
+           7   0%                  re-search-backward
+           8   0%              - seed7-line-inside-array-definition-block
+           8   0%               - seed7-re-search-backward
+           1   0%                - seed7-inside-comment-p
+           1   0%                 - syntax-ppss
+           1   0%                    parse-partial-sexp
+           7   0%                  re-search-backward
+          71   0%              - seed7-line-is-defun-end
+           2   0%               - seed7-move-to-line
+           2   0%                - seed7-to-previous-non-empty-line
+           2   0%                 - seed7-inside-comment-p
+           2   0%                  - syntax-ppss
+           2   0%                     parse-partial-sexp
+          15   0%               - seed7--safe-current-line-defun-start-indent
+          15   0%                - seed7-to-block-backward
+          15   0%                 - seed7-re-search-backward
+           2   0%                  - run-with-timer
+           2   0%                   - run-at-time
+           1   0%                    - timer-set-time
+           1   0%                       timer--time-setter
+           1   0%                    - timer-activate
+           1   0%                     - timer--activate
+           1   0%                        timer--time-less-p
+           3   0%                  - seed7-inside-comment-p
+           3   0%                   - syntax-ppss
+           1   0%                      make-closure
+           2   0%                      parse-partial-sexp
+          10   0%                    re-search-backward
+          19   0%               - seed7-beg-of-defun
+           4   0%                - seed7-re-search-backward-closest
+           4   0%                 - seed7-re-search-backward
+           4   0%                    re-search-backward
+          15   0%                - seed7-re-search-backward
+           1   0%                 - run-with-timer
+           1   0%                  - run-at-time
+           1   0%                   - timer-activate
+           1   0%                    - timer--activate
+           1   0%                       timer--time-less-p
+           5   0%                 - seed7-inside-comment-p
+           5   0%                  - syntax-ppss
+           4   0%                     parse-partial-sexp
+           9   0%                   re-search-backward
+          35   0%               - seed7-end-of-defun
+           1   0%                - seed7-re-search-backward
+           1   0%                 - run-with-timer
+           1   0%                  - run-at-time
+           1   0%                   - timer-set-time
+           1   0%                      timer--time-setter
+           8   0%                - seed7-top-block-name
+           8   0%                 - seed7--to-top
+           1   0%                  - run-with-timer
+           1   0%                   - run-at-time
+           1   0%                      timer-relative-time
+           6   0%                  - seed7-re-search-backward
+           1   0%                   - seed7-inside-comment-p
+           1   0%                    - syntax-ppss
+           1   0%                       parse-partial-sexp
+           2   0%                     re-search-backward
+           3   0%                   - run-with-timer
+           3   0%                    - run-at-time
+           3   0%                     - timer-activate
+           3   0%                      - timer--activate
+           3   0%                         timer--time-less-p
+          26   0%                - seed7-re-search-forward
+           1   0%                 - seed7-inside-string-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           3   0%                 - seed7-inside-comment-p
+           3   0%                  - syntax-ppss
+           3   0%                     parse-partial-sexp
+         118   0%              - seed7--indent-search-boundary
+         118   0%               - seed7--indent-search-boundary-uncached
+         110   0%                - syntax-ppss
+         110   0%                   parse-partial-sexp
+         410   0%              - seed7-line-inside-parens-pair-column
+         410   0%               - seed7-line-inside-parens-pair
+           7   0%                - forward-sexp
+           7   0%                   seed7--forward-sexp-function
+         382   0%                - seed7-re-search-backward
+           2   0%                 - seed7-inside-string-p
+           2   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           3   0%                   re-search-backward
+         132   0%                 - run-with-timer
+         131   0%                  - run-at-time
+           1   0%                     timer-create
+           6   0%                     timer-relative-time
+          42   0%                   - timer-set-time
+          42   0%                      timer--time-setter
+          82   0%                   - timer-activate
+          82   0%                    - timer--activate
+          82   0%                     - timer--time-less-p
+           1   0%                        timer--time
+         244   0%                 - seed7-inside-comment-p
+         244   0%                  - syntax-ppss
+         244   0%                     parse-partial-sexp
+        5471   1%              - seed7-line-inside-a-block-cached
+        5471   1%               - seed7-line-inside-a-block
+          44   0%                - seed7-re-search-backward
+          12   0%                 - run-with-timer
+          12   0%                  - run-at-time
+           5   0%                   - timer-set-time
+           5   0%                      timer--time-setter
+           7   0%                   - timer-activate
+           7   0%                    - timer--activate
+           7   0%                       timer--time-less-p
+          14   0%                   re-search-backward
+          18   0%                 - seed7-inside-comment-p
+          18   0%                  - syntax-ppss
+          17   0%                     parse-partial-sexp
+        5423   1%                - seed7--safe-enclosing-block-bounds
+         275   0%                 - seed7-to-block-backward
+           2   0%                  - seed7-inside-line-indent-before-comment-p
+           1   0%                     seed7-to-indent
+           3   0%                  - seed7--current-line-nth-word
+           3   0%                   - thing-at-point
+           3   0%                    - bounds-of-thing-at-point
+           2   0%                     - #<byte-code-function 606>
+           2   0%                      - forward-thing
+           2   0%                         forward-word
+          10   0%                  - seed7-inside-comment-p
+          10   0%                   - syntax-ppss
+          10   0%                      parse-partial-sexp
+         125   0%                  - seed7-beg-of-defun
+           2   0%                   - seed7-top-block-name
+           2   0%                    - seed7--to-top
+           1   0%                     - run-with-timer
+           1   0%                      - run-at-time
+           1   0%                         timer-relative-time
+          60   0%                   - seed7-re-search-backward
+           8   0%                    - run-with-timer
+           8   0%                     - run-at-time
+           3   0%                      - timer-set-time
+           3   0%                         timer--time-setter
+           5   0%                      - timer-activate
+           5   0%                       - timer--activate
+           5   0%                          timer--time-less-p
+          22   0%                    - seed7-inside-comment-p
+          21   0%                     - syntax-ppss
+          21   0%                        parse-partial-sexp
+          30   0%                      re-search-backward
+          63   0%                   - seed7-re-search-backward-closest
+          63   0%                    - seed7-re-search-backward
+           1   0%                     - seed7-inside-comment-p
+           1   0%                      - syntax-ppss
+           1   0%                         parse-partial-sexp
+          62   0%                       re-search-backward
+         135   0%                  - seed7-re-search-backward
+           4   0%                   - seed7-inside-string-p
+           2   0%                    - syntax-ppss
+           1   0%                       parse-partial-sexp
+           1   0%                       make-closure
+          28   0%                   - run-with-timer
+          28   0%                    - run-at-time
+           1   0%                       timer-relative-time
+           8   0%                     - timer-set-time
+           8   0%                        timer--time-setter
+          19   0%                     - timer-activate
+          19   0%                      - timer--activate
+          19   0%                         timer--time-less-p
+          51   0%                     re-search-backward
+          52   0%                   - seed7-inside-comment-p
+          52   0%                    - syntax-ppss
+          52   0%                       parse-partial-sexp
+        5148   1%                 - seed7--block-end-pos-for
+        5148   1%                  - seed7-to-block-forward
+           1   0%                   - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+           1   0%                    - seed7-inside-comment-p
+           1   0%                     - syntax-ppss
+           1   0%                        parse-partial-sexp
+           1   0%                     seed7--end-regexp-for
+           2   0%                   - seed7-inside-comment-p
+           2   0%                    - syntax-ppss
+           2   0%                       parse-partial-sexp
+          10   0%                   - seed7--current-line-nth-word
+           7   0%                    - thing-at-point
+           6   0%                     - bounds-of-thing-at-point
+           2   0%                        make-closure
+           4   0%                      - #<byte-code-function 24E>
+           4   0%                       - forward-thing
+           1   0%                          format
+           3   0%                          forward-word
+          37   0%                   - seed7-re-search-forward
+           4   0%                    - seed7-inside-string-p
+           4   0%                     - syntax-ppss
+           1   0%                        make-closure
+           3   0%                        parse-partial-sexp
+           4   0%                    - seed7-inside-comment-p
+           4   0%                     - syntax-ppss
+           4   0%                        parse-partial-sexp
+        5096   1%                   - seed7-end-of-defun
+           1   0%                      match-string-no-properties
+           4   0%                      match-string
+          24   0%                    - seed7-re-search-backward
+           6   0%                     - seed7-inside-comment-p
+           6   0%                      - syntax-ppss
+           6   0%                         parse-partial-sexp
+           8   0%                     - run-with-timer
+           8   0%                      - run-at-time
+           1   0%                         timer-relative-time
+           2   0%                       - timer-set-time
+           2   0%                          timer--time-setter
+           5   0%                       - timer-activate
+           5   0%                        - timer--activate
+           5   0%                           timer--time-less-p
+          10   0%                       re-search-backward
+        1391   0%                    - seed7-top-block-name
+          22   0%                     - seed7--block-name
+          22   0%                      - seed7-re-search-forward
+           2   0%                       - seed7-inside-string-p
+           2   0%                        - syntax-ppss
+           1   0%                           make-closure
+           1   0%                           parse-partial-sexp
+          14   0%                       - seed7-inside-comment-p
+          14   0%                        - syntax-ppss
+          14   0%                           parse-partial-sexp
+        1369   0%                     - seed7--to-top
+           3   0%                        seed7-to-indent
+           9   0%                      - run-with-timer
+           9   0%                       - run-at-time
+           2   0%                          timer-relative-time
+           3   0%                        - timer-set-time
+           3   0%                           timer--time-setter
+           4   0%                        - timer-activate
+           4   0%                         - timer--activate
+           4   0%                          - timer--time-less-p
+           1   0%                             timer--time
+        1343   0%                      - seed7-re-search-backward
+           9   0%                       - seed7-inside-string-p
+           5   0%                        - syntax-ppss
+           1   0%                           syntax-propertize
+           1   0%                           #<byte-code-function 3B7>
+           3   0%                           parse-partial-sexp
+          82   0%                         re-search-backward
+         228   0%                       - run-with-timer
+         228   0%                        - run-at-time
+           1   0%                           timer-set-function
+          26   0%                           timer-relative-time
+          56   0%                         - timer-set-time
+          56   0%                            timer--time-setter
+         144   0%                         - timer-activate
+         144   0%                          - timer--activate
+         143   0%                           - timer--time-less-p
+           8   0%                              timer--time
+        1019   0%                       - seed7-inside-comment-p
+        1018   0%                        - syntax-ppss
+           1   0%                           syntax-ppss--data
+        1013   0%                           parse-partial-sexp
+        3674   1%                    - seed7-re-search-forward
+         114   0%                     - seed7-inside-string-p
+           1   0%                      - #<byte-code-function A04>
+           1   0%                         set-match-data
+         112   0%                      - syntax-ppss
+         110   0%                         parse-partial-sexp
+         166   0%                     - seed7-inside-comment-p
+         164   0%                      - syntax-ppss
+         164   0%                         parse-partial-sexp
+      108711  32%             - seed7--safe-enclosing-block-bounds
+        8091   2%              - seed7-to-block-backward
+           1   0%               - backward-sexp
+           1   0%                - forward-sexp
+           1   0%                 - seed7--forward-sexp-function
+           1   0%                  - seed7--at-set-definition-end-line-p
+           1   0%                   - seed7-line-code-ends-with
+           1   0%                    - seed7-re-search-backward
+           1   0%                     - run-with-timer
+           1   0%                      - run-at-time
+           1   0%                       - timer-activate
+           1   0%                        - timer--activate
+           1   0%                           timer--time-less-p
+           1   0%               - seed7-line-code-ends-with
+           1   0%                - seed7-re-search-backward
+           1   0%                 - run-with-timer
+           1   0%                  - run-at-time
+           1   0%                   - timer-activate
+           1   0%                    - timer--activate
+           1   0%                       timer--time-less-p
+           8   0%                 seed7--start-regexp-for
+          97   0%               - seed7-inside-line-indent-before-comment-p
+          19   0%                  seed7-to-indent
+          66   0%                - seed7-inside-comment-p
+          63   0%                 - syntax-ppss
+           1   0%                    set-syntax-table
+           1   0%                    #<byte-code-function 264>
+           1   0%                    syntax-ppss--update-stats
+          60   0%                    parse-partial-sexp
+         273   0%               - seed7--current-line-nth-word
+         198   0%                - thing-at-point
+         188   0%                 - bounds-of-thing-at-point
+           9   0%                    make-closure
+          10   0%                  - seq-some
+           2   0%                     make-closure
+           6   0%                   - seq-do
+           2   0%                      mapc
+          19   0%                    re-search-forward
+          36   0%                  - #<byte-code-function 5C6>
+          35   0%                   - forward-thing
+           1   0%                      intern-soft
+           1   0%                      functionp
+           4   0%                      format
+          27   0%                      forward-word
+          92   0%                  - #<byte-code-function 2A9>
+          90   0%                   - forward-thing
+           2   0%                      intern-soft
+          14   0%                      format
+          70   0%                      forward-word
+         285   0%               - seed7-inside-comment-p
+         283   0%                - syntax-ppss
+           1   0%                   syntax-table
+           3   0%                   make-closure
+           4   0%                   #<byte-code-function 37B>
+         269   0%                   parse-partial-sexp
+         505   0%               - seed7-beg-of-defun
+         137   0%                - seed7-re-search-backward
+          19   0%                 - run-with-timer
+          19   0%                  - run-at-time
+           4   0%                     timer-relative-time
+           6   0%                   - timer-set-time
+           5   0%                      timer--time-setter
+           9   0%                   - timer-activate
+           9   0%                    - timer--activate
+           9   0%                       timer--time-less-p
+          48   0%                   re-search-backward
+          70   0%                 - seed7-inside-comment-p
+          70   0%                  - syntax-ppss
+           1   0%                     #<byte-code-function 66C>
+          69   0%                     parse-partial-sexp
+         169   0%                - seed7-top-block-name
+         169   0%                 - seed7--to-top
+           1   0%                  - run-with-timer
+           1   0%                   - run-at-time
+           1   0%                    - timer-activate
+           1   0%                     - timer--activate
+           1   0%                        timer--time-less-p
+         164   0%                  - seed7-re-search-backward
+           1   0%                     seed7-inside-string-p
+           9   0%                     re-search-backward
+          56   0%                   - run-with-timer
+          56   0%                    - run-at-time
+           3   0%                       timer-relative-time
+          15   0%                     - timer-set-time
+          15   0%                        timer--time-setter
+          38   0%                     - timer-activate
+          38   0%                      - timer--activate
+          38   0%                       - timer--time-less-p
+           2   0%                          timer--time
+          98   0%                   - seed7-inside-comment-p
+          97   0%                    - syntax-ppss
+          97   0%                       parse-partial-sexp
+         198   0%                - seed7-re-search-backward-closest
+         198   0%                 - seed7-re-search-backward
+           3   0%                  - seed7-inside-comment-p
+           3   0%                   - syntax-ppss
+           3   0%                      parse-partial-sexp
+           3   0%                  - run-with-timer
+           3   0%                   - run-at-time
+           1   0%                      timer-relative-time
+           1   0%                    - timer-activate
+           1   0%                     - timer--activate
+           1   0%                        timer--time-less-p
+           1   0%                    - timer-set-time
+           1   0%                       timer--time-setter
+         192   0%                    re-search-backward
+        6914   2%               - seed7-re-search-backward
+           1   0%                  make-closure
+           6   0%                - #<byte-code-function 4AA>
+           5   0%                   cancel-timer
+         160   0%                - seed7-inside-string-p
+           3   0%                 - #<byte-code-function DC0>
+           2   0%                    set-match-data
+         144   0%                 - syntax-ppss
+           2   0%                    syntax-ppss--update-stats
+           2   0%                    make-closure
+           2   0%                    syntax-ppss--data
+           4   0%                  - #<byte-code-function 8A8>
+           1   0%                     set-syntax-table
+         130   0%                    parse-partial-sexp
+        1781   0%                - run-with-timer
+        1781   0%                 - run-at-time
+           1   0%                    timer-set-function
+           4   0%                    timer-create
+         152   0%                    timer-relative-time
+         561   0%                  - timer-set-time
+         559   0%                     timer--time-setter
+        1063   0%                  - timer-activate
+        1062   0%                   - timer--activate
+        1060   0%                    - timer--time-less-p
+          12   0%                       timer--time
+        1899   0%                  re-search-backward
+        3054   0%                - seed7-inside-comment-p
+        3047   0%                 - syntax-ppss
+           1   0%                    syntax-ppss--data
+           1   0%                    syntax-ppss--update-stats
+           1   0%                    syntax-propertize
+           1   0%                    syntax-ppss-toplevel-pos
+           1   0%                    syntax-table
+           3   0%                    #<byte-code-function F57>
+           5   0%                    make-closure
+        3029   0%                    parse-partial-sexp
+      100616  29%              - seed7--block-end-pos-for
+           7   0%               - seed7-to-next-line-starts-with
+           6   0%                - seed7-re-search-forward
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           3   0%                 - seed7-inside-string-p
+           3   0%                  - syntax-ppss
+           3   0%                     parse-partial-sexp
+      100605  29%               - seed7-to-block-forward
+          11   0%                  seed7--end-regexp-for
+          20   0%                - seed7-inside-line-indent-before-comment-p
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           9   0%                   seed7-to-indent
+          77   0%                - seed7-inside-comment-p
+          75   0%                 - syntax-ppss
+           1   0%                    syntax-propertize
+           1   0%                    make-closure
+           1   0%                    syntax-table
+           4   0%                    #<byte-code-function 286>
+          65   0%                    parse-partial-sexp
+         104   0%                - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          17   0%                 - seed7-inside-line-indent-before-comment-p
+           2   0%                  - seed7-inside-comment-p
+           2   0%                   - syntax-ppss
+           2   0%                      parse-partial-sexp
+          10   0%                    seed7-to-indent
+          77   0%                 - seed7-inside-comment-p
+          77   0%                  - syntax-ppss
+           1   0%                     syntax-propertize
+           1   0%                   - #<byte-code-function BAC>
+           1   0%                      set-syntax-table
+           1   0%                     syntax-ppss--update-stats
+           1   0%                     make-closure
+          72   0%                     parse-partial-sexp
+         381   0%                - seed7--current-line-nth-word
+         262   0%                 - thing-at-point
+         244   0%                  - bounds-of-thing-at-point
+           7   0%                   - seq-some
+           1   0%                      seq-do
+           2   0%                      make-closure
+          13   0%                     re-search-forward
+          15   0%                     make-closure
+          62   0%                   - #<byte-code-function 1C6>
+          62   0%                    - forward-thing
+           1   0%                       intern-soft
+           1   0%                       functionp
+           9   0%                       format
+          50   0%                       forward-word
+         119   0%                   - #<byte-code-function 634>
+         118   0%                    - forward-thing
+           1   0%                       functionp
+           4   0%                       intern-soft
+          19   0%                       format
+          90   0%                       forward-word
+        2917   0%                - seed7-re-search-forward
+         520   0%                 - seed7-inside-string-p
+           5   0%                  - #<byte-code-function 62D>
+           4   0%                     set-match-data
+         498   0%                  - syntax-ppss
+           1   0%                     syntax-ppss--data
+           3   0%                     #<byte-code-function BBD>
+           5   0%                     make-closure
+         484   0%                     parse-partial-sexp
+         796   0%                 - seed7-inside-comment-p
+         792   0%                  - syntax-ppss
+           1   0%                     make-closure
+           1   0%                     syntax-ppss--data
+           3   0%                   - #<byte-code-function DB5>
+           1   0%                      set-syntax-table
+          55   0%                   - syntax-propertize
+          51   0%                      seed7-mode-syntax-propertize
+         725   0%                     parse-partial-sexp
+       97081  28%                - seed7-end-of-defun
+           5   0%                   match-string
+         152   0%                 - seed7-re-search-backward
+           2   0%                  - seed7-inside-string-p
+           2   0%                   - syntax-ppss
+           1   0%                      syntax-propertize
+          33   0%                    re-search-backward
+          53   0%                  - run-with-timer
+          53   0%                   - run-at-time
+           9   0%                      timer-relative-time
+          15   0%                    - timer-set-time
+          15   0%                       timer--time-setter
+          29   0%                    - timer-activate
+          29   0%                     - timer--activate
+          29   0%                        timer--time-less-p
+          64   0%                  - seed7-inside-comment-p
+          64   0%                   - syntax-ppss
+          63   0%                      parse-partial-sexp
+       12510   3%                 - seed7-top-block-name
+         123   0%                  - seed7--block-name
+         123   0%                   - seed7-re-search-forward
+           6   0%                    - seed7-inside-string-p
+           6   0%                     - syntax-ppss
+           6   0%                        parse-partial-sexp
+          60   0%                    - seed7-inside-comment-p
+          60   0%                     - syntax-ppss
+          57   0%                        parse-partial-sexp
+       12387   3%                  - seed7--to-top
+          23   0%                     seed7-to-indent
+          59   0%                   - run-with-timer
+          59   0%                    - run-at-time
+           1   0%                       timer-create
+           6   0%                       timer-relative-time
+          19   0%                     - timer-set-time
+          19   0%                        timer--time-setter
+          32   0%                     - timer-activate
+          32   0%                      - timer--activate
+          32   0%                         timer--time-less-p
+       12039   3%                   - seed7-re-search-backward
+           2   0%                      make-closure
+           5   0%                    - #<byte-code-function 522>
+           5   0%                       cancel-timer
+          50   0%                    - seed7-inside-string-p
+           3   0%                     - #<byte-code-function 5E9>
+           1   0%                        set-match-data
+          36   0%                     - syntax-ppss
+           1   0%                        syntax-table
+           1   0%                        make-closure
+           1   0%                        syntax-propertize
+           2   0%                        syntax-ppss--update-stats
+           3   0%                      - #<byte-code-function 039>
+           1   0%                         set-syntax-table
+          19   0%                      - parse-partial-sexp
+           4   0%                       - internal--syntax-propertize
+           4   0%                        - syntax-propertize
+           4   0%                           seed7-mode-syntax-propertize
+         872   0%                      re-search-backward
+        2070   0%                    - run-with-timer
+        2067   0%                     - run-at-time
+           2   0%                        timer-create
+           3   0%                      - timer-set-function
+           1   0%                         timerp
+         147   0%                        timer-relative-time
+         578   0%                      - timer-set-time
+         578   0%                       - timer--time-setter
+           1   0%                          timerp
+        1334   0%                      - timer-activate
+        1333   0%                       - timer--activate
+        1324   0%                          timer--time-less-p
+        9021   2%                    - seed7-inside-comment-p
+        9016   2%                     - syntax-ppss
+           1   0%                        make-closure
+           1   0%                        syntax-ppss--data
+           1   0%                        syntax-table
+           1   0%                        #<byte-code-function 8D7>
+           1   0%                        set-syntax-table
+           2   0%                        syntax-ppss--update-stats
+         208   0%                      - syntax-propertize
+         204   0%                         seed7-mode-syntax-propertize
+        8786   2%                        parse-partial-sexp
+       84403  24%                 - seed7-re-search-forward
+         133   0%                  - seed7-inside-string-p
+           1   0%                   - #<byte-code-function 4A0>
+           1   0%                      set-match-data
+         128   0%                   - syntax-ppss
+           1   0%                      #<byte-code-function C3A>
+           1   0%                      syntax-ppss--update-stats
+           3   0%                      make-closure
+         122   0%                      parse-partial-sexp
+         490   0%                  - seed7-inside-comment-p
+         486   0%                   - syntax-ppss
+           1   0%                      #<byte-code-function 694>
+           1   0%                      make-closure
+           2   0%                      syntax-ppss--update-stats
+          45   0%                    - syntax-propertize
+           1   0%                     - #<byte-code-function 0FB>
+           1   0%                      - syntax-propertize-wholelines
+           1   0%                         syntax--lbp
+           1   0%                       #<byte-code-function 4B3E>
+           1   0%                     - syntax-ppss-flush-cache
+           1   0%                        syntax-propertize--in-process-p
+          40   0%                       seed7-mode-syntax-propertize
+         434   0%                      parse-partial-sexp

--- a/reports/18.1/bas7.sd7-perf-mem.txt
+++ b/reports/18.1/bas7.sd7-perf-mem.txt
@@ -1,0 +1,2466 @@
+  4,175,599,888  80% - command-execute
+  4,175,599,888  80%  - call-interactively
+  4,175,599,888  80%   - apply
+  4,175,599,888  80%    - call-interactively@ido-cr+-record-current-command
+  4,175,599,888  80%     - #<primitive-function call-interactively>
+  4,175,599,888  80%      - funcall-interactively
+  4,161,134,541  80%       - seed7-complete-statement-or-indent
+  4,161,134,541  80%        - seed7-indent-region
+  4,161,134,541  80%         - seed7--indent-one-line
+  4,081,062,277  78%          - seed7-calc-indent
+  1,816,452,322  35%           - seed7-line-is-defun-end
+  1,437,430,048  27%            - seed7-end-of-defun
+  1,336,758,774  25%             - seed7-top-block-name
+  1,332,005,782  25%              - seed7--to-top
+  1,322,492,126  25%               - seed7-re-search-backward
+  1,059,759,743  20%                - run-with-timer
+  1,059,759,743  20%                 - run-at-time
+    516,851,767   9%                  - timer-activate
+    516,851,767   9%                   - timer--activate
+    516,851,767   9%                    - timer--time-less-p
+      3,741,398   0%                       timer--time
+    295,306,880   5%                    timer-relative-time
+    201,635,848   3%                  - timer-set-time
+    201,634,448   3%                     timer--time-setter
+     45,965,248   0%                    timer-create
+    167,930,485   3%                - seed7-inside-string-p
+     24,818,165   0%                 - syntax-ppss
+     23,695,392   0%                    make-closure
+      1,120,864   0%                  - parse-partial-sexp
+        924,112   0%                   - internal--syntax-propertize
+        667,184   0%                    - syntax-propertize
+        352,240   0%                       seed7-mode-syntax-propertize
+     62,463,037   1%                - seed7-inside-comment-p
+     32,588,941   0%                 - syntax-ppss
+     23,061,360   0%                    make-closure
+      9,330,597   0%                  - syntax-propertize
+      8,982,501   0%                     seed7-mode-syntax-propertize
+        196,752   0%                    parse-partial-sexp
+            232   0%                    #<byte-code-function CCB>
+     32,335,632   0%                  make-closure
+          1,178   0%                  re-search-backward
+      9,178,712   0%               - run-with-timer
+      9,178,712   0%                - run-at-time
+      3,686,120   0%                 - timer-activate
+      3,686,120   0%                  - timer--activate
+      3,686,120   0%                   - timer--time-less-p
+         32,792   0%                      timer--time
+      3,038,784   0%                   timer-relative-time
+      2,051,840   0%                 - timer-set-time
+      2,051,840   0%                    timer--time-setter
+        401,968   0%                   timer-create
+        269,360   0%                 make-closure
+      4,512,640   0%              - seed7--block-name
+      3,804,192   0%               - seed7-re-search-forward
+      3,178,448   0%                - seed7-inside-string-p
+        377,104   0%                 - syntax-ppss
+        377,104   0%                    make-closure
+        625,744   0%                - seed7-inside-comment-p
+        414,400   0%                 - syntax-ppss
+        414,400   0%                    make-closure
+        164,616   0%                 match-string
+     71,652,778   1%             - seed7-re-search-forward
+     41,227,011   0%              - seed7-inside-comment-p
+     35,243,075   0%               - syntax-ppss
+     31,232,043   0%                - syntax-propertize
+     20,590,251   0%                   seed7-mode-syntax-propertize
+      3,978,240   0%                  make-closure
+     24,636,961   0%              - seed7-inside-string-p
+      4,716,753   0%               - syntax-ppss
+      4,649,568   0%                  make-closure
+         65,584   0%                  parse-partial-sexp
+     13,231,904   0%             - seed7-re-search-backward
+      9,170,784   0%              - run-with-timer
+      9,170,784   0%               - run-at-time
+      3,669,904   0%                - timer-activate
+      3,669,904   0%                 - timer--activate
+      3,669,904   0%                    timer--time-less-p
+      3,038,784   0%                  timer-relative-time
+      1,985,536   0%                - timer-set-time
+      1,985,536   0%                   timer--time-setter
+        476,560   0%                  timer-create
+      3,103,856   0%              - seed7-inside-string-p
+        323,232   0%               - syntax-ppss
+        323,232   0%                  make-closure
+        671,328   0%              - seed7-inside-comment-p
+        343,952   0%               - syntax-ppss
+        343,952   0%                  make-closure
+        285,936   0%                make-closure
+      5,355,480   0%               match-string-no-properties
+      2,711,968   0%               match-string
+    335,167,504   6%            - seed7-beg-of-defun
+    217,352,921   4%             - seed7-top-block-name
+    209,751,651   4%              - seed7--to-top
+    207,229,779   4%               - seed7-re-search-backward
+    165,449,992   3%                - run-with-timer
+    165,449,992   3%                 - run-at-time
+     80,964,111   1%                  - timer-activate
+     80,964,111   1%                   - timer--activate
+     80,964,111   1%                    - timer--time-less-p
+         32,792   0%                       timer--time
+     46,143,625   0%                    timer-relative-time
+     31,570,960   0%                  - timer-set-time
+     31,570,960   0%                     timer--time-setter
+      6,771,296   0%                    timer-create
+     25,488,020   0%                - seed7-inside-string-p
+      3,968,228   0%                 - syntax-ppss
+      3,932,656   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+      8,123,319   0%                - seed7-inside-comment-p
+      3,991,751   0%                 - syntax-ppss
+      3,924,368   0%                    make-closure
+         65,584   0%                    parse-partial-sexp
+            159   0%                    #<byte-code-function 8EC>
+      5,243,878   0%                  make-closure
+      2,924,570   0%                  re-search-backward
+      2,430,704   0%               - run-with-timer
+      2,430,704   0%                - run-at-time
+        926,608   0%                 - timer-activate
+        926,608   0%                  - timer--activate
+        926,608   0%                     timer--time-less-p
+        789,792   0%                   timer-relative-time
+        523,680   0%                 - timer-set-time
+        523,680   0%                    timer--time-setter
+        190,624   0%                   timer-create
+         91,168   0%                 make-closure
+      7,568,118   0%              - seed7--block-name
+      7,492,718   0%               - seed7-re-search-forward
+        426,832   0%                - seed7-inside-string-p
+         33,152   0%                 - syntax-ppss
+         33,152   0%                    make-closure
+         78,736   0%                - seed7-inside-comment-p
+         33,152   0%                 - syntax-ppss
+         33,152   0%                    make-closure
+         17,384   0%                 match-string
+     77,307,868   1%             - seed7-re-search-backward
+     56,007,540   1%              - run-with-timer
+     56,007,540   1%               - run-at-time
+     22,402,902   0%                - timer-activate
+     22,402,902   0%                 - timer--activate
+     22,402,902   0%                  - timer--time-less-p
+          4,558   0%                     timer--time
+     18,201,694   0%                  timer-relative-time
+     12,013,152   0%                - timer-set-time
+     12,013,152   0%                   timer--time-setter
+      3,389,792   0%                  timer-create
+     11,006,864   0%              - seed7-inside-string-p
+      2,217,440   0%               - syntax-ppss
+      2,212,896   0%                  make-closure
+            753   0%                  #<byte-code-function D52>
+            197   0%                  syntax-table
+      4,795,579   0%                re-search-backward
+      3,666,016   0%              - seed7-inside-comment-p
+      2,223,904   0%               - syntax-ppss
+      2,221,184   0%                  make-closure
+          2,720   0%                  #<byte-code-function 961>
+      1,827,856   0%                make-closure
+     15,563,855   0%             - seed7-re-search-backward-closest
+     14,778,511   0%              - seed7-re-search-backward
+      8,471,000   0%                 re-search-backward
+      4,992,024   0%               - run-with-timer
+      4,992,024   0%                - run-at-time
+      2,005,800   0%                 - timer-activate
+      2,005,800   0%                  - timer--activate
+      2,005,800   0%                   - timer--time-less-p
+         32,792   0%                      timer--time
+      1,639,776   0%                   timer-relative-time
+      1,081,232   0%                 - timer-set-time
+      1,081,232   0%                    timer--time-setter
+        265,216   0%                   timer-create
+        920,076   0%               - seed7-inside-string-p
+        174,156   0%                - syntax-ppss
+        174,048   0%                   make-closure
+            108   0%                   #<byte-code-function 221>
+        250,371   0%               - seed7-inside-comment-p
+        125,227   0%                - syntax-ppss
+        124,320   0%                   make-closure
+        145,040   0%                 make-closure
+        101,584   0%              - seq-filter
+         99,456   0%                 make-closure
+          2,128   0%                 make-symbol
+      4,069,544   0%               match-string-no-properties
+      1,570,720   0%               match-string
+          8,184   0%             - user-error
+          8,184   0%                format-message
+     20,371,417   0%            - seed7-line-starts-with-any
+     20,371,417   0%               seed7-line-starts-with
+     11,632,000   0%            - seed7-move-to-line
+     11,632,000   0%             - seed7-to-previous-non-empty-line
+        649,888   0%              - seed7-inside-comment-p
+        446,832   0%               - syntax-ppss
+        381,248   0%                  make-closure
+         65,584   0%                  parse-partial-sexp
+      9,320,128   0%            - seed7--current-line-nth-word
+      8,681,952   0%             - thing-at-point
+      8,159,224   0%              - bounds-of-thing-at-point
+      2,846,928   0%                 make-closure
+      1,410,032   0%                 re-search-forward
+      1,350,960   0%               - #<byte-code-function ACE>
+      1,350,960   0%                - forward-thing
+      1,350,960   0%                   format
+        940,688   0%               - seq-some
+        940,688   0%                  make-closure
+        694,792   0%               - #<byte-code-function 9D5>
+        694,792   0%                - forward-thing
+        694,792   0%                   format
+      1,856,791   0%            - seed7--safe-current-line-defun-start-indent
+      1,831,927   0%             - seed7-to-block-backward
+      1,349,615   0%              - seed7-re-search-backward
+        760,872   0%               - run-with-timer
+        760,872   0%                - run-at-time
+        285,432   0%                 - timer-activate
+        285,432   0%                  - timer--activate
+        285,432   0%                     timer--time-less-p
+        266,000   0%                   timer-relative-time
+        172,144   0%                 - timer-set-time
+        172,144   0%                    timer--time-setter
+         37,296   0%                   timer-create
+        402,263   0%                 re-search-backward
+        103,600   0%               - seed7-inside-string-p
+         12,432   0%                - syntax-ppss
+         12,432   0%                   make-closure
+         49,728   0%               - seed7-inside-comment-p
+         37,296   0%                - syntax-ppss
+         37,296   0%                   make-closure
+         33,152   0%                 make-closure
+        347,808   0%              - seed7--current-line-nth-word
+        331,232   0%               - thing-at-point
+        313,904   0%                - bounds-of-thing-at-point
+        124,320   0%                   make-closure
+         40,920   0%                 - #<byte-code-function CF1>
+         40,920   0%                  - forward-thing
+         40,920   0%                     format
+         40,920   0%                 - #<byte-code-function A4E>
+         40,920   0%                  - forward-thing
+         40,920   0%                     format
+         37,296   0%                 - seq-some
+         37,296   0%                    make-closure
+         87,024   0%              - seed7-inside-line-indent-before-comment-p
+         45,584   0%               - seed7-inside-comment-p
+         33,152   0%                - syntax-ppss
+         33,152   0%                   make-closure
+         12,432   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+         10,184   0%              - user-error
+         10,184   0%                 format-message
+         12,432   0%               seed7-current-line-indent
+          3,106   0%              line-end-position
+  1,406,169,189  27%           - seed7-line-inside-a-block-cached
+  1,405,680,080  27%            - seed7-line-inside-a-block
+  1,106,700,569  21%             - seed7--safe-enclosing-block-bounds
+    632,754,292  12%              - seed7--block-end-pos-for
+    632,294,036  12%               - seed7-to-block-forward
+    365,520,518   7%                - seed7-end-of-defun
+    324,251,439   6%                 - seed7-top-block-name
+    319,126,694   6%                  - seed7--to-top
+    310,710,397   6%                   - seed7-re-search-backward
+    249,070,264   4%                    - run-with-timer
+    249,070,264   4%                     - run-at-time
+    119,180,928   2%                      - timer-activate
+    119,180,928   2%                       - timer--activate
+    119,180,928   2%                          timer--time-less-p
+     70,961,424   1%                        timer-relative-time
+     47,859,288   0%                      - timer-set-time
+     47,859,288   0%                         timer--time-setter
+     11,068,624   0%                        timer-create
+     39,751,390   0%                    - seed7-inside-string-p
+      6,251,294   0%                     - syntax-ppss
+      6,054,384   0%                        make-closure
+        194,048   0%                      - parse-partial-sexp
+        128,464   0%                       - internal--syntax-propertize
+         87,024   0%                        - syntax-propertize
+         45,584   0%                           seed7-mode-syntax-propertize
+          1,439   0%                        #<byte-code-function 0A8>
+     14,358,259   0%                    - seed7-inside-comment-p
+      7,541,379   0%                     - syntax-ppss
+      5,988,080   0%                        make-closure
+      1,388,548   0%                      - syntax-propertize
+      1,363,684   0%                         seed7-mode-syntax-propertize
+        163,960   0%                        parse-partial-sexp
+            495   0%                        syntax-table
+            296   0%                        #<byte-code-function 5CD>
+      7,278,055   0%                      make-closure
+        252,429   0%                      re-search-backward
+      8,130,361   0%                   - run-with-timer
+      8,130,361   0%                    - run-at-time
+      3,234,461   0%                     - timer-activate
+      3,234,461   0%                      - timer--activate
+      3,234,461   0%                       - timer--time-less-p
+            173   0%                          timer--time
+      2,703,788   0%                       timer-relative-time
+      1,810,864   0%                     - timer-set-time
+      1,810,864   0%                        timer--time-setter
+        381,248   0%                       timer-create
+        285,936   0%                     make-closure
+      4,880,249   0%                  - seed7--block-name
+      4,005,825   0%                   - seed7-re-search-forward
+      2,730,896   0%                    - seed7-inside-string-p
+        327,376   0%                     - syntax-ppss
+        327,376   0%                        make-closure
+        488,992   0%                    - seed7-inside-comment-p
+        285,936   0%                     - syntax-ppss
+        281,792   0%                        make-closure
+          4,144   0%                        syntax-propertize
+        355,192   0%                     match-string
+     21,891,559   0%                 - seed7-re-search-forward
+     13,044,874   0%                  - seed7-inside-string-p
+      2,357,498   0%                   - syntax-ppss
+      2,353,792   0%                      make-closure
+            140   0%                      syntax-table
+      7,172,618   0%                  - seed7-inside-comment-p
+      4,864,410   0%                   - syntax-ppss
+      2,623,350   0%                    - syntax-propertize
+      1,668,587   0%                       seed7-mode-syntax-propertize
+          1,643   0%                       #<byte-code-function 85B>
+      2,237,760   0%                      make-closure
+          3,250   0%                      syntax-table
+             50   0%                      #<byte-code-function ED8>
+     11,651,968   0%                 - seed7-re-search-backward
+      8,204,160   0%                  - run-with-timer
+      8,204,160   0%                   - run-at-time
+      3,263,296   0%                    - timer-activate
+      3,263,296   0%                     - timer--activate
+      3,263,296   0%                        timer--time-less-p
+      2,703,168   0%                      timer-relative-time
+      1,777,712   0%                    - timer-set-time
+      1,777,712   0%                       timer--time-setter
+        459,984   0%                      timer-create
+      2,614,864   0%                  - seed7-inside-string-p
+        314,944   0%                   - syntax-ppss
+        314,944   0%                      make-closure
+        576,016   0%                  - seed7-inside-comment-p
+        310,800   0%                   - syntax-ppss
+        310,800   0%                      make-closure
+        256,928   0%                    make-closure
+      2,856,216   0%                   match-string-no-properties
+      2,854,608   0%                   match-string
+    126,086,495   2%                - seed7--current-line-nth-word
+    114,666,978   2%                 - thing-at-point
+    104,855,331   2%                  - bounds-of-thing-at-point
+     45,856,313   0%                     make-closure
+     17,190,231   0%                   - #<byte-code-function BEC>
+     17,184,760   0%                    - forward-thing
+     17,182,440   0%                       format
+          2,320   0%                       intern-soft
+     14,374,564   0%                   - seq-some
+     14,371,392   0%                      make-closure
+      8,590,411   0%                   - #<byte-code-function 7CB>
+      8,585,432   0%                    - forward-thing
+      8,585,432   0%                       format
+      1,277,396   0%                     re-search-forward
+     88,694,479   1%                - seed7-re-search-forward
+     43,477,075   0%                 - seed7-inside-string-p
+      9,487,987   0%                  - syntax-ppss
+      9,402,736   0%                     make-closure
+         65,584   0%                     parse-partial-sexp
+          2,946   0%                     #<byte-code-function E16>
+            549   0%                     syntax-table
+     23,391,149   0%                 - seed7-inside-comment-p
+     17,083,981   0%                  - syntax-ppss
+      8,631,952   0%                     make-closure
+      8,442,448   0%                   - syntax-propertize
+      7,945,168   0%                      seed7-mode-syntax-propertize
+          7,663   0%                     #<byte-code-function D86>
+            898   0%                     syntax-table
+         33,376   0%                 - internal--syntax-propertize
+         33,376   0%                  - syntax-propertize
+         33,376   0%                     seed7-mode-syntax-propertize
+     29,707,761   0%                - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+      7,852,182   0%                 - seed7-inside-comment-p
+      4,614,105   0%                  - syntax-ppss
+      4,603,984   0%                     make-closure
+          6,861   0%                     syntax-table
+          3,260   0%                     #<byte-code-function FC5>
+      7,214,803   0%                 - seed7-inside-line-indent-before-comment-p
+        132,608   0%                  - seed7-inside-comment-p
+         87,024   0%                   - syntax-ppss
+         87,024   0%                      make-closure
+          4,243   0%                    seed7-to-indent
+      7,907,329   0%                - seed7-inside-comment-p
+      5,089,399   0%                 - syntax-ppss
+      5,051,536   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+          3,909   0%                    #<byte-code-function 7F2>
+      6,679,310   0%                - seed7-inside-line-indent-before-comment-p
+        161,616   0%                 - seed7-inside-comment-p
+         95,312   0%                  - syntax-ppss
+         95,312   0%                     make-closure
+          3,326   0%                   seed7-to-indent
+      4,167,456   0%                  seed7--end-regexp-for
+        460,256   0%               - seed7-to-next-line-starts-with
+        418,080   0%                - seed7-re-search-forward
+         82,880   0%                 - seed7-inside-string-p
+         37,296   0%                  - syntax-ppss
+         37,296   0%                     make-closure
+         53,872   0%                 - seed7-inside-comment-p
+         29,008   0%                  - syntax-ppss
+         29,008   0%                     make-closure
+    470,141,976   9%              - seed7-to-block-backward
+    328,090,326   6%               - seed7-re-search-backward
+    241,206,370   4%                - run-with-timer
+    241,206,370   4%                 - run-at-time
+     95,099,340   1%                  - timer-activate
+     95,099,340   1%                   - timer--activate
+     95,099,340   1%                    - timer--time-less-p
+            604   0%                       timer--time
+     79,450,443   1%                    timer-relative-time
+     52,678,875   1%                  - timer-set-time
+     52,676,688   1%                     timer--time-setter
+     13,977,712   0%                    timer-create
+     47,677,121   0%                - seed7-inside-string-p
+     10,576,249   0%                 - syntax-ppss
+     10,529,904   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+          6,737   0%                    #<byte-code-function C52>
+          2,912   0%                    syntax-table
+     16,392,433   0%                - seed7-inside-comment-p
+      9,708,161   0%                 - syntax-ppss
+      9,701,104   0%                    make-closure
+          6,241   0%                    #<byte-code-function 10A>
+     13,985,483   0%                  re-search-backward
+      8,827,495   0%                  make-closure
+     88,722,237   1%               - seed7--current-line-nth-word
+     81,928,373   1%                - thing-at-point
+     74,933,445   1%                 - bounds-of-thing-at-point
+     33,959,205   0%                    make-closure
+     12,602,018   0%                  - #<byte-code-function 3B4>
+     12,590,374   0%                   - forward-thing
+     12,589,912   0%                      format
+            462   0%                      intern-soft
+     10,935,944   0%                  - seq-some
+     10,931,872   0%                     make-closure
+      5,883,061   0%                  - #<byte-code-function 1E6>
+      5,883,061   0%                   - forward-thing
+      5,879,768   0%                      format
+          3,293   0%                      intern-soft
+          8,033   0%                    re-search-forward
+     22,788,086   0%               - seed7-inside-line-indent-before-comment-p
+      7,630,178   0%                - seed7-inside-comment-p
+      4,024,898   0%                 - syntax-ppss
+      4,023,824   0%                    make-closure
+          1,074   0%                    #<byte-code-function 911>
+          3,300   0%                  seed7-to-indent
+     12,616,397   0%               - seed7-beg-of-defun
+      6,830,662   0%                - seed7-top-block-name
+      6,755,674   0%                 - seed7--to-top
+      6,593,242   0%                  - seed7-re-search-backward
+      5,283,712   0%                   - run-with-timer
+      5,283,712   0%                    - run-at-time
+      2,484,672   0%                     - timer-activate
+      2,484,672   0%                      - timer--activate
+      2,484,672   0%                         timer--time-less-p
+      1,492,032   0%                       timer-relative-time
+      1,021,072   0%                     - timer-set-time
+      1,021,072   0%                        timer--time-setter
+        285,936   0%                       timer-create
+        857,808   0%                   - seed7-inside-string-p
+        136,752   0%                    - syntax-ppss
+        136,752   0%                       make-closure
+        261,072   0%                   - seed7-inside-comment-p
+        132,608   0%                    - syntax-ppss
+        132,608   0%                       make-closure
+        169,904   0%                     make-closure
+         20,746   0%                     re-search-backward
+        154,144   0%                  - run-with-timer
+        154,144   0%                   - run-at-time
+         66,496   0%                    - timer-activate
+         66,496   0%                     - timer--activate
+         66,496   0%                        timer--time-less-p
+         48,640   0%                      timer-relative-time
+         30,720   0%                    - timer-set-time
+         30,720   0%                       timer--time-setter
+          8,288   0%                      timer-create
+          8,288   0%                    make-closure
+         74,988   0%                 - seed7--block-name
+         70,844   0%                  - seed7-re-search-forward
+         20,720   0%                     seed7-inside-string-p
+          4,144   0%                   - seed7-inside-comment-p
+          4,144   0%                    - syntax-ppss
+          4,144   0%                       make-closure
+      3,394,888   0%                - seed7-re-search-backward
+      2,640,680   0%                 - run-with-timer
+      2,640,680   0%                  - run-at-time
+      1,046,584   0%                   - timer-activate
+      1,046,584   0%                    - timer--activate
+      1,046,584   0%                       timer--time-less-p
+        870,352   0%                     timer-relative-time
+        566,272   0%                   - timer-set-time
+        566,272   0%                      timer--time-setter
+        157,472   0%                     timer-create
+        501,424   0%                 - seed7-inside-string-p
+        107,744   0%                  - syntax-ppss
+        107,744   0%                     make-closure
+        145,040   0%                 - seed7-inside-comment-p
+         82,880   0%                  - syntax-ppss
+         82,880   0%                     make-closure
+        107,744   0%                   make-closure
+        624,696   0%                - seed7-re-search-backward-closest
+        603,976   0%                 - seed7-re-search-backward
+        304,144   0%                  - run-with-timer
+        304,144   0%                   - run-at-time
+        128,848   0%                    - timer-activate
+        128,848   0%                     - timer--activate
+        128,848   0%                        timer--time-less-p
+         97,280   0%                      timer-relative-time
+         65,584   0%                    - timer-set-time
+         65,584   0%                       timer--time-setter
+         12,432   0%                      timer-create
+        287,400   0%                    re-search-backward
+          8,288   0%                    seed7-inside-string-p
+          4,144   0%                  - seed7-inside-comment-p
+          4,144   0%                   - syntax-ppss
+          4,144   0%                      make-closure
+          4,144   0%                 - seq-filter
+          4,144   0%                    make-closure
+        180,048   0%                  match-string-no-properties
+         71,344   0%                  match-string
+      7,995,091   0%               - seed7-inside-comment-p
+      4,862,227   0%                - syntax-ppss
+      4,848,480   0%                   make-closure
+          9,711   0%                   #<byte-code-function 5AF>
+            983   0%                   syntax-table
+      6,258,991   0%               - seed7--start-regexp-for
+          8,184   0%                  seed7--type-regexp
+        608,816   0%               - seed7-line-code-ends-with
+        596,384   0%                - seed7-re-search-backward
+        372,720   0%                 - run-with-timer
+        372,720   0%                  - run-at-time
+        148,640   0%                   - timer-activate
+        148,640   0%                    - timer--activate
+        148,640   0%                       timer--time-less-p
+        124,640   0%                     timer-relative-time
+         82,864   0%                   - timer-set-time
+         82,864   0%                      timer--time-setter
+         16,576   0%                     timer-create
+        153,216   0%                   re-search-backward
+         37,296   0%                 - seed7-inside-comment-p
+         20,720   0%                  - syntax-ppss
+         20,720   0%                     make-closure
+         33,152   0%                 - seed7-inside-string-p
+          4,144   0%                  - syntax-ppss
+          4,144   0%                     make-closure
+        329,384   0%               - backward-sexp
+        329,384   0%                - forward-sexp
+        329,384   0%                 - seed7--forward-sexp-function
+        175,600   0%                  - seed7--at-array-definition-end-line-p
+        175,600   0%                   - seed7-line-code-ends-with
+        175,600   0%                    - seed7-re-search-backward
+        117,584   0%                     - run-with-timer
+        117,584   0%                      - run-at-time
+         64,448   0%                         timer-relative-time
+         44,848   0%                       - timer-set-time
+         44,848   0%                          timer--time-setter
+          8,288   0%                         timer-create
+         33,152   0%                     - seed7-inside-string-p
+         12,432   0%                      - syntax-ppss
+         12,432   0%                         make-closure
+         16,576   0%                     - seed7-inside-comment-p
+         12,432   0%                      - syntax-ppss
+         12,432   0%                         make-closure
+          8,288   0%                       make-closure
+        138,304   0%                  - seed7--at-set-definition-end-line-p
+        138,304   0%                   - seed7-line-code-ends-with
+        134,160   0%                    - seed7-re-search-backward
+        109,296   0%                     - run-with-timer
+        109,296   0%                      - run-at-time
+         64,448   0%                         timer-relative-time
+         40,704   0%                       - timer-set-time
+         40,704   0%                          timer--time-setter
+          4,144   0%                         timer-create
+         12,432   0%                       make-closure
+          8,288   0%                       seed7-inside-comment-p
+          4,144   0%                       seed7-inside-string-p
+         12,432   0%                    seed7--line-comment-hash
+        112,640   0%                 looking-at
+          1,000   0%               - user-error
+          1,000   0%                  format-message
+    170,674,007   3%             - seed7-re-search-backward
+    118,357,882   2%              - run-with-timer
+    118,357,882   2%               - run-at-time
+     46,906,376   0%                - timer-activate
+     46,906,376   0%                 - timer--activate
+     46,906,376   0%                  - timer--time-less-p
+         33,958   0%                     timer--time
+     39,227,860   0%                  timer-relative-time
+     26,019,792   0%                - timer-set-time
+     26,019,792   0%                   timer--time-setter
+      6,203,568   0%                  timer-create
+            286   0%                  timer-set-function
+     25,839,859   0%              - seed7-inside-string-p
+      4,891,939   0%               - syntax-ppss
+      4,881,632   0%                  make-closure
+          3,328   0%                  #<byte-code-function 87F>
+            693   0%                  syntax-table
+     13,413,174   0%                re-search-backward
+      7,963,430   0%              - seed7-inside-comment-p
+      4,287,702   0%               - syntax-ppss
+      4,284,896   0%                  make-closure
+          1,363   0%                  #<byte-code-function F77>
+            834   0%                  syntax-table
+      5,099,662   0%                make-closure
+     80,314,262   1%             - seed7-calc-indent
+     58,237,265   1%              - seed7-line-inside-a-block-cached
+     58,237,265   1%               - seed7-line-inside-a-block
+     55,650,585   1%                - seed7--safe-enclosing-block-bounds
+     47,902,992   0%                 - seed7--block-end-pos-for
+     47,896,035   0%                  - seed7-to-block-forward
+     45,007,968   0%                   - seed7-end-of-defun
+     36,119,865   0%                    - seed7-top-block-name
+     35,673,445   0%                     - seed7--to-top
+     34,702,253   0%                      - seed7-re-search-backward
+     26,824,096   0%                       - run-with-timer
+     26,824,096   0%                        - run-at-time
+     12,549,511   0%                         - timer-activate
+     12,549,511   0%                          - timer--activate
+     12,549,511   0%                           - timer--time-less-p
+        164,543   0%                              timer--time
+      7,583,601   0%                           timer-relative-time
+      5,199,144   0%                         - timer-set-time
+      5,199,144   0%                            timer--time-setter
+      1,491,840   0%                           timer-create
+      5,271,245   0%                       - seed7-inside-string-p
+        833,021   0%                        - syntax-ppss
+        799,792   0%                           make-closure
+         32,792   0%                           parse-partial-sexp
+            437   0%                           syntax-table
+      1,670,101   0%                       - seed7-inside-comment-p
+        779,141   0%                        - syntax-ppss
+        779,072   0%                           make-closure
+             69   0%                           #<byte-code-function D0F>
+        924,531   0%                         make-closure
+         12,280   0%                         re-search-backward
+        942,184   0%                      - run-with-timer
+        942,184   0%                       - run-at-time
+        371,000   0%                        - timer-activate
+        371,000   0%                         - timer--activate
+        371,000   0%                            timer--time-less-p
+        317,056   0%                          timer-relative-time
+        220,976   0%                        - timer-set-time
+        220,976   0%                           timer--time-setter
+         33,152   0%                          timer-create
+         29,008   0%                        make-closure
+        438,132   0%                     - seed7--block-name
+        379,644   0%                      - seed7-re-search-forward
+        302,512   0%                       - seed7-inside-string-p
+         37,296   0%                        - syntax-ppss
+         37,296   0%                           make-closure
+         66,304   0%                       - seed7-inside-comment-p
+         37,296   0%                        - syntax-ppss
+         37,296   0%                           make-closure
+         28,536   0%                        match-string
+      5,691,369   0%                    - seed7-re-search-forward
+      4,226,880   0%                     - seed7-inside-string-p
+        588,448   0%                      - syntax-ppss
+        588,448   0%                         make-closure
+      1,354,933   0%                     - seed7-inside-comment-p
+        737,477   0%                      - syntax-ppss
+        712,768   0%                         make-closure
+         24,709   0%                       - syntax-propertize
+         24,709   0%                          seed7-mode-syntax-propertize
+      1,335,880   0%                    - seed7-re-search-backward
+        938,056   0%                     - run-with-timer
+        938,056   0%                      - run-at-time
+        371,000   0%                       - timer-activate
+        371,000   0%                        - timer--activate
+        371,000   0%                           timer--time-less-p
+        317,072   0%                         timer-relative-time
+        220,976   0%                       - timer-set-time
+        220,976   0%                          timer--time-setter
+         29,008   0%                         timer-create
+        294,224   0%                     - seed7-inside-string-p
+         33,152   0%                      - syntax-ppss
+         33,152   0%                         make-closure
+         70,448   0%                     - seed7-inside-comment-p
+         45,584   0%                      - syntax-ppss
+         45,584   0%                         make-closure
+         33,152   0%                       make-closure
+        942,312   0%                      match-string-no-properties
+        607,144   0%                      match-string
+      1,537,896   0%                   - seed7--current-line-nth-word
+      1,421,864   0%                    - thing-at-point
+      1,207,856   0%                     - bounds-of-thing-at-point
+        538,720   0%                        make-closure
+        238,384   0%                      - #<byte-code-function FEE>
+        238,384   0%                       - forward-thing
+        238,384   0%                          format
+        149,184   0%                      - seq-some
+        149,184   0%                         make-closure
+        100,304   0%                      - #<byte-code-function 597>
+        100,304   0%                       - forward-thing
+        100,304   0%                          format
+          3,072   0%                        re-search-forward
+        741,002   0%                   - seed7-re-search-forward
+        480,704   0%                    - seed7-inside-string-p
+         87,024   0%                     - syntax-ppss
+         87,024   0%                        make-closure
+        169,904   0%                    - seed7-inside-comment-p
+        111,888   0%                     - syntax-ppss
+        111,888   0%                        make-closure
+        276,072   0%                   - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+        116,032   0%                    - seed7-inside-comment-p
+         62,160   0%                     - syntax-ppss
+         62,160   0%                        make-closure
+         70,448   0%                      seed7-inside-line-indent-before-comment-p
+        118,233   0%                   - seed7-inside-line-indent-before-comment-p
+          2,201   0%                      seed7-to-indent
+        111,888   0%                   - seed7-inside-comment-p
+         66,304   0%                    - syntax-ppss
+         66,304   0%                       make-closure
+         49,104   0%                     seed7--end-regexp-for
+          6,192   0%                  - seed7-to-next-line-starts-with
+          6,192   0%                   - seed7-re-search-forward
+          4,144   0%                      seed7-inside-string-p
+      7,718,585   0%                 - seed7-to-block-backward
+      3,775,684   0%                  - seed7-re-search-backward
+      2,940,996   0%                   - run-with-timer
+      2,940,996   0%                    - run-at-time
+      1,176,516   0%                     - timer-activate
+      1,176,516   0%                      - timer--activate
+      1,176,516   0%                       - timer--time-less-p
+            364   0%                          timer--time
+        992,560   0%                       timer-relative-time
+        655,888   0%                     - timer-set-time
+        655,888   0%                        timer--time-setter
+        116,032   0%                       timer-create
+        551,152   0%                   - seed7-inside-string-p
+        157,472   0%                    - syntax-ppss
+        157,472   0%                       make-closure
+        124,320   0%                   - seed7-inside-comment-p
+         62,160   0%                    - syntax-ppss
+         62,160   0%                       make-closure
+         87,024   0%                     make-closure
+         72,192   0%                     re-search-backward
+      1,831,149   0%                  - seed7-beg-of-defun
+        999,528   0%                   - seed7-re-search-backward
+        945,656   0%                    - run-with-timer
+        945,656   0%                     - run-at-time
+        368,648   0%                      - timer-activate
+        368,648   0%                       - timer--activate
+        368,648   0%                          timer--time-less-p
+        351,104   0%                        timer-relative-time
+        221,760   0%                      - timer-set-time
+        221,760   0%                         timer--time-setter
+          4,144   0%                        timer-create
+         41,440   0%                    - seed7-inside-string-p
+         12,432   0%                     - syntax-ppss
+         12,432   0%                        make-closure
+          8,288   0%                    - seed7-inside-comment-p
+          4,144   0%                     - syntax-ppss
+          4,144   0%                        make-closure
+          4,144   0%                      make-closure
+        172,320   0%                   - seed7-re-search-backward-closest
+        172,320   0%                    - seed7-re-search-backward
+         88,384   0%                     - run-with-timer
+         88,384   0%                      - run-at-time
+         41,760   0%                       - timer-activate
+         41,760   0%                        - timer--activate
+         41,760   0%                           timer--time-less-p
+         28,576   0%                         timer-relative-time
+         18,048   0%                       - timer-set-time
+         18,048   0%                          timer--time-setter
+         71,504   0%                       re-search-backward
+         12,432   0%                       make-closure
+        121,700   0%                   - seed7-top-block-name
+        112,192   0%                    - seed7--to-top
+         74,216   0%                     - seed7-re-search-backward
+         58,072   0%                      - run-with-timer
+         58,072   0%                       - run-at-time
+         22,328   0%                        - timer-activate
+         22,328   0%                         - timer--activate
+         22,328   0%                            timer--time-less-p
+         14,288   0%                          timer-relative-time
+         12,432   0%                          timer-create
+          9,024   0%                        - timer-set-time
+          9,024   0%                           timer--time-setter
+         12,432   0%                        seed7-inside-string-p
+          3,712   0%                        re-search-backward
+         37,976   0%                     - run-with-timer
+         37,976   0%                      - run-at-time
+         14,664   0%                       - timer-activate
+         14,664   0%                        - timer--activate
+         14,664   0%                           timer--time-less-p
+         14,288   0%                         timer-relative-time
+          9,024   0%                       - timer-set-time
+          9,024   0%                          timer--time-setter
+          9,508   0%                    - seed7--block-name
+          9,508   0%                       seed7-re-search-forward
+         50,152   0%                     match-string-no-properties
+         24,496   0%                     match-string
+      1,124,048   0%                  - seed7--current-line-nth-word
+      1,037,024   0%                   - thing-at-point
+        903,520   0%                    - bounds-of-thing-at-point
+        401,968   0%                       make-closure
+        164,728   0%                     - #<byte-code-function 2D8>
+        164,728   0%                      - forward-thing
+        164,728   0%                         format
+         99,456   0%                     - seq-some
+         99,456   0%                        make-closure
+         75,752   0%                     - #<byte-code-function BCA>
+         75,752   0%                      - forward-thing
+         75,752   0%                         format
+        317,112   0%                  - backward-sexp
+        317,112   0%                   - forward-sexp
+        317,112   0%                    - seed7--forward-sexp-function
+        159,088   0%                     - seed7--at-array-definition-end-line-p
+        159,088   0%                      - seed7-line-code-ends-with
+        154,944   0%                       - seed7-re-search-backward
+        130,080   0%                        - run-with-timer
+        130,080   0%                         - run-at-time
+         93,376   0%                          - timer-activate
+         93,376   0%                           - timer--activate
+         93,376   0%                              timer--time-less-p
+         22,496   0%                            timer-relative-time
+         14,208   0%                          - timer-set-time
+         14,208   0%                             timer--time-setter
+         12,432   0%                        - seed7-inside-comment-p
+         12,432   0%                         - syntax-ppss
+         12,432   0%                            make-closure
+          8,288   0%                          seed7-inside-string-p
+          4,144   0%                          make-closure
+        154,944   0%                     - seed7--at-set-definition-end-line-p
+        154,944   0%                      - seed7-line-code-ends-with
+        150,800   0%                       - seed7-re-search-backward
+        134,224   0%                        - run-with-timer
+        134,224   0%                         - run-at-time
+         97,520   0%                          - timer-activate
+         97,520   0%                           - timer--activate
+         97,520   0%                              timer--time-less-p
+         22,496   0%                            timer-relative-time
+         14,208   0%                          - timer-set-time
+         14,208   0%                             timer--time-setter
+         12,432   0%                        - seed7-inside-comment-p
+          8,288   0%                         - syntax-ppss
+          8,288   0%                            make-closure
+          4,144   0%                          make-closure
+        265,216   0%                  - seed7-inside-line-indent-before-comment-p
+         82,880   0%                   - seed7-inside-comment-p
+         37,296   0%                    - syntax-ppss
+         37,296   0%                       make-closure
+        176,288   0%                  - seed7-line-code-ends-with
+        176,288   0%                   - seed7-re-search-backward
+         93,936   0%                    - run-with-timer
+         93,936   0%                     - run-at-time
+         41,360   0%                      - timer-activate
+         41,360   0%                       - timer--activate
+         41,360   0%                          timer--time-less-p
+         32,224   0%                        timer-relative-time
+         20,352   0%                      - timer-set-time
+         20,352   0%                         timer--time-setter
+         45,056   0%                      re-search-backward
+         20,720   0%                      seed7-inside-string-p
+         12,432   0%                    - seed7-inside-comment-p
+          8,288   0%                     - syntax-ppss
+          8,288   0%                        make-closure
+          4,144   0%                      make-closure
+         99,456   0%                  - seed7-inside-comment-p
+         66,304   0%                   - syntax-ppss
+         66,304   0%                      make-closure
+         65,472   0%                    seed7--start-regexp-for
+         39,296   0%                    looking-at
+      2,179,872   0%                - seed7-re-search-backward
+      1,572,696   0%                 - run-with-timer
+      1,572,696   0%                  - run-at-time
+        627,096   0%                   - timer-activate
+        627,096   0%                    - timer--activate
+        627,096   0%                       timer--time-less-p
+        526,224   0%                     timer-relative-time
+        344,784   0%                   - timer-set-time
+        344,784   0%                      timer--time-setter
+         74,592   0%                     timer-create
+        364,672   0%                 - seed7-inside-string-p
+         78,736   0%                  - syntax-ppss
+         78,736   0%                     make-closure
+         99,456   0%                 - seed7-inside-comment-p
+         53,872   0%                  - syntax-ppss
+         53,872   0%                     make-closure
+         85,032   0%                   re-search-backward
+         58,016   0%                   make-closure
+        304,680   0%                - replace-regexp-in-string
+         24,552   0%                   concat
+         81,616   0%                  match-string
+     19,470,588   0%              - seed7-line-inside-parens-pair-column
+     19,470,588   0%               - seed7-line-inside-parens-pair
+     19,445,964   0%                - seed7-re-search-backward
+     15,220,208   0%                 - run-with-timer
+     15,220,208   0%                  - run-at-time
+      5,994,256   0%                   - timer-activate
+      5,994,256   0%                    - timer--activate
+      5,994,256   0%                       timer--time-less-p
+      5,133,936   0%                     timer-relative-time
+      3,362,672   0%                   - timer-set-time
+      3,362,672   0%                      timer--time-setter
+        729,344   0%                     timer-create
+      2,015,958   0%                 - seed7-inside-string-p
+        752,038   0%                  - syntax-ppss
+        750,064   0%                     make-closure
+      1,510,760   0%                 - seed7-inside-comment-p
+      1,133,656   0%                  - syntax-ppss
+        969,696   0%                     make-closure
+        163,960   0%                     parse-partial-sexp
+        670,238   0%                   make-closure
+         28,800   0%                   re-search-backward
+         20,480   0%                - forward-sexp
+         20,480   0%                   seed7--forward-sexp-function
+          4,144   0%                - seed7-line-inside-syntax-parens-pair
+          4,144   0%                 - syntax-ppss
+          4,144   0%                    make-closure
+      1,479,821   0%              - seed7-line-is-defun-end
+        659,375   0%               - seed7-end-of-defun
+        431,816   0%                - seed7-top-block-name
+        419,384   0%                 - seed7--to-top
+        407,160   0%                  - seed7-re-search-backward
+        307,704   0%                   - run-with-timer
+        307,704   0%                    - run-at-time
+        150,408   0%                     - timer-activate
+        150,408   0%                      - timer--activate
+        150,408   0%                         timer--time-less-p
+         81,168   0%                       timer-relative-time
+         59,552   0%                     - timer-set-time
+         59,552   0%                        timer--time-setter
+         16,576   0%                       timer-create
+         66,304   0%                   - seed7-inside-string-p
+          4,144   0%                    - syntax-ppss
+          4,144   0%                       make-closure
+         16,576   0%                     make-closure
+         16,576   0%                   - seed7-inside-comment-p
+          4,144   0%                    - syntax-ppss
+          4,144   0%                       make-closure
+         12,224   0%                  - run-with-timer
+         12,224   0%                   - run-at-time
+          4,144   0%                      timer-create
+          3,120   0%                    - timer-activate
+          3,120   0%                     - timer--activate
+          3,120   0%                        timer--time-less-p
+          3,040   0%                      timer-relative-time
+          1,920   0%                    - timer-set-time
+          1,920   0%                       timer--time-setter
+         12,432   0%                 - seed7--block-name
+         12,432   0%                  - seed7-re-search-forward
+         12,432   0%                     seed7-inside-string-p
+        182,615   0%                - seed7-re-search-forward
+        140,896   0%                 - seed7-inside-string-p
+          8,288   0%                  - syntax-ppss
+          8,288   0%                     make-closure
+         34,551   0%                 - seed7-inside-comment-p
+         26,263   0%                  - syntax-ppss
+         13,831   0%                   - syntax-propertize
+         13,831   0%                      seed7-mode-syntax-propertize
+         12,432   0%                     make-closure
+         20,512   0%                - seed7-re-search-backward
+          8,288   0%                   seed7-inside-string-p
+          8,080   0%                 - run-with-timer
+          8,080   0%                  - run-at-time
+          3,120   0%                   - timer-activate
+          3,120   0%                    - timer--activate
+          3,120   0%                       timer--time-less-p
+          3,040   0%                     timer-relative-time
+          1,920   0%                   - timer-set-time
+          1,920   0%                      timer--time-setter
+          4,144   0%                   seed7-inside-comment-p
+         10,216   0%                  match-string
+          8,184   0%                  match-string-no-properties
+        489,540   0%               - seed7-beg-of-defun
+        353,892   0%                - seed7-re-search-backward
+        312,800   0%                 - run-with-timer
+        312,800   0%                  - run-at-time
+        119,184   0%                   - timer-activate
+        119,184   0%                    - timer--activate
+        119,184   0%                       timer--time-less-p
+        116,128   0%                     timer-relative-time
+         77,488   0%                   - timer-set-time
+         77,488   0%                      timer--time-setter
+         20,720   0%                 - seed7-inside-string-p
+          8,288   0%                  - syntax-ppss
+          8,288   0%                     make-closure
+          8,288   0%                 - seed7-inside-comment-p
+          4,144   0%                  - syntax-ppss
+          4,144   0%                     make-closure
+          7,940   0%                   re-search-backward
+          4,144   0%                   make-closure
+         24,552   0%                  match-string-no-properties
+         24,320   0%                - seed7-re-search-backward-closest
+         24,320   0%                 - seed7-re-search-backward
+         14,624   0%                    re-search-backward
+          9,696   0%                  - run-with-timer
+          9,696   0%                   - run-at-time
+          3,744   0%                    - timer-activate
+          3,744   0%                     - timer--activate
+          3,744   0%                        timer--time-less-p
+          3,648   0%                      timer-relative-time
+          2,304   0%                    - timer-set-time
+          2,304   0%                       timer--time-setter
+         20,506   0%                - seed7-top-block-name
+         12,704   0%                 - seed7--to-top
+         10,280   0%                  - seed7-re-search-backward
+          6,888   0%                   - run-with-timer
+          6,888   0%                    - run-at-time
+          5,400   0%                     - timer-activate
+          5,400   0%                      - timer--activate
+          5,400   0%                         timer--time-less-p
+            912   0%                       timer-relative-time
+            576   0%                     - timer-set-time
+            576   0%                        timer--time-setter
+          3,392   0%                     re-search-backward
+          2,424   0%                  - run-with-timer
+          2,424   0%                   - run-at-time
+            936   0%                    - timer-activate
+            936   0%                     - timer--activate
+            936   0%                        timer--time-less-p
+            912   0%                      timer-relative-time
+            576   0%                    - timer-set-time
+            576   0%                       timer--time-setter
+          7,802   0%                 - seed7--block-name
+          7,802   0%                    seed7-re-search-forward
+          8,184   0%                  seed7--no-defun-found-msg-for
+          1,016   0%                  match-string
+        251,112   0%               - seed7--safe-current-line-defun-start-indent
+        251,112   0%                - seed7-to-block-backward
+        241,928   0%                 - seed7-re-search-backward
+        208,776   0%                  - run-with-timer
+        208,776   0%                   - run-at-time
+         79,960   0%                    - timer-activate
+         79,960   0%                     - timer--activate
+         79,960   0%                        timer--time-less-p
+         73,872   0%                      timer-relative-time
+         46,656   0%                    - timer-set-time
+         46,656   0%                       timer--time-setter
+          8,288   0%                      timer-create
+         20,720   0%                  - seed7-inside-string-p
+          4,144   0%                   - syntax-ppss
+          4,144   0%                      make-closure
+          8,288   0%                  - seed7-inside-comment-p
+          4,144   0%                   - syntax-ppss
+          4,144   0%                      make-closure
+          4,144   0%                    make-closure
+          8,184   0%                 - seed7--current-line-nth-word
+          8,184   0%                  - thing-at-point
+          8,184   0%                   - bounds-of-thing-at-point
+          8,184   0%                    - #<byte-code-function 657>
+          8,184   0%                     - forward-thing
+          8,184   0%                        format
+          1,000   0%                 - user-error
+          1,000   0%                    format-message
+         53,978   0%               - seed7-line-starts-with-any
+         53,978   0%                  seed7-line-starts-with
+         16,480   0%               - seed7-move-to-line
+         16,480   0%                  seed7-to-previous-non-empty-line
+          5,192   0%               - seed7--current-line-nth-word
+          5,192   0%                - thing-at-point
+          5,192   0%                 - bounds-of-thing-at-point
+          4,144   0%                    make-closure
+          1,048   0%                  - #<byte-code-function 096>
+          1,048   0%                   - forward-thing
+          1,048   0%                      format
+        389,536   0%              - seed7--indent-search-boundary
+        385,392   0%               - seed7--indent-search-boundary-uncached
+        385,392   0%                - syntax-ppss
+        385,392   0%                   make-closure
+        183,740   0%              - seed7-line-at-endof-array-definition-block
+        128,568   0%               - seed7-line-code-ends-with
+        128,568   0%                - seed7-re-search-backward
+         52,624   0%                 - run-with-timer
+         52,624   0%                  - run-at-time
+         22,864   0%                   - timer-activate
+         22,864   0%                    - timer--activate
+         22,864   0%                       timer--time-less-p
+         18,240   0%                     timer-relative-time
+         11,520   0%                   - timer-set-time
+         11,520   0%                      timer--time-setter
+         36,936   0%                 - seed7-inside-string-p
+         32,792   0%                  - syntax-ppss
+         32,792   0%                     parse-partial-sexp
+         30,720   0%                   re-search-backward
+          4,144   0%                   make-closure
+          4,144   0%                   seed7-inside-comment-p
+         32,124   0%               - backward-sexp
+         32,124   0%                - forward-sexp
+         32,124   0%                 - seed7--forward-sexp-function
+         11,228   0%                  - seed7-beg-of-defun
+          2,640   0%                   - seed7-re-search-backward-closest
+          2,640   0%                    - seed7-re-search-backward
+          1,616   0%                     - run-with-timer
+          1,616   0%                      - run-at-time
+            624   0%                       - timer-activate
+            624   0%                        - timer--activate
+            624   0%                           timer--time-less-p
+            608   0%                         timer-relative-time
+            384   0%                       - timer-set-time
+            384   0%                          timer--time-setter
+          1,024   0%                       re-search-backward
+          1,616   0%                   - seed7-top-block-name
+          1,616   0%                    - seed7--to-top
+            808   0%                     - run-with-timer
+            808   0%                      - run-at-time
+            312   0%                       - timer-activate
+            312   0%                        - timer--activate
+            312   0%                           timer--time-less-p
+            304   0%                         timer-relative-time
+            192   0%                       - timer-set-time
+            192   0%                          timer--time-setter
+            808   0%                     - seed7-re-search-backward
+            808   0%                      - run-with-timer
+            808   0%                       - run-at-time
+            312   0%                        - timer-activate
+            312   0%                         - timer--activate
+            312   0%                            timer--time-less-p
+            304   0%                          timer-relative-time
+            192   0%                        - timer-set-time
+            192   0%                           timer--time-setter
+            808   0%                   - seed7-re-search-backward
+            808   0%                    - run-with-timer
+            808   0%                     - run-at-time
+            312   0%                      - timer-activate
+            312   0%                       - timer--activate
+            312   0%                          timer--time-less-p
+            304   0%                        timer-relative-time
+            192   0%                      - timer-set-time
+            192   0%                         timer--time-setter
+          9,424   0%                  - seed7--at-array-definition-end-line-p
+          7,376   0%                   - seed7-line-code-ends-with
+          7,376   0%                    - seed7-re-search-backward
+          4,144   0%                     - seed7-inside-comment-p
+          4,144   0%                      - syntax-ppss
+          4,144   0%                         make-closure
+          3,232   0%                     - run-with-timer
+          3,232   0%                      - run-at-time
+          1,248   0%                       - timer-activate
+          1,248   0%                        - timer--activate
+          1,248   0%                           timer--time-less-p
+          1,216   0%                         timer-relative-time
+            768   0%                       - timer-set-time
+            768   0%                          timer--time-setter
+          2,048   0%                     looking-at
+          5,760   0%                  - seed7--safe-to-block-backward
+          5,760   0%                   - seed7-to-block-backward
+          5,760   0%                    - seed7-line-code-ends-with
+          5,760   0%                     - seed7-re-search-backward
+          4,144   0%                      - seed7-inside-comment-p
+          4,144   0%                       - syntax-ppss
+          4,144   0%                          make-closure
+          1,616   0%                      - run-with-timer
+          1,616   0%                       - run-at-time
+            624   0%                        - timer-activate
+            624   0%                         - timer--activate
+            624   0%                            timer--time-less-p
+            608   0%                          timer-relative-time
+            384   0%                        - timer-set-time
+            384   0%                           timer--time-setter
+          1,616   0%                  - seed7--at-set-definition-end-line-p
+          1,616   0%                   - seed7-line-code-ends-with
+          1,616   0%                    - seed7-re-search-backward
+          1,616   0%                     - run-with-timer
+          1,616   0%                      - run-at-time
+            624   0%                       - timer-activate
+            624   0%                        - timer--activate
+            624   0%                           timer--time-less-p
+            608   0%                         timer-relative-time
+            384   0%                       - timer-set-time
+            384   0%                          timer--time-setter
+         19,600   0%               - seed7-move-to-line
+         19,600   0%                - seed7-to-previous-non-empty-line
+          8,288   0%                 - seed7-inside-comment-p
+          8,288   0%                  - syntax-ppss
+          8,288   0%                     make-closure
+          2,424   0%               - seed7-re-search-backward
+          2,424   0%                - run-with-timer
+          2,424   0%                 - run-at-time
+            936   0%                  - timer-activate
+            936   0%                   - timer--activate
+            936   0%                      timer--time-less-p
+            912   0%                    timer-relative-time
+            576   0%                  - timer-set-time
+            576   0%                     timer--time-setter
+          1,024   0%                 looking-at
+        121,592   0%              - seed7-line-inside-set-definition-block
+         76,536   0%               - seed7-re-search-backward
+         39,864   0%                  re-search-backward
+         28,384   0%                - run-with-timer
+         28,384   0%                 - run-at-time
+          9,360   0%                  - timer-activate
+          9,360   0%                   - timer--activate
+          9,360   0%                      timer--time-less-p
+          9,120   0%                    timer-relative-time
+          5,760   0%                  - timer-set-time
+          5,760   0%                     timer--time-setter
+          4,144   0%                    timer-create
+          4,144   0%                  make-closure
+          4,144   0%                - seed7-inside-comment-p
+          4,144   0%                 - syntax-ppss
+          4,144   0%                    make-closure
+         45,056   0%               - forward-sexp
+         45,056   0%                  seed7--forward-sexp-function
+         88,520   0%              - seed7-line-inside-assign-statement-continuation
+         76,088   0%               - seed7-assign-op-pos
+         76,088   0%                - seed7-re-search-backward
+         39,416   0%                   re-search-backward
+         32,528   0%                 - run-with-timer
+         32,528   0%                  - run-at-time
+         17,648   0%                   - timer-activate
+         17,648   0%                    - timer--activate
+         17,648   0%                       timer--time-less-p
+          9,120   0%                     timer-relative-time
+          5,760   0%                   - timer-set-time
+          5,760   0%                      timer--time-setter
+          4,144   0%                   make-closure
+          4,144   0%               - seed7-statement-end-pos
+          4,144   0%                - seed7-forward-char-pos
+          4,144   0%                 - seed7-re-search-forward
+          4,144   0%                    seed7-inside-string-p
+         81,848   0%              - seed7-line-at-endof-set-definition-block
+         75,872   0%               - seed7-line-code-ends-with
+         75,872   0%                - seed7-re-search-backward
+         59,296   0%                 - run-with-timer
+         59,296   0%                  - run-at-time
+         22,240   0%                   - timer-activate
+         22,240   0%                    - timer--activate
+         22,240   0%                       timer--time-less-p
+         17,632   0%                     timer-relative-time
+         11,136   0%                   - timer-set-time
+         11,136   0%                      timer--time-setter
+          8,288   0%                     timer-create
+          8,288   0%                 - seed7-inside-string-p
+          8,288   0%                  - syntax-ppss
+          8,288   0%                     make-closure
+          8,288   0%                   make-closure
+          4,144   0%               - seed7-move-to-line
+          4,144   0%                  seed7-to-previous-non-empty-line
+          1,024   0%                 looking-at
+            808   0%               - seed7-re-search-backward
+            808   0%                - run-with-timer
+            808   0%                 - run-at-time
+            312   0%                  - timer-activate
+            312   0%                   - timer--activate
+            312   0%                      timer--time-less-p
+            304   0%                    timer-relative-time
+            192   0%                  - timer-set-time
+            192   0%                     timer--time-setter
+         80,168   0%              - seed7-line-inside-array-definition-block
+         63,784   0%               - seed7-re-search-backward
+         39,544   0%                  re-search-backward
+         24,240   0%                - run-with-timer
+         24,240   0%                 - run-at-time
+          9,360   0%                  - timer-activate
+          9,360   0%                   - timer--activate
+          9,360   0%                      timer--time-less-p
+          9,120   0%                    timer-relative-time
+          5,760   0%                  - timer-set-time
+          5,760   0%                     timer--time-setter
+         16,384   0%               - forward-sexp
+         16,384   0%                  seed7--forward-sexp-function
+         41,232   0%              - seed7-line-indent-step
+         12,432   0%               - seed7-move-to-line
+         12,432   0%                - seed7-to-previous-non-empty-line
+          8,288   0%                   seed7-inside-comment-p
+         40,336   0%                seed7-line-starts-with
+         34,864   0%              - seed7-line-isa-string
+         34,864   0%                 seed7-line-starts-with
+         28,672   0%              - seed7-line-starts-with-open-paren-after-logic-operator
+         28,672   0%                 seed7-line-starts-with
+         27,792   0%              - seed7-line-after-func-return-logic-operator-column
+         14,480   0%               - seed7-move-to-line
+         14,480   0%                - seed7-to-previous-non-empty-line
+          4,144   0%                   seed7-inside-comment-p
+          8,288   0%              - seed7-current-line-start-inside-comment-p
+          8,288   0%               - seed7-inside-comment-p
+          4,144   0%                - syntax-ppss
+          4,144   0%                   make-closure
+     37,945,202   0%             - replace-regexp-in-string
+      2,255,165   0%                concat
+      3,775,040   0%               match-string
+      2,077,528   0%               seed7--indent-offset-for
+      1,147,888   0%               seed7--on-lineof
+          1,680   0%               #<byte-code-function 4CC>
+        489,109   0%              seed7--cache-block-spec
+    489,306,194   9%           - seed7-line-inside-parens-pair-column
+    489,306,194   9%            - seed7-line-inside-parens-pair
+    482,464,122   9%             - seed7-re-search-backward
+    365,350,389   7%              - run-with-timer
+    365,350,389   7%               - run-at-time
+    143,828,398   2%                - timer-activate
+    143,828,398   2%                 - timer--activate
+    143,828,398   2%                  - timer--time-less-p
+        173,298   0%                     timer--time
+    120,856,494   2%                  timer-relative-time
+     81,255,340   1%                - timer-set-time
+     81,246,408   1%                   timer--time-setter
+     19,402,208   0%                  timer-create
+          7,949   0%                  timer-set-function
+     58,161,209   1%              - seed7-inside-string-p
+     21,412,577   0%               - syntax-ppss
+     21,329,168   0%                  make-closure
+         65,584   0%                  parse-partial-sexp
+          5,015   0%                  #<byte-code-function A03>
+          2,523   0%                  syntax-table
+     31,962,182   0%              - seed7-inside-comment-p
+     21,378,406   0%               - syntax-ppss
+     20,736,576   0%                  make-closure
+        623,048   0%                  parse-partial-sexp
+          9,343   0%                  #<byte-code-function BDC>
+          5,991   0%                  syntax-table
+     16,474,564   0%                make-closure
+     10,515,778   0%                re-search-backward
+      5,806,792   0%             - forward-sexp
+      5,806,312   0%                seed7--forward-sexp-function
+        745,200   0%             - seed7-line-inside-syntax-parens-pair
+        381,248   0%              - syntax-ppss
+        381,248   0%                 make-closure
+         94,592   0%              - forward-sexp
+         94,592   0%                 seed7--forward-sexp-function
+     73,835,921   1%           - seed7--current-line-nth-word
+     73,496,113   1%            - thing-at-point
+     73,286,297   1%             - bounds-of-thing-at-point
+     70,500,614   1%              - #<byte-code-function 63E>
+     70,500,614   1%               - forward-thing
+     70,048,198   1%                - forward-word
+     70,048,198   1%                 - internal--syntax-propertize
+     69,144,806   1%                  - syntax-propertize
+     67,349,573   1%                     seed7-mode-syntax-propertize
+            881   0%                     #<byte-code-function 95C>
+        452,416   0%                  format
+      1,384,096   0%                make-closure
+        530,432   0%              - seq-some
+        530,432   0%                 make-closure
+        272,168   0%              - #<byte-code-function 207>
+        272,168   0%               - forward-thing
+        272,168   0%                  format
+         80,987   0%                re-search-forward
+     50,757,105   0%           - seed7--indent-search-boundary
+     50,218,385   0%            - seed7--indent-search-boundary-uncached
+     50,033,127   0%             - syntax-ppss
+     48,430,928   0%                make-closure
+      1,410,056   0%                parse-partial-sexp
+         24,311   0%                #<byte-code-function 899>
+          3,872   0%                syntax-table
+            578   0%               seed7-to-indent
+     38,210,883   0%           - seed7-line-inside-argument-list-section
+     23,940,659   0%            - seed7-re-search-backward
+     14,399,331   0%               re-search-backward
+      9,164,224   0%             - run-with-timer
+      9,164,224   0%              - run-at-time
+      3,578,112   0%               - timer-activate
+      3,578,112   0%                - timer--activate
+      3,545,320   0%                 - timer--time-less-p
+         32,792   0%                    timer--time
+      3,063,072   0%                 timer-relative-time
+      2,054,768   0%               - timer-set-time
+      2,054,768   0%                  timer--time-setter
+        468,272   0%                 timer-create
+        348,096   0%               make-closure
+         24,864   0%             - seed7-inside-string-p
+          8,288   0%              - syntax-ppss
+          8,288   0%                 make-closure
+          4,144   0%               seed7-inside-comment-p
+     13,968,000   0%            - seed7-line-is-procfunc-beg-of-decl
+     13,968,000   0%             - seed7-line-starts-with
+          3,265   0%                seed7-move-to-line
+         53,872   0%            - seed7-forward-char-pos
+         49,728   0%             - seed7-re-search-forward
+         33,152   0%              - seed7-inside-string-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+         16,576   0%              - seed7-inside-comment-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+         24,576   0%            - forward-sexp
+         24,576   0%               seed7--forward-sexp-function
+     31,483,994   0%           - seed7-line-inside-array-definition-block
+     24,072,818   0%            - seed7-re-search-backward
+     11,742,113   0%               re-search-backward
+      9,900,291   0%             - run-with-timer
+      9,900,291   0%              - run-at-time
+      3,873,024   0%               - timer-activate
+      3,873,024   0%                - timer--activate
+      3,873,024   0%                   timer--time-less-p
+      3,265,211   0%                 timer-relative-time
+      2,210,904   0%               - timer-set-time
+      2,210,904   0%                  timer--time-setter
+        551,152   0%                 timer-create
+      1,427,566   0%             - seed7-inside-string-p
+        408,142   0%              - syntax-ppss
+        406,112   0%                 make-closure
+          2,030   0%                 #<byte-code-function C6D>
+        667,184   0%             - seed7-inside-comment-p
+        331,520   0%              - syntax-ppss
+        331,520   0%                 make-closure
+        335,664   0%               make-closure
+      7,121,096   0%            - forward-sexp
+      7,121,096   0%               seed7--forward-sexp-function
+     26,761,831   0%           - seed7-line-inside-logic-check-expression
+     22,880,937   0%            - seed7-to-previous-line-starts-with
+     22,121,697   0%             - seed7-re-search-backward
+     11,122,326   0%                re-search-backward
+      9,290,888   0%              - run-with-timer
+      9,290,888   0%               - run-at-time
+      3,704,136   0%                - timer-activate
+      3,704,136   0%                 - timer--activate
+      3,704,136   0%                    timer--time-less-p
+      3,076,176   0%                  timer-relative-time
+      2,092,032   0%                - timer-set-time
+      2,092,032   0%                   timer--time-setter
+        418,544   0%                  timer-create
+        940,688   0%              - seed7-inside-string-p
+        310,800   0%               - syntax-ppss
+        310,800   0%                  make-closure
+        427,744   0%              - seed7-inside-comment-p
+        208,112   0%               - syntax-ppss
+        207,200   0%                  make-closure
+            912   0%                  #<byte-code-function CDC>
+        340,051   0%                make-closure
+      2,303,980   0%            - seed7--current-line-nth-word
+      2,146,508   0%             - thing-at-point
+      1,992,108   0%              - bounds-of-thing-at-point
+        766,974   0%                 make-closure
+        443,184   0%               - #<byte-code-function 321>
+        443,184   0%                - forward-thing
+        443,184   0%                   format
+        285,936   0%               - seq-some
+        285,936   0%                  make-closure
+        135,486   0%               - #<byte-code-function 41D>
+        135,136   0%                - forward-thing
+        135,136   0%                   format
+      1,311,698   0%            - seed7-re-search-forward
+        865,526   0%             - seed7-inside-string-p
+        376,534   0%              - syntax-ppss
+        372,960   0%                 make-closure
+        445,295   0%             - seed7-inside-comment-p
+        262,959   0%              - syntax-ppss
+        261,072   0%                 make-closure
+          1,887   0%                 syntax-table
+     26,647,738   0%           - seed7-line-inside-assign-statement-continuation
+     23,751,442   0%            - seed7-assign-op-pos
+     23,540,098   0%             - seed7-re-search-backward
+     11,460,864   0%                re-search-backward
+      9,577,488   0%              - run-with-timer
+      9,577,488   0%               - run-at-time
+      3,696,464   0%                - timer-activate
+      3,696,464   0%                 - timer--activate
+      3,696,464   0%                  - timer--time-less-p
+         32,792   0%                     timer--time
+      3,218,432   0%                  timer-relative-time
+      2,107,296   0%                - timer-set-time
+      2,107,296   0%                   timer--time-setter
+        555,296   0%                  timer-create
+      1,446,256   0%              - seed7-inside-string-p
+        435,120   0%               - syntax-ppss
+        435,120   0%                  make-closure
+        723,970   0%              - seed7-inside-comment-p
+        334,434   0%               - syntax-ppss
+        298,368   0%                  make-closure
+         32,792   0%                  parse-partial-sexp
+          3,274   0%                  #<byte-code-function 3B3>
+        331,520   0%                make-closure
+      2,614,504   0%            - seed7-statement-end-pos
+      2,175,240   0%             - seed7-forward-char-pos
+      1,926,600   0%              - seed7-re-search-forward
+      1,305,360   0%               - seed7-inside-string-p
+        352,240   0%                - syntax-ppss
+        352,240   0%                   make-closure
+        621,240   0%               - seed7-inside-comment-p
+        414,040   0%                - syntax-ppss
+        381,248   0%                   make-closure
+         32,792   0%                   parse-partial-sexp
+     24,126,121   0%           - seed7-line-inside-set-definition-block
+     23,715,994   0%            - seed7-re-search-backward
+     11,671,818   0%               re-search-backward
+      9,719,392   0%             - run-with-timer
+      9,719,392   0%              - run-at-time
+      3,687,344   0%               - timer-activate
+      3,687,344   0%                - timer--activate
+      3,687,344   0%                   timer--time-less-p
+      3,257,664   0%                 timer-relative-time
+      2,198,368   0%               - timer-set-time
+      2,198,368   0%                  timer--time-setter
+        576,016   0%                 timer-create
+      1,272,208   0%             - seed7-inside-string-p
+        418,544   0%              - syntax-ppss
+        418,544   0%                 make-closure
+        663,040   0%             - seed7-inside-comment-p
+        435,120   0%              - syntax-ppss
+        435,120   0%                 make-closure
+        389,536   0%               make-closure
+         77,824   0%            - forward-sexp
+         77,824   0%               seed7--forward-sexp-function
+            783   0%              seed7-move-to-line
+     23,506,327   0%           - seed7-line-inside-until-logic-expression
+     20,763,863   0%            - seed7-re-search-backward
+     10,968,936   0%               re-search-backward
+      9,299,904   0%             - run-with-timer
+      9,299,904   0%              - run-at-time
+      3,689,072   0%               - timer-activate
+      3,689,072   0%                - timer--activate
+      3,689,072   0%                   timer--time-less-p
+      3,065,536   0%                 timer-relative-time
+      2,081,168   0%               - timer-set-time
+      2,081,168   0%                  timer--time-setter
+        464,128   0%                 timer-create
+        349,983   0%               make-closure
+         95,312   0%             - seed7-inside-string-p
+         33,152   0%              - syntax-ppss
+         33,152   0%                 make-closure
+         49,728   0%             - seed7-inside-comment-p
+         33,152   0%              - syntax-ppss
+         33,152   0%                 make-closure
+      2,452,384   0%            - seed7-line-code-ends-with
+      2,444,096   0%             - seed7-re-search-backward
+      1,361,808   0%              - run-with-timer
+      1,361,808   0%               - run-at-time
+        541,520   0%                - timer-activate
+        541,520   0%                 - timer--activate
+        541,520   0%                    timer--time-less-p
+        446,880   0%                  timer-relative-time
+        294,672   0%                - timer-set-time
+        294,672   0%                   timer--time-setter
+         78,736   0%                  timer-create
+        771,488   0%                re-search-backward
+        198,912   0%              - seed7-inside-string-p
+         29,008   0%               - syntax-ppss
+         29,008   0%                  make-closure
+         95,312   0%              - seed7-inside-comment-p
+         74,592   0%               - syntax-ppss
+         74,592   0%                  make-closure
+         16,576   0%                make-closure
+     20,658,274   0%           - seed7-line-inside-func-return-statement
+     20,406,706   0%            - seed7-re-search-backward
+     10,728,448   0%               re-search-backward
+      9,363,314   0%             - run-with-timer
+      9,363,314   0%              - run-at-time
+      3,622,144   0%               - timer-activate
+      3,622,144   0%                - timer--activate
+      3,622,144   0%                   timer--time-less-p
+      3,064,928   0%                 timer-relative-time
+      2,049,562   0%               - timer-set-time
+      2,047,632   0%                  timer--time-setter
+        625,744   0%                 timer-create
+            936   0%                 timer-set-function
+        310,800   0%               make-closure
+          4,144   0%               seed7-inside-string-p
+     13,950,962   0%           - seed7-line-after-func-return-logic-operator-column
+      2,603,250   0%            - seed7-move-to-line
+      2,603,250   0%             - seed7-to-previous-non-empty-line
+        724,458   0%              - seed7-inside-comment-p
+        343,952   0%               - syntax-ppss
+        343,952   0%                  make-closure
+     11,943,409   0%           - seed7-comment-column
+     10,818,035   0%            - seed7-calc-indent
+      3,705,092   0%             - seed7-line-inside-a-block-cached
+      3,705,092   0%              - seed7-line-inside-a-block
+      2,954,613   0%               - seed7--safe-enclosing-block-bounds
+      1,924,408   0%                - seed7-to-block-backward
+      1,520,632   0%                 - seed7-re-search-backward
+      1,063,368   0%                  - run-with-timer
+      1,063,368   0%                   - run-at-time
+        418,280   0%                    - timer-activate
+        418,280   0%                     - timer--activate
+        418,280   0%                        timer--time-less-p
+        326,800   0%                      timer-relative-time
+        210,544   0%                    - timer-set-time
+        210,544   0%                       timer--time-setter
+        107,744   0%                      timer-create
+        219,632   0%                  - seed7-inside-string-p
+         58,016   0%                   - syntax-ppss
+         58,016   0%                      make-closure
+         99,456   0%                  - seed7-inside-comment-p
+         58,016   0%                   - syntax-ppss
+         58,016   0%                      make-closure
+         88,448   0%                    re-search-backward
+         49,728   0%                    make-closure
+        266,080   0%                 - seed7--current-line-nth-word
+        261,936   0%                  - thing-at-point
+        223,984   0%                   - bounds-of-thing-at-point
+         70,448   0%                      make-closure
+         48,256   0%                    - #<byte-code-function A39>
+         48,256   0%                     - forward-thing
+         48,256   0%                        format
+         34,832   0%                    - #<byte-code-function 7E1>
+         34,832   0%                     - forward-thing
+         34,832   0%                        format
+         33,152   0%                    - seq-some
+         33,152   0%                       make-closure
+         78,736   0%                 - seed7-inside-line-indent-before-comment-p
+         16,576   0%                  - seed7-inside-comment-p
+          4,144   0%                   - syntax-ppss
+          4,144   0%                      make-closure
+         41,440   0%                 - seed7-inside-comment-p
+         24,864   0%                  - syntax-ppss
+         24,864   0%                     make-closure
+          9,232   0%                   seed7--start-regexp-for
+      1,013,629   0%                - seed7--block-end-pos-for
+      1,013,629   0%                 - seed7-to-block-forward
+        486,533   0%                  - seed7-re-search-forward
+        232,064   0%                   - seed7-inside-string-p
+         33,152   0%                    - syntax-ppss
+         33,152   0%                       make-closure
+        136,707   0%                   - seed7-inside-comment-p
+         66,259   0%                    - syntax-ppss
+         41,440   0%                       make-closure
+         24,819   0%                     - syntax-propertize
+         24,819   0%                        seed7-mode-syntax-propertize
+        427,688   0%                  - seed7--current-line-nth-word
+        398,680   0%                   - thing-at-point
+        356,592   0%                    - bounds-of-thing-at-point
+        149,184   0%                       make-closure
+         77,000   0%                     - #<byte-code-function DD6>
+         77,000   0%                      - forward-thing
+         77,000   0%                         format
+         53,872   0%                     - seq-some
+         53,872   0%                        make-closure
+         10,280   0%                     - #<byte-code-function 439>
+         10,280   0%                      - forward-thing
+         10,280   0%                         format
+          4,096   0%                       re-search-forward
+         66,256   0%                  - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+         33,152   0%                   - seed7-inside-comment-p
+         16,576   0%                    - syntax-ppss
+         16,576   0%                       make-closure
+         20,720   0%                     seed7-inside-line-indent-before-comment-p
+         16,576   0%                  - seed7-inside-comment-p
+         12,432   0%                   - syntax-ppss
+         12,432   0%                      make-closure
+          8,288   0%                    seed7-inside-line-indent-before-comment-p
+        518,927   0%               - seed7-re-search-backward
+        329,480   0%                - run-with-timer
+        329,480   0%                 - run-at-time
+        125,912   0%                  - timer-activate
+        125,912   0%                   - timer--activate
+        125,912   0%                      timer--time-less-p
+        114,608   0%                    timer-relative-time
+         72,384   0%                  - timer-set-time
+         72,384   0%                     timer--time-setter
+         16,576   0%                    timer-create
+         89,991   0%                  re-search-backward
+         62,160   0%                - seed7-inside-string-p
+          8,288   0%                 - syntax-ppss
+          8,288   0%                    make-closure
+         20,720   0%                - seed7-inside-comment-p
+         20,720   0%                 - syntax-ppss
+         20,720   0%                    make-closure
+         16,576   0%                  make-closure
+        151,312   0%               - replace-regexp-in-string
+          9,232   0%                  concat
+         14,376   0%                 match-string
+         12,432   0%                 seed7--on-lineof
+          5,120   0%                 seed7--indent-offset-for
+      2,675,751   0%             - seed7-line-is-defun-end
+      2,061,316   0%              - seed7-end-of-defun
+      2,011,428   0%               - seed7-top-block-name
+      2,007,284   0%                - seed7--to-top
+      1,990,212   0%                 - seed7-re-search-backward
+      1,559,088   0%                  - run-with-timer
+      1,559,088   0%                   - run-at-time
+        743,408   0%                    - timer-activate
+        743,408   0%                     - timer--activate
+        743,408   0%                        timer--time-less-p
+        438,976   0%                      timer-relative-time
+        302,112   0%                    - timer-set-time
+        302,112   0%                       timer--time-setter
+         74,592   0%                      timer-create
+        290,080   0%                  - seed7-inside-string-p
+         41,440   0%                   - syntax-ppss
+         37,296   0%                      make-closure
+          4,144   0%                    - parse-partial-sexp
+          4,144   0%                     - internal--syntax-propertize
+          4,144   0%                        syntax-propertize
+         91,316   0%                  - seed7-inside-comment-p
+         45,732   0%                   - syntax-ppss
+         29,008   0%                      make-closure
+         16,724   0%                    - syntax-propertize
+         16,724   0%                       seed7-mode-syntax-propertize
+         49,728   0%                    make-closure
+         12,928   0%                 - run-with-timer
+         12,928   0%                  - run-at-time
+          4,992   0%                   - timer-activate
+          4,992   0%                    - timer--activate
+          4,992   0%                       timer--time-less-p
+          4,864   0%                     timer-relative-time
+          3,072   0%                   - timer-set-time
+          3,072   0%                      timer--time-setter
+          4,144   0%                   make-closure
+          4,144   0%                - seed7--block-name
+          4,144   0%                 - seed7-re-search-forward
+          4,144   0%                    seed7-inside-comment-p
+         25,360   0%               - seed7-re-search-backward
+         17,072   0%                - run-with-timer
+         17,072   0%                 - run-at-time
+          4,992   0%                  - timer-activate
+          4,992   0%                   - timer--activate
+          4,992   0%                      timer--time-less-p
+          4,864   0%                    timer-relative-time
+          4,144   0%                    timer-create
+          3,072   0%                  - timer-set-time
+          3,072   0%                     timer--time-setter
+          8,288   0%                - seed7-inside-string-p
+          8,288   0%                 - syntax-ppss
+          8,288   0%                    make-closure
+         14,512   0%               - seed7-re-search-forward
+          4,144   0%                  seed7-inside-string-p
+          2,048   0%                - seed7-inside-comment-p
+          2,048   0%                 - syntax-ppss
+          2,048   0%                  - syntax-propertize
+          2,048   0%                     seed7-mode-syntax-propertize
+        285,216   0%              - seed7-move-to-line
+        285,216   0%               - seed7-to-previous-non-empty-line
+        231,344   0%                - seed7-inside-comment-p
+        173,328   0%                 - syntax-ppss
+        107,744   0%                    make-closure
+         65,584   0%                    parse-partial-sexp
+        140,480   0%              - seed7--current-line-nth-word
+        132,192   0%               - thing-at-point
+        132,192   0%                - bounds-of-thing-at-point
+         66,304   0%                   make-closure
+         16,576   0%                 - seq-some
+         16,576   0%                    make-closure
+         16,368   0%                 - #<byte-code-function 5C2>
+         16,368   0%                  - forward-thing
+         16,368   0%                     format
+         16,368   0%                 - #<byte-code-function A33>
+         16,368   0%                  - forward-thing
+         16,368   0%                     format
+        110,400   0%              - seed7-beg-of-defun
+         30,153   0%               - seed7-re-search-backward-closest
+         30,153   0%                - seed7-re-search-backward
+         19,545   0%                   re-search-backward
+         10,608   0%                 - run-with-timer
+         10,608   0%                  - run-at-time
+          6,640   0%                   - timer-activate
+          6,640   0%                    - timer--activate
+          6,640   0%                       timer--time-less-p
+          2,432   0%                     timer-relative-time
+          1,536   0%                   - timer-set-time
+          1,536   0%                      timer--time-setter
+         26,152   0%               - seed7-top-block-name
+         15,184   0%                - seed7--to-top
+         11,952   0%                 - seed7-re-search-backward
+          7,856   0%                  - run-with-timer
+          7,856   0%                   - run-at-time
+          5,872   0%                    - timer-activate
+          5,872   0%                     - timer--activate
+          5,872   0%                        timer--time-less-p
+          1,216   0%                      timer-relative-time
+            768   0%                    - timer-set-time
+            768   0%                       timer--time-setter
+          4,096   0%                    re-search-backward
+          3,232   0%                 - run-with-timer
+          3,232   0%                  - run-at-time
+          1,248   0%                   - timer-activate
+          1,248   0%                    - timer--activate
+          1,248   0%                       timer--time-less-p
+          1,216   0%                     timer-relative-time
+            768   0%                   - timer-set-time
+            768   0%                      timer--time-setter
+         10,968   0%                - seed7--block-name
+         10,968   0%                   seed7-re-search-forward
+         12,464   0%               - seed7-re-search-backward
+          9,232   0%                  re-search-backward
+          3,232   0%                - run-with-timer
+          3,232   0%                 - run-at-time
+          1,248   0%                  - timer-activate
+          1,248   0%                   - timer--activate
+          1,248   0%                      timer--time-less-p
+          1,216   0%                    timer-relative-time
+            768   0%                  - timer-set-time
+            768   0%                     timer--time-setter
+         40,212   0%              - seed7-line-starts-with-any
+         40,212   0%                 seed7-line-starts-with
+         29,839   0%              - seed7--safe-current-line-defun-start-indent
+         29,839   0%               - seed7-to-block-backward
+         17,407   0%                - seed7-re-search-backward
+         12,559   0%                   re-search-backward
+          4,848   0%                 - run-with-timer
+          4,848   0%                  - run-at-time
+          1,872   0%                   - timer-activate
+          1,872   0%                    - timer--activate
+          1,872   0%                       timer--time-less-p
+          1,824   0%                     timer-relative-time
+          1,152   0%                   - timer-set-time
+          1,152   0%                      timer--time-setter
+         12,432   0%                - seed7--current-line-nth-word
+          8,288   0%                 - thing-at-point
+          8,288   0%                  - bounds-of-thing-at-point
+          8,288   0%                     make-closure
+      1,018,328   0%             - seed7-line-inside-parens-pair-column
+      1,018,328   0%              - seed7-line-inside-parens-pair
+        997,752   0%               - seed7-re-search-backward
+        556,968   0%                - run-with-timer
+        556,968   0%                 - run-at-time
+        223,560   0%                  - timer-activate
+        223,560   0%                   - timer--activate
+        223,560   0%                      timer--time-less-p
+        181,488   0%                    timer-relative-time
+        122,912   0%                  - timer-set-time
+        122,912   0%                     timer--time-setter
+         29,008   0%                    timer-create
+        268,640   0%                - seed7-inside-comment-p
+        181,616   0%                 - syntax-ppss
+        116,032   0%                    make-closure
+         65,584   0%                    parse-partial-sexp
+         85,120   0%                  re-search-backward
+         66,304   0%                - seed7-inside-string-p
+         24,864   0%                 - syntax-ppss
+         24,864   0%                    make-closure
+         20,720   0%                  make-closure
+         12,288   0%               - forward-sexp
+         12,288   0%                  seed7--forward-sexp-function
+          8,288   0%                 seed7-line-inside-syntax-parens-pair
+        524,400   0%             - seed7-line-after-func-return-logic-operator-column
+        432,912   0%              - seed7-move-to-line
+        432,912   0%               - seed7-to-previous-non-empty-line
+        350,080   0%                - seed7-inside-comment-p
+        279,632   0%                 - syntax-ppss
+        196,752   0%                    parse-partial-sexp
+         82,880   0%                    make-closure
+        376,328   0%             - seed7-line-starts-with-open-paren-after-logic-operator
+        375,304   0%              - seed7-move-to-line
+        375,304   0%               - seed7-to-previous-non-empty-line
+        342,152   0%                - seed7-inside-comment-p
+        304,856   0%                 - syntax-ppss
+        163,960   0%                    parse-partial-sexp
+        140,896   0%                    make-closure
+          1,024   0%                seed7-line-starts-with
+        292,378   0%             - seed7-line-inside-argument-list-section
+        169,107   0%              - seed7-re-search-backward
+         98,707   0%                 re-search-backward
+         66,256   0%               - run-with-timer
+         66,256   0%                - run-at-time
+         25,584   0%                 - timer-activate
+         25,584   0%                  - timer--activate
+         25,584   0%                     timer--time-less-p
+         24,928   0%                   timer-relative-time
+         15,744   0%                 - timer-set-time
+         15,744   0%                    timer--time-setter
+          4,144   0%                 make-closure
+        123,271   0%              - seed7-line-is-procfunc-beg-of-decl
+        123,271   0%                 seed7-line-starts-with
+        291,040   0%             - seed7-line-inside-array-definition-block
+        250,080   0%              - seed7-re-search-backward
+        136,368   0%               - run-with-timer
+        136,368   0%                - run-at-time
+         59,632   0%                 - timer-activate
+         59,632   0%                  - timer--activate
+         59,632   0%                     timer--time-less-p
+         41,952   0%                   timer-relative-time
+         26,496   0%                 - timer-set-time
+         26,496   0%                    timer--time-setter
+          8,288   0%                   timer-create
+         92,992   0%                 re-search-backward
+          8,288   0%               - seed7-inside-comment-p
+          4,144   0%                - syntax-ppss
+          4,144   0%                   make-closure
+          8,288   0%                 seed7-inside-string-p
+          4,144   0%                 make-closure
+         40,960   0%              - forward-sexp
+         40,960   0%                 seed7--forward-sexp-function
+        281,072   0%             - seed7-line-at-endof-set-definition-block
+        281,072   0%              - seed7-move-to-line
+        281,072   0%               - seed7-to-previous-non-empty-line
+        227,200   0%                - seed7-inside-comment-p
+        156,752   0%                 - syntax-ppss
+         91,168   0%                    make-closure
+         65,584   0%                    parse-partial-sexp
+        235,856   0%             - seed7-line-inside-set-definition-block
+        235,856   0%              - seed7-re-search-backward
+        115,648   0%               - run-with-timer
+        115,648   0%                - run-at-time
+         43,056   0%                 - timer-activate
+         43,056   0%                  - timer--activate
+         43,056   0%                     timer--time-less-p
+         41,952   0%                   timer-relative-time
+         26,496   0%                 - timer-set-time
+         26,496   0%                    timer--time-setter
+          4,144   0%                   timer-create
+         91,200   0%                 re-search-backward
+         20,720   0%               - seed7-inside-string-p
+         16,576   0%                - syntax-ppss
+         16,576   0%                   make-closure
+          4,144   0%                 seed7-inside-comment-p
+          4,144   0%                 make-closure
+        235,848   0%             - seed7-line-at-endof-array-definition-block
+        235,848   0%              - seed7-move-to-line
+        235,848   0%               - seed7-to-previous-non-empty-line
+        152,968   0%                - seed7-inside-comment-p
+         90,808   0%                 - syntax-ppss
+         58,016   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+        231,200   0%             - seed7-line-inside-logic-check-expression
+        205,320   0%              - seed7-to-previous-line-starts-with
+        196,088   0%               - seed7-re-search-backward
+         92,536   0%                  re-search-backward
+         82,832   0%                - run-with-timer
+         82,832   0%                 - run-at-time
+         33,872   0%                  - timer-activate
+         33,872   0%                   - timer--activate
+         33,872   0%                      timer--time-less-p
+         24,928   0%                    timer-relative-time
+         15,744   0%                  - timer-set-time
+         15,744   0%                     timer--time-setter
+          8,288   0%                    timer-create
+         16,576   0%                - seed7-inside-string-p
+          4,144   0%                 - syntax-ppss
+          4,144   0%                    make-closure
+          4,144   0%                  make-closure
+         21,736   0%              - seed7--current-line-nth-word
+         13,448   0%               - thing-at-point
+         12,432   0%                - bounds-of-thing-at-point
+          8,288   0%                   make-closure
+          4,144   0%                 - seq-some
+          4,144   0%                    make-closure
+          4,144   0%              - seed7-re-search-forward
+          4,144   0%                 seed7-inside-comment-p
+        222,720   0%             - seed7-line-inside-assign-statement-continuation
+        206,144   0%              - seed7-assign-op-pos
+        206,144   0%               - seed7-re-search-backward
+        111,504   0%                - run-with-timer
+        111,504   0%                 - run-at-time
+         43,056   0%                  - timer-activate
+         43,056   0%                   - timer--activate
+         43,056   0%                      timer--time-less-p
+         41,952   0%                    timer-relative-time
+         26,496   0%                  - timer-set-time
+         26,496   0%                     timer--time-setter
+         90,496   0%                  re-search-backward
+          4,144   0%                  seed7-inside-string-p
+         16,576   0%              - seed7-statement-end-pos
+         16,576   0%               - seed7-forward-char-pos
+         12,432   0%                - seed7-re-search-forward
+         12,432   0%                 - seed7-inside-string-p
+         12,432   0%                  - syntax-ppss
+         12,432   0%                     make-closure
+        183,392   0%             - seed7-line-inside-until-logic-expression
+        171,328   0%              - seed7-re-search-backward
+         84,352   0%                 re-search-backward
+         78,688   0%               - run-with-timer
+         78,688   0%                - run-at-time
+         33,872   0%                 - timer-activate
+         33,872   0%                  - timer--activate
+         33,872   0%                     timer--time-less-p
+         24,928   0%                   timer-relative-time
+         15,744   0%                 - timer-set-time
+         15,744   0%                    timer--time-setter
+          4,144   0%                   timer-create
+          8,288   0%                 make-closure
+         12,064   0%              - seed7-line-code-ends-with
+         12,064   0%               - seed7-re-search-backward
+          8,992   0%                - run-with-timer
+          8,992   0%                 - run-at-time
+          6,016   0%                  - timer-activate
+          6,016   0%                   - timer--activate
+          6,016   0%                      timer--time-less-p
+          1,824   0%                    timer-relative-time
+          1,152   0%                  - timer-set-time
+          1,152   0%                     timer--time-setter
+          3,072   0%                  re-search-backward
+        166,800   0%             - seed7-line-inside-func-return-statement
+        158,512   0%              - seed7-re-search-backward
+         83,968   0%                 re-search-backward
+         74,544   0%               - run-with-timer
+         74,544   0%                - run-at-time
+         25,584   0%                 - timer-activate
+         25,584   0%                  - timer--activate
+         25,584   0%                     timer--time-less-p
+         24,928   0%                   timer-relative-time
+         15,744   0%                 - timer-set-time
+         15,744   0%                    timer--time-setter
+          8,288   0%                   timer-create
+         90,496   0%               seed7-line-starts-with
+         90,112   0%             - seed7-line-isa-string
+         90,112   0%                seed7-line-starts-with
+         86,920   0%             - seed7--current-line-nth-word
+         74,488   0%              - thing-at-point
+         74,488   0%               - bounds-of-thing-at-point
+         45,584   0%                  make-closure
+          8,288   0%                - seq-some
+          8,288   0%                   make-closure
+          8,184   0%                - #<byte-code-function C29>
+          8,184   0%                 - forward-thing
+          8,184   0%                    format
+         68,862   0%             - seed7--indent-search-boundary
+         52,286   0%              - seed7--indent-search-boundary-uncached
+         52,286   0%               - syntax-ppss
+         49,728   0%                  make-closure
+          2,558   0%                  #<byte-code-function E20>
+         41,440   0%             - seed7-current-line-start-inside-comment-p
+         29,008   0%              - seed7-inside-comment-p
+         20,720   0%               - syntax-ppss
+         20,720   0%                  make-closure
+        909,125   0%            - seed7-line-code-ends-with
+        607,229   0%             - seed7-move-to-line
+        607,229   0%              - seed7-to-previous-non-empty-line
+        520,445   0%               - seed7-inside-comment-p
+        479,005   0%                - syntax-ppss
+        116,032   0%                   make-closure
+         65,584   0%                   parse-partial-sexp
+        301,896   0%             - seed7-re-search-backward
+        172,416   0%              - run-with-timer
+        172,416   0%               - run-at-time
+         65,920   0%                - timer-activate
+         65,920   0%                 - timer--activate
+         65,920   0%                    timer--time-less-p
+         60,192   0%                  timer-relative-time
+         42,160   0%                - timer-set-time
+         42,160   0%                   timer--time-setter
+          4,144   0%                  timer-create
+        100,472   0%                re-search-backward
+         20,720   0%                seed7-inside-string-p
+          8,288   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+        130,504   0%            - seed7-line-starts-with
+          8,288   0%             - seed7-move-to-line
+          8,288   0%              - seed7-to-previous-non-empty-line
+          4,144   0%               - seed7-inside-comment-p
+          4,144   0%                - syntax-ppss
+          4,144   0%                   make-closure
+         78,529   0%            - seed7-line-inside-a-block
+         53,497   0%             - seed7--safe-enclosing-block-bounds
+         32,993   0%              - seed7--block-end-pos-for
+         32,993   0%               - seed7-to-block-forward
+         20,561   0%                - seed7-re-search-forward
+         16,465   0%                 - seed7-inside-comment-p
+         12,321   0%                  - syntax-ppss
+         12,321   0%                   - syntax-propertize
+         12,321   0%                      seed7-mode-syntax-propertize
+          8,288   0%                - seed7--current-line-nth-word
+          8,288   0%                 - thing-at-point
+          8,288   0%                    bounds-of-thing-at-point
+          4,144   0%                  seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+         20,504   0%              - seed7-to-block-backward
+         12,216   0%               - seed7-re-search-backward
+          8,888   0%                - run-with-timer
+          8,888   0%                 - run-at-time
+          3,432   0%                  - timer-activate
+          3,432   0%                   - timer--activate
+          3,432   0%                      timer--time-less-p
+          3,344   0%                    timer-relative-time
+          2,112   0%                  - timer-set-time
+          2,112   0%                     timer--time-setter
+          3,328   0%                  re-search-backward
+          8,288   0%               - seed7--current-line-nth-word
+          4,144   0%                - thing-at-point
+          4,144   0%                 - bounds-of-thing-at-point
+          4,144   0%                    make-closure
+         13,464   0%             - seed7-re-search-backward
+          8,888   0%              - run-with-timer
+          8,888   0%               - run-at-time
+          3,432   0%                - timer-activate
+          3,432   0%                 - timer--activate
+          3,432   0%                    timer--time-less-p
+          3,344   0%                  timer-relative-time
+          2,112   0%                - timer-set-time
+          2,112   0%                   timer--time-setter
+          4,576   0%                re-search-backward
+          4,144   0%             - seed7-move-to-line
+          4,144   0%              - seed7-to-previous-non-empty-line
+          4,144   0%               - seed7-inside-comment-p
+          4,144   0%                - syntax-ppss
+          4,144   0%                   make-closure
+          4,096   0%               replace-regexp-in-string
+          3,328   0%               seed7--indent-offset-for
+          4,144   0%            - seed7-inside-comment-p
+          4,144   0%             - syntax-ppss
+          4,144   0%                make-closure
+          3,072   0%              looking-at
+     11,832,176   0%           - seed7-line-starts-with
+         53,512   0%            - seed7-move-to-line
+         53,512   0%             - seed7-to-previous-non-empty-line
+         45,224   0%              - seed7-inside-comment-p
+         32,792   0%               - syntax-ppss
+         32,792   0%                  parse-partial-sexp
+     11,154,075   0%           - seed7-line-isa-string
+     11,154,075   0%            - seed7-line-starts-with
+          3,123   0%               seed7-move-to-line
+      2,039,734   0%           - seed7-line-indent-step
+      1,707,846   0%            - seed7-move-to-line
+      1,707,846   0%             - seed7-to-previous-non-empty-line
+      1,611,278   0%              - seed7-inside-comment-p
+      1,602,990   0%               - syntax-ppss
+      1,540,830   0%                - syntax-propertize
+      1,511,822   0%                   seed7-mode-syntax-propertize
+         62,160   0%                  make-closure
+        864,254   0%           - seed7-current-line-start-inside-comment-p
+        557,311   0%            - seed7-inside-comment-p
+        292,095   0%             - syntax-ppss
+        290,080   0%                make-closure
+          2,015   0%                #<byte-code-function 257>
+        476,800   0%           - seed7-line-at-endof-array-definition-block
+        278,216   0%            - seed7-line-code-ends-with
+        274,072   0%             - seed7-re-search-backward
+        165,040   0%              - run-with-timer
+        165,040   0%               - run-at-time
+         60,528   0%                - timer-activate
+         60,528   0%                 - timer--activate
+         60,528   0%                    timer--time-less-p
+         58,976   0%                  timer-relative-time
+         37,248   0%                - timer-set-time
+         37,248   0%                   timer--time-setter
+          8,288   0%                  timer-create
+         47,232   0%                re-search-backward
+         41,080   0%              - seed7-inside-comment-p
+         36,936   0%               - syntax-ppss
+         32,792   0%                  parse-partial-sexp
+          4,144   0%                  make-closure
+         12,432   0%              - seed7-inside-string-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+          8,288   0%                make-closure
+        125,304   0%            - backward-sexp
+        125,304   0%             - forward-sexp
+        125,304   0%              - seed7--forward-sexp-function
+         41,104   0%               - seed7--at-array-definition-end-line-p
+         26,768   0%                - seed7-line-code-ends-with
+         26,768   0%                 - seed7-re-search-backward
+         22,624   0%                  - run-with-timer
+         22,624   0%                   - run-at-time
+          8,736   0%                    - timer-activate
+          8,736   0%                     - timer--activate
+          8,736   0%                        timer--time-less-p
+          8,512   0%                      timer-relative-time
+          5,376   0%                    - timer-set-time
+          5,376   0%                       timer--time-setter
+          4,144   0%                    seed7-inside-string-p
+         14,336   0%                  looking-at
+         33,440   0%               - seed7--at-set-definition-end-line-p
+         29,296   0%                - seed7-line-code-ends-with
+         29,296   0%                 - seed7-re-search-backward
+         25,152   0%                  - run-with-timer
+         25,152   0%                   - run-at-time
+          8,112   0%                    - timer-activate
+          8,112   0%                     - timer--activate
+          8,112   0%                        timer--time-less-p
+          7,904   0%                      timer-relative-time
+          4,992   0%                    - timer-set-time
+          4,992   0%                       timer--time-setter
+          4,144   0%                      timer-create
+          4,144   0%                  - seed7-inside-string-p
+          4,144   0%                   - syntax-ppss
+          4,144   0%                      make-closure
+         12,440   0%               - seed7-beg-of-defun
+          5,920   0%                - seed7-top-block-name
+          5,920   0%                 - seed7--to-top
+          5,112   0%                  - seed7-re-search-backward
+          4,144   0%                     seed7-inside-string-p
+            968   0%                   - run-with-timer
+            968   0%                    - run-at-time
+            472   0%                     - timer-activate
+            472   0%                      - timer--activate
+            472   0%                         timer--time-less-p
+            304   0%                       timer-relative-time
+            192   0%                     - timer-set-time
+            192   0%                        timer--time-setter
+            808   0%                  - run-with-timer
+            808   0%                   - run-at-time
+            312   0%                    - timer-activate
+            312   0%                     - timer--activate
+            312   0%                        timer--time-less-p
+            304   0%                      timer-relative-time
+            192   0%                    - timer-set-time
+            192   0%                       timer--time-setter
+          2,640   0%                - seed7-re-search-backward-closest
+          2,640   0%                 - seed7-re-search-backward
+          1,616   0%                  - run-with-timer
+          1,616   0%                   - run-at-time
+            624   0%                    - timer-activate
+            624   0%                     - timer--activate
+            624   0%                        timer--time-less-p
+            608   0%                      timer-relative-time
+            384   0%                    - timer-set-time
+            384   0%                       timer--time-setter
+          1,024   0%                    re-search-backward
+            808   0%                - seed7-re-search-backward
+            808   0%                 - run-with-timer
+            808   0%                  - run-at-time
+            312   0%                   - timer-activate
+            312   0%                    - timer--activate
+            312   0%                       timer--time-less-p
+            304   0%                     timer-relative-time
+            192   0%                   - timer-set-time
+            192   0%                      timer--time-setter
+          5,760   0%               - seed7--safe-to-block-backward
+          5,760   0%                - seed7-to-block-backward
+          4,144   0%                 - seed7--current-line-nth-word
+          4,144   0%                  - thing-at-point
+          4,144   0%                   - bounds-of-thing-at-point
+          4,144   0%                    - seq-some
+          4,144   0%                       make-closure
+          1,616   0%                 - seed7-line-code-ends-with
+          1,616   0%                  - seed7-re-search-backward
+          1,616   0%                   - run-with-timer
+          1,616   0%                    - run-at-time
+            624   0%                     - timer-activate
+            624   0%                      - timer--activate
+            624   0%                         timer--time-less-p
+            608   0%                       timer-relative-time
+            384   0%                     - timer-set-time
+            384   0%                        timer--time-setter
+         41,248   0%            - seed7-move-to-line
+         41,248   0%             - seed7-to-previous-non-empty-line
+         12,432   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+         23,744   0%            - seed7-re-search-backward
+         11,312   0%             - run-with-timer
+         11,312   0%              - run-at-time
+          4,368   0%               - timer-activate
+          4,368   0%                - timer--activate
+          4,368   0%                   timer--time-less-p
+          4,256   0%                 timer-relative-time
+          2,688   0%               - timer-set-time
+          2,688   0%                  timer--time-setter
+          8,288   0%               seed7-inside-string-p
+          4,144   0%             - seed7-inside-comment-p
+          4,144   0%              - syntax-ppss
+          4,144   0%                 make-closure
+        301,616   0%           - seed7-line-ends-with
+        195,072   0%            - seed7-re-search-backward
+        104,576   0%               re-search-backward
+         90,496   0%             - run-with-timer
+         90,496   0%              - run-at-time
+         34,944   0%               - timer-activate
+         34,944   0%                - timer--activate
+         34,944   0%                   timer--time-less-p
+         34,048   0%                 timer-relative-time
+         21,504   0%               - timer-set-time
+         21,504   0%                  timer--time-setter
+        106,544   0%            - seed7-move-to-line
+        106,544   0%               seed7-to-previous-non-empty-line
+        285,456   0%           - seed7-line-at-endof-set-definition-block
+        238,016   0%            - seed7-line-code-ends-with
+        238,016   0%             - seed7-re-search-backward
+        184,144   0%              - run-with-timer
+        184,144   0%               - run-at-time
+         76,480   0%                - timer-activate
+         76,480   0%                 - timer--activate
+         76,480   0%                    timer--time-less-p
+         58,368   0%                  timer-relative-time
+         36,864   0%                - timer-set-time
+         36,864   0%                   timer--time-setter
+         12,432   0%                  timer-create
+         24,864   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+         16,576   0%                make-closure
+         12,432   0%              - seed7-inside-string-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+         22,464   0%            - backward-sexp
+         22,464   0%             - forward-sexp
+         22,464   0%              - seed7--forward-sexp-function
+          9,696   0%               - seed7--safe-to-block-backward
+          9,696   0%                - seed7-to-block-backward
+          9,696   0%                 - seed7-line-code-ends-with
+          9,696   0%                  - seed7-re-search-backward
+          9,696   0%                   - run-with-timer
+          9,696   0%                    - run-at-time
+          3,744   0%                     - timer-activate
+          3,744   0%                      - timer--activate
+          3,744   0%                         timer--time-less-p
+          3,648   0%                       timer-relative-time
+          2,304   0%                     - timer-set-time
+          2,304   0%                        timer--time-setter
+          7,920   0%               - seed7--at-set-definition-end-line-p
+          4,848   0%                - seed7-line-code-ends-with
+          4,848   0%                 - seed7-re-search-backward
+          4,848   0%                  - run-with-timer
+          4,848   0%                   - run-at-time
+          1,872   0%                    - timer-activate
+          1,872   0%                     - timer--activate
+          1,872   0%                        timer--time-less-p
+          1,824   0%                      timer-relative-time
+          1,152   0%                    - timer-set-time
+          1,152   0%                       timer--time-setter
+          3,072   0%                  looking-at
+          4,848   0%               - seed7--at-array-definition-end-line-p
+          4,848   0%                - seed7-line-code-ends-with
+          4,848   0%                 - seed7-re-search-backward
+          4,848   0%                  - run-with-timer
+          4,848   0%                   - run-at-time
+          1,872   0%                    - timer-activate
+          1,872   0%                     - timer--activate
+          1,872   0%                        timer--time-less-p
+          1,824   0%                      timer-relative-time
+          1,152   0%                    - timer-set-time
+          1,152   0%                       timer--time-setter
+         20,720   0%            - seed7-move-to-line
+         20,720   0%             - seed7-to-previous-non-empty-line
+          8,288   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+          3,232   0%            - seed7-re-search-backward
+          3,232   0%             - run-with-timer
+          3,232   0%              - run-at-time
+          1,248   0%               - timer-activate
+          1,248   0%                - timer--activate
+          1,248   0%                   timer--time-less-p
+          1,216   0%                 timer-relative-time
+            768   0%               - timer-set-time
+            768   0%                  timer--time-setter
+          1,024   0%              looking-at
+        158,048   0%           - seed7-position-of-end-of-statement
+        158,048   0%            - seed7-line-code-ends-with
+        158,048   0%             - seed7-re-search-backward
+        128,080   0%              - run-with-timer
+        128,080   0%               - run-at-time
+         47,200   0%                - timer-activate
+         47,200   0%                 - timer--activate
+         47,200   0%                    timer--time-less-p
+         41,952   0%                  timer-relative-time
+         26,496   0%                - timer-set-time
+         26,496   0%                   timer--time-setter
+         12,432   0%                  timer-create
+         17,536   0%                re-search-backward
+          8,288   0%              - seed7-inside-comment-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+          4,144   0%              - seed7-inside-string-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+         68,024   0%           - seed7-line-inside-nested-parens-pairs-column
+         68,024   0%            - seed7-line-inside-nested-parens-pairs
+         68,024   0%             - seed7-line-inside-parens-pair
+         63,880   0%              - seed7-re-search-backward
+         52,520   0%               - run-with-timer
+         52,520   0%                - run-at-time
+         20,280   0%                 - timer-activate
+         20,280   0%                  - timer--activate
+         20,280   0%                     timer--time-less-p
+         19,760   0%                   timer-relative-time
+         12,480   0%                 - timer-set-time
+         12,480   0%                    timer--time-setter
+          4,144   0%               - seed7-inside-comment-p
+          4,144   0%                - syntax-ppss
+          4,144   0%                   make-closure
+          4,144   0%                 make-closure
+          3,072   0%                 re-search-backward
+         58,416   0%           - seed7-line-starts-with-open-paren-after-logic-operator
+         54,272   0%              seed7-line-starts-with
+         13,408   0%           - seed7-line-is-procfunc-beg-of-decl
+         13,408   0%              seed7-line-starts-with
+        857,864   0%          - jit-lock-after-change
+        410,256   0%             font-lock-extend-jit-lock-region-after-change
+        512,448   0%          - #<byte-code-function EAE>
+        512,448   0%           - filter-buffer-substring
+        512,448   0%            - buffer-substring--filter
+        512,448   0%             - #<byte-code-function 6B6>
+        512,448   0%              - apply
+        512,448   0%                 #<byte-code-function 954>
+     14,465,347   0%       - smex
+     14,243,427   0%        - smex-read-and-run
+     12,416,743   0%         - smex-completing-read
+     12,416,743   0%          - ido-completing-read
+     12,416,743   0%           - apply
+     12,416,743   0%            - ido-completing-read@ido-cr+-replace
+     12,416,743   0%             - #<native-comp-function ido-completing-read>
+     12,416,743   0%              - ido-read-internal
+     12,416,743   0%               - apply
+     12,416,743   0%                - ad-Advice-ido-read-internal
+     12,416,743   0%                 - #<native-comp-function ido-read-internal>
+     12,416,743   0%                  - read-from-minibuffer
+      7,479,132   0%                   - redisplay_internal (C function)
+          4,664   0%                      file-remote-p
+          3,072   0%                    - tty-color-desc
+          3,072   0%                     - tty-color-canonicalize
+          1,024   0%                        replace-regexp-in-string
+      4,057,295   0%                   - ido-exhibit
+      4,057,295   0%                    - apply
+      4,057,295   0%                     - #<native-comp-function ido-exhibit>
+      3,317,789   0%                      - ido-set-matches
+      3,317,789   0%                       - apply
+      3,317,789   0%                        - ido-grid--set-matches
+      3,317,789   0%                         - apply
+      3,317,789   0%                          - #<native-comp-function ido-set-matches>
+      3,317,789   0%                           - ido-set-matches-1
+      3,317,789   0%                            - apply
+      3,317,789   0%                             - ad-Advice-ido-set-matches-1
+      3,317,789   0%                              - flx-ido-match
+      3,309,605   0%                               - flx-ido-match-internal
+      3,101,741   0%                                - flx-score
+        457,773   0%                                 - flx-find-best-match
+        399,405   0%                                  - flx-find-best-match
+        325,229   0%                                   - flx-find-best-match
+        122,816   0%                                    - flx-find-best-match
+         83,904   0%                                     - flx-find-best-match
+         59,584   0%                                      - flx-find-best-match
+         30,400   0%                                         puthash
+         29,184   0%                                       - flx-find-best-match
+         18,240   0%                                        - flx-find-best-match
+         18,240   0%                                           puthash
+         10,944   0%                                          puthash
+         24,320   0%                                        puthash
+         38,912   0%                                       puthash
+        109,997   0%                                      +
+         92,416   0%                                      puthash
+         74,176   0%                                     puthash
+         58,368   0%                                    puthash
+         17,408   0%                                 - flx-process-cache
+         17,408   0%                                    flx-get-hash-for-string
+         81,064   0%                                - flx-ido-decorate
+         28,504   0%                                   flx-propertize
+         26,264   0%                                - flx-flex-match
+         26,264   0%                                 - #<byte-code-function 854>
+         26,264   0%                                    string-match
+          8,184   0%                               - flx-ido-narrowed
+          8,184   0%                                - flx-ido-undecorate
+          8,184   0%                                 - flx-ido-decorate
+          8,184   0%                                    flx-propertize
+        387,738   0%                      - ido-completions
+        387,738   0%                       - apply
+        387,738   0%                        - ido-grid--completions
+        278,586   0%                         - ido-grid--grid-ensure-visible
+        278,586   0%                          - ido-grid--grid
+         89,712   0%                             buffer-string
+         12,132   0%                             move-to-column
+         10,160   0%                             add-face-text-property
+          2,176   0%                           - ido-final-slash
+          1,152   0%                              ido-is-tramp-root
+          1,024   0%                             string-match
+            462   0%                             generate-new-buffer
+        271,504   0%                      - ido-set-common-completion
+        271,504   0%                       - ido-find-common-substring
+        185,528   0%                          ido-word-matching-substring
+          1,016   0%                        put-text-property
+          2,192   0%                   - timer-event-handler
+          2,192   0%                    - timer-activate-when-idle
+          2,192   0%                     - timer--activate
+          2,192   0%                        timer--time-less-p
+          1,024   0%                     minibuffer--regexp-setup
+          1,016   0%                   - command-execute
+          1,016   0%                    - call-interactively
+          1,016   0%                     - apply
+          1,016   0%                      - call-interactively@ido-cr+-record-current-command
+          1,016   0%                       - #<primitive-function call-interactively>
+          1,016   0%                        - funcall-interactively
+            648   0%                         - self-insert-command
+            648   0%                          - undo-auto--undoable-change
+            648   0%                           - undo-auto--boundary-ensure-timer
+            648   0%                            - run-at-time
+            304   0%                               timer-relative-time
+            192   0%                             - timer-set-time
+            192   0%                                timer--time-setter
+            152   0%                             - timer-activate
+            152   0%                              - timer--activate
+            152   0%                                 timer--time-less-p
+            648   0%                   - undo-auto--undoable-change
+            648   0%                    - undo-auto--boundary-ensure-timer
+            648   0%                     - run-at-time
+            304   0%                        timer-relative-time
+            192   0%                      - timer-set-time
+            192   0%                         timer--time-setter
+            152   0%                      - timer-activate
+            152   0%                       - timer--activate
+            152   0%                          timer--time-less-p
+      1,826,684   0%         - execute-extended-command
+      1,648,396   0%          - command-execute
+      1,648,396   0%           - call-interactively
+      1,648,396   0%            - apply
+      1,648,396   0%             - call-interactively@ido-cr+-record-current-command
+      1,648,396   0%              - #<primitive-function call-interactively>
+      1,648,396   0%               - funcall-interactively
+      1,648,380   0%                  profiler-stop
+        221,920   0%        - smex-update
+        221,920   0%         - smex-rebuild-cache
+         67,928   0%            smex-convert-for-ido
+    981,683,306  18% + redisplay_internal (C function)
+      8,225,572   0% + timer-event-handler
+      6,002,763   0%   Automatic GC
+         18,424   0% + flyspell-post-command-hook
+          7,237   0% + help--append-keystrokes-help
+              0   0%   ...

--- a/reports/18.1/castle.sd7-perf-cpu.txt
+++ b/reports/18.1/castle.sd7-perf-cpu.txt
@@ -1,0 +1,943 @@
+       43601  93% - command-execute
+       43601  93%  - call-interactively
+       43601  93%   - apply
+       43601  93%    - call-interactively@ido-cr+-record-current-command
+       43601  93%     - #<primitive-function call-interactively>
+       43601  93%      - funcall-interactively
+       43418  93%       - seed7-complete-statement-or-indent
+       43418  93%        - seed7-indent-region
+       43417  93%         - seed7--indent-one-line
+       43403  93%          - seed7-calc-indent
+       23544  50%           - seed7-line-is-defun-end
+       22461  48%            - seed7-end-of-defun
+       20954  45%             - seed7-top-block-name
+       20933  44%              - seed7--to-top
+       20861  44%               - seed7-re-search-backward
+       18010  38%                - seed7-inside-comment-p
+       18004  38%                 - syntax-ppss
+       17866  38%                    parse-partial-sexp
+          98   0%                  - syntax-propertize
+          53   0%                     seed7-mode-syntax-propertize
+           8   0%                    make-closure
+           6   0%                    #<byte-code-function 965>
+           4   0%                    syntax-ppss--update-stats
+           4   0%                    syntax-ppss-toplevel-pos
+           2   0%                    syntax-ppss--data
+           1   0%                    syntax-table
+           1   0%                    set-syntax-table
+        2177   4%                - run-with-timer
+        2174   4%                 - run-at-time
+        1298   2%                  - timer-activate
+        1296   2%                   - timer--activate
+        1285   2%                    - timer--time-less-p
+          31   0%                       timer--time
+           1   0%                      timerp
+         553   1%                  - timer-set-time
+         551   1%                     timer--time-setter
+         294   0%                    timer-relative-time
+          21   0%                    timer-create
+           4   0%                  - timer-set-function
+           2   0%                     timerp
+         444   0%                  re-search-backward
+         135   0%                - seed7-inside-string-p
+          87   0%                 - syntax-ppss
+          48   0%                  - parse-partial-sexp
+           1   0%                   - internal--syntax-propertize
+           1   0%                    - syntax-propertize
+           1   0%                       seed7-mode-syntax-propertize
+          17   0%                    make-closure
+           5   0%                  - #<byte-code-function B15>
+           1   0%                     set-syntax-table
+           3   0%                    syntax-propertize
+           1   0%                    syntax-ppss--update-stats
+           1   0%                    syntax-ppss--data
+           7   0%                 - #<byte-code-function 044>
+           4   0%                    set-match-data
+          13   0%                - #<byte-code-function 114>
+           9   0%                   cancel-timer
+           2   0%                  make-closure
+          27   0%               - run-with-timer
+          27   0%                - run-at-time
+          11   0%                 - timer-activate
+          11   0%                  - timer--activate
+          10   0%                     timer--time-less-p
+           9   0%                 - timer-set-time
+           9   0%                    timer--time-setter
+           7   0%                   timer-relative-time
+          21   0%                 seed7-to-indent
+          21   0%              - seed7--block-name
+          21   0%               - seed7-re-search-forward
+           4   0%                - seed7-inside-comment-p
+           4   0%                 - syntax-ppss
+           4   0%                    parse-partial-sexp
+           3   0%                - seed7-inside-string-p
+           3   0%                 - syntax-ppss
+           3   0%                    parse-partial-sexp
+        1310   2%             - seed7-re-search-forward
+         499   1%              - seed7-inside-comment-p
+         496   1%               - syntax-ppss
+         427   0%                  parse-partial-sexp
+          65   0%                - syntax-propertize
+          34   0%                   seed7-mode-syntax-propertize
+           2   0%                 - #<byte-code-function D6E>
+           2   0%                  - syntax-propertize-wholelines
+           1   0%                     syntax--lbp
+           2   0%                  make-closure
+           1   0%                  syntax-ppss--update-stats
+           1   0%                  set-syntax-table
+         265   0%              - seed7-inside-string-p
+         246   0%               - syntax-ppss
+         241   0%                  parse-partial-sexp
+           2   0%                  make-closure
+           1   0%                - #<byte-code-function 532>
+           1   0%                   set-syntax-table
+           1   0%               - #<byte-code-function F8E>
+           1   0%                  set-match-data
+         184   0%             - seed7-re-search-backward
+         165   0%              - seed7-inside-comment-p
+         165   0%               - syntax-ppss
+         164   0%                  parse-partial-sexp
+          15   0%              - run-with-timer
+          15   0%               - run-at-time
+           9   0%                - timer-activate
+           9   0%                 - timer--activate
+           9   0%                  - timer--time-less-p
+           1   0%                     timer--time
+           5   0%                - timer-set-time
+           5   0%                   timer--time-setter
+           1   0%                  timer-relative-time
+           2   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           2   0%                re-search-backward
+           2   0%               match-string
+           1   0%               seed7--no-defun-found-msg-for
+         998   2%            - seed7-beg-of-defun
+         594   1%             - seed7-re-search-backward
+         491   1%              - seed7-inside-comment-p
+         491   1%               - syntax-ppss
+         489   1%                  parse-partial-sexp
+           1   0%                  #<byte-code-function F81>
+          57   0%              - run-with-timer
+          57   0%               - run-at-time
+          27   0%                - timer-activate
+          27   0%                 - timer--activate
+          27   0%                  - timer--time-less-p
+           1   0%                     timer--time
+          25   0%                - timer-set-time
+          25   0%                   timer--time-setter
+           5   0%                  timer-relative-time
+          36   0%                re-search-backward
+           7   0%              - seed7-inside-string-p
+           6   0%               - syntax-ppss
+           4   0%                  parse-partial-sexp
+           1   0%                  syntax-ppss--data
+           1   0%                  make-closure
+           1   0%              - #<byte-code-function 3E5>
+           1   0%                 cancel-timer
+         369   0%             - seed7-re-search-backward-closest
+         369   0%              - seed7-re-search-backward
+         358   0%                 re-search-backward
+          10   0%               - run-with-timer
+           9   0%                - run-at-time
+           7   0%                 - timer-activate
+           7   0%                  - timer--activate
+           7   0%                     timer--time-less-p
+           1   0%                 - timer-set-time
+           1   0%                    timer--time-setter
+           1   0%                   timer-relative-time
+           1   0%               - #<byte-code-function B3F>
+           1   0%                  cancel-timer
+          29   0%             - seed7-top-block-name
+          22   0%              - seed7--to-top
+          16   0%               - seed7-re-search-backward
+           8   0%                - seed7-inside-comment-p
+           8   0%                 - syntax-ppss
+           8   0%                    parse-partial-sexp
+           6   0%                - run-with-timer
+           6   0%                 - run-at-time
+           4   0%                  - timer-activate
+           4   0%                   - timer--activate
+           4   0%                      timer--time-less-p
+           1   0%                    timer-relative-time
+           1   0%                  - timer-set-time
+           1   0%                     timer--time-setter
+           2   0%                  re-search-backward
+           5   0%               - run-with-timer
+           5   0%                - run-at-time
+           3   0%                 - timer-set-time
+           3   0%                    timer--time-setter
+           1   0%                 - timer-activate
+           1   0%                  - timer--activate
+           1   0%                     timer--time-less-p
+           1   0%                   timer-relative-time
+           7   0%              - seed7--block-name
+           7   0%               - seed7-re-search-forward
+           4   0%                - seed7-inside-string-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+          45   0%            - seed7-move-to-line
+          45   0%             - seed7-to-previous-non-empty-line
+          44   0%              - seed7-inside-comment-p
+          43   0%               - syntax-ppss
+          41   0%                  parse-partial-sexp
+           1   0%                  syntax-ppss--update-stats
+          23   0%            - seed7--safe-current-line-defun-start-indent
+          23   0%             - seed7-to-block-backward
+          21   0%              - seed7-re-search-backward
+          16   0%               - seed7-inside-comment-p
+          16   0%                - syntax-ppss
+          16   0%                   parse-partial-sexp
+           3   0%               - run-with-timer
+           3   0%                - run-at-time
+           2   0%                 - timer-activate
+           2   0%                  - timer--activate
+           2   0%                     timer--time-less-p
+           1   0%                   timer-relative-time
+           2   0%                 re-search-backward
+           2   0%              - seed7-inside-comment-p
+           2   0%               - syntax-ppss
+           2   0%                  parse-partial-sexp
+          11   0%            - seed7--current-line-nth-word
+          10   0%             - thing-at-point
+           8   0%              - bounds-of-thing-at-point
+           4   0%               - #<byte-code-function 7C6>
+           4   0%                - forward-thing
+           3   0%                   forward-word
+           1   0%                   intern-soft
+           2   0%               - #<byte-code-function E3A>
+           1   0%                - forward-thing
+           1   0%                   forward-word
+           1   0%                 make-closure
+           1   0%                 re-search-forward
+           6   0%            - seed7-line-starts-with-any
+           6   0%               seed7-line-starts-with
+       12536  26%           - seed7--indent-search-boundary
+       12534  26%            - seed7--indent-search-boundary-uncached
+       12337  26%             - syntax-ppss
+       12281  26%                parse-partial-sexp
+          18   0%                make-closure
+           5   0%                #<byte-code-function C0C>
+           4   0%                syntax-propertize
+           3   0%                syntax-table
+           2   0%                set-syntax-table
+           2   0%                syntax-ppss-toplevel-pos
+           2   0%                syntax-ppss--update-stats
+          16   0%               seed7-to-indent
+        5336  11%           - seed7-line-inside-a-block-cached
+        5336  11%            - seed7-line-inside-a-block
+        4989  10%             - seed7--safe-enclosing-block-bounds
+        4401   9%              - seed7--block-end-pos-for
+        4401   9%               - seed7-to-block-forward
+        4218   9%                - seed7-end-of-defun
+        4081   8%                 - seed7-top-block-name
+        4075   8%                  - seed7--to-top
+        4063   8%                   - seed7-re-search-backward
+        3491   7%                    - seed7-inside-comment-p
+        3491   7%                     - syntax-ppss
+        3468   7%                        parse-partial-sexp
+          13   0%                      - syntax-propertize
+           7   0%                         seed7-mode-syntax-propertize
+           1   0%                        make-closure
+           1   0%                        syntax-ppss--update-stats
+           1   0%                      - #<byte-code-function 53A>
+           1   0%                         set-syntax-table
+           1   0%                        syntax-ppss--data
+         430   0%                    - run-with-timer
+         430   0%                     - run-at-time
+         270   0%                      - timer-activate
+         270   0%                       - timer--activate
+         268   0%                        - timer--time-less-p
+           5   0%                           timer--time
+         106   0%                      - timer-set-time
+         104   0%                       - timer--time-setter
+           2   0%                          timerp
+          51   0%                        timer-relative-time
+           3   0%                        timer-create
+         103   0%                      re-search-backward
+          25   0%                    - seed7-inside-string-p
+           9   0%                     - syntax-ppss
+           4   0%                        parse-partial-sexp
+           2   0%                        syntax-ppss--update-stats
+           1   0%                        make-closure
+           1   0%                        #<byte-code-function CF0>
+           2   0%                     - #<byte-code-function 207>
+           1   0%                        set-match-data
+           2   0%                    - #<byte-code-function 574>
+           1   0%                       cancel-timer
+           1   0%                      make-closure
+           2   0%                     seed7-to-indent
+           6   0%                  - seed7--block-name
+           6   0%                   - seed7-re-search-forward
+           1   0%                    - seed7-inside-string-p
+           1   0%                     - syntax-ppss
+           1   0%                        parse-partial-sexp
+           1   0%                    - seed7-inside-comment-p
+           1   0%                       syntax-ppss
+         101   0%                 - seed7-re-search-forward
+          21   0%                  - seed7-inside-comment-p
+          20   0%                   - syntax-ppss
+          18   0%                      parse-partial-sexp
+           1   0%                    - syntax-propertize
+           1   0%                     - #<byte-code-function 4BB>
+           1   0%                      - syntax-propertize-wholelines
+           1   0%                         syntax--lbp
+           1   0%                      make-closure
+          12   0%                  - seed7-inside-string-p
+           7   0%                   - syntax-ppss
+           6   0%                      parse-partial-sexp
+           1   0%                      syntax-ppss--data
+          35   0%                 - seed7-re-search-backward
+          33   0%                  - seed7-inside-comment-p
+          33   0%                   - syntax-ppss
+          33   0%                      parse-partial-sexp
+           1   0%                    re-search-backward
+           1   0%                  - run-with-timer
+           1   0%                   - run-at-time
+           1   0%                    - timer-activate
+           1   0%                     - timer--activate
+           1   0%                        timer--time-less-p
+           1   0%                   match-string
+         125   0%                - seed7-re-search-forward
+          53   0%                 - seed7-inside-string-p
+          50   0%                  - syntax-ppss
+          49   0%                     parse-partial-sexp
+           1   0%                     syntax-table
+           1   0%                  - #<byte-code-function F54>
+           1   0%                     set-match-data
+          53   0%                 - seed7-inside-comment-p
+          52   0%                  - syntax-ppss
+          50   0%                     parse-partial-sexp
+           2   0%                   - syntax-propertize
+           2   0%                      seed7-mode-syntax-propertize
+          36   0%                - seed7--current-line-nth-word
+          27   0%                 - thing-at-point
+          25   0%                  - bounds-of-thing-at-point
+           9   0%                   - #<byte-code-function B4E>
+           9   0%                    - forward-thing
+           8   0%                       forward-word
+           1   0%                       format
+           5   0%                   - #<byte-code-function B46>
+           5   0%                    - forward-thing
+           4   0%                       forward-word
+           1   0%                       format
+           3   0%                     re-search-forward
+           2   0%                   - seq-some
+           2   0%                      make-closure
+          10   0%                - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+           5   0%                 - seed7-inside-comment-p
+           5   0%                  - syntax-ppss
+           5   0%                     parse-partial-sexp
+           4   0%                 - seed7-inside-line-indent-before-comment-p
+           2   0%                    seed7-to-indent
+           2   0%                  - seed7-inside-comment-p
+           2   0%                   - syntax-ppss
+           2   0%                      parse-partial-sexp
+           7   0%                - seed7-inside-comment-p
+           7   0%                 - syntax-ppss
+           6   0%                    parse-partial-sexp
+           2   0%                - seed7-inside-line-indent-before-comment-p
+           1   0%                   seed7-to-indent
+           1   0%                  seed7--end-regexp-for
+         588   1%              - seed7-to-block-backward
+         522   1%               - seed7-re-search-backward
+         398   0%                - seed7-inside-comment-p
+         398   0%                 - syntax-ppss
+         392   0%                    parse-partial-sexp
+           3   0%                    make-closure
+           1   0%                    syntax-ppss--update-stats
+           1   0%                    syntax-ppss-toplevel-pos
+          80   0%                - run-with-timer
+          80   0%                 - run-at-time
+          39   0%                  - timer-activate
+          38   0%                   - timer--activate
+          38   0%                      timer--time-less-p
+          26   0%                  - timer-set-time
+          26   0%                     timer--time-setter
+          14   0%                    timer-relative-time
+           1   0%                    timer-create
+          23   0%                  re-search-backward
+          21   0%                - seed7-inside-string-p
+          20   0%                 - syntax-ppss
+          19   0%                    parse-partial-sexp
+           1   0%                    make-closure
+          32   0%               - seed7-inside-comment-p
+          32   0%                - syntax-ppss
+          32   0%                   parse-partial-sexp
+          22   0%               - seed7--current-line-nth-word
+          18   0%                - thing-at-point
+          18   0%                 - bounds-of-thing-at-point
+           9   0%                  - #<byte-code-function 199>
+           8   0%                   - forward-thing
+           6   0%                      forward-word
+           1   0%                      format
+           5   0%                  - #<byte-code-function 238>
+           5   0%                   - forward-thing
+           5   0%                      forward-word
+           2   0%                    re-search-forward
+          12   0%               - seed7-inside-line-indent-before-comment-p
+           7   0%                - seed7-inside-comment-p
+           7   0%                 - syntax-ppss
+           6   0%                    parse-partial-sexp
+           1   0%                    syntax-ppss--data
+           2   0%                  seed7-to-indent
+         207   0%             - seed7-re-search-backward
+         145   0%              - seed7-inside-comment-p
+         145   0%               - syntax-ppss
+         143   0%                  parse-partial-sexp
+           1   0%                  make-closure
+           1   0%                  syntax-ppss--data
+          32   0%              - run-with-timer
+          32   0%               - run-at-time
+          15   0%                - timer-activate
+          15   0%                 - timer--activate
+          15   0%                    timer--time-less-p
+           8   0%                - timer-set-time
+           8   0%                   timer--time-setter
+           8   0%                  timer-relative-time
+           1   0%                  timer-create
+          21   0%                re-search-backward
+           8   0%              - seed7-inside-string-p
+           7   0%               - syntax-ppss
+           7   0%                  parse-partial-sexp
+         129   0%             - seed7-calc-indent
+         114   0%              - seed7-line-is-defun-end
+         113   0%               - seed7-end-of-defun
+         103   0%                - seed7-top-block-name
+         103   0%                 - seed7--to-top
+         102   0%                  - seed7-re-search-backward
+          92   0%                   - seed7-inside-comment-p
+          92   0%                    - syntax-ppss
+          92   0%                       parse-partial-sexp
+           5   0%                   - run-with-timer
+           5   0%                    - run-at-time
+           3   0%                       timer-relative-time
+           2   0%                     - timer-activate
+           2   0%                      - timer--activate
+           2   0%                         timer--time-less-p
+           4   0%                     re-search-backward
+           1   0%                   - seed7-inside-string-p
+           1   0%                    - syntax-ppss
+           1   0%                       syntax-propertize
+           1   0%                    seed7-to-indent
+           8   0%                - seed7-re-search-forward
+           3   0%                 - seed7-inside-string-p
+           3   0%                  - syntax-ppss
+           3   0%                     parse-partial-sexp
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           1   0%                  match-string-no-properties
+           1   0%                - seed7-re-search-backward
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           1   0%               - seed7-beg-of-defun
+           1   0%                - seed7-re-search-backward
+           1   0%                 - seed7-inside-string-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+          12   0%              - seed7-line-inside-parens-pair-column
+          12   0%               - seed7-line-inside-parens-pair
+          12   0%                - seed7-re-search-backward
+          11   0%                 - seed7-inside-comment-p
+          11   0%                  - syntax-ppss
+          11   0%                     parse-partial-sexp
+           1   0%                 - run-with-timer
+           1   0%                  - run-at-time
+           1   0%                   - timer-activate
+           1   0%                    - timer--activate
+           1   0%                       timer--time-less-p
+           1   0%              - seed7-line-at-endof-set-definition-block
+           1   0%               - seed7-line-code-ends-with
+           1   0%                - seed7-re-search-backward
+           1   0%                 - run-with-timer
+           1   0%                  - run-at-time
+           1   0%                   - timer-set-time
+           1   0%                      timer--time-setter
+           1   0%                seed7-line-starts-with
+           1   0%              - seed7-line-at-endof-array-definition-block
+           1   0%               - backward-sexp
+           1   0%                - forward-sexp
+           1   0%                 - seed7--forward-sexp-function
+           1   0%                  - seed7--at-set-definition-end-line-p
+           1   0%                   - seed7-line-code-ends-with
+           1   0%                    - seed7-re-search-backward
+           1   0%                     - run-with-timer
+           1   0%                      - run-at-time
+           1   0%                         timer-relative-time
+           2   0%               seed7--on-lineof
+           1   0%               replace-regexp-in-string
+           1   0%               seed7--indent-offset-for
+           1   0%               match-string
+         641   1%           - seed7-line-inside-parens-pair-column
+         641   1%            - seed7-line-inside-parens-pair
+         594   1%             - seed7-re-search-backward
+         390   0%              - seed7-inside-comment-p
+         387   0%               - syntax-ppss
+         382   0%                  parse-partial-sexp
+           2   0%                  make-closure
+           1   0%                  syntax-table
+         141   0%              - run-with-timer
+         141   0%               - run-at-time
+          77   0%                - timer-activate
+          77   0%                 - timer--activate
+          77   0%                  - timer--time-less-p
+           2   0%                     timer--time
+          45   0%                - timer-set-time
+          45   0%                   timer--time-setter
+          16   0%                  timer-relative-time
+           1   0%                  timer-create
+          53   0%              - seed7-inside-string-p
+          50   0%               - syntax-ppss
+          49   0%                  parse-partial-sexp
+           7   0%                re-search-backward
+           1   0%                make-closure
+          14   0%             - forward-sexp
+          13   0%                seed7--forward-sexp-function
+           7   0%             - seed7-line-inside-syntax-parens-pair
+           7   0%              - syntax-ppss
+           6   0%                 parse-partial-sexp
+           1   0%                 syntax-ppss--data
+         451   0%           - seed7-line-inside-set-definition-block
+         451   0%            - seed7-re-search-backward
+         427   0%               re-search-backward
+          23   0%             - run-with-timer
+          23   0%              - run-at-time
+          10   0%               - timer-activate
+          10   0%                - timer--activate
+          10   0%                   timer--time-less-p
+           7   0%               - timer-set-time
+           7   0%                  timer--time-setter
+           6   0%                 timer-relative-time
+         384   0%           - seed7-line-inside-array-definition-block
+         381   0%            - seed7-re-search-backward
+         292   0%               re-search-backward
+          71   0%             - seed7-inside-comment-p
+          71   0%              - syntax-ppss
+          71   0%                 parse-partial-sexp
+          16   0%             - run-with-timer
+          16   0%              - run-at-time
+          10   0%               - timer-activate
+          10   0%                - timer--activate
+          10   0%                   timer--time-less-p
+           3   0%               - timer-set-time
+           3   0%                  timer--time-setter
+           3   0%                 timer-relative-time
+           2   0%             - seed7-inside-string-p
+           2   0%              - syntax-ppss
+           2   0%                 parse-partial-sexp
+           3   0%            - forward-sexp
+           3   0%               seed7--forward-sexp-function
+         156   0%           - seed7-line-inside-assign-statement-continuation
+         151   0%            - seed7-assign-op-pos
+         151   0%             - seed7-re-search-backward
+         124   0%              - seed7-inside-comment-p
+         123   0%               - syntax-ppss
+         123   0%                  parse-partial-sexp
+          21   0%              - run-with-timer
+          21   0%               - run-at-time
+          10   0%                - timer-activate
+          10   0%                 - timer--activate
+          10   0%                    timer--time-less-p
+           6   0%                - timer-set-time
+           6   0%                   timer--time-setter
+           4   0%                  timer-relative-time
+           5   0%                re-search-backward
+           1   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           5   0%            - seed7-statement-end-pos
+           5   0%             - seed7-forward-char-pos
+           5   0%              - seed7-re-search-forward
+           2   0%               - seed7-inside-string-p
+           2   0%                - syntax-ppss
+           2   0%                   parse-partial-sexp
+           2   0%               - seed7-inside-comment-p
+           2   0%                - syntax-ppss
+           2   0%                   parse-partial-sexp
+          84   0%           - seed7--current-line-nth-word
+          81   0%            - thing-at-point
+          81   0%             - bounds-of-thing-at-point
+          73   0%              - #<byte-code-function 623>
+          73   0%               - forward-thing
+          73   0%                - forward-word
+          70   0%                 - internal--syntax-propertize
+          70   0%                  - syntax-propertize
+          57   0%                     seed7-mode-syntax-propertize
+           1   0%                   - #<byte-code-function 1EC>
+           1   0%                      syntax-propertize-wholelines
+           6   0%              - #<byte-code-function 83D>
+           6   0%               - forward-thing
+           4   0%                  forward-word
+          72   0%           - seed7-comment-column
+          71   0%            - seed7-calc-indent
+          54   0%             - seed7-line-is-defun-end
+          53   0%              - seed7-end-of-defun
+          46   0%               - seed7-top-block-name
+          46   0%                - seed7--to-top
+          46   0%                 - seed7-re-search-backward
+          37   0%                  - seed7-inside-comment-p
+          37   0%                   - syntax-ppss
+          36   0%                      parse-partial-sexp
+           1   0%                      make-closure
+           4   0%                  - run-with-timer
+           4   0%                   - run-at-time
+           3   0%                    - timer-activate
+           3   0%                     - timer--activate
+           3   0%                        timer--time-less-p
+           1   0%                      timer-create
+           3   0%                    seed7-inside-string-p
+           1   0%                    re-search-backward
+           1   0%                    make-closure
+           6   0%               - seed7-re-search-forward
+           3   0%                - seed7-inside-string-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           2   0%                - seed7-inside-comment-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           1   0%               - seed7-re-search-backward
+           1   0%                - seed7-inside-comment-p
+           1   0%                 - syntax-ppss
+           1   0%                    parse-partial-sexp
+           1   0%              - seed7--current-line-nth-word
+           1   0%               - thing-at-point
+           1   0%                - bounds-of-thing-at-point
+           1   0%                   make-closure
+           4   0%             - seed7-line-inside-a-block-cached
+           4   0%              - seed7-line-inside-a-block
+           4   0%               - seed7--safe-enclosing-block-bounds
+           4   0%                - seed7-to-block-backward
+           4   0%                 - seed7-re-search-backward
+           3   0%                  - seed7-inside-comment-p
+           3   0%                   - syntax-ppss
+           3   0%                      parse-partial-sexp
+           1   0%                  - run-with-timer
+           1   0%                   - run-at-time
+           1   0%                    - timer-activate
+           1   0%                     - timer--activate
+           1   0%                        timer--time-less-p
+           3   0%             - seed7-line-inside-parens-pair-column
+           3   0%              - seed7-line-inside-parens-pair
+           3   0%               - seed7-re-search-backward
+           2   0%                  re-search-backward
+           1   0%                - seed7-inside-comment-p
+           1   0%                 - syntax-ppss
+           1   0%                    make-closure
+           2   0%             - seed7-line-at-endof-array-definition-block
+           2   0%              - seed7-move-to-line
+           2   0%               - seed7-to-previous-non-empty-line
+           2   0%                - seed7-inside-comment-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           2   0%             - seed7-line-starts-with-open-paren-after-logic-operator
+           2   0%              - seed7-move-to-line
+           2   0%               - seed7-to-previous-non-empty-line
+           2   0%                - seed7-inside-comment-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           1   0%             - seed7-line-inside-array-definition-block
+           1   0%                seed7-re-search-backward
+           1   0%             - seed7-line-at-endof-set-definition-block
+           1   0%              - seed7-move-to-line
+           1   0%               - seed7-to-previous-non-empty-line
+           1   0%                - seed7-inside-comment-p
+           1   0%                 - syntax-ppss
+           1   0%                    parse-partial-sexp
+           1   0%             - seed7--current-line-nth-word
+           1   0%              - thing-at-point
+           1   0%               - bounds-of-thing-at-point
+           1   0%                - #<byte-code-function 7AC>
+           1   0%                 - forward-thing
+           1   0%                    format
+           1   0%             - seed7-line-after-func-return-logic-operator-column
+           1   0%              - seed7-move-to-line
+           1   0%               - seed7-to-previous-non-empty-line
+           1   0%                - seed7-inside-comment-p
+           1   0%                 - syntax-ppss
+           1   0%                    parse-partial-sexp
+           1   0%             - seed7--indent-search-boundary
+           1   0%              - seed7--indent-search-boundary-uncached
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           1   0%             - seed7-line-inside-logic-check-expression
+           1   0%              - seed7-to-previous-line-starts-with
+           1   0%               - seed7-re-search-backward
+           1   0%                - run-with-timer
+           1   0%                 - run-at-time
+           1   0%                  - timer-set-time
+           1   0%                     timer--time-setter
+           1   0%            - seed7-line-code-ends-with
+           1   0%             - seed7-move-to-line
+           1   0%              - seed7-to-previous-non-empty-line
+           1   0%               - seed7-inside-comment-p
+           1   0%                - syntax-ppss
+           1   0%                   parse-partial-sexp
+          39   0%           - seed7-line-inside-logic-check-expression
+          26   0%            - seed7-to-previous-line-starts-with
+          25   0%             - seed7-re-search-backward
+          14   0%              - run-with-timer
+          14   0%               - run-at-time
+           5   0%                  timer-relative-time
+           5   0%                - timer-activate
+           5   0%                 - timer--activate
+           5   0%                    timer--time-less-p
+           4   0%                - timer-set-time
+           4   0%                   timer--time-setter
+           6   0%              - seed7-inside-string-p
+           5   0%               - syntax-ppss
+           5   0%                  parse-partial-sexp
+           1   0%               - #<byte-code-function CFC>
+           1   0%                  set-match-data
+           3   0%                re-search-backward
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+          10   0%            - seed7-re-search-forward
+           7   0%             - seed7-inside-comment-p
+           7   0%              - syntax-ppss
+           7   0%                 parse-partial-sexp
+           2   0%             - seed7-inside-string-p
+           1   0%              - syntax-ppss
+           1   0%                 parse-partial-sexp
+           2   0%            - seed7--current-line-nth-word
+           2   0%             - thing-at-point
+           2   0%              - bounds-of-thing-at-point
+           1   0%               - #<byte-code-function F04>
+           1   0%                - forward-thing
+           1   0%                   format
+           1   0%              seed7-move-to-line
+          34   0%           - seed7-line-after-func-return-logic-operator-column
+          32   0%            - seed7-move-to-line
+          31   0%             - seed7-to-previous-non-empty-line
+          28   0%              - seed7-inside-comment-p
+          28   0%               - syntax-ppss
+          28   0%                  parse-partial-sexp
+          22   0%           - seed7-line-inside-func-return-statement
+          21   0%            - seed7-re-search-backward
+          17   0%             - run-with-timer
+          17   0%              - run-at-time
+           7   0%               - timer-activate
+           7   0%                - timer--activate
+           7   0%                   timer--time-less-p
+           6   0%               - timer-set-time
+           6   0%                  timer--time-setter
+           4   0%                 timer-relative-time
+           4   0%               re-search-backward
+           1   0%              seed7-move-to-line
+          22   0%           - seed7-line-inside-argument-list-section
+          19   0%            - seed7-re-search-backward
+          10   0%               re-search-backward
+           9   0%             - run-with-timer
+           9   0%              - run-at-time
+           5   0%               - timer-activate
+           5   0%                - timer--activate
+           5   0%                   timer--time-less-p
+           3   0%               - timer-set-time
+           3   0%                  timer--time-setter
+           1   0%                 timer-relative-time
+           3   0%            - seed7-line-is-procfunc-beg-of-decl
+           3   0%               seed7-line-starts-with
+          20   0%           - seed7-line-inside-nested-parens-pairs-column
+          20   0%            - seed7-line-inside-nested-parens-pairs
+          19   0%             - seed7-line-inside-parens-pair
+          15   0%              - seed7-re-search-backward
+          13   0%               - run-with-timer
+          13   0%                - run-at-time
+           9   0%                 - timer-activate
+           9   0%                  - timer--activate
+           9   0%                     timer--time-less-p
+           2   0%                 - timer-set-time
+           2   0%                    timer--time-setter
+           2   0%                   timer-relative-time
+           1   0%               - seed7-inside-comment-p
+           1   0%                - syntax-ppss
+           1   0%                   parse-partial-sexp
+           1   0%               - seed7-inside-string-p
+           1   0%                - syntax-ppss
+           1   0%                   parse-partial-sexp
+           3   0%              - seed7-line-inside-syntax-parens-pair
+           3   0%               - syntax-ppss
+           3   0%                  parse-partial-sexp
+          16   0%           - seed7-line-inside-until-logic-expression
+          16   0%            - seed7-re-search-backward
+          13   0%             - run-with-timer
+          13   0%              - run-at-time
+           8   0%               - timer-activate
+           8   0%                - timer--activate
+           8   0%                   timer--time-less-p
+           3   0%                 timer-relative-time
+           2   0%               - timer-set-time
+           2   0%                  timer--time-setter
+           3   0%               re-search-backward
+          12   0%           - seed7-current-line-start-inside-comment-p
+          11   0%            - seed7-inside-comment-p
+          11   0%             - syntax-ppss
+          11   0%                parse-partial-sexp
+          10   0%           - seed7-line-at-endof-array-definition-block
+           4   0%            - seed7-line-code-ends-with
+           4   0%             - seed7-re-search-backward
+           1   0%                re-search-backward
+           1   0%              - run-with-timer
+           1   0%               - run-at-time
+           1   0%                - timer-activate
+           1   0%                 - timer--activate
+           1   0%                    timer--time-less-p
+           1   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           4   0%            - backward-sexp
+           4   0%             - forward-sexp
+           4   0%              - seed7--forward-sexp-function
+           4   0%               - seed7--safe-to-block-backward
+           4   0%                - seed7-to-block-backward
+           3   0%                 - seed7-inside-line-indent-before-comment-p
+           3   0%                  - seed7-inside-comment-p
+           3   0%                   - syntax-ppss
+           3   0%                      parse-partial-sexp
+           1   0%                 - seed7-line-code-ends-with
+           1   0%                  - seed7-re-search-backward
+           1   0%                   - run-with-timer
+           1   0%                    - run-at-time
+           1   0%                     - timer-activate
+           1   0%                      - timer--activate
+           1   0%                         timer--time-less-p
+           2   0%            - seed7-move-to-line
+           2   0%             - seed7-to-previous-non-empty-line
+           2   0%              - seed7-inside-comment-p
+           2   0%               - syntax-ppss
+           2   0%                  parse-partial-sexp
+           7   0%           - seed7-line-starts-with
+           5   0%            - seed7-move-to-line
+           4   0%             - seed7-to-previous-non-empty-line
+           4   0%              - seed7-inside-comment-p
+           4   0%               - syntax-ppss
+           4   0%                  parse-partial-sexp
+           6   0%           - seed7-line-ends-with
+           6   0%            - seed7-move-to-line
+           6   0%             - seed7-to-previous-non-empty-line
+           6   0%              - seed7-inside-comment-p
+           6   0%               - syntax-ppss
+           6   0%                  parse-partial-sexp
+           4   0%           - seed7-line-at-endof-set-definition-block
+           3   0%            - seed7-line-code-ends-with
+           3   0%             - seed7-re-search-backward
+           2   0%              - run-with-timer
+           2   0%               - run-at-time
+           1   0%                - timer-set-time
+           1   0%                   timer--time-setter
+           1   0%                - timer-activate
+           1   0%                 - timer--activate
+           1   0%                    timer--time-less-p
+           1   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           1   0%            - seed7-move-to-line
+           1   0%             - seed7-to-previous-non-empty-line
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  syntax-ppss--update-stats
+           4   0%           - seed7-line-indent-step
+           4   0%            - seed7-move-to-line
+           4   0%             - seed7-to-previous-non-empty-line
+           4   0%              - seed7-inside-comment-p
+           4   0%               - syntax-ppss
+           3   0%                  parse-partial-sexp
+           1   0%                - syntax-propertize
+           1   0%                   seed7-mode-syntax-propertize
+           2   0%             seed7-blank-line-p
+           1   0%             seed7-line-isa-string
+           4   0%          - jit-lock-after-change
+           1   0%             font-lock-extend-jit-lock-region-after-change
+           2   0%          - #<byte-code-function 2AE>
+           2   0%           - filter-buffer-substring
+           2   0%            - buffer-substring--filter
+           2   0%             - #<byte-code-function 0BF>
+           2   0%              - apply
+           2   0%                 #<byte-code-function 554>
+           2   0%          - syntax-ppss-flush-cache
+           1   0%             syntax-propertize--in-process-p
+           1   0%          - delete-horizontal-space
+           1   0%             delete-space--internal
+         183   0%       - smex
+         152   0%        - smex-read-and-run
+         149   0%         - smex-completing-read
+         149   0%          - ido-completing-read
+         149   0%           - apply
+         149   0%            - ido-completing-read@ido-cr+-replace
+         149   0%             - #<native-comp-function ido-completing-read>
+         149   0%              - ido-read-internal
+         149   0%               - apply
+         149   0%                - ad-Advice-ido-read-internal
+         149   0%                 - #<native-comp-function ido-read-internal>
+         148   0%                  - read-from-minibuffer
+          96   0%                   - ido-exhibit
+          96   0%                    - apply
+          96   0%                     - #<native-comp-function ido-exhibit>
+          89   0%                      - ido-set-matches
+          89   0%                       - apply
+          89   0%                        - ido-grid--set-matches
+          89   0%                         - apply
+          89   0%                          - #<native-comp-function ido-set-matches>
+          84   0%                           - ido-set-matches-1
+          84   0%                            - apply
+          84   0%                             - ad-Advice-ido-set-matches-1
+          84   0%                              - flx-ido-match
+          84   0%                               - flx-ido-match-internal
+          45   0%                                - flx-score
+          14   0%                                 - flx-find-best-match
+           6   0%                                  - flx-find-best-match
+           2   0%                                   - flx-find-best-match
+           1   0%                                      puthash
+           1   0%                                    - flx-find-best-match
+           1   0%                                       puthash
+           1   0%                                     gethash
+           1   0%                                     puthash
+           3   0%                                    gethash
+           2   0%                                    make-closure
+           1   0%                                   flx-process-cache
+          11   0%                                - flx-flex-match
+          11   0%                                 - #<byte-code-function 3FE>
+          11   0%                                    string-match
+           5   0%                      - ido-completions
+           5   0%                       - apply
+           5   0%                        - ido-grid--completions
+           5   0%                         - ido-grid--grid-ensure-visible
+           5   0%                          - ido-grid--grid
+           2   0%                             move-to-column
+           1   0%                             generate-new-buffer
+           1   0%                             ido-final-slash
+           2   0%                      - ido-set-common-completion
+           2   0%                       - ido-find-common-substring
+           2   0%                          ido-word-matching-substring
+          36   0%                   - redisplay_internal (C function)
+           1   0%                    - tty-color-desc
+           1   0%                     - tty-color-approximate
+           1   0%                        tty-color-off-gray-diag
+           1   0%                   - minibuffer-inactive-mode
+           1   0%                    - mode-local-on-major-mode-change
+           1   0%                       add-hook
+           1   0%                  - ido-set-matches
+           1   0%                   - apply
+           1   0%                    - ido-grid--set-matches
+           1   0%                     - apply
+           1   0%                        #<native-comp-function ido-set-matches>
+           3   0%           execute-extended-command
+          23   0%        - smex-detect-new-commands
+          21   0%         - #<byte-code-function 805>
+          13   0%            commandp
+           8   0%        - smex-update
+           8   0%         - smex-rebuild-cache
+           5   0%          - #<byte-code-function 875>
+           1   0%             commandp
+           1   0%            #<native-comp-function smex-sorting-rules>
+        2782   5%   Automatic GC
+         101   0% + flyspell-post-command-hook
+          32   0% + redisplay_internal (C function)
+           5   0% + timer-event-handler
+           1   0%   help-command-error-confusable-suggestions
+           0   0%   ...

--- a/reports/18.1/castle.sd7-perf-mem.txt
+++ b/reports/18.1/castle.sd7-perf-mem.txt
@@ -1,0 +1,1584 @@
+    684,130,128  91% - command-execute
+    684,130,128  91%  - call-interactively
+    684,130,128  91%   - apply
+    684,130,128  91%    - call-interactively@ido-cr+-record-current-command
+    684,130,128  91%     - #<primitive-function call-interactively>
+    684,130,128  91%      - funcall-interactively
+    667,782,740  89%       - seed7-complete-statement-or-indent
+    667,782,740  89%        - seed7-indent-region
+    667,782,740  89%         - seed7--indent-one-line
+    665,802,348  88%          - seed7-calc-indent
+    426,516,273  56%           - seed7-line-is-defun-end
+    391,240,678  52%            - seed7-end-of-defun
+    365,476,789  48%             - seed7-top-block-name
+    363,998,485  48%              - seed7--to-top
+    361,575,805  48%               - seed7-re-search-backward
+    272,397,042  36%                - run-with-timer
+    272,397,042  36%                 - run-at-time
+    126,417,163  16%                  - timer-activate
+    126,417,163  16%                   - timer--activate
+    126,417,163  16%                    - timer--time-less-p
+        361,311   0%                       timer--time
+     78,041,584  10%                    timer-relative-time
+     52,642,128   7%                  - timer-set-time
+     52,642,128   7%                     timer--time-setter
+     15,295,504   2%                    timer-create
+            663   0%                    timer-set-function
+     58,224,696   7%                - seed7-inside-string-p
+     11,872,072   1%                 - syntax-ppss
+     11,603,200   1%                    make-closure
+        267,920   0%                  - parse-partial-sexp
+        136,752   0%                   - internal--syntax-propertize
+         99,456   0%                    - syntax-propertize
+         53,872   0%                       seed7-mode-syntax-propertize
+            311   0%                    #<byte-code-function 39D>
+     21,734,027   2%                - seed7-inside-comment-p
+     12,588,219   1%                 - syntax-ppss
+     10,380,720   1%                    make-closure
+      1,976,915   0%                  - syntax-propertize
+      1,910,611   0%                     seed7-mode-syntax-propertize
+        229,544   0%                    parse-partial-sexp
+            509   0%                    syntax-table
+             71   0%                    #<byte-code-function 55F>
+      9,187,248   1%                  make-closure
+      2,253,496   0%               - run-with-timer
+      2,253,496   0%                - run-at-time
+        910,232   0%                 - timer-activate
+        910,232   0%                  - timer--activate
+        910,232   0%                   - timer--time-less-p
+         32,792   0%                      timer--time
+        721,696   0%                   timer-relative-time
+        472,384   0%                 - timer-set-time
+        472,384   0%                    timer--time-setter
+        149,184   0%                   timer-create
+        103,600   0%                 make-closure
+      1,391,280   0%              - seed7--block-name
+      1,139,600   0%               - seed7-re-search-forward
+        961,408   0%                - seed7-inside-string-p
+        136,752   0%                 - syntax-ppss
+        136,752   0%                    make-closure
+        178,192   0%                - seed7-inside-comment-p
+        145,040   0%                 - syntax-ppss
+        145,040   0%                    make-closure
+         94,936   0%                 match-string
+     17,103,078   2%             - seed7-re-search-forward
+      8,963,112   1%              - seed7-inside-string-p
+      1,611,656   0%               - syntax-ppss
+      1,578,864   0%                  make-closure
+         32,792   0%                  parse-partial-sexp
+      6,726,862   0%              - seed7-inside-comment-p
+      5,247,454   0%               - syntax-ppss
+      3,672,734   0%                - syntax-propertize
+      2,338,726   0%                   seed7-mode-syntax-propertize
+      1,574,720   0%                  make-closure
+      3,248,416   0%             - seed7-re-search-backward
+      2,324,304   0%              - run-with-timer
+      2,324,304   0%               - run-at-time
+        931,312   0%                - timer-activate
+        931,312   0%                 - timer--activate
+        931,312   0%                    timer--time-less-p
+        721,696   0%                  timer-relative-time
+        497,248   0%                - timer-set-time
+        497,248   0%                   timer--time-setter
+        174,048   0%                  timer-create
+        687,904   0%              - seed7-inside-string-p
+         82,880   0%               - syntax-ppss
+         82,880   0%                  make-closure
+        178,192   0%              - seed7-inside-comment-p
+        107,744   0%               - syntax-ppss
+        107,744   0%                  make-closure
+         58,016   0%                make-closure
+      2,189,344   0%               match-string
+      1,366,728   0%               match-string-no-properties
+         32,736   0%             - user-error
+         32,736   0%                format-message
+          8,184   0%               seed7--no-defun-found-msg-for
+     24,857,724   3%            - seed7-beg-of-defun
+     11,124,626   1%             - seed7-re-search-backward
+      7,502,909   1%              - run-with-timer
+      7,502,909   1%               - run-at-time
+      2,968,144   0%                - timer-activate
+      2,968,144   0%                 - timer--activate
+      2,968,144   0%                  - timer--time-less-p
+          1,832   0%                     timer--time
+      2,398,861   0%                  timer-relative-time
+      1,588,896   0%                - timer-set-time
+      1,588,896   0%                   timer--time-setter
+        547,008   0%                  timer-create
+      1,563,693   0%              - seed7-inside-string-p
+        337,069   0%               - syntax-ppss
+        335,664   0%                  make-closure
+          1,405   0%                  #<byte-code-function 312>
+      1,128,762   0%                re-search-backward
+        620,807   0%              - seed7-inside-comment-p
+        376,311   0%               - syntax-ppss
+        372,960   0%                  make-closure
+          3,351   0%                  #<byte-code-function 334>
+        308,455   0%                make-closure
+      4,068,467   0%             - seed7-top-block-name
+      2,194,938   0%              - seed7--to-top
+      1,542,498   0%               - seed7-re-search-backward
+        720,712   0%                - run-with-timer
+        720,712   0%                 - run-at-time
+        327,720   0%                  - timer-activate
+        327,720   0%                   - timer--activate
+        327,720   0%                      timer--time-less-p
+        202,768   0%                    timer-relative-time
+        136,352   0%                  - timer-set-time
+        136,352   0%                     timer--time-setter
+         53,872   0%                    timer-create
+        618,730   0%                  re-search-backward
+        140,896   0%                - seed7-inside-string-p
+         37,296   0%                 - syntax-ppss
+         37,296   0%                    make-closure
+         45,584   0%                - seed7-inside-comment-p
+         29,008   0%                 - syntax-ppss
+         29,008   0%                    make-closure
+         16,576   0%                  make-closure
+        635,864   0%               - run-with-timer
+        635,864   0%                - run-at-time
+        267,736   0%                 - timer-activate
+        267,736   0%                  - timer--activate
+        267,736   0%                   - timer--time-less-p
+          1,616   0%                      timer--time
+        202,768   0%                   timer-relative-time
+        136,352   0%                 - timer-set-time
+        136,352   0%                    timer--time-setter
+         29,008   0%                   timer-create
+         16,576   0%                 make-closure
+      1,852,809   0%              - seed7--block-name
+      1,797,321   0%               - seed7-re-search-forward
+        182,336   0%                - seed7-inside-string-p
+         29,008   0%                 - syntax-ppss
+         29,008   0%                    make-closure
+         33,152   0%                - seed7-inside-comment-p
+         12,432   0%                 - syntax-ppss
+         12,432   0%                    make-closure
+         18,400   0%                 match-string
+      3,641,196   0%             - seed7-re-search-backward-closest
+      3,568,620   0%              - seed7-re-search-backward
+      2,207,388   0%                 re-search-backward
+      1,294,928   0%               - run-with-timer
+      1,294,928   0%                - run-at-time
+        517,008   0%                 - timer-activate
+        517,008   0%                  - timer--activate
+        517,008   0%                     timer--time-less-p
+        431,072   0%                   timer-relative-time
+        280,544   0%                 - timer-set-time
+        280,544   0%                    timer--time-setter
+         66,304   0%                   timer-create
+         66,304   0%                 make-closure
+         31,136   0%              - seq-filter
+         29,008   0%                 make-closure
+          2,128   0%                 make-symbol
+        272,960   0%               match-string
+        270,072   0%               match-string-no-properties
+          8,184   0%             - user-error
+          8,184   0%                format-message
+      5,398,953   0%            - seed7-line-starts-with-any
+      5,398,953   0%               seed7-line-starts-with
+      2,235,656   0%            - seed7-move-to-line
+      2,235,656   0%             - seed7-to-previous-non-empty-line
+        165,760   0%              - seed7-inside-comment-p
+         82,880   0%               - syntax-ppss
+         82,880   0%                  make-closure
+      2,154,630   0%            - seed7--current-line-nth-word
+      1,959,862   0%             - thing-at-point
+      1,864,150   0%              - bounds-of-thing-at-point
+        663,040   0%                 make-closure
+        382,976   0%                 re-search-forward
+        269,360   0%               - seq-some
+        269,360   0%                  make-closure
+        214,670   0%               - #<byte-code-function FCE>
+        214,670   0%                - forward-thing
+        212,784   0%                   format
+          1,886   0%                   intern-soft
+        122,760   0%               - #<byte-code-function DE9>
+        122,760   0%                - forward-thing
+        122,760   0%                   format
+        491,880   0%            - seed7--safe-current-line-defun-start-indent
+        491,880   0%             - seed7-to-block-backward
+        305,688   0%              - seed7-re-search-backward
+        132,128   0%                 re-search-backward
+        119,688   0%               - run-with-timer
+        119,688   0%                - run-at-time
+         44,616   0%                 - timer-activate
+         44,616   0%                  - timer--activate
+         44,616   0%                     timer--time-less-p
+         43,472   0%                   timer-relative-time
+         27,456   0%                 - timer-set-time
+         27,456   0%                    timer--time-setter
+          4,144   0%                   timer-create
+         37,296   0%               - seed7-inside-string-p
+          8,288   0%                - syntax-ppss
+          8,288   0%                   make-closure
+         12,432   0%               - seed7-inside-comment-p
+          4,144   0%                - syntax-ppss
+          4,144   0%                   make-closure
+          4,144   0%                 make-closure
+        136,464   0%              - seed7--current-line-nth-word
+        132,320   0%               - thing-at-point
+        120,072   0%                - bounds-of-thing-at-point
+         74,592   0%                   make-closure
+         12,432   0%                 - seq-some
+         12,432   0%                    make-closure
+          8,184   0%                 - #<byte-code-function A36>
+          8,184   0%                  - forward-thing
+          8,184   0%                     format
+         29,008   0%              - seed7-inside-line-indent-before-comment-p
+         16,576   0%               - seed7-inside-comment-p
+          8,288   0%                - syntax-ppss
+          8,288   0%                   make-closure
+         12,432   0%              - seed7-inside-comment-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+    127,615,836  17%           - seed7-line-inside-a-block-cached
+    127,520,524  17%            - seed7-line-inside-a-block
+    112,338,089  15%             - seed7--safe-enclosing-block-bounds
+     91,990,334  12%              - seed7--block-end-pos-for
+     91,990,334  12%               - seed7-to-block-forward
+     75,751,525  10%                - seed7-end-of-defun
+     73,891,503   9%                 - seed7-top-block-name
+     73,486,009   9%                  - seed7--to-top
+     72,904,353   9%                   - seed7-re-search-backward
+     55,373,751   7%                    - run-with-timer
+     55,373,751   7%                     - run-at-time
+     25,615,476   3%                      - timer-activate
+     25,615,476   3%                       - timer--activate
+     25,615,476   3%                        - timer--time-less-p
+        196,752   0%                           timer--time
+     16,044,624   2%                        timer-relative-time
+     10,770,960   1%                      - timer-set-time
+     10,770,960   1%                         timer--time-setter
+      2,942,240   0%                        timer-create
+            451   0%                        timer-set-function
+     11,429,544   1%                    - seed7-inside-string-p
+      2,428,776   0%                     - syntax-ppss
+      2,333,072   0%                        make-closure
+         94,592   0%                      - parse-partial-sexp
+         29,008   0%                       - internal--syntax-propertize
+         20,720   0%                        - syntax-propertize
+          4,144   0%                           seed7-mode-syntax-propertize
+      4,242,522   0%                    - seed7-inside-comment-p
+      2,473,034   0%                     - syntax-ppss
+      2,005,696   0%                        make-closure
+        401,754   0%                      - syntax-propertize
+        364,458   0%                         seed7-mode-syntax-propertize
+         65,584   0%                        parse-partial-sexp
+      1,806,784   0%                      make-closure
+         51,752   0%                      re-search-backward
+        487,064   0%                   - run-with-timer
+        487,064   0%                    - run-at-time
+        190,536   0%                     - timer-activate
+        190,536   0%                      - timer--activate
+        190,536   0%                         timer--time-less-p
+        161,424   0%                       timer-relative-time
+        110,240   0%                     - timer-set-time
+        110,240   0%                        timer--time-setter
+         24,864   0%                       timer-create
+         29,008   0%                     make-closure
+        397,206   0%                  - seed7--block-name
+        347,662   0%                   - seed7-re-search-forward
+        194,768   0%                    - seed7-inside-string-p
+         16,576   0%                     - syntax-ppss
+         16,576   0%                        make-closure
+         24,864   0%                    - seed7-inside-comment-p
+         24,864   0%                     - syntax-ppss
+         24,864   0%                        make-closure
+          4,064   0%                     match-string
+        764,352   0%                 - seed7-re-search-backward
+        503,640   0%                  - run-with-timer
+        503,640   0%                   - run-at-time
+        211,256   0%                    - timer-activate
+        211,256   0%                     - timer--activate
+        211,256   0%                        timer--time-less-p
+        161,424   0%                      timer-relative-time
+        101,952   0%                    - timer-set-time
+        101,952   0%                       timer--time-setter
+         29,008   0%                      timer-create
+        202,696   0%                  - seed7-inside-string-p
+         57,656   0%                   - syntax-ppss
+         32,792   0%                      parse-partial-sexp
+         24,864   0%                      make-closure
+         37,296   0%                  - seed7-inside-comment-p
+         16,576   0%                   - syntax-ppss
+         16,576   0%                      make-closure
+         20,720   0%                    make-closure
+        733,375   0%                 - seed7-re-search-forward
+        364,672   0%                  - seed7-inside-string-p
+         49,728   0%                   - syntax-ppss
+         49,728   0%                      make-closure
+        139,055   0%                  - seed7-inside-comment-p
+         72,751   0%                   - syntax-ppss
+         58,016   0%                      make-closure
+         13,782   0%                    - syntax-propertize
+         13,782   0%                       seed7-mode-syntax-propertize
+        172,096   0%                   match-string
+         57,288   0%                   match-string-no-properties
+      6,914,416   0%                - seed7-re-search-forward
+      1,806,784   0%                 - seed7-inside-string-p
+        323,232   0%                  - syntax-ppss
+        323,232   0%                     make-closure
+      1,466,066   0%                 - seed7-inside-comment-p
+      1,171,842   0%                  - syntax-ppss
+        769,874   0%                   - syntax-propertize
+        732,578   0%                      seed7-mode-syntax-propertize
+        401,968   0%                     make-closure
+      5,491,100   0%                - seed7--current-line-nth-word
+      4,982,757   0%                 - thing-at-point
+      4,700,609   0%                  - bounds-of-thing-at-point
+      1,964,256   0%                     make-closure
+        645,433   0%                   - seq-some
+        642,320   0%                      make-closure
+        564,696   0%                   - #<byte-code-function 6B6>
+        564,696   0%                    - forward-thing
+        564,696   0%                       format
+        360,096   0%                   - #<byte-code-function 65F>
+        360,096   0%                    - forward-thing
+        360,096   0%                       format
+        300,032   0%                     re-search-forward
+      2,909,912   0%                - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+        389,176   0%                 - seed7-inside-comment-p
+        239,992   0%                  - syntax-ppss
+        207,200   0%                     make-closure
+         32,792   0%                     parse-partial-sexp
+        323,232   0%                 - seed7-inside-line-indent-before-comment-p
+         45,584   0%                  - seed7-inside-comment-p
+         20,720   0%                   - syntax-ppss
+         20,720   0%                      make-closure
+        306,656   0%                - seed7-inside-line-indent-before-comment-p
+         45,584   0%                 - seed7-inside-comment-p
+         33,152   0%                  - syntax-ppss
+         33,152   0%                     make-closure
+        294,224   0%                - seed7-inside-comment-p
+        165,760   0%                 - syntax-ppss
+        165,760   0%                    make-closure
+        173,317   0%                - seed7--end-regexp-for
+         16,368   0%                   seed7--type-regexp
+     20,181,995   2%              - seed7-to-block-backward
+     14,964,195   1%               - seed7-re-search-backward
+      9,758,091   1%                - run-with-timer
+      9,758,091   1%                 - run-at-time
+      3,852,728   0%                  - timer-activate
+      3,852,728   0%                   - timer--activate
+      3,852,728   0%                      timer--time-less-p
+      3,164,776   0%                    timer-relative-time
+      2,089,968   0%                  - timer-set-time
+      2,089,968   0%                     timer--time-setter
+        650,608   0%                    timer-create
+             11   0%                    timer-set-function
+      2,167,312   0%                - seed7-inside-string-p
+        488,992   0%                 - syntax-ppss
+        488,992   0%                    make-closure
+      1,911,624   0%                  re-search-backward
+        733,488   0%                - seed7-inside-comment-p
+        418,544   0%                 - syntax-ppss
+        418,544   0%                    make-closure
+        393,680   0%                  make-closure
+      3,481,528   0%               - seed7--current-line-nth-word
+      3,245,320   0%                - thing-at-point
+      3,096,368   0%                 - bounds-of-thing-at-point
+      1,516,704   0%                    make-closure
+        501,424   0%                  - seq-some
+        501,424   0%                     make-closure
+        335,544   0%                  - #<byte-code-function EBE>
+        335,544   0%                   - forward-thing
+        335,544   0%                      format
+        253,704   0%                  - #<byte-code-function BF9>
+        253,704   0%                   - forward-thing
+        253,704   0%                      format
+        911,320   0%               - seed7-inside-line-indent-before-comment-p
+        314,584   0%                - seed7-inside-comment-p
+        169,544   0%                 - syntax-ppss
+        136,752   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+        381,248   0%               - seed7-inside-comment-p
+        244,496   0%                - syntax-ppss
+        244,496   0%                   make-closure
+        302,808   0%               - seed7--start-regexp-for
+          8,184   0%                  seed7--type-regexp
+      8,578,136   1%             - seed7-re-search-backward
+      4,455,453   0%              - run-with-timer
+      4,455,453   0%               - run-at-time
+      1,738,733   0%                - timer-activate
+      1,738,733   0%                 - timer--activate
+      1,738,733   0%                    timer--time-less-p
+      1,477,136   0%                  timer-relative-time
+        978,512   0%                - timer-set-time
+        978,512   0%                   timer--time-setter
+        261,072   0%                  timer-create
+      2,448,507   0%                re-search-backward
+      1,131,312   0%              - seed7-inside-string-p
+        203,056   0%               - syntax-ppss
+        203,056   0%                  make-closure
+        360,528   0%              - seed7-inside-comment-p
+        265,216   0%               - syntax-ppss
+        265,216   0%                  make-closure
+        182,336   0%                make-closure
+      3,077,848   0%             - replace-regexp-in-string
+         74,200   0%                concat
+      2,618,979   0%             - seed7-calc-indent
+      1,921,459   0%              - seed7-line-is-defun-end
+      1,766,060   0%               - seed7-end-of-defun
+      1,613,264   0%                - seed7-top-block-name
+      1,603,960   0%                 - seed7--to-top
+      1,590,928   0%                  - seed7-re-search-backward
+      1,014,912   0%                   - run-with-timer
+      1,014,912   0%                    - run-at-time
+        424,064   0%                     - timer-activate
+        424,064   0%                      - timer--activate
+        424,064   0%                         timer--time-less-p
+        296,096   0%                       timer-relative-time
+        191,152   0%                     - timer-set-time
+        191,152   0%                        timer--time-setter
+        103,600   0%                       timer-create
+        410,256   0%                   - seed7-inside-string-p
+         87,024   0%                    - syntax-ppss
+         87,024   0%                       make-closure
+        120,176   0%                   - seed7-inside-comment-p
+         62,160   0%                    - syntax-ppss
+         62,160   0%                       make-closure
+         45,584   0%                     make-closure
+         13,032   0%                  - run-with-timer
+         13,032   0%                   - run-at-time
+          7,576   0%                    - timer-activate
+          7,576   0%                     - timer--activate
+          7,576   0%                        timer--time-less-p
+          3,344   0%                      timer-relative-time
+          2,112   0%                    - timer-set-time
+          2,112   0%                       timer--time-setter
+          5,160   0%                 - seed7--block-name
+          4,144   0%                  - seed7-re-search-forward
+          4,144   0%                     seed7-inside-string-p
+          1,016   0%                    match-string
+        116,212   0%                - seed7-re-search-forward
+         82,880   0%                 - seed7-inside-string-p
+         12,432   0%                  - syntax-ppss
+         12,432   0%                     make-closure
+         27,188   0%                 - seed7-inside-comment-p
+         18,900   0%                  - syntax-ppss
+         10,612   0%                   - syntax-propertize
+         10,612   0%                      seed7-mode-syntax-propertize
+          8,288   0%                     make-closure
+         17,176   0%                - seed7-re-search-backward
+         13,032   0%                 - run-with-timer
+         13,032   0%                  - run-at-time
+          7,576   0%                   - timer-activate
+          7,576   0%                    - timer--activate
+          7,576   0%                       timer--time-less-p
+          3,344   0%                     timer-relative-time
+          2,112   0%                   - timer-set-time
+          2,112   0%                      timer--time-setter
+          4,144   0%                   make-closure
+          8,184   0%                  match-string-no-properties
+          5,080   0%                  match-string
+        108,257   0%               - seed7-beg-of-defun
+         28,251   0%                - seed7-re-search-backward
+         14,307   0%                   re-search-backward
+          9,800   0%                 - run-with-timer
+          9,800   0%                  - run-at-time
+          4,144   0%                     timer-create
+          2,184   0%                   - timer-activate
+          2,184   0%                    - timer--activate
+          2,184   0%                       timer--time-less-p
+          2,128   0%                     timer-relative-time
+          1,344   0%                   - timer-set-time
+          1,344   0%                      timer--time-setter
+          4,144   0%                   make-closure
+         25,670   0%                - seed7-top-block-name
+         17,558   0%                 - seed7--block-name
+         17,558   0%                    seed7-re-search-forward
+          8,112   0%                 - seed7--to-top
+          5,688   0%                  - seed7-re-search-backward
+          3,264   0%                     re-search-backward
+          2,424   0%                   - run-with-timer
+          2,424   0%                    - run-at-time
+            936   0%                     - timer-activate
+            936   0%                      - timer--activate
+            936   0%                         timer--time-less-p
+            912   0%                       timer-relative-time
+            576   0%                     - timer-set-time
+            576   0%                        timer--time-setter
+          2,424   0%                  - run-with-timer
+          2,424   0%                   - run-at-time
+            936   0%                    - timer-activate
+            936   0%                     - timer--activate
+            936   0%                        timer--time-less-p
+            912   0%                      timer-relative-time
+            576   0%                    - timer-set-time
+            576   0%                       timer--time-setter
+         20,521   0%                - seed7-re-search-backward-closest
+         16,377   0%                 - seed7-re-search-backward
+          9,913   0%                    re-search-backward
+          6,464   0%                  - run-with-timer
+          6,464   0%                   - run-at-time
+          2,496   0%                    - timer-activate
+          2,496   0%                     - timer--activate
+          2,496   0%                        timer--time-less-p
+          2,432   0%                      timer-relative-time
+          1,536   0%                    - timer-set-time
+          1,536   0%                       timer--time-setter
+          4,144   0%                 - seq-filter
+          4,144   0%                    make-closure
+          1,016   0%                  match-string
+         35,790   0%               - seed7-line-starts-with-any
+         35,790   0%                  seed7-line-starts-with
+          6,192   0%               - seed7-move-to-line
+          6,192   0%                - seed7-to-previous-non-empty-line
+          4,144   0%                 - seed7-inside-comment-p
+          4,144   0%                  - syntax-ppss
+          4,144   0%                     make-closure
+          5,160   0%               - seed7--current-line-nth-word
+          1,016   0%                  thing-at-point
+        516,464   0%              - seed7-line-inside-parens-pair-column
+        516,464   0%               - seed7-line-inside-parens-pair
+        504,176   0%                - seed7-re-search-backward
+        347,696   0%                 - run-with-timer
+        347,696   0%                  - run-at-time
+        142,752   0%                   - timer-activate
+        142,752   0%                    - timer--activate
+        142,752   0%                       timer--time-less-p
+        102,752   0%                     timer-relative-time
+         69,040   0%                   - timer-set-time
+         69,040   0%                      timer--time-setter
+         33,152   0%                     timer-create
+         66,304   0%                 - seed7-inside-string-p
+         20,720   0%                  - syntax-ppss
+         20,720   0%                     make-closure
+         62,160   0%                 - seed7-inside-comment-p
+         45,584   0%                  - syntax-ppss
+         45,584   0%                     make-closure
+         20,720   0%                   make-closure
+          7,296   0%                   re-search-backward
+         12,288   0%                - forward-sexp
+         12,288   0%                   seed7--forward-sexp-function
+         61,456   0%              - seed7-line-at-endof-array-definition-block
+         29,408   0%               - backward-sexp
+         29,408   0%                - forward-sexp
+         29,408   0%                 - seed7--forward-sexp-function
+         10,608   0%                  - seed7--at-set-definition-end-line-p
+         10,608   0%                   - seed7-line-code-ends-with
+         10,608   0%                    - seed7-re-search-backward
+          6,464   0%                     - run-with-timer
+          6,464   0%                      - run-at-time
+          2,496   0%                       - timer-activate
+          2,496   0%                        - timer--activate
+          2,496   0%                           timer--time-less-p
+          2,432   0%                         timer-relative-time
+          1,536   0%                       - timer-set-time
+          1,536   0%                          timer--time-setter
+          4,144   0%                       seed7-inside-string-p
+          8,512   0%                  - seed7--at-array-definition-end-line-p
+          6,464   0%                   - seed7-line-code-ends-with
+          6,464   0%                    - seed7-re-search-backward
+          6,464   0%                     - run-with-timer
+          6,464   0%                      - run-at-time
+          2,496   0%                       - timer-activate
+          2,496   0%                        - timer--activate
+          2,496   0%                           timer--time-less-p
+          2,432   0%                         timer-relative-time
+          1,536   0%                       - timer-set-time
+          1,536   0%                          timer--time-setter
+          2,048   0%                     looking-at
+         22,624   0%               - seed7-line-code-ends-with
+         22,624   0%                - seed7-re-search-backward
+         11,312   0%                 - run-with-timer
+         11,312   0%                  - run-at-time
+          4,368   0%                   - timer-activate
+          4,368   0%                    - timer--activate
+          4,368   0%                       timer--time-less-p
+          4,256   0%                     timer-relative-time
+          2,688   0%                   - timer-set-time
+          2,688   0%                      timer--time-setter
+          7,168   0%                   re-search-backward
+          4,144   0%                 - seed7-inside-string-p
+          4,144   0%                  - syntax-ppss
+          4,144   0%                     make-closure
+          4,144   0%               - seed7-move-to-line
+          4,144   0%                - seed7-to-previous-non-empty-line
+          4,144   0%                 - seed7-inside-comment-p
+          4,144   0%                  - syntax-ppss
+          4,144   0%                     make-closure
+          3,232   0%               - seed7-re-search-backward
+          3,232   0%                - run-with-timer
+          3,232   0%                 - run-at-time
+          1,248   0%                  - timer-activate
+          1,248   0%                   - timer--activate
+          1,248   0%                      timer--time-less-p
+          1,216   0%                    timer-relative-time
+            768   0%                  - timer-set-time
+            768   0%                     timer--time-setter
+          2,048   0%                 looking-at
+         23,744   0%              - seed7-line-at-endof-set-definition-block
+         19,600   0%               - seed7-line-code-ends-with
+         19,600   0%                - seed7-re-search-backward
+         11,312   0%                 - run-with-timer
+         11,312   0%                  - run-at-time
+          4,368   0%                   - timer-activate
+          4,368   0%                    - timer--activate
+          4,368   0%                       timer--time-less-p
+          4,256   0%                     timer-relative-time
+          2,688   0%                   - timer-set-time
+          2,688   0%                      timer--time-setter
+          4,144   0%                   seed7-inside-string-p
+          4,144   0%                 - seed7-inside-comment-p
+          4,144   0%                  - syntax-ppss
+          4,144   0%                     make-closure
+          4,144   0%               - seed7-move-to-line
+          4,144   0%                  seed7-to-previous-non-empty-line
+         17,352   0%              - seed7-line-inside-set-definition-block
+         17,352   0%               - seed7-re-search-backward
+          9,800   0%                - run-with-timer
+          9,800   0%                 - run-at-time
+          6,328   0%                  - timer-activate
+          6,328   0%                   - timer--activate
+          6,328   0%                      timer--time-less-p
+          2,128   0%                    timer-relative-time
+          1,344   0%                  - timer-set-time
+          1,344   0%                     timer--time-setter
+          7,552   0%                  re-search-backward
+         17,304   0%              - seed7-line-inside-array-definition-block
+         13,208   0%               - seed7-re-search-backward
+          7,552   0%                  re-search-backward
+          5,656   0%                - run-with-timer
+          5,656   0%                 - run-at-time
+          2,184   0%                  - timer-activate
+          2,184   0%                   - timer--activate
+          2,184   0%                      timer--time-less-p
+          2,128   0%                    timer-relative-time
+          1,344   0%                  - timer-set-time
+          1,344   0%                     timer--time-setter
+          4,096   0%               - forward-sexp
+          4,096   0%                  seed7--forward-sexp-function
+         12,952   0%              - seed7-line-inside-assign-statement-continuation
+         12,952   0%               - seed7-assign-op-pos
+         12,952   0%                - seed7-re-search-backward
+          7,296   0%                   re-search-backward
+          5,656   0%                 - run-with-timer
+          5,656   0%                  - run-at-time
+          2,184   0%                   - timer-activate
+          2,184   0%                    - timer--activate
+          2,184   0%                       timer--time-less-p
+          2,128   0%                     timer-relative-time
+          1,344   0%                   - timer-set-time
+          1,344   0%                      timer--time-setter
+         11,256   0%              - seed7-line-inside-a-block-cached
+         11,256   0%               - seed7-line-inside-a-block
+         11,256   0%                - seed7-re-search-backward
+          5,656   0%                 - run-with-timer
+          5,656   0%                  - run-at-time
+          2,184   0%                   - timer-activate
+          2,184   0%                    - timer--activate
+          2,184   0%                       timer--time-less-p
+          2,128   0%                     timer-relative-time
+          1,344   0%                   - timer-set-time
+          1,344   0%                      timer--time-setter
+          5,600   0%                   re-search-backward
+          8,192   0%              - seed7-line-after-func-return-logic-operator-column
+          3,072   0%               - seed7-move-to-line
+          3,072   0%                  seed7-to-previous-non-empty-line
+          7,296   0%                seed7-line-starts-with
+          7,168   0%              - seed7-line-isa-string
+          7,168   0%                 seed7-line-starts-with
+          7,168   0%              - seed7-line-starts-with-open-paren-after-logic-operator
+          7,168   0%                 seed7-line-starts-with
+          7,168   0%                seed7-line-indent-step
+        268,672   0%               seed7--indent-offset-for
+        240,352   0%               seed7--on-lineof
+        149,968   0%               match-string
+            616   0%               #<byte-code-function E3C>
+         95,312   0%              seed7--cache-block-spec
+     28,473,182   3%           - seed7-line-inside-parens-pair-column
+     28,473,182   3%            - seed7-line-inside-parens-pair
+     27,221,856   3%             - seed7-re-search-backward
+     19,764,504   2%              - run-with-timer
+     19,764,504   2%               - run-at-time
+      7,763,856   1%                - timer-activate
+      7,763,856   1%                 - timer--activate
+      7,763,856   1%                  - timer--time-less-p
+         65,584   0%                     timer--time
+      6,342,048   0%                  timer-relative-time
+      4,390,536   0%                - timer-set-time
+      4,390,536   0%                   timer--time-setter
+      1,268,064   0%                  timer-create
+      2,750,736   0%              - seed7-inside-string-p
+        914,944   0%               - syntax-ppss
+        911,680   0%                  make-closure
+            691   0%                  #<byte-code-function F13>
+      1,951,576   0%                re-search-backward
+      1,901,376   0%              - seed7-inside-comment-p
+      1,263,200   0%               - syntax-ppss
+      1,197,616   0%                  make-closure
+         65,584   0%                  parse-partial-sexp
+        853,664   0%                make-closure
+        968,432   0%             - forward-sexp
+        968,432   0%                seed7--forward-sexp-function
+        204,158   0%             - seed7-line-inside-syntax-parens-pair
+         92,270   0%              - syntax-ppss
+         91,168   0%                 make-closure
+          1,102   0%                 #<byte-code-function 79A>
+         33,152   0%              - forward-sexp
+         33,152   0%                 seed7--forward-sexp-function
+     20,030,846   2%           - seed7--indent-search-boundary
+     19,927,246   2%            - seed7--indent-search-boundary-uncached
+     19,559,590   2%             - syntax-ppss
+     17,127,152   2%                make-closure
+      2,229,856   0%                parse-partial-sexp
+          4,217   0%                #<byte-code-function 0D9>
+          1,613   0%                syntax-table
+          2,800   0%               seed7-to-indent
+     14,069,236   1%           - seed7--current-line-nth-word
+     14,019,508   1%            - thing-at-point
+     13,918,308   1%             - bounds-of-thing-at-point
+     13,004,271   1%              - #<byte-code-function AC2>
+     13,004,271   1%               - forward-thing
+     12,865,143   1%                - forward-word
+     12,865,143   1%                 - internal--syntax-propertize
+     12,550,199   1%                  - syntax-propertize
+     12,015,145   1%                     seed7-mode-syntax-propertize
+        139,128   0%                  format
+        480,704   0%                make-closure
+        136,752   0%              - seq-some
+        136,752   0%                 make-closure
+         76,213   0%              - #<byte-code-function 83D>
+         73,656   0%               - forward-thing
+         73,656   0%                  format
+         25,600   0%                re-search-forward
+      7,032,339   0%           - seed7-line-inside-array-definition-block
+      5,747,219   0%            - seed7-re-search-backward
+      2,721,728   0%             - run-with-timer
+      2,721,728   0%              - run-at-time
+      1,073,088   0%               - timer-activate
+      1,073,088   0%                - timer--activate
+      1,073,088   0%                   timer--time-less-p
+        868,224   0%                 timer-relative-time
+        581,504   0%               - timer-set-time
+        581,504   0%                  timer--time-setter
+        198,912   0%                 timer-create
+      2,287,859   0%               re-search-backward
+        422,688   0%             - seed7-inside-string-p
+        145,040   0%              - syntax-ppss
+        145,040   0%                 make-closure
+        190,624   0%             - seed7-inside-comment-p
+        107,744   0%              - syntax-ppss
+        107,744   0%                 make-closure
+        124,320   0%               make-closure
+      1,218,816   0%            - forward-sexp
+      1,218,816   0%               seed7--forward-sexp-function
+      6,566,524   0%           - seed7-line-inside-argument-list-section
+      4,217,254   0%            - seed7-re-search-backward
+      2,474,598   0%               re-search-backward
+      1,676,352   0%             - run-with-timer
+      1,676,352   0%              - run-at-time
+        646,976   0%               - timer-activate
+        646,976   0%                - timer--activate
+        646,976   0%                   timer--time-less-p
+        549,632   0%                 timer-relative-time
+        372,000   0%               - timer-set-time
+        372,000   0%                  timer--time-setter
+        107,744   0%                 timer-create
+         58,016   0%               make-closure
+          4,144   0%               seed7-inside-string-p
+          4,144   0%             - seed7-inside-comment-p
+          4,144   0%              - syntax-ppss
+          4,144   0%                 make-closure
+      2,213,286   0%            - seed7-line-is-procfunc-beg-of-decl
+      2,213,286   0%               seed7-line-starts-with
+         65,536   0%            - forward-sexp
+         65,536   0%               seed7--forward-sexp-function
+         16,576   0%            - seed7-forward-char-pos
+         12,432   0%             - seed7-re-search-forward
+         12,432   0%                seed7-inside-string-p
+      5,314,296   0%           - seed7-line-inside-assign-statement-continuation
+      4,725,848   0%            - seed7-assign-op-pos
+      4,659,544   0%             - seed7-re-search-backward
+      2,065,560   0%                re-search-backward
+      2,046,976   0%              - run-with-timer
+      2,046,976   0%               - run-at-time
+        809,504   0%                - timer-activate
+        809,504   0%                 - timer--activate
+        809,504   0%                    timer--time-less-p
+        651,776   0%                  timer-relative-time
+        440,656   0%                - timer-set-time
+        440,656   0%                   timer--time-setter
+        145,040   0%                  timer-create
+        285,936   0%              - seed7-inside-string-p
+        103,600   0%               - syntax-ppss
+        103,600   0%                  make-closure
+        190,624   0%              - seed7-inside-comment-p
+        107,744   0%               - syntax-ppss
+        107,744   0%                  make-closure
+         70,448   0%                make-closure
+        551,152   0%            - seed7-statement-end-pos
+        488,992   0%             - seed7-forward-char-pos
+        406,112   0%              - seed7-re-search-forward
+        310,800   0%               - seed7-inside-string-p
+        111,888   0%                - syntax-ppss
+        111,888   0%                   make-closure
+         95,312   0%               - seed7-inside-comment-p
+         66,304   0%                - syntax-ppss
+         66,304   0%                   make-closure
+      4,972,184   0%           - seed7-line-inside-logic-check-expression
+      4,203,192   0%            - seed7-to-previous-line-starts-with
+      3,956,632   0%             - seed7-re-search-backward
+      1,964,552   0%                re-search-backward
+      1,706,144   0%              - run-with-timer
+      1,706,144   0%               - run-at-time
+        676,656   0%                - timer-activate
+        676,656   0%                 - timer--activate
+        676,656   0%                    timer--time-less-p
+        562,400   0%                  timer-relative-time
+        396,640   0%                - timer-set-time
+        396,640   0%                   timer--time-setter
+         70,448   0%                  timer-create
+        145,040   0%              - seed7-inside-string-p
+         62,160   0%               - syntax-ppss
+         62,160   0%                  make-closure
+         78,736   0%              - seed7-inside-comment-p
+         37,296   0%               - syntax-ppss
+         37,296   0%                  make-closure
+         62,160   0%                make-closure
+        392,248   0%            - seed7--current-line-nth-word
+        371,528   0%             - thing-at-point
+        342,912   0%              - bounds-of-thing-at-point
+        132,608   0%                 make-closure
+         73,656   0%               - #<byte-code-function FED>
+         73,656   0%                - forward-thing
+         73,656   0%                   format
+         62,160   0%               - seq-some
+         62,160   0%                  make-closure
+          8,184   0%               - #<byte-code-function 2B7>
+          8,184   0%                - forward-thing
+          8,184   0%                   format
+        314,584   0%            - seed7-re-search-forward
+        244,136   0%             - seed7-inside-string-p
+         82,520   0%              - syntax-ppss
+         49,728   0%                 make-closure
+         32,792   0%                 parse-partial-sexp
+         70,448   0%             - seed7-inside-comment-p
+         41,440   0%              - syntax-ppss
+         41,440   0%                 make-closure
+      4,471,109   0%           - seed7-line-inside-set-definition-block
+      4,404,805   0%            - seed7-re-search-backward
+      2,243,938   0%               re-search-backward
+      2,090,419   0%             - run-with-timer
+      2,090,419   0%              - run-at-time
+        805,155   0%               - timer-activate
+        805,155   0%                - timer--activate
+        805,155   0%                 - timer--time-less-p
+          1,347   0%                    timer--time
+        678,528   0%                 timer-relative-time
+        449,264   0%               - timer-set-time
+        449,264   0%                  timer--time-setter
+        157,472   0%                 timer-create
+         70,448   0%               make-closure
+      3,843,256   0%           - seed7-line-inside-until-logic-expression
+      3,719,272   0%            - seed7-re-search-backward
+      1,946,008   0%               re-search-backward
+      1,686,240   0%             - run-with-timer
+      1,686,240   0%              - run-at-time
+        668,320   0%               - timer-activate
+        668,320   0%                - timer--activate
+        668,320   0%                   timer--time-less-p
+        550,224   0%                 timer-relative-time
+        364,096   0%               - timer-set-time
+        364,096   0%                  timer--time-setter
+        103,600   0%                 timer-create
+         82,880   0%               make-closure
+          4,144   0%             - seed7-inside-comment-p
+          4,144   0%              - syntax-ppss
+          4,144   0%                 make-closure
+         36,960   0%            - seed7-line-code-ends-with
+         36,960   0%             - seed7-re-search-backward
+         22,624   0%              - run-with-timer
+         22,624   0%               - run-at-time
+          8,736   0%                - timer-activate
+          8,736   0%                 - timer--activate
+          8,736   0%                    timer--time-less-p
+          8,512   0%                  timer-relative-time
+          5,376   0%                - timer-set-time
+          5,376   0%                   timer--time-setter
+         14,336   0%                re-search-backward
+      3,738,775   0%           - seed7-line-inside-func-return-statement
+      3,705,623   0%            - seed7-re-search-backward
+      1,918,760   0%               re-search-backward
+      1,728,847   0%             - run-with-timer
+      1,728,847   0%              - run-at-time
+        695,144   0%               - timer-activate
+        695,144   0%                - timer--activate
+        695,144   0%                   timer--time-less-p
+        548,112   0%                 timer-relative-time
+        358,608   0%               - timer-set-time
+        358,608   0%                  timer--time-setter
+        124,320   0%                 timer-create
+          2,663   0%                 timer-set-function
+         58,016   0%               make-closure
+      2,780,824   0%           - seed7-line-after-func-return-logic-operator-column
+        680,416   0%            - seed7-move-to-line
+        680,416   0%             - seed7-to-previous-non-empty-line
+        169,904   0%              - seed7-inside-comment-p
+        111,888   0%               - syntax-ppss
+        111,888   0%                  make-closure
+      2,348,912   0%           - seed7-line-starts-with
+         12,432   0%            - seed7-move-to-line
+         12,432   0%             - seed7-to-previous-non-empty-line
+          8,288   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+      2,175,600   0%           - seed7-line-isa-string
+      2,175,600   0%              seed7-line-starts-with
+      1,584,992   0%           - seed7-line-inside-nested-parens-pairs-column
+      1,584,992   0%            - seed7-line-inside-nested-parens-pairs
+      1,555,984   0%             - seed7-line-inside-parens-pair
+      1,435,808   0%              - seed7-re-search-backward
+      1,190,720   0%               - run-with-timer
+      1,190,720   0%                - run-at-time
+        480,544   0%                 - timer-activate
+        480,544   0%                  - timer--activate
+        480,544   0%                     timer--time-less-p
+        379,392   0%                   timer-relative-time
+        247,904   0%                 - timer-set-time
+        247,904   0%                    timer--time-setter
+         82,880   0%                   timer-create
+        103,600   0%               - seed7-inside-string-p
+         29,008   0%                - syntax-ppss
+         29,008   0%                   make-closure
+         66,304   0%                 make-closure
+         37,888   0%                 re-search-backward
+         37,296   0%               - seed7-inside-comment-p
+         37,296   0%                - syntax-ppss
+         37,296   0%                   make-closure
+         91,168   0%              - seed7-line-inside-syntax-parens-pair
+         49,728   0%               - syntax-ppss
+         49,728   0%                  make-closure
+      1,244,448   0%           - seed7-comment-column
+      1,193,632   0%            - seed7-calc-indent
+        776,376   0%             - seed7-line-is-defun-end
+        691,832   0%              - seed7-end-of-defun
+        598,632   0%               - seed7-top-block-name
+        594,488   0%                - seed7--to-top
+        587,920   0%                 - seed7-re-search-backward
+        397,296   0%                  - run-with-timer
+        397,296   0%                   - run-at-time
+        161,248   0%                    - timer-activate
+        161,248   0%                     - timer--activate
+        161,248   0%                        timer--time-less-p
+        116,736   0%                      timer-relative-time
+         77,872   0%                    - timer-set-time
+         77,872   0%                       timer--time-setter
+         41,440   0%                      timer-create
+        120,176   0%                  - seed7-inside-string-p
+         24,864   0%                   - syntax-ppss
+         24,864   0%                      make-closure
+         49,728   0%                  - seed7-inside-comment-p
+         29,008   0%                   - syntax-ppss
+         29,008   0%                      make-closure
+         20,720   0%                    make-closure
+          4,144   0%                   make-closure
+          2,424   0%                 - run-with-timer
+          2,424   0%                  - run-at-time
+            936   0%                   - timer-activate
+            936   0%                    - timer--activate
+            936   0%                       timer--time-less-p
+            912   0%                     timer-relative-time
+            576   0%                   - timer-set-time
+            576   0%                      timer--time-setter
+          4,144   0%                - seed7--block-name
+          4,144   0%                 - seed7-re-search-forward
+          4,144   0%                    seed7-inside-string-p
+         64,208   0%               - seed7-re-search-forward
+         45,584   0%                - seed7-inside-string-p
+          8,288   0%                 - syntax-ppss
+          8,288   0%                    make-closure
+         16,576   0%                - seed7-inside-comment-p
+          8,288   0%                 - syntax-ppss
+          8,288   0%                    make-closure
+         12,192   0%                 match-string
+          6,568   0%               - seed7-re-search-backward
+          4,144   0%                  seed7-inside-string-p
+          2,424   0%                - run-with-timer
+          2,424   0%                 - run-at-time
+            936   0%                  - timer-activate
+            936   0%                   - timer--activate
+            936   0%                      timer--time-less-p
+            912   0%                    timer-relative-time
+            576   0%                  - timer-set-time
+            576   0%                     timer--time-setter
+         41,440   0%              - seed7-move-to-line
+         41,440   0%               - seed7-to-previous-non-empty-line
+         41,440   0%                - seed7-inside-comment-p
+         29,008   0%                 - syntax-ppss
+         29,008   0%                    make-closure
+         23,984   0%              - seed7-beg-of-defun
+          7,676   0%               - seed7-re-search-backward
+          5,760   0%                - run-with-timer
+          5,760   0%                 - run-at-time
+          4,144   0%                    timer-create
+            624   0%                  - timer-activate
+            624   0%                   - timer--activate
+            624   0%                      timer--time-less-p
+            608   0%                    timer-relative-time
+            384   0%                  - timer-set-time
+            384   0%                     timer--time-setter
+          1,916   0%                  re-search-backward
+          5,284   0%               - seed7-top-block-name
+          2,644   0%                - seed7--block-name
+          2,644   0%                   seed7-re-search-forward
+          2,640   0%                - seed7--to-top
+          1,832   0%                 - seed7-re-search-backward
+          1,024   0%                    re-search-backward
+            808   0%                  - run-with-timer
+            808   0%                   - run-at-time
+            312   0%                    - timer-activate
+            312   0%                     - timer--activate
+            312   0%                        timer--time-less-p
+            304   0%                      timer-relative-time
+            192   0%                    - timer-set-time
+            192   0%                       timer--time-setter
+            808   0%                 - run-with-timer
+            808   0%                  - run-at-time
+            312   0%                   - timer-activate
+            312   0%                    - timer--activate
+            312   0%                       timer--time-less-p
+            304   0%                     timer-relative-time
+            192   0%                   - timer-set-time
+            192   0%                      timer--time-setter
+          3,664   0%               - seed7-re-search-backward-closest
+          3,664   0%                - seed7-re-search-backward
+          2,048   0%                   re-search-backward
+          1,616   0%                 - run-with-timer
+          1,616   0%                  - run-at-time
+            624   0%                   - timer-activate
+            624   0%                    - timer--activate
+            624   0%                       timer--time-less-p
+            608   0%                     timer-relative-time
+            384   0%                   - timer-set-time
+            384   0%                      timer--time-setter
+         12,328   0%              - seed7--current-line-nth-word
+         12,328   0%               - thing-at-point
+         12,328   0%                - bounds-of-thing-at-point
+          8,184   0%                 - #<byte-code-function BEA>
+          8,184   0%                  - forward-thing
+          8,184   0%                     format
+          4,144   0%                   make-closure
+          6,792   0%              - seed7-line-starts-with-any
+          6,792   0%                 seed7-line-starts-with
+         86,176   0%             - seed7-line-inside-parens-pair-column
+         86,176   0%              - seed7-line-inside-parens-pair
+         84,128   0%               - seed7-re-search-backward
+         49,728   0%                - seed7-inside-comment-p
+         37,296   0%                 - syntax-ppss
+         37,296   0%                    make-closure
+         31,328   0%                - run-with-timer
+         31,328   0%                 - run-at-time
+         11,552   0%                    timer-relative-time
+          8,336   0%                  - timer-activate
+          8,336   0%                   - timer--activate
+          8,336   0%                      timer--time-less-p
+          7,296   0%                  - timer-set-time
+          7,296   0%                     timer--time-setter
+          4,144   0%                    timer-create
+          3,072   0%                  re-search-backward
+          2,048   0%               - forward-sexp
+          2,048   0%                  seed7--forward-sexp-function
+         78,232   0%             - seed7-line-inside-a-block-cached
+         78,232   0%              - seed7-line-inside-a-block
+         44,328   0%               - seed7--safe-enclosing-block-bounds
+         35,064   0%                - seed7-to-block-backward
+         26,880   0%                 - seed7-re-search-backward
+         25,856   0%                  - run-with-timer
+         25,856   0%                   - run-at-time
+          9,984   0%                    - timer-activate
+          9,984   0%                     - timer--activate
+          9,984   0%                        timer--time-less-p
+          9,728   0%                      timer-relative-time
+          6,144   0%                    - timer-set-time
+          6,144   0%                       timer--time-setter
+          1,024   0%                    re-search-backward
+          8,184   0%                 - seed7--current-line-nth-word
+          8,184   0%                  - thing-at-point
+          8,184   0%                   - bounds-of-thing-at-point
+          8,184   0%                    - #<byte-code-function F26>
+          8,184   0%                     - forward-thing
+          8,184   0%                        format
+          9,264   0%                - seed7--block-end-pos-for
+          9,264   0%                 - seed7-to-block-forward
+          5,168   0%                  - seed7--current-line-nth-word
+          5,168   0%                   - thing-at-point
+          5,168   0%                    - bounds-of-thing-at-point
+          4,144   0%                     - seq-some
+          4,144   0%                        make-closure
+          1,024   0%                       re-search-forward
+          3,072   0%                  - seed7-re-search-forward
+          2,048   0%                   - seed7-inside-comment-p
+          2,048   0%                    - syntax-ppss
+          2,048   0%                     - syntax-propertize
+          2,048   0%                        seed7-mode-syntax-propertize
+          1,024   0%                    seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+         27,712   0%               - seed7-re-search-backward
+         20,016   0%                - run-with-timer
+         20,016   0%                 - run-at-time
+          7,296   0%                    timer-relative-time
+          4,608   0%                  - timer-set-time
+          4,608   0%                     timer--time-setter
+          4,144   0%                    timer-create
+          3,968   0%                  - timer-activate
+          3,968   0%                   - timer--activate
+          3,968   0%                      timer--time-less-p
+          4,144   0%                  make-closure
+          3,552   0%                  re-search-backward
+          2,048   0%                 replace-regexp-in-string
+         43,056   0%             - seed7-line-at-endof-set-definition-block
+         41,440   0%              - seed7-move-to-line
+         41,440   0%               - seed7-to-previous-non-empty-line
+         29,008   0%                - seed7-inside-comment-p
+          8,288   0%                 - syntax-ppss
+          8,288   0%                    make-closure
+          1,616   0%              - seed7-line-code-ends-with
+          1,616   0%               - seed7-re-search-backward
+          1,616   0%                - run-with-timer
+          1,616   0%                 - run-at-time
+            624   0%                  - timer-activate
+            624   0%                   - timer--activate
+            624   0%                      timer--time-less-p
+            608   0%                    timer-relative-time
+            384   0%                  - timer-set-time
+            384   0%                     timer--time-setter
+         40,368   0%             - seed7-line-starts-with-open-paren-after-logic-operator
+         37,296   0%              - seed7-move-to-line
+         37,296   0%               - seed7-to-previous-non-empty-line
+         20,720   0%                - seed7-inside-comment-p
+         12,432   0%                 - syntax-ppss
+         12,432   0%                    make-closure
+          2,048   0%                seed7-line-starts-with
+         40,368   0%             - seed7-line-after-func-return-logic-operator-column
+         38,320   0%              - seed7-move-to-line
+         38,320   0%               - seed7-to-previous-non-empty-line
+         24,864   0%                - seed7-inside-comment-p
+         24,864   0%                 - syntax-ppss
+         24,864   0%                    make-closure
+         39,936   0%             - seed7-line-at-endof-array-definition-block
+         37,296   0%              - seed7-move-to-line
+         37,296   0%               - seed7-to-previous-non-empty-line
+         24,864   0%                - seed7-inside-comment-p
+         20,720   0%                 - syntax-ppss
+         20,720   0%                    make-closure
+          2,640   0%              - seed7-line-code-ends-with
+          2,640   0%               - seed7-re-search-backward
+          1,616   0%                - run-with-timer
+          1,616   0%                 - run-at-time
+            624   0%                  - timer-activate
+            624   0%                   - timer--activate
+            624   0%                      timer--time-less-p
+            608   0%                    timer-relative-time
+            384   0%                  - timer-set-time
+            384   0%                     timer--time-setter
+          1,024   0%                  re-search-backward
+         23,088   0%             - seed7-line-inside-assign-statement-continuation
+         23,088   0%              - seed7-assign-op-pos
+         23,088   0%               - seed7-re-search-backward
+         20,016   0%                - run-with-timer
+         20,016   0%                 - run-at-time
+          7,296   0%                    timer-relative-time
+          4,608   0%                  - timer-set-time
+          4,608   0%                     timer--time-setter
+          4,144   0%                    timer-create
+          3,968   0%                  - timer-activate
+          3,968   0%                   - timer--activate
+          3,968   0%                      timer--time-less-p
+          3,072   0%                  re-search-backward
+         20,160   0%             - seed7-line-inside-array-definition-block
+         19,136   0%              - seed7-re-search-backward
+         15,872   0%               - run-with-timer
+         15,872   0%                - run-at-time
+          7,296   0%                   timer-relative-time
+          4,608   0%                 - timer-set-time
+          4,608   0%                    timer--time-setter
+          3,968   0%                 - timer-activate
+          3,968   0%                  - timer--activate
+          3,968   0%                     timer--time-less-p
+          3,264   0%                 re-search-backward
+          1,024   0%              - forward-sexp
+          1,024   0%                 seed7--forward-sexp-function
+         18,944   0%             - seed7-line-inside-set-definition-block
+         18,944   0%              - seed7-re-search-backward
+         15,872   0%               - run-with-timer
+         15,872   0%                - run-at-time
+          7,296   0%                   timer-relative-time
+          4,608   0%                 - timer-set-time
+          4,608   0%                    timer--time-setter
+          3,968   0%                 - timer-activate
+          3,968   0%                  - timer--activate
+          3,968   0%                     timer--time-less-p
+          3,072   0%                 re-search-backward
+          8,288   0%             - seed7--indent-search-boundary
+          8,288   0%              - seed7--indent-search-boundary-uncached
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+          4,144   0%               seed7--current-line-nth-word
+          3,072   0%             - seed7-line-isa-string
+          3,072   0%                seed7-line-starts-with
+          3,072   0%               seed7-line-starts-with
+          2,856   0%             - seed7-line-inside-argument-list-section
+          1,832   0%              - seed7-re-search-backward
+          1,024   0%                 re-search-backward
+            808   0%               - run-with-timer
+            808   0%                - run-at-time
+            312   0%                 - timer-activate
+            312   0%                  - timer--activate
+            312   0%                     timer--time-less-p
+            304   0%                   timer-relative-time
+            192   0%                 - timer-set-time
+            192   0%                    timer--time-setter
+          1,024   0%              - seed7-line-is-procfunc-beg-of-decl
+          1,024   0%                 seed7-line-starts-with
+          1,832   0%             - seed7-line-inside-logic-check-expression
+          1,832   0%              - seed7-to-previous-line-starts-with
+          1,832   0%               - seed7-re-search-backward
+          1,024   0%                  re-search-backward
+            808   0%                - run-with-timer
+            808   0%                 - run-at-time
+            312   0%                  - timer-activate
+            312   0%                   - timer--activate
+            312   0%                      timer--time-less-p
+            304   0%                    timer-relative-time
+            192   0%                  - timer-set-time
+            192   0%                     timer--time-setter
+          1,832   0%             - seed7-line-inside-until-logic-expression
+          1,832   0%              - seed7-re-search-backward
+          1,024   0%                 re-search-backward
+            808   0%               - run-with-timer
+            808   0%                - run-at-time
+            312   0%                 - timer-activate
+            312   0%                  - timer--activate
+            312   0%                     timer--time-less-p
+            304   0%                   timer-relative-time
+            192   0%                 - timer-set-time
+            192   0%                    timer--time-setter
+          1,832   0%             - seed7-line-inside-func-return-statement
+          1,832   0%              - seed7-re-search-backward
+          1,024   0%                 re-search-backward
+            808   0%               - run-with-timer
+            808   0%                - run-at-time
+            312   0%                 - timer-activate
+            312   0%                  - timer--activate
+            312   0%                     timer--time-less-p
+            304   0%                   timer-relative-time
+            192   0%                 - timer-set-time
+            192   0%                    timer--time-setter
+         46,720   0%            - seed7-line-code-ends-with
+         42,464   0%             - seed7-move-to-line
+         42,464   0%              - seed7-to-previous-non-empty-line
+         29,008   0%               - seed7-inside-comment-p
+         16,576   0%                - syntax-ppss
+         16,576   0%                   make-closure
+          4,256   0%             - seed7-re-search-backward
+          3,232   0%              - run-with-timer
+          3,232   0%               - run-at-time
+          1,248   0%                - timer-activate
+          1,248   0%                 - timer--activate
+          1,248   0%                    timer--time-less-p
+          1,216   0%                  timer-relative-time
+            768   0%                - timer-set-time
+            768   0%                   timer--time-setter
+          1,024   0%                re-search-backward
+          3,072   0%              seed7-line-starts-with
+          1,024   0%              looking-at
+      1,018,464   0%           - seed7-line-at-endof-array-definition-block
+        515,848   0%            - seed7-line-code-ends-with
+        511,704   0%             - seed7-re-search-backward
+        329,504   0%              - run-with-timer
+        329,504   0%               - run-at-time
+        137,984   0%                - timer-activate
+        137,984   0%                 - timer--activate
+        137,984   0%                    timer--time-less-p
+        102,144   0%                  timer-relative-time
+         72,800   0%                - timer-set-time
+         72,800   0%                   timer--time-setter
+         16,576   0%                  timer-create
+        132,472   0%                re-search-backward
+         29,008   0%              - seed7-inside-string-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+         12,432   0%                make-closure
+          8,288   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+        413,456   0%            - backward-sexp
+        413,456   0%             - forward-sexp
+        413,456   0%              - seed7--forward-sexp-function
+        161,312   0%               - seed7--at-array-definition-end-line-p
+        118,304   0%                - seed7-line-code-ends-with
+        110,016   0%                 - seed7-re-search-backward
+         89,296   0%                  - run-with-timer
+         89,296   0%                   - run-at-time
+         40,512   0%                    - timer-activate
+         40,512   0%                     - timer--activate
+         40,512   0%                        timer--time-less-p
+         27,360   0%                      timer-relative-time
+         21,424   0%                    - timer-set-time
+         21,424   0%                       timer--time-setter
+         16,576   0%                  - seed7-inside-string-p
+         12,432   0%                   - syntax-ppss
+         12,432   0%                      make-closure
+          4,144   0%                    make-closure
+         43,008   0%                  looking-at
+        148,432   0%               - seed7--safe-to-block-backward
+        148,432   0%                - seed7-to-block-backward
+        102,848   0%                 - seed7-line-code-ends-with
+        102,848   0%                  - seed7-re-search-backward
+         82,128   0%                   - run-with-timer
+         82,128   0%                    - run-at-time
+         27,856   0%                     - timer-activate
+         27,856   0%                      - timer--activate
+         27,856   0%                         timer--time-less-p
+         23,104   0%                       timer-relative-time
+         18,736   0%                     - timer-set-time
+         18,736   0%                        timer--time-setter
+         12,432   0%                       timer-create
+         16,576   0%                   - seed7-inside-string-p
+         12,432   0%                    - syntax-ppss
+         12,432   0%                       make-closure
+          4,144   0%                     make-closure
+         20,720   0%                 - seed7-inside-line-indent-before-comment-p
+          8,288   0%                  - seed7-inside-comment-p
+          4,144   0%                   - syntax-ppss
+          4,144   0%                      make-closure
+         20,720   0%                 - seed7--current-line-nth-word
+         16,576   0%                  - thing-at-point
+         16,576   0%                   - bounds-of-thing-at-point
+          8,288   0%                      make-closure
+          4,144   0%                    - seq-some
+          4,144   0%                       make-closure
+          4,144   0%                   seed7-inside-comment-p
+         15,456   0%               - seed7--at-set-definition-end-line-p
+         15,456   0%                - seed7-line-code-ends-with
+         15,456   0%                 - seed7-re-search-backward
+         11,312   0%                  - run-with-timer
+         11,312   0%                   - run-at-time
+          4,368   0%                    - timer-activate
+          4,368   0%                     - timer--activate
+          4,368   0%                        timer--time-less-p
+          4,256   0%                      timer-relative-time
+          2,688   0%                    - timer-set-time
+          2,688   0%                       timer--time-setter
+          4,144   0%                    make-closure
+         57,080   0%            - seed7-re-search-backward
+         44,648   0%             - run-with-timer
+         44,648   0%              - run-at-time
+         22,328   0%               - timer-activate
+         22,328   0%                - timer--activate
+         22,328   0%                   timer--time-less-p
+         13,680   0%                 timer-relative-time
+          8,640   0%               - timer-set-time
+          8,640   0%                  timer--time-setter
+         12,432   0%               seed7-inside-string-p
+         24,864   0%            - seed7-move-to-line
+         24,864   0%             - seed7-to-previous-non-empty-line
+         16,576   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+          3,072   0%              looking-at
+        944,162   0%           - seed7-line-indent-step
+        715,538   0%            - seed7-move-to-line
+        715,538   0%             - seed7-to-previous-non-empty-line
+        675,266   0%              - seed7-inside-comment-p
+        666,978   0%               - syntax-ppss
+        646,258   0%                - syntax-propertize
+        608,962   0%                   seed7-mode-syntax-propertize
+         20,720   0%                  make-closure
+        343,952   0%           - seed7-current-line-start-inside-comment-p
+        215,488   0%            - seed7-inside-comment-p
+        140,896   0%             - syntax-ppss
+        140,896   0%                make-closure
+        314,458   0%           - seed7-line-at-endof-set-definition-block
+        302,026   0%            - seed7-line-code-ends-with
+        302,026   0%             - seed7-re-search-backward
+        243,232   0%              - run-with-timer
+        243,232   0%               - run-at-time
+        101,840   0%                - timer-activate
+        101,840   0%                 - timer--activate
+        101,840   0%                    timer--time-less-p
+         79,040   0%                  timer-relative-time
+         58,208   0%                - timer-set-time
+         58,208   0%                   timer--time-setter
+          4,144   0%                  timer-create
+         21,498   0%              - seed7-inside-string-p
+          4,922   0%               - syntax-ppss
+          4,144   0%                  make-closure
+         20,720   0%              - seed7-inside-comment-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+         16,576   0%                make-closure
+         12,432   0%            - seed7-move-to-line
+         12,432   0%             - seed7-to-previous-non-empty-line
+          8,288   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+        276,336   0%           - seed7-line-ends-with
+        167,504   0%            - seed7-re-search-backward
+         83,968   0%               re-search-backward
+         71,104   0%             - run-with-timer
+         71,104   0%              - run-at-time
+         27,456   0%               - timer-activate
+         27,456   0%                - timer--activate
+         27,456   0%                   timer--time-less-p
+         26,752   0%                 timer-relative-time
+         16,896   0%               - timer-set-time
+         16,896   0%                  timer--time-setter
+         12,432   0%               seed7-inside-string-p
+        100,544   0%            - seed7-move-to-line
+        100,544   0%             - seed7-to-previous-non-empty-line
+          8,288   0%                seed7-inside-comment-p
+         92,152   0%           - seed7-line-starts-with-open-paren-after-logic-operator
+         92,152   0%              seed7-line-starts-with
+         30,048   0%           - seed7-position-of-end-of-statement
+         30,048   0%            - seed7-line-code-ends-with
+         30,048   0%             - seed7-re-search-backward
+         14,544   0%              - run-with-timer
+         14,544   0%               - run-at-time
+          5,616   0%                - timer-activate
+          5,616   0%                 - timer--activate
+          5,616   0%                    timer--time-less-p
+          5,472   0%                  timer-relative-time
+          3,456   0%                - timer-set-time
+          3,456   0%                   timer--time-setter
+          8,288   0%              - seed7-inside-string-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+          4,144   0%              - seed7-inside-comment-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+          3,072   0%                re-search-backward
+      1,230,768   0%          - #<byte-code-function 2AE>
+      1,230,768   0%           - filter-buffer-substring
+      1,230,768   0%            - buffer-substring--filter
+      1,230,768   0%             - #<byte-code-function 0BF>
+      1,230,768   0%              - apply
+      1,230,768   0%                 #<byte-code-function 554>
+        190,544   0%          - jit-lock-after-change
+         95,312   0%             font-lock-extend-jit-lock-region-after-change
+            648   0%          - undo-auto--undoable-change
+            648   0%           - undo-auto--boundary-ensure-timer
+            648   0%            - run-at-time
+            304   0%               timer-relative-time
+            192   0%             - timer-set-time
+            192   0%                timer--time-setter
+            152   0%             - timer-activate
+            152   0%              - timer--activate
+            152   0%                 timer--time-less-p
+     16,347,388   2%       - smex
+     16,121,500   2%        - smex-read-and-run
+     14,339,872   1%         - smex-completing-read
+     14,339,872   1%          - ido-completing-read
+     14,339,872   1%           - apply
+     14,339,872   1%            - ido-completing-read@ido-cr+-replace
+     14,339,872   1%             - #<native-comp-function ido-completing-read>
+     14,339,872   1%              - ido-read-internal
+     14,339,872   1%               - apply
+     14,339,872   1%                - ad-Advice-ido-read-internal
+     14,339,872   1%                 - #<native-comp-function ido-read-internal>
+     14,339,872   1%                  - read-from-minibuffer
+      6,600,121   0%                   - ido-exhibit
+      6,600,121   0%                    - apply
+      6,600,121   0%                     - #<native-comp-function ido-exhibit>
+      5,924,092   0%                      - ido-set-matches
+      5,924,092   0%                       - apply
+      5,924,092   0%                        - ido-grid--set-matches
+      5,924,092   0%                         - apply
+      5,924,092   0%                          - #<native-comp-function ido-set-matches>
+      5,924,092   0%                           - ido-set-matches-1
+      3,248,328   0%                            - apply
+      3,248,328   0%                             - ad-Advice-ido-set-matches-1
+      3,248,328   0%                              - flx-ido-match
+      3,248,328   0%                               - flx-ido-match-internal
+      3,053,312   0%                                - flx-score
+        373,952   0%                                 - flx-find-best-match
+        320,448   0%                                  - flx-find-best-match
+        252,352   0%                                   - flx-find-best-match
+        140,432   0%                                    - flx-find-best-match
+         58,368   0%                                     - flx-find-best-match
+         38,912   0%                                      - flx-find-best-match
+         29,184   0%                                       - flx-find-best-match
+         20,672   0%                                        - flx-find-best-match
+         18,240   0%                                           puthash
+          2,432   0%                                         - flx-find-best-match
+          2,432   0%                                            puthash
+          8,512   0%                                          puthash
+          9,728   0%                                         puthash
+         19,456   0%                                        puthash
+         45,584   0%                                       make-closure
+         36,480   0%                                       puthash
+         91,200   0%                                      puthash
+         20,720   0%                                      make-closure
+         68,096   0%                                     puthash
+         53,504   0%                                    puthash
+         17,408   0%                                 - flx-process-cache
+         17,408   0%                                    flx-get-hash-for-string
+         70,280   0%                                - flx-ido-decorate
+         17,272   0%                                   flx-propertize
+         21,128   0%                                - flx-flex-match
+         21,128   0%                                 - #<byte-code-function 3FE>
+         21,128   0%                                    string-match
+        327,565   0%                      - ido-completions
+        327,565   0%                       - apply
+        327,565   0%                        - ido-grid--completions
+        242,381   0%                         - ido-grid--grid-ensure-visible
+        242,381   0%                          - ido-grid--grid
+         84,040   0%                             buffer-string
+         20,320   0%                             add-face-text-property
+         20,220   0%                             move-to-column
+          4,096   0%                           - ido-final-slash
+          2,048   0%                              ido-is-tramp-root
+          2,048   0%                             string-match
+            315   0%                             generate-new-buffer
+        271,248   0%                      - ido-set-common-completion
+        271,248   0%                       - ido-find-common-substring
+        184,488   0%                          ido-word-matching-substring
+      5,416,511   0%                   - redisplay_internal (C function)
+          8,184   0%                    - which-key--hide-popup-on-frame-size-change
+          8,184   0%                     - which-key--frame-size-changed-p
+          8,184   0%                        frame-width
+          3,072   0%                    - tty-color-desc
+          3,072   0%                     - tty-color-canonicalize
+          1,024   0%                        replace-regexp-in-string
+          4,144   0%                   - winner-save-unconditionally
+          4,144   0%                      winner-remember
+          2,048   0%                     minibuffer--regexp-setup
+          1,296   0%                   - undo-auto--undoable-change
+          1,296   0%                    - undo-auto--boundary-ensure-timer
+          1,296   0%                     - run-at-time
+            608   0%                        timer-relative-time
+            384   0%                      - timer-set-time
+            384   0%                         timer--time-setter
+            304   0%                      - timer-activate
+            304   0%                       - timer--activate
+            304   0%                          timer--time-less-p
+          1,200   0%                   - timer-event-handler
+          1,200   0%                    - timer-activate-when-idle
+          1,200   0%                     - timer--activate
+          1,200   0%                        timer--time-less-p
+            240   0%                   - command-execute
+            240   0%                    - call-interactively
+            240   0%                     - apply
+            240   0%                      - call-interactively@ido-cr+-record-current-command
+            240   0%                       - #<primitive-function call-interactively>
+            240   0%                          funcall-interactively
+      1,781,628   0%         - execute-extended-command
+      1,603,340   0%          - command-execute
+      1,603,340   0%           - call-interactively
+      1,603,340   0%            - apply
+      1,603,340   0%             - call-interactively@ido-cr+-record-current-command
+      1,603,340   0%              - #<primitive-function call-interactively>
+      1,603,340   0%               - funcall-interactively
+      1,603,324   0%                  profiler-stop
+        225,888   0%        - smex-update
+        225,888   0%         - smex-rebuild-cache
+         69,064   0%            smex-convert-for-ido
+     56,621,062   7% + flyspell-post-command-hook
+      6,921,875   0% + redisplay_internal (C function)
+      1,101,516   0%   Automatic GC
+          5,552   0% + timer-event-handler
+          4,165   0% + help-command-error-confusable-suggestions
+          4,144   0% + winner-save-old-configurations
+              0   0%   ...

--- a/reports/18.1/chkarr.sd7-profiler-cpu.txt
+++ b/reports/18.1/chkarr.sd7-profiler-cpu.txt
@@ -1,0 +1,1015 @@
+      442797  93% - command-execute
+      442797  93%  - call-interactively
+      442797  93%   - apply
+      442797  93%    - call-interactively@ido-cr+-record-current-command
+      442797  93%     - #<primitive-function call-interactively>
+      442797  93%      - funcall-interactively
+      442759  93%       - seed7-complete-statement-or-indent
+      442759  93%        - seed7-indent-region
+      442758  93%         - seed7--indent-one-line
+      442727  93%          - seed7-calc-indent
+      204042  43%           - seed7-line-is-defun-end
+      201318  42%            - seed7-end-of-defun
+      193979  41%             - seed7-top-block-name
+      193726  40%              - seed7--to-top
+      192843  40%               - seed7-re-search-backward
+      162791  34%                - seed7-inside-comment-p
+      162712  34%                 - syntax-ppss
+      158800  33%                    parse-partial-sexp
+        3550   0%                  - syntax-propertize
+        3445   0%                     seed7-mode-syntax-propertize
+          44   0%                    make-closure
+          41   0%                  - #<byte-code-function 98C>
+           8   0%                     set-syntax-table
+          22   0%                    syntax-ppss--update-stats
+          22   0%                    syntax-ppss--data
+          21   0%                    syntax-ppss-toplevel-pos
+          10   0%                    syntax-table
+           8   0%                    set-syntax-table
+       23805   5%                - run-with-timer
+       23791   5%                 - run-at-time
+       14865   3%                  - timer-activate
+       14849   3%                   - timer--activate
+       14776   3%                    - timer--time-less-p
+         267   0%                       timer--time
+          12   0%                      timerp
+        6143   1%                  - timer-set-time
+        6123   1%                   - timer--time-setter
+           8   0%                      timerp
+        2684   0%                    timer-relative-time
+          35   0%                    timer-create
+          33   0%                  - timer-set-function
+          13   0%                     timerp
+        4865   1%                  re-search-backward
+         827   0%                - seed7-inside-string-p
+         537   0%                 - syntax-ppss
+         270   0%                  - parse-partial-sexp
+           6   0%                   - internal--syntax-propertize
+           6   0%                    - syntax-propertize
+           4   0%                       seed7-mode-syntax-propertize
+           1   0%                       syntax-ppss-flush-cache
+          42   0%                  - #<byte-code-function BB7>
+          10   0%                     set-syntax-table
+          37   0%                    make-closure
+          26   0%                    syntax-propertize
+          21   0%                    syntax-ppss--data
+          16   0%                    syntax-ppss--update-stats
+          10   0%                    syntax-table
+           4   0%                    set-syntax-table
+          73   0%                 - #<byte-code-function DD9>
+          46   0%                    set-match-data
+          77   0%                - #<byte-code-function B3D>
+          61   0%                 - cancel-timer
+          11   0%                    timerp
+          58   0%                  make-closure
+         247   0%                 seed7-to-indent
+          73   0%               - run-with-timer
+          71   0%                - run-at-time
+          42   0%                 - timer-activate
+          42   0%                  - timer--activate
+          41   0%                   - timer--time-less-p
+           1   0%                      timer--time
+          15   0%                 - timer-set-time
+          15   0%                    timer--time-setter
+          14   0%                   timer-relative-time
+         251   0%              - seed7--block-name
+         249   0%               - seed7-re-search-forward
+         114   0%                - seed7-inside-comment-p
+         113   0%                 - syntax-ppss
+          98   0%                    parse-partial-sexp
+          14   0%                  - syntax-propertize
+          10   0%                     seed7-mode-syntax-propertize
+           1   0%                   - #<byte-code-function 8CA>
+           1   0%                    - syntax-propertize-wholelines
+           1   0%                       syntax--lbp
+          37   0%                - seed7-inside-string-p
+          35   0%                 - syntax-ppss
+          34   0%                    parse-partial-sexp
+           1   0%                    #<byte-code-function 587>
+           1   0%                 match-string
+        6631   1%             - seed7-re-search-forward
+         738   0%              - seed7-inside-comment-p
+         737   0%               - syntax-ppss
+         402   0%                  parse-partial-sexp
+         331   0%                - syntax-propertize
+         322   0%                   seed7-mode-syntax-propertize
+           2   0%                 - #<byte-code-function 777>
+           1   0%                  - syntax-propertize-wholelines
+           1   0%                     syntax--lbp
+           2   0%                  make-closure
+           1   0%                  set-syntax-table
+          28   0%              - seed7-inside-string-p
+          26   0%               - syntax-ppss
+          25   0%                  parse-partial-sexp
+           1   0%                  make-closure
+         695   0%             - seed7-re-search-backward
+         543   0%              - seed7-inside-comment-p
+         543   0%               - syntax-ppss
+         543   0%                  parse-partial-sexp
+          87   0%                re-search-backward
+          60   0%              - run-with-timer
+          60   0%               - run-at-time
+          30   0%                - timer-activate
+          29   0%                 - timer--activate
+          29   0%                  - timer--time-less-p
+           1   0%                     timer--time
+          18   0%                - timer-set-time
+          18   0%                   timer--time-setter
+          12   0%                  timer-relative-time
+           3   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           1   0%              - #<byte-code-function 6CA>
+           1   0%                 cancel-timer
+           4   0%               match-string
+           2   0%               seed7--no-defun-found-msg-for
+        2558   0%            - seed7-beg-of-defun
+        1952   0%             - seed7-re-search-backward-closest
+        1950   0%              - seed7-re-search-backward
+        1917   0%                 re-search-backward
+          33   0%               - run-with-timer
+          33   0%                - run-at-time
+          16   0%                 - timer-activate
+          16   0%                  - timer--activate
+          16   0%                     timer--time-less-p
+          12   0%                 - timer-set-time
+          12   0%                    timer--time-setter
+           5   0%                   timer-relative-time
+           2   0%                seq-filter
+         428   0%             - seed7-re-search-backward
+         242   0%              - seed7-inside-comment-p
+         242   0%               - syntax-ppss
+         240   0%                  parse-partial-sexp
+           1   0%                  syntax-table
+         154   0%                re-search-backward
+          30   0%              - run-with-timer
+          30   0%               - run-at-time
+          16   0%                - timer-activate
+          16   0%                 - timer--activate
+          16   0%                    timer--time-less-p
+          11   0%                - timer-set-time
+          11   0%                   timer--time-setter
+           3   0%                  timer-relative-time
+           1   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+         152   0%             - seed7-top-block-name
+         102   0%              - seed7--to-top
+          87   0%               - seed7-re-search-backward
+          41   0%                  re-search-backward
+          18   0%                - run-with-timer
+          18   0%                 - run-at-time
+          12   0%                  - timer-activate
+          12   0%                   - timer--activate
+          12   0%                      timer--time-less-p
+           6   0%                  - timer-set-time
+           6   0%                     timer--time-setter
+          14   0%                - seed7-inside-string-p
+          14   0%                 - syntax-ppss
+          14   0%                    parse-partial-sexp
+          13   0%                - seed7-inside-comment-p
+          13   0%                 - syntax-ppss
+          13   0%                    parse-partial-sexp
+          15   0%               - run-with-timer
+          15   0%                - run-at-time
+           6   0%                   timer-relative-time
+           6   0%                 - timer-activate
+           6   0%                  - timer--activate
+           6   0%                     timer--time-less-p
+           3   0%                 - timer-set-time
+           3   0%                    timer--time-setter
+          50   0%              - seed7--block-name
+          50   0%               - seed7-re-search-forward
+           3   0%                - seed7-inside-comment-p
+           3   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           2   0%               seed7-to-indent
+         123   0%            - seed7-move-to-line
+         122   0%             - seed7-to-previous-non-empty-line
+         109   0%              - seed7-inside-comment-p
+         109   0%               - syntax-ppss
+         108   0%                  parse-partial-sexp
+           1   0%                  syntax-ppss--update-stats
+          18   0%            - seed7-line-starts-with-any
+          18   0%             - seed7-line-starts-with
+           1   0%                seed7-move-to-line
+          13   0%            - seed7--current-line-nth-word
+          10   0%             - thing-at-point
+           7   0%              - bounds-of-thing-at-point
+           4   0%               - #<byte-code-function BBF>
+           4   0%                - forward-thing
+           2   0%                   forward-word
+           1   0%                   format
+           2   0%               - #<byte-code-function 52C>
+           2   0%                - forward-thing
+           2   0%                   forward-word
+           7   0%            - seed7--safe-current-line-defun-start-indent
+           7   0%             - seed7-to-block-backward
+           6   0%              - seed7-re-search-backward
+           4   0%                 re-search-backward
+           1   0%               - run-with-timer
+           1   0%                - run-at-time
+           1   0%                 - timer-activate
+           1   0%                  - timer--activate
+           1   0%                     timer--time-less-p
+           1   0%               - seed7-inside-comment-p
+           1   0%                - syntax-ppss
+           1   0%                   parse-partial-sexp
+           1   0%              - seed7-inside-line-indent-before-comment-p
+           1   0%               - seed7-inside-comment-p
+           1   0%                - syntax-ppss
+           1   0%                   parse-partial-sexp
+           1   0%              line-end-position
+      146546  31%           - seed7--indent-search-boundary
+      146536  30%            - seed7--indent-search-boundary-uncached
+      144993  30%             - syntax-ppss
+      144558  30%                parse-partial-sexp
+          66   0%                make-closure
+          56   0%              - #<byte-code-function 193>
+          11   0%                 set-syntax-table
+          26   0%                syntax-ppss-toplevel-pos
+          24   0%                syntax-ppss--update-stats
+          20   0%                syntax-table
+          18   0%                syntax-propertize
+          13   0%                syntax-ppss--data
+          12   0%                set-syntax-table
+         183   0%               seed7-to-indent
+           1   0%              seed7--indent-search-boundary-valid-p
+       59976  12%           - seed7-line-inside-parens-pair-column
+       59976  12%            - seed7-line-inside-parens-pair
+       57529  12%             - seed7-re-search-backward
+       47278  10%              - seed7-inside-comment-p
+       47232   9%               - syntax-ppss
+       47027   9%                  parse-partial-sexp
+          28   0%                  make-closure
+          28   0%                - #<byte-code-function 77C>
+           7   0%                   set-syntax-table
+          18   0%                  syntax-ppss--update-stats
+          11   0%                  syntax-ppss-toplevel-pos
+          11   0%                  syntax-propertize
+          10   0%                  syntax-ppss--data
+           5   0%                  set-syntax-table
+           3   0%                  syntax-table
+        9074   1%              - run-with-timer
+        9066   1%               - run-at-time
+        4759   1%                - timer-activate
+        4753   1%                 - timer--activate
+        4713   0%                  - timer--time-less-p
+          77   0%                     timer--time
+           3   0%                    timerp
+        2911   0%                - timer-set-time
+        2901   0%                 - timer--time-setter
+           7   0%                    timerp
+        1337   0%                  timer-relative-time
+          24   0%                  timer-create
+          10   0%                - timer-set-function
+           5   0%                   timerp
+         717   0%              - seed7-inside-string-p
+         608   0%               - syntax-ppss
+         446   0%                  parse-partial-sexp
+          28   0%                  make-closure
+          20   0%                - #<byte-code-function 23E>
+           4   0%                   set-syntax-table
+          16   0%                  syntax-propertize
+          14   0%                  syntax-ppss--data
+          11   0%                  syntax-ppss--update-stats
+           6   0%                  set-syntax-table
+           5   0%                  syntax-table
+          35   0%               - #<byte-code-function 359>
+          22   0%                  set-match-data
+         272   0%                re-search-backward
+          46   0%              - #<byte-code-function 8D7>
+          37   0%               - cancel-timer
+           6   0%                  timerp
+          20   0%                make-closure
+         716   0%             - forward-sexp
+         707   0%              - seed7--forward-sexp-function
+           7   0%                 seed7--at-line-comment-start-p
+          99   0%             - seed7-line-inside-syntax-parens-pair
+          95   0%              - syntax-ppss
+          95   0%                 parse-partial-sexp
+           3   0%                seed7-move-to-line
+           7   0%               seed7--paren-pair-string
+           2   0%               seed7-move-to-line
+       26873   5%           - seed7-line-inside-a-block-cached
+       26869   5%            - seed7-line-inside-a-block
+       20040   4%             - seed7--safe-enclosing-block-bounds
+       18415   3%              - seed7--block-end-pos-for
+       18411   3%               - seed7-to-block-forward
+       16971   3%                - seed7-end-of-defun
+       15925   3%                 - seed7-top-block-name
+       15915   3%                  - seed7--to-top
+       15862   3%                   - seed7-re-search-backward
+       13144   2%                    - seed7-inside-comment-p
+       13134   2%                     - syntax-ppss
+       12990   2%                        parse-partial-sexp
+         105   0%                      - syntax-propertize
+          99   0%                         seed7-mode-syntax-propertize
+           8   0%                        make-closure
+           6   0%                        #<byte-code-function FE0>
+           3   0%                        syntax-ppss--update-stats
+           2   0%                        syntax-table
+           1   0%                        syntax-ppss-toplevel-pos
+        2064   0%                    - run-with-timer
+        2061   0%                     - run-at-time
+        1153   0%                      - timer-activate
+        1148   0%                       - timer--activate
+        1141   0%                        - timer--time-less-p
+          15   0%                           timer--time
+         602   0%                      - timer-set-time
+         602   0%                       - timer--time-setter
+           4   0%                          timerp
+         284   0%                        timer-relative-time
+          14   0%                        timer-create
+           3   0%                        timer-set-function
+         494   0%                      re-search-backward
+          97   0%                    - seed7-inside-string-p
+          51   0%                     - syntax-ppss
+          24   0%                        parse-partial-sexp
+           8   0%                        make-closure
+           3   0%                        syntax-ppss--data
+           2   0%                        syntax-propertize
+           1   0%                        syntax-table
+           1   0%                        set-syntax-table
+           5   0%                     - #<byte-code-function 8FA>
+           4   0%                        set-match-data
+          10   0%                    - #<byte-code-function 365>
+           7   0%                     - cancel-timer
+           2   0%                        timerp
+           9   0%                      make-closure
+          14   0%                     seed7-to-indent
+           7   0%                   - run-with-timer
+           7   0%                    - run-at-time
+           6   0%                     - timer-activate
+           6   0%                      - timer--activate
+           5   0%                         timer--time-less-p
+           1   0%                     - timer-set-time
+           1   0%                        timer--time-setter
+          10   0%                  - seed7--block-name
+           9   0%                   - seed7-re-search-forward
+           5   0%                    - seed7-inside-comment-p
+           5   0%                     - syntax-ppss
+           5   0%                        parse-partial-sexp
+           2   0%                    - seed7-inside-string-p
+           2   0%                     - syntax-ppss
+           2   0%                        parse-partial-sexp
+         990   0%                 - seed7-re-search-forward
+          17   0%                  - seed7-inside-comment-p
+          17   0%                   - syntax-ppss
+          16   0%                      parse-partial-sexp
+           1   0%                    - syntax-propertize
+           1   0%                       seed7-mode-syntax-propertize
+           5   0%                  - seed7-inside-string-p
+           4   0%                   - syntax-ppss
+           4   0%                      parse-partial-sexp
+          53   0%                 - seed7-re-search-backward
+          43   0%                  - seed7-inside-comment-p
+          43   0%                   - syntax-ppss
+          43   0%                      parse-partial-sexp
+           8   0%                  - run-with-timer
+           8   0%                   - run-at-time
+           4   0%                    - timer-activate
+           4   0%                     - timer--activate
+           4   0%                        timer--time-less-p
+           2   0%                      timer-relative-time
+           1   0%                    - timer-set-function
+           1   0%                       timerp
+           1   0%                    - timer-set-time
+           1   0%                       timer--time-setter
+           1   0%                  - seed7-inside-string-p
+           1   0%                   - syntax-ppss
+           1   0%                      parse-partial-sexp
+           1   0%                    re-search-backward
+           1   0%                   match-string
+         896   0%                - seed7-re-search-forward
+         515   0%                 - seed7-inside-comment-p
+         514   0%                  - syntax-ppss
+         319   0%                     parse-partial-sexp
+         188   0%                   - syntax-propertize
+         185   0%                    - seed7-mode-syntax-propertize
+           1   0%                       #<byte-code-function FFE>
+           1   0%                     syntax-ppss--data
+           1   0%                     make-closure
+           1   0%                     syntax-ppss--update-stats
+         120   0%                 - seed7-inside-string-p
+         117   0%                  - syntax-ppss
+         106   0%                     parse-partial-sexp
+           2   0%                     syntax-propertize
+           2   0%                     syntax-ppss--update-stats
+           1   0%                     syntax-ppss--data
+           1   0%                     syntax-table
+           1   0%                   - #<byte-code-function 370>
+           1   0%                      set-syntax-table
+         409   0%                - seed7--current-line-nth-word
+         300   0%                 - thing-at-point
+         280   0%                  - bounds-of-thing-at-point
+         133   0%                   - #<byte-code-function D60>
+         131   0%                    - forward-thing
+          93   0%                       forward-word
+          23   0%                       format
+           3   0%                       intern-soft
+           2   0%                       functionp
+          65   0%                   - #<byte-code-function E85>
+          62   0%                    - forward-thing
+          47   0%                       forward-word
+          11   0%                       format
+           1   0%                       intern-soft
+           1   0%                       functionp
+          22   0%                     re-search-forward
+          19   0%                     make-closure
+          10   0%                   - seq-some
+           4   0%                      make-closure
+           3   0%                      seq-do
+          45   0%                - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          23   0%                 - seed7-inside-comment-p
+          20   0%                  - syntax-ppss
+          12   0%                     parse-partial-sexp
+           2   0%                     make-closure
+           1   0%                     syntax-propertize
+           1   0%                     syntax-ppss--data
+          11   0%                 - seed7-inside-line-indent-before-comment-p
+           5   0%                    seed7-to-indent
+           3   0%                  - seed7-inside-comment-p
+           3   0%                   - syntax-ppss
+           3   0%                      parse-partial-sexp
+          37   0%                - seed7-inside-comment-p
+          32   0%                 - syntax-ppss
+          19   0%                    parse-partial-sexp
+           4   0%                    #<byte-code-function B09>
+           3   0%                    syntax-ppss--data
+           2   0%                    make-closure
+          21   0%                - seed7-inside-line-indent-before-comment-p
+           8   0%                   seed7-to-indent
+           2   0%                 - seed7-inside-comment-p
+           2   0%                  - syntax-ppss
+           2   0%                     parse-partial-sexp
+           8   0%                  seed7--end-regexp-for
+        1619   0%              - seed7-to-block-backward
+        1105   0%               - seed7-re-search-backward
+         560   0%                - run-with-timer
+         559   0%                 - run-at-time
+         319   0%                  - timer-activate
+         319   0%                   - timer--activate
+         315   0%                    - timer--time-less-p
+           6   0%                       timer--time
+         154   0%                  - timer-set-time
+         154   0%                     timer--time-setter
+          80   0%                    timer-relative-time
+           3   0%                    timer-create
+           2   0%                    timer-set-function
+         256   0%                - seed7-inside-comment-p
+         255   0%                 - syntax-ppss
+         242   0%                    parse-partial-sexp
+           4   0%                  - #<byte-code-function E41>
+           3   0%                     set-syntax-table
+           2   0%                    syntax-ppss--update-stats
+           2   0%                    make-closure
+           1   0%                    syntax-table
+           1   0%                    syntax-ppss--data
+         249   0%                  re-search-backward
+          32   0%                - seed7-inside-string-p
+          25   0%                 - syntax-ppss
+          16   0%                    parse-partial-sexp
+           3   0%                    make-closure
+           1   0%                    syntax-table
+           2   0%                 - #<byte-code-function D91>
+           2   0%                    set-match-data
+           5   0%                - #<byte-code-function 170>
+           4   0%                   cancel-timer
+           1   0%                  make-closure
+         300   0%               - seed7--current-line-nth-word
+         240   0%                - thing-at-point
+         222   0%                 - bounds-of-thing-at-point
+         119   0%                  - #<byte-code-function 38D>
+         117   0%                   - forward-thing
+          84   0%                      forward-word
+          22   0%                      format
+           2   0%                      intern-soft
+          45   0%                  - #<byte-code-function 13C>
+          45   0%                   - forward-thing
+          38   0%                      forward-word
+           5   0%                      format
+           1   0%                      intern-soft
+           1   0%                      functionp
+          18   0%                    make-closure
+          15   0%                    re-search-forward
+           7   0%                  - seq-some
+           3   0%                     make-closure
+           1   0%                     seq-do
+         137   0%               - seed7-inside-comment-p
+         132   0%                - syntax-ppss
+         126   0%                   parse-partial-sexp
+           2   0%                   syntax-ppss--update-stats
+           1   0%                   make-closure
+          57   0%               - seed7-inside-line-indent-before-comment-p
+          31   0%                - seed7-inside-comment-p
+          26   0%                 - syntax-ppss
+          11   0%                    parse-partial-sexp
+           2   0%                    syntax-ppss--update-stats
+           2   0%                    make-closure
+           2   0%                  - #<byte-code-function 765>
+           1   0%                     set-syntax-table
+           1   0%                    syntax-ppss--data
+           1   0%                    syntax-table
+           8   0%                  seed7-to-indent
+          11   0%                 seed7--start-regexp-for
+        5542   1%             - seed7-re-search-backward
+        4731   1%              - seed7-inside-comment-p
+        4729   1%               - syntax-ppss
+        4717   0%                  parse-partial-sexp
+           3   0%                  #<byte-code-function 221>
+           1   0%                  syntax-ppss--update-stats
+         565   0%              - run-with-timer
+         564   0%               - run-at-time
+         286   0%                - timer-activate
+         286   0%                 - timer--activate
+         284   0%                  - timer--time-less-p
+           5   0%                     timer--time
+         188   0%                - timer-set-time
+         187   0%                 - timer--time-setter
+           1   0%                    timerp
+          87   0%                  timer-relative-time
+           2   0%                  timer-create
+         175   0%                re-search-backward
+          51   0%              - seed7-inside-string-p
+          38   0%               - syntax-ppss
+          26   0%                  parse-partial-sexp
+           4   0%                  make-closure
+           2   0%                - #<byte-code-function 993>
+           1   0%                   set-syntax-table
+           1   0%                  syntax-ppss--update-stats
+           1   0%                  syntax-ppss--data
+           1   0%                  syntax-propertize
+           3   0%               - #<byte-code-function AEC>
+           3   0%                  set-match-data
+           6   0%              - #<byte-code-function 57A>
+           6   0%               - cancel-timer
+           1   0%                  timerp
+        1210   0%             - seed7-calc-indent
+         687   0%              - seed7-line-inside-parens-pair-column
+         687   0%               - seed7-line-inside-parens-pair
+         654   0%                - seed7-re-search-backward
+         531   0%                 - seed7-inside-comment-p
+         531   0%                  - syntax-ppss
+         526   0%                     parse-partial-sexp
+           1   0%                     make-closure
+           1   0%                     syntax-propertize
+           1   0%                     #<byte-code-function A5A>
+           1   0%                     syntax-ppss--data
+         107   0%                 - run-with-timer
+         107   0%                  - run-at-time
+          56   0%                   - timer-activate
+          56   0%                    - timer--activate
+          54   0%                     - timer--time-less-p
+           1   0%                        timer--time
+           1   0%                       timerp
+          30   0%                   - timer-set-time
+          30   0%                      timer--time-setter
+          21   0%                     timer-relative-time
+          12   0%                 - seed7-inside-string-p
+           7   0%                  - syntax-ppss
+           4   0%                     parse-partial-sexp
+           1   0%                     syntax-ppss--update-stats
+           1   0%                   - #<byte-code-function 7EF>
+           1   0%                      set-syntax-table
+           3   0%                   re-search-backward
+          13   0%                - forward-sexp
+          13   0%                   seed7--forward-sexp-function
+         518   0%              - seed7-line-is-defun-end
+         503   0%               - seed7-end-of-defun
+         458   0%                - seed7-top-block-name
+         458   0%                 - seed7--to-top
+         455   0%                  - seed7-re-search-backward
+         370   0%                   - seed7-inside-comment-p
+         370   0%                    - syntax-ppss
+         369   0%                       parse-partial-sexp
+           1   0%                       #<byte-code-function 5EB>
+          70   0%                   - run-with-timer
+          70   0%                    - run-at-time
+          35   0%                     - timer-activate
+          35   0%                      - timer--activate
+          35   0%                         timer--time-less-p
+          23   0%                     - timer-set-time
+          23   0%                        timer--time-setter
+          11   0%                       timer-relative-time
+           1   0%                       timer-set-function
+           9   0%                     re-search-backward
+           2   0%                   - seed7-inside-string-p
+           1   0%                    - syntax-ppss
+           1   0%                       parse-partial-sexp
+           1   0%                    seed7-to-indent
+          44   0%                - seed7-re-search-forward
+           7   0%                 - seed7-inside-comment-p
+           7   0%                  - syntax-ppss
+           7   0%                     parse-partial-sexp
+           2   0%                 - seed7-inside-string-p
+           2   0%                  - syntax-ppss
+           2   0%                     parse-partial-sexp
+           1   0%                - seed7-re-search-backward
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+          15   0%               - seed7-beg-of-defun
+          13   0%                - seed7-re-search-backward
+          10   0%                 - seed7-inside-comment-p
+          10   0%                  - syntax-ppss
+          10   0%                     parse-partial-sexp
+           2   0%                 - run-with-timer
+           2   0%                  - run-at-time
+           2   0%                   - timer-activate
+           2   0%                    - timer--activate
+           2   0%                       timer--time-less-p
+           1   0%                   re-search-backward
+           2   0%                - seed7-re-search-backward-closest
+           2   0%                 - seed7-re-search-backward
+           2   0%                    re-search-backward
+           2   0%              - seed7-line-inside-set-definition-block
+           2   0%               - seed7-re-search-backward
+           2   0%                  re-search-backward
+           2   0%              - seed7-line-at-endof-array-definition-block
+           2   0%               - seed7-line-code-ends-with
+           2   0%                - seed7-re-search-backward
+           1   0%                 - run-with-timer
+           1   0%                  - run-at-time
+           1   0%                   - timer-activate
+           1   0%                    - timer--activate
+           1   0%                       timer--time-less-p
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           1   0%              - seed7-line-inside-assign-statement-continuation
+           1   0%               - seed7-assign-op-pos
+           1   0%                - seed7-re-search-backward
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+          30   0%             - replace-regexp-in-string
+           2   0%              - #<byte-code-function 243>
+           2   0%                 set-match-data
+           1   0%                concat
+           9   0%               match-string
+           4   0%               seed7--on-lineof
+           1   0%               seed7--indent-offset-for
+           1   0%              seed7--cached-block-spec-current-line
+           1   0%              seed7--cache-block-spec
+        3339   0%           - seed7-line-inside-set-definition-block
+        3337   0%            - seed7-re-search-backward
+        3282   0%               re-search-backward
+          55   0%             - run-with-timer
+          55   0%              - run-at-time
+          26   0%               - timer-activate
+          26   0%                - timer--activate
+          25   0%                 - timer--time-less-p
+           1   0%                    timer--time
+          16   0%               - timer-set-time
+          16   0%                  timer--time-setter
+          12   0%                 timer-relative-time
+           1   0%               - timer-set-function
+           1   0%                  timerp
+           1   0%              seed7-move-to-line
+         714   0%           - seed7-line-inside-array-definition-block
+         705   0%            - seed7-re-search-backward
+         396   0%             - seed7-inside-comment-p
+         396   0%              - syntax-ppss
+         394   0%                 parse-partial-sexp
+         263   0%               re-search-backward
+          40   0%             - run-with-timer
+          40   0%              - run-at-time
+          31   0%               - timer-activate
+          31   0%                - timer--activate
+          31   0%                   timer--time-less-p
+           8   0%                 timer-relative-time
+           1   0%                 timer-create
+           6   0%             - seed7-inside-string-p
+           5   0%              - syntax-ppss
+           4   0%                 parse-partial-sexp
+           1   0%                 syntax-ppss--data
+           1   0%                #<byte-code-function 90F>
+           5   0%            - forward-sexp
+           5   0%               seed7--forward-sexp-function
+         391   0%           - seed7-line-inside-assign-statement-continuation
+         367   0%            - seed7-assign-op-pos
+         367   0%             - seed7-re-search-backward
+         290   0%              - seed7-inside-comment-p
+         290   0%               - syntax-ppss
+         290   0%                  parse-partial-sexp
+          57   0%              - run-with-timer
+          57   0%               - run-at-time
+          25   0%                - timer-activate
+          25   0%                 - timer--activate
+          24   0%                    timer--time-less-p
+          18   0%                - timer-set-time
+          17   0%                   timer--time-setter
+          13   0%                  timer-relative-time
+           1   0%                - timer-set-function
+           1   0%                   timerp
+          11   0%              - seed7-inside-string-p
+           9   0%               - syntax-ppss
+           9   0%                  parse-partial-sexp
+           2   0%               - #<byte-code-function E2E>
+           2   0%                  set-match-data
+           9   0%                re-search-backward
+          23   0%            - seed7-statement-end-pos
+          22   0%             - seed7-forward-char-pos
+          22   0%              - seed7-re-search-forward
+          11   0%               - seed7-inside-string-p
+          11   0%                - syntax-ppss
+          11   0%                   parse-partial-sexp
+           7   0%               - seed7-inside-comment-p
+           7   0%                - syntax-ppss
+           5   0%                   parse-partial-sexp
+           1   0%                   #<byte-code-function 374>
+           1   0%                   make-closure
+           1   0%              seed7-move-to-line
+         213   0%           - seed7-line-inside-logic-check-expression
+         148   0%            - seed7-to-previous-line-starts-with
+         147   0%             - seed7-re-search-backward
+          81   0%              - seed7-inside-comment-p
+          81   0%               - syntax-ppss
+          81   0%                  parse-partial-sexp
+          38   0%              - run-with-timer
+          38   0%               - run-at-time
+          16   0%                - timer-activate
+          16   0%                 - timer--activate
+          16   0%                    timer--time-less-p
+          15   0%                - timer-set-time
+          15   0%                   timer--time-setter
+           7   0%                  timer-relative-time
+          17   0%                re-search-backward
+           9   0%              - seed7-inside-string-p
+           9   0%               - syntax-ppss
+           8   0%                  parse-partial-sexp
+           1   0%                  syntax-table
+           1   0%              - #<byte-code-function 63A>
+           1   0%                 cancel-timer
+          52   0%            - seed7-re-search-forward
+          32   0%             - seed7-inside-comment-p
+          32   0%              - syntax-ppss
+          32   0%                 parse-partial-sexp
+          17   0%             - seed7-inside-string-p
+          17   0%              - syntax-ppss
+          17   0%                 parse-partial-sexp
+          11   0%            - seed7--current-line-nth-word
+          10   0%             - thing-at-point
+           8   0%              - bounds-of-thing-at-point
+           3   0%               - #<byte-code-function CDA>
+           3   0%                - forward-thing
+           1   0%                   format
+           1   0%                   forward-word
+           1   0%                   intern-soft
+           2   0%               - #<byte-code-function 833>
+           2   0%                - forward-thing
+           2   0%                   forward-word
+           1   0%                 make-closure
+           1   0%              seed7-move-to-line
+         201   0%           - seed7--current-line-nth-word
+         199   0%            - thing-at-point
+         199   0%             - bounds-of-thing-at-point
+         193   0%              - #<byte-code-function CB9>
+         193   0%               - forward-thing
+         192   0%                - forward-word
+         188   0%                 - internal--syntax-propertize
+         187   0%                  - syntax-propertize
+         176   0%                     seed7-mode-syntax-propertize
+           3   0%                   - #<byte-code-function D51>
+           2   0%                    - syntax-propertize-wholelines
+           1   0%                       syntax--lbp
+           1   0%                  format
+           3   0%              - #<byte-code-function 693>
+           3   0%               - forward-thing
+           1   0%                  format
+           1   0%                  intern-soft
+           1   0%                  forward-word
+           2   0%                re-search-forward
+          99   0%           - seed7-line-after-func-return-logic-operator-column
+          92   0%            - seed7-move-to-line
+          91   0%             - seed7-to-previous-non-empty-line
+          88   0%              - seed7-inside-comment-p
+          88   0%               - syntax-ppss
+          88   0%                  parse-partial-sexp
+          95   0%           - seed7-line-inside-argument-list-section
+          82   0%            - seed7-re-search-backward
+          44   0%               re-search-backward
+          38   0%             - run-with-timer
+          38   0%              - run-at-time
+          19   0%               - timer-activate
+          19   0%                - timer--activate
+          19   0%                   timer--time-less-p
+           9   0%               - timer-set-time
+           9   0%                  timer--time-setter
+           9   0%                 timer-relative-time
+           1   0%                 timer-create
+          11   0%            - seed7-line-is-procfunc-beg-of-decl
+          11   0%             - seed7-line-starts-with
+           2   0%                seed7-move-to-line
+           1   0%            - seed7-forward-char-pos
+           1   0%             - seed7-re-search-forward
+           1   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+          74   0%           - seed7-line-inside-until-logic-expression
+          73   0%            - seed7-re-search-backward
+          39   0%               re-search-backward
+          34   0%             - run-with-timer
+          34   0%              - run-at-time
+          22   0%               - timer-activate
+          22   0%                - timer--activate
+          22   0%                   timer--time-less-p
+           9   0%               - timer-set-time
+           9   0%                  timer--time-setter
+           3   0%                 timer-relative-time
+           1   0%              seed7-move-to-line
+          69   0%           - seed7-line-inside-func-return-statement
+          68   0%            - seed7-re-search-backward
+          37   0%             - run-with-timer
+          37   0%              - run-at-time
+          18   0%               - timer-activate
+          18   0%                - timer--activate
+          17   0%                   timer--time-less-p
+          12   0%                 timer-relative-time
+           7   0%               - timer-set-time
+           7   0%                  timer--time-setter
+          29   0%               re-search-backward
+           1   0%             - #<byte-code-function 161>
+           1   0%                cancel-timer
+          45   0%           - seed7-current-line-start-inside-comment-p
+          45   0%            - seed7-inside-comment-p
+          45   0%             - syntax-ppss
+          45   0%                parse-partial-sexp
+          19   0%           - seed7-comment-column
+          16   0%            - seed7-calc-indent
+           3   0%             - seed7-line-starts-with-open-paren-after-logic-operator
+           3   0%              - seed7-move-to-line
+           3   0%               - seed7-to-previous-non-empty-line
+           2   0%                - seed7-inside-comment-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           3   0%             - seed7-line-inside-parens-pair-column
+           3   0%              - seed7-line-inside-parens-pair
+           3   0%               - seed7-re-search-backward
+           3   0%                - seed7-inside-comment-p
+           3   0%                 - syntax-ppss
+           3   0%                    parse-partial-sexp
+           2   0%             - seed7-line-at-endof-array-definition-block
+           2   0%              - seed7-move-to-line
+           2   0%               - seed7-to-previous-non-empty-line
+           2   0%                - seed7-inside-comment-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           2   0%             - seed7-line-at-endof-set-definition-block
+           2   0%              - seed7-move-to-line
+           2   0%               - seed7-to-previous-non-empty-line
+           2   0%                - seed7-inside-comment-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           2   0%             - seed7-line-after-func-return-logic-operator-column
+           2   0%              - seed7-move-to-line
+           2   0%               - seed7-to-previous-non-empty-line
+           2   0%                - seed7-inside-comment-p
+           2   0%                 - syntax-ppss
+           2   0%                    parse-partial-sexp
+           2   0%             - seed7-line-inside-array-definition-block
+           2   0%              - seed7-re-search-backward
+           2   0%               - seed7-inside-comment-p
+           2   0%                - syntax-ppss
+           2   0%                   parse-partial-sexp
+           1   0%             - seed7-line-inside-a-block-cached
+           1   0%              - seed7-line-inside-a-block
+           1   0%               - seed7--safe-enclosing-block-bounds
+           1   0%                - seed7--block-end-pos-for
+           1   0%                 - seed7-to-block-forward
+           1   0%                  - seed7-re-search-forward
+           1   0%                   - seed7-inside-comment-p
+           1   0%                    - syntax-ppss
+           1   0%                       parse-partial-sexp
+           1   0%             - seed7-line-is-defun-end
+           1   0%              - seed7--safe-current-line-defun-start-indent
+           1   0%               - seed7-to-block-backward
+           1   0%                - seed7-re-search-backward
+           1   0%                 - seed7-inside-comment-p
+           1   0%                  - syntax-ppss
+           1   0%                     parse-partial-sexp
+           2   0%            - seed7-line-code-ends-with
+           2   0%             - seed7-move-to-line
+           2   0%              - seed7-to-previous-non-empty-line
+           2   0%               - seed7-inside-comment-p
+           2   0%                - syntax-ppss
+           2   0%                   parse-partial-sexp
+           1   0%              seed7-line-starts-with
+           9   0%           - seed7-line-at-endof-array-definition-block
+           4   0%            - backward-sexp
+           4   0%             - forward-sexp
+           4   0%              - seed7--forward-sexp-function
+           3   0%               - seed7--at-array-definition-end-line-p
+           3   0%                - seed7-line-code-ends-with
+           3   0%                 - seed7-re-search-backward
+           2   0%                  - seed7-inside-string-p
+           2   0%                   - syntax-ppss
+           2   0%                      parse-partial-sexp
+           1   0%                  - run-with-timer
+           1   0%                   - run-at-time
+           1   0%                      timer-relative-time
+           1   0%               - seed7--line-comment-hash
+           1   0%                  beginning-of-line
+           3   0%            - seed7-line-code-ends-with
+           3   0%             - seed7-re-search-backward
+           2   0%              - run-with-timer
+           2   0%               - run-at-time
+           2   0%                - timer-set-time
+           2   0%                   timer--time-setter
+           1   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           2   0%            - seed7-re-search-backward
+           1   0%             - run-with-timer
+           1   0%              - run-at-time
+           1   0%               - timer-activate
+           1   0%                - timer--activate
+           1   0%                   timer--time-less-p
+           1   0%             - seed7-inside-string-p
+           1   0%              - syntax-ppss
+           1   0%                 parse-partial-sexp
+           7   0%           - seed7-line-at-endof-set-definition-block
+           5   0%            - seed7-move-to-line
+           5   0%             - seed7-to-previous-non-empty-line
+           5   0%              - seed7-inside-comment-p
+           5   0%               - syntax-ppss
+           5   0%                  parse-partial-sexp
+           2   0%            - seed7-line-code-ends-with
+           2   0%             - seed7-re-search-backward
+           1   0%              - seed7-inside-comment-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           1   0%              - seed7-inside-string-p
+           1   0%               - syntax-ppss
+           1   0%                  parse-partial-sexp
+           7   0%           - seed7-line-indent-step
+           7   0%            - seed7-move-to-line
+           7   0%             - seed7-to-previous-non-empty-line
+           7   0%              - seed7-inside-comment-p
+           7   0%               - syntax-ppss
+           4   0%                  parse-partial-sexp
+           3   0%                - syntax-propertize
+           3   0%                   seed7-mode-syntax-propertize
+           2   0%           - seed7-line-isa-string
+           2   0%              seed7-line-starts-with
+           2   0%           - seed7-line-starts-with
+           1   0%              seed7-move-to-line
+           1   0%           - seed7-line-inside-nested-parens-pairs-column
+           1   0%            - seed7-line-inside-nested-parens-pairs
+           1   0%             - seed7-line-inside-parens-pair
+           1   0%              - seed7-re-search-backward
+           1   0%               - run-with-timer
+           1   0%                - run-at-time
+           1   0%                 - timer-activate
+           1   0%                  - timer--activate
+           1   0%                     timer--time-less-p
+           1   0%             seed7-blank-line-p
+           1   0%           - seed7-line-starts-with-open-paren-after-logic-operator
+           1   0%            - seed7-line-starts-with
+           1   0%               seed7-move-to-line
+           7   0%          - jit-lock-after-change
+           4   0%             font-lock-extend-jit-lock-region-after-change
+           3   0%          - delete-horizontal-space
+           2   0%             delete-space--internal
+           1   0%            flyspell-after-change-function
+           1   0%            syntax-ppss-flush-cache
+           1   0%            undo-auto--undoable-change
+          38   0%       - smex
+          25   0%        - smex-read-and-run
+          23   0%         - smex-completing-read
+          23   0%          - ido-completing-read
+          23   0%           - apply
+          23   0%            - ido-completing-read@ido-cr+-replace
+          23   0%             - #<native-comp-function ido-completing-read>
+          23   0%              - ido-read-internal
+          23   0%               - apply
+          23   0%                - ad-Advice-ido-read-internal
+          23   0%                 - #<native-comp-function ido-read-internal>
+          22   0%                  - read-from-minibuffer
+          10   0%                     redisplay_internal (C function)
+           6   0%                   - ido-exhibit
+           6   0%                    - apply
+           6   0%                     - #<native-comp-function ido-exhibit>
+           4   0%                      - ido-set-matches
+           4   0%                       - apply
+           4   0%                        - ido-grid--set-matches
+           3   0%                         - ido-grid--same-matches
+           1   0%                            ido-grid--matches-differ-from
+           1   0%                         - apply
+           1   0%                            #<native-comp-function ido-set-matches>
+           2   0%                      - ido-completions
+           2   0%                       - apply
+           2   0%                        - ido-grid--completions
+           2   0%                         - ido-grid--grid-ensure-visible
+           2   0%                          - ido-grid--grid
+           2   0%                             move-to-column
+           1   0%                    ido-setup-completion-map
+           2   0%           execute-extended-command
+          13   0%        - smex-detect-new-commands
+          13   0%         - #<byte-code-function E15>
+          11   0%            commandp
+       29891   6%   Automatic GC
+          11   0% + redisplay_internal (C function)
+           5   0% + timer-event-handler
+           0   0%   ...

--- a/reports/18.1/chkarr.sd7-profiler-mem.txt
+++ b/reports/18.1/chkarr.sd7-profiler-mem.txt
@@ -1,0 +1,1546 @@
+  7,230,294,517  99% - command-execute
+  7,230,294,517  99%  - call-interactively
+  7,230,294,517  99%   - apply
+  7,230,294,517  99%    - call-interactively@ido-cr+-record-current-command
+  7,230,294,517  99%     - #<primitive-function call-interactively>
+  7,230,294,517  99%      - funcall-interactively
+  7,224,688,087  99%       - seed7-complete-statement-or-indent
+  7,224,688,087  99%        - seed7-indent-region
+  7,224,688,087  99%         - seed7--indent-one-line
+  7,221,872,847  99%          - seed7-calc-indent
+  4,096,456,012  56%           - seed7-line-is-defun-end
+  4,002,234,506  55%            - seed7-end-of-defun
+  3,961,004,891  54%             - seed7-top-block-name
+  3,954,744,725  54%              - seed7--to-top
+  3,944,649,629  54%               - seed7-re-search-backward
+  3,074,990,320  42%                - run-with-timer
+  3,074,990,320  42%                 - run-at-time
+  1,512,128,530  20%                  - timer-activate
+  1,512,128,530  20%                   - timer--activate
+  1,511,669,442  20%                    - timer--time-less-p
+     12,363,703   0%                       timer--time
+    829,745,109  11%                    timer-relative-time
+    577,070,217   7%                  - timer-set-time
+    577,069,392   7%                     timer--time-setter
+    156,046,464   2%                    timer-create
+    570,004,895   7%                - seed7-inside-string-p
+     82,274,087   1%                 - syntax-ppss
+     74,898,656   1%                    make-closure
+      7,371,520   0%                  - parse-partial-sexp
+      1,272,208   0%                   - internal--syntax-propertize
+        870,240   0%                    - syntax-propertize
+        406,112   0%                       seed7-mode-syntax-propertize
+          1,098   0%                    syntax-table
+              4   0%                    #<byte-code-function 736>
+    190,096,334   2%                - seed7-inside-comment-p
+     85,290,430   1%                 - syntax-ppss
+     72,818,368   1%                    make-closure
+      7,345,408   0%                    parse-partial-sexp
+      4,599,352   0%                  - syntax-propertize
+      4,226,392   0%                   - seed7-mode-syntax-propertize
+          1,402   0%                      #<byte-code-function 6DB>
+          2,000   0%                    syntax-table
+            155   0%                    #<byte-code-function 939D>
+    108,670,217   1%                  make-closure
+            853   0%                  re-search-backward
+      8,537,480   0%               - run-with-timer
+      8,537,480   0%                - run-at-time
+      3,292,456   0%                 - timer-activate
+      3,292,456   0%                  - timer--activate
+      3,292,456   0%                   - timer--time-less-p
+         32,792   0%                      timer--time
+      2,780,368   0%                   timer-relative-time
+      1,876,208   0%                 - timer-set-time
+      1,876,208   0%                    timer--time-setter
+        588,448   0%                   timer-create
+        377,104   0%                 make-closure
+      5,941,078   0%              - seed7--block-name
+      5,113,590   0%               - seed7-re-search-forward
+      3,335,920   0%                - seed7-inside-string-p
+        319,088   0%                 - syntax-ppss
+        319,088   0%                    make-closure
+      1,777,670   0%                - seed7-inside-comment-p
+      1,686,502   0%                 - syntax-ppss
+        982,382   0%                  - syntax-propertize
+        621,854   0%                     seed7-mode-syntax-propertize
+        671,328   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+        270,016   0%                 match-string
+     21,134,356   0%             - seed7-re-search-forward
+     13,858,530   0%              - seed7-inside-comment-p
+     13,435,842   0%               - syntax-ppss
+     12,968,650   0%                - syntax-propertize
+     12,376,418   0%                   seed7-mode-syntax-propertize
+        368,816   0%                  make-closure
+         98,376   0%                  parse-partial-sexp
+      2,406,522   0%              - seed7-inside-string-p
+        526,226   0%               - syntax-ppss
+        393,680   0%                  make-closure
+        131,168   0%                  parse-partial-sexp
+     12,556,440   0%             - seed7-re-search-backward
+      8,636,936   0%              - run-with-timer
+      8,636,936   0%               - run-at-time
+      3,342,544   0%                - timer-activate
+      3,342,544   0%                 - timer--activate
+      3,342,544   0%                    timer--time-less-p
+      2,780,368   0%                  timer-relative-time
+      1,971,160   0%                - timer-set-time
+      1,971,160   0%                   timer--time-setter
+        542,864   0%                  timer-create
+      2,950,528   0%              - seed7-inside-string-p
+        401,968   0%               - syntax-ppss
+        401,968   0%                  make-closure
+        865,736   0%              - seed7-inside-comment-p
+        376,744   0%               - syntax-ppss
+        343,952   0%                  make-closure
+         32,792   0%                  parse-partial-sexp
+         70,448   0%                make-closure
+        624,784   0%               match-string
+        229,152   0%               match-string-no-properties
+         16,368   0%               seed7--no-defun-found-msg-for
+          8,184   0%             - user-error
+          8,184   0%                format-message
+     60,648,006   0%            - seed7-beg-of-defun
+     16,962,487   0%             - seed7-top-block-name
+      8,528,333   0%              - seed7--block-name
+      8,457,885   0%               - seed7-re-search-forward
+         99,456   0%                - seed7-inside-string-p
+          8,288   0%                 - syntax-ppss
+          8,288   0%                    make-closure
+         12,432   0%                - seed7-inside-comment-p
+          8,288   0%                 - syntax-ppss
+          8,288   0%                    make-closure
+      8,371,994   0%              - seed7--to-top
+      6,044,994   0%               - seed7-re-search-backward
+      2,747,146   0%                  re-search-backward
+      2,531,568   0%                - run-with-timer
+      2,531,568   0%                 - run-at-time
+      1,277,072   0%                  - timer-activate
+      1,277,072   0%                   - timer--activate
+      1,277,072   0%                      timer--time-less-p
+        702,848   0%                    timer-relative-time
+        464,624   0%                  - timer-set-time
+        464,624   0%                     timer--time-setter
+         87,024   0%                    timer-create
+        513,856   0%                - seed7-inside-string-p
+        116,032   0%                 - syntax-ppss
+        116,032   0%                    make-closure
+        173,688   0%                - seed7-inside-comment-p
+        111,528   0%                 - syntax-ppss
+         78,736   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+         78,736   0%                  make-closure
+      2,190,608   0%               - run-with-timer
+      2,190,608   0%                - run-at-time
+        919,536   0%                 - timer-activate
+        919,536   0%                  - timer--activate
+        919,536   0%                   - timer--time-less-p
+         65,584   0%                      timer--time
+        702,848   0%                   timer-relative-time
+        472,912   0%                 - timer-set-time
+        472,912   0%                    timer--time-setter
+         95,312   0%                   timer-create
+        103,600   0%                 make-closure
+     13,470,863   0%             - seed7-re-search-backward-closest
+     13,242,943   0%              - seed7-re-search-backward
+      8,651,197   0%                 re-search-backward
+      4,391,576   0%               - run-with-timer
+      4,391,576   0%                - run-at-time
+      1,730,320   0%                 - timer-activate
+      1,730,320   0%                  - timer--activate
+      1,730,320   0%                     timer--time-less-p
+      1,448,216   0%                   timer-relative-time
+        985,120   0%                 - timer-set-time
+        985,120   0%                    timer--time-setter
+        227,920   0%                   timer-create
+        198,912   0%                 make-closure
+          1,258   0%                 #<byte-code-function 7A8>
+        111,888   0%              - seq-filter
+        111,888   0%                 make-closure
+     11,599,016   0%             - seed7-re-search-backward
+      5,380,246   0%                re-search-backward
+      4,606,951   0%              - run-with-timer
+      4,606,951   0%               - run-at-time
+      1,945,943   0%                - timer-activate
+      1,945,943   0%                 - timer--activate
+      1,913,151   0%                  - timer--time-less-p
+        100,346   0%                     timer--time
+      1,437,904   0%                  timer-relative-time
+        962,032   0%                - timer-set-time
+        962,032   0%                   timer--time-setter
+        261,072   0%                  timer-create
+      1,101,944   0%              - seed7-inside-string-p
+        306,296   0%               - syntax-ppss
+        273,504   0%                  make-closure
+         32,792   0%                  parse-partial-sexp
+        339,971   0%              - seed7-inside-comment-p
+        190,624   0%               - syntax-ppss
+        190,624   0%                  make-closure
+        169,904   0%                make-closure
+        152,858   0%               match-string
+        147,312   0%               match-string-no-properties
+          8,184   0%             - user-error
+          8,184   0%                format-message
+     18,420,877   0%            - seed7-line-starts-with-any
+     18,420,877   0%               seed7-line-starts-with
+      7,223,256   0%            - seed7--current-line-nth-word
+      6,767,416   0%             - thing-at-point
+      6,538,336   0%              - bounds-of-thing-at-point
+      2,573,424   0%                 make-closure
+      1,216,632   0%                 re-search-forward
+        845,376   0%               - seq-some
+        845,376   0%                  make-closure
+        744,744   0%               - #<byte-code-function 9A3>
+        744,744   0%                - forward-thing
+        744,744   0%                   format
+        420,528   0%               - #<byte-code-function 613>
+        420,528   0%                - forward-thing
+        420,528   0%                   format
+      7,079,784   0%            - seed7-move-to-line
+      7,079,784   0%             - seed7-to-previous-non-empty-line
+        563,224   0%              - seed7-inside-comment-p
+        401,608   0%               - syntax-ppss
+        368,816   0%                  make-closure
+         32,792   0%                  parse-partial-sexp
+        369,739   0%            - seed7--safe-current-line-defun-start-indent
+        361,451   0%             - seed7-to-block-backward
+        270,387   0%              - seed7-re-search-backward
+        157,096   0%               - run-with-timer
+        157,096   0%                - run-at-time
+        101,864   0%                 - timer-activate
+        101,864   0%                  - timer--activate
+         69,072   0%                   - timer--time-less-p
+         32,792   0%                      timer--time
+         31,312   0%                   timer-relative-time
+         19,776   0%                 - timer-set-time
+         19,776   0%                    timer--time-setter
+          4,144   0%                   timer-create
+         80,139   0%                 re-search-backward
+         20,720   0%               - seed7-inside-string-p
+          8,288   0%                - syntax-ppss
+          8,288   0%                   make-closure
+          8,288   0%                 make-closure
+          4,144   0%                 seed7-inside-comment-p
+         66,200   0%              - seed7--current-line-nth-word
+         53,768   0%               - thing-at-point
+         53,768   0%                - bounds-of-thing-at-point
+         37,296   0%                   make-closure
+          8,184   0%                 - #<byte-code-function 709>
+          8,184   0%                  - forward-thing
+          8,184   0%                     format
+          4,144   0%                 - seq-some
+          4,144   0%                    make-closure
+         20,720   0%              - seed7-inside-line-indent-before-comment-p
+         12,432   0%               - seed7-inside-comment-p
+          4,144   0%                - syntax-ppss
+          4,144   0%                   make-closure
+          3,284   0%              line-end-position
+  1,736,806,274  23%           - seed7-line-inside-parens-pair-column
+  1,736,806,274  23%            - seed7-line-inside-parens-pair
+  1,731,247,907  23%             - seed7-re-search-backward
+  1,314,048,256  18%              - run-with-timer
+  1,314,048,256  18%               - run-at-time
+    519,911,572   7%                - timer-activate
+    519,911,572   7%                 - timer--activate
+    519,911,572   7%                  - timer--time-less-p
+        361,490   0%                     timer--time
+    430,109,774   5%                  timer-relative-time
+    290,791,993   4%                - timer-set-time
+    290,781,912   4%                   timer--time-setter
+     73,220,336   1%                  timer-create
+         14,581   0%                  timer-set-function
+    229,178,821   3%              - seed7-inside-string-p
+     75,930,277   1%               - syntax-ppss
+     75,652,864   1%                  make-closure
+        163,960   0%                  parse-partial-sexp
+         51,812   0%                  #<byte-code-function 800>
+          9,234   0%                  syntax-table
+    123,687,602   1%              - seed7-inside-comment-p
+     80,283,346   1%               - syntax-ppss
+     80,012,352   1%                  make-closure
+        163,960   0%                  parse-partial-sexp
+         80,898   0%                  #<byte-code-function C10>
+         13,862   0%                  syntax-table
+     58,106,384   0%                make-closure
+      6,226,844   0%                re-search-backward
+      4,531,831   0%             - forward-sexp
+      4,521,920   0%                seed7--forward-sexp-function
+        667,088   0%             - seed7-line-inside-syntax-parens-pair
+        343,952   0%              - syntax-ppss
+        343,952   0%                 make-closure
+          8,192   0%              - forward-sexp
+          8,192   0%                 seed7--forward-sexp-function
+  1,062,298,316  14%           - seed7-line-inside-a-block-cached
+  1,061,875,628  14%            - seed7-line-inside-a-block
+    880,151,177  12%             - seed7--safe-enclosing-block-bounds
+    655,905,679   9%              - seed7--block-end-pos-for
+    655,839,232   9%               - seed7-to-block-forward
+    459,875,988   6%                - seed7-end-of-defun
+    456,615,211   6%                 - seed7-top-block-name
+    455,756,522   6%                  - seed7--to-top
+    453,039,626   6%                   - seed7-re-search-backward
+    331,743,122   4%                    - run-with-timer
+    331,743,122   4%                     - run-at-time
+    153,974,338   2%                      - timer-activate
+    153,974,338   2%                       - timer--activate
+    153,088,954   2%                        - timer--time-less-p
+     13,217,641   0%                           timer--time
+     93,344,198   1%                        timer-relative-time
+     62,431,359   0%                      - timer-set-time
+     62,430,024   0%                         timer--time-setter
+     21,992,208   0%                        timer-create
+          1,019   0%                        timer-set-function
+     80,613,652   1%                    - seed7-inside-string-p
+     19,466,196   0%                     - syntax-ppss
+     11,499,600   0%                        make-closure
+      7,964,672   0%                      - parse-partial-sexp
+         61,800   0%                       - internal--syntax-propertize
+         49,368   0%                        - syntax-propertize
+         32,792   0%                           syntax-ppss-flush-cache
+          8,288   0%                           seed7-mode-syntax-propertize
+            925   0%                        #<byte-code-function 5F1>
+            155   0%                        syntax-table
+     33,370,664   0%                    - seed7-inside-comment-p
+     21,609,992   0%                     - syntax-ppss
+     11,300,688   0%                        make-closure
+      8,591,504   0%                        parse-partial-sexp
+      1,027,386   0%                      - syntax-propertize
+      1,023,242   0%                         seed7-mode-syntax-propertize
+          1,453   0%                        #<byte-code-function 3D2>
+            329   0%                        syntax-table
+      6,411,960   0%                      make-closure
+         80,007   0%                      re-search-backward
+      1,023,424   0%                   - run-with-timer
+      1,023,424   0%                    - run-at-time
+        469,728   0%                     - timer-activate
+        469,728   0%                      - timer--activate
+        469,728   0%                       - timer--time-less-p
+         98,376   0%                          timer--time
+        301,264   0%                       timer-relative-time
+        202,704   0%                     - timer-set-time
+        202,704   0%                        timer--time-setter
+         49,728   0%                       timer-create
+         53,872   0%                     make-closure
+        850,401   0%                  - seed7--block-name
+        735,201   0%                   - seed7-re-search-forward
+        414,400   0%                    - seed7-inside-string-p
+         16,576   0%                     - syntax-ppss
+         16,576   0%                        make-closure
+         87,024   0%                    - seed7-inside-comment-p
+         45,584   0%                     - syntax-ppss
+         41,440   0%                        make-closure
+          4,144   0%                        syntax-propertize
+         24,552   0%                     match-string
+      1,652,232   0%                 - seed7-re-search-backward
+      1,076,936   0%                  - run-with-timer
+      1,076,936   0%                   - run-at-time
+        436,936   0%                    - timer-activate
+        436,936   0%                     - timer--activate
+        436,936   0%                      - timer--time-less-p
+         65,584   0%                         timer--time
+        334,056   0%                      timer-relative-time
+        239,640   0%                    - timer-set-time
+        239,640   0%                       timer--time-setter
+         66,304   0%                      timer-create
+        455,120   0%                  - seed7-inside-string-p
+         65,944   0%                   - syntax-ppss
+         33,152   0%                      make-closure
+         32,792   0%                      parse-partial-sexp
+        107,744   0%                  - seed7-inside-comment-p
+         41,440   0%                   - syntax-ppss
+         41,440   0%                      make-closure
+         12,432   0%                    make-closure
+      1,141,291   0%                 - seed7-re-search-forward
+        533,136   0%                  - seed7-inside-string-p
+        176,752   0%                   - syntax-ppss
+        131,168   0%                      parse-partial-sexp
+         45,584   0%                      make-closure
+        218,481   0%                  - seed7-inside-comment-p
+        156,321   0%                   - syntax-ppss
+         65,584   0%                      parse-partial-sexp
+         62,160   0%                      make-closure
+         28,577   0%                    - syntax-propertize
+         28,577   0%                       seed7-mode-syntax-propertize
+        114,688   0%                   match-string
+         57,288   0%                   match-string-no-properties
+    109,511,027   1%                - seed7--current-line-nth-word
+     99,714,611   1%                 - thing-at-point
+     95,208,427   1%                  - bounds-of-thing-at-point
+     42,862,421   0%                     make-closure
+     15,095,195   0%                   - seq-some
+     10,492,608   0%                      make-closure
+      4,597,997   0%                      seq-do
+     12,887,216   0%                   - #<byte-code-function 1B8>
+     12,883,869   0%                    - forward-thing
+     12,880,920   0%                       format
+          2,949   0%                       intern-soft
+      6,663,579   0%                   - #<byte-code-function B54>
+      6,663,579   0%                    - forward-thing
+      6,659,432   0%                       format
+          4,147   0%                       intern-soft
+      1,170,680   0%                     re-search-forward
+     46,092,149   0%                - seed7-re-search-forward
+     18,616,351   0%                 - seed7-inside-comment-p
+     15,690,687   0%                  - syntax-ppss
+     11,056,838   0%                   - syntax-propertize
+     10,795,766   0%                      seed7-mode-syntax-propertize
+      4,496,240   0%                     make-closure
+        131,168   0%                     parse-partial-sexp
+          3,952   0%                     #<byte-code-function E20>
+          1,682   0%                     syntax-table
+     17,856,064   0%                 - seed7-inside-string-p
+      2,618,576   0%                  - syntax-ppss
+      2,544,416   0%                     make-closure
+         65,584   0%                     parse-partial-sexp
+     21,454,342   0%                - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+      7,310,016   0%                 - seed7-inside-line-indent-before-comment-p
+         66,304   0%                  - seed7-inside-comment-p
+         53,872   0%                   - syntax-ppss
+         53,872   0%                      make-closure
+      3,637,342   0%                 - seed7-inside-comment-p
+      2,355,965   0%                  - syntax-ppss
+      2,283,344   0%                     make-closure
+         65,584   0%                     parse-partial-sexp
+          4,665   0%                     syntax-table
+      6,298,062   0%                - seed7-inside-comment-p
+      2,477,294   0%                 - syntax-ppss
+      2,436,672   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+          7,830   0%                    #<byte-code-function 025>
+      5,930,064   0%                - seed7-inside-line-indent-before-comment-p
+         70,448   0%                 - seed7-inside-comment-p
+         53,872   0%                  - syntax-ppss
+         53,872   0%                     make-closure
+      3,979,856   0%                  seed7--end-regexp-for
+         64,880   0%               - seed7-to-next-line-starts-with
+         64,880   0%                - seed7-re-search-forward
+         20,720   0%                 - seed7-inside-string-p
+          4,144   0%                  - syntax-ppss
+          4,144   0%                     make-closure
+    220,888,858   3%              - seed7-to-block-backward
+    116,671,511   1%               - seed7-re-search-backward
+     80,683,996   1%                - run-with-timer
+     80,683,996   1%                 - run-at-time
+     33,507,232   0%                  - timer-activate
+     33,507,232   0%                   - timer--activate
+     33,507,232   0%                    - timer--time-less-p
+        197,008   0%                       timer--time
+     26,278,627   0%                    timer-relative-time
+     17,197,384   0%                  - timer-set-time
+     17,197,384   0%                     timer--time-setter
+      3,696,448   0%                    timer-create
+          4,305   0%                    timer-set-function
+     20,386,525   0%                - seed7-inside-string-p
+      5,149,037   0%                 - syntax-ppss
+      5,014,240   0%                    make-closure
+        131,168   0%                    parse-partial-sexp
+      5,824,120   0%                  re-search-backward
+      5,125,632   0%                - seed7-inside-comment-p
+      4,412,864   0%                 - syntax-ppss
+      4,305,616   0%                    make-closure
+         98,376   0%                    parse-partial-sexp
+          4,651   0%                    #<byte-code-function DB6>
+      4,643,040   0%                  make-closure
+     70,432,741   0%               - seed7--current-line-nth-word
+     67,101,527   0%                - thing-at-point
+     63,603,712   0%                 - bounds-of-thing-at-point
+     32,036,723   0%                    make-closure
+     10,592,904   0%                  - #<byte-code-function 56E>
+     10,581,876   0%                   - forward-thing
+     10,580,816   0%                      format
+          1,060   0%                      intern-soft
+      8,470,591   0%                  - seq-some
+      8,462,048   0%                     make-closure
+          3,384   0%                     seq-do
+      3,154,630   0%                  - #<byte-code-function 235>
+      3,154,384   0%                   - forward-thing
+      3,154,384   0%                      format
+     18,681,407   0%               - seed7-inside-line-indent-before-comment-p
+      6,124,812   0%                - seed7-inside-comment-p
+      3,787,596   0%                 - syntax-ppss
+      3,750,320   0%                    make-closure
+         32,792   0%                    parse-partial-sexp
+          4,398   0%                    syntax-table
+            275   0%                  seed7-to-indent
+      7,807,336   0%               - seed7-inside-comment-p
+      5,262,920   0%                - syntax-ppss
+      5,217,296   0%                   make-closure
+         32,792   0%                   parse-partial-sexp
+         12,832   0%                   #<byte-code-function F09>
+      4,933,783   0%                 seed7--start-regexp-for
+    117,643,271   1%             - seed7-re-search-backward
+     80,137,856   1%              - run-with-timer
+     80,137,856   1%               - run-at-time
+     31,305,608   0%                - timer-activate
+     31,305,608   0%                 - timer--activate
+     31,305,608   0%                  - timer--time-less-p
+        131,168   0%                     timer--time
+     26,211,454   0%                  timer-relative-time
+     16,706,275   0%                - timer-set-time
+     16,701,696   0%                   timer--time-setter
+      5,913,488   0%                  timer-create
+          1,031   0%                  timer-set-function
+     18,717,528   0%              - seed7-inside-string-p
+      3,538,416   0%               - syntax-ppss
+      3,468,528   0%                  make-closure
+         65,584   0%                  parse-partial-sexp
+      8,291,067   0%                re-search-backward
+      6,497,438   0%              - seed7-inside-comment-p
+      4,935,150   0%               - syntax-ppss
+      4,894,064   0%                  make-closure
+         32,792   0%                  parse-partial-sexp
+          4,587   0%                  #<byte-code-function DA8>
+          3,707   0%                  syntax-table
+      3,999,382   0%                make-closure
+     33,371,981   0%             - seed7-calc-indent
+     20,089,436   0%              - seed7-line-inside-parens-pair-column
+     20,089,436   0%               - seed7-line-inside-parens-pair
+     20,077,148   0%                - seed7-re-search-backward
+     15,682,434   0%                 - run-with-timer
+     15,682,434   0%                  - run-at-time
+      6,166,176   0%                   - timer-activate
+      6,166,176   0%                    - timer--activate
+      6,166,176   0%                     - timer--time-less-p
+         98,376   0%                        timer--time
+      5,210,674   0%                     timer-relative-time
+      3,493,360   0%                   - timer-set-time
+      3,493,360   0%                      timer--time-setter
+        812,224   0%                     timer-create
+      2,400,826   0%                 - seed7-inside-string-p
+        830,250   0%                  - syntax-ppss
+        795,648   0%                     make-closure
+         32,792   0%                     parse-partial-sexp
+          1,810   0%                     syntax-table
+      1,300,496   0%                 - seed7-inside-comment-p
+        931,680   0%                  - syntax-ppss
+        866,096   0%                     make-closure
+         65,584   0%                     parse-partial-sexp
+        675,472   0%                   make-closure
+         17,920   0%                   re-search-backward
+         12,288   0%                - forward-sexp
+         12,288   0%                   seed7--forward-sexp-function
+     12,674,219   0%              - seed7-line-is-defun-end
+     11,942,942   0%               - seed7-end-of-defun
+     11,642,320   0%                - seed7-top-block-name
+     11,625,848   0%                 - seed7--to-top
+     11,607,160   0%                  - seed7-re-search-backward
+      8,421,144   0%                   - run-with-timer
+      8,421,144   0%                    - run-at-time
+      4,192,024   0%                     - timer-activate
+      4,192,024   0%                      - timer--activate
+      4,192,024   0%                       - timer--time-less-p
+         32,792   0%                          timer--time
+      2,145,024   0%                       timer-relative-time
+      1,545,376   0%                     - timer-set-time
+      1,545,376   0%                        timer--time-setter
+        538,720   0%                       timer-create
+      2,092,360   0%                   - seed7-inside-string-p
+        331,160   0%                    - syntax-ppss
+        298,368   0%                       make-closure
+         32,792   0%                       parse-partial-sexp
+        695,832   0%                   - seed7-inside-comment-p
+        298,008   0%                    - syntax-ppss
+        265,216   0%                       make-closure
+         32,792   0%                       parse-partial-sexp
+        397,824   0%                     make-closure
+         18,688   0%                  - run-with-timer
+         18,688   0%                   - run-at-time
+          9,760   0%                    - timer-activate
+          9,760   0%                     - timer--activate
+          9,760   0%                        timer--time-less-p
+          5,472   0%                      timer-relative-time
+          3,456   0%                    - timer-set-time
+          3,456   0%                       timer--time-setter
+         16,472   0%                 - seed7--block-name
+          8,288   0%                  - seed7-re-search-forward
+          4,144   0%                   - seed7-inside-comment-p
+          4,144   0%                    - syntax-ppss
+          4,144   0%                       make-closure
+          4,144   0%                     seed7-inside-string-p
+        259,334   0%                - seed7-re-search-forward
+        178,192   0%                 - seed7-inside-string-p
+         29,008   0%                  - syntax-ppss
+         29,008   0%                     make-closure
+         68,854   0%                 - seed7-inside-comment-p
+         39,846   0%                  - syntax-ppss
+         24,864   0%                     make-closure
+         14,982   0%                   - syntax-propertize
+         14,982   0%                      seed7-mode-syntax-propertize
+         18,688   0%                - seed7-re-search-backward
+         18,688   0%                 - run-with-timer
+         18,688   0%                  - run-at-time
+          9,760   0%                   - timer-activate
+          9,760   0%                    - timer--activate
+          9,760   0%                       timer--time-less-p
+          5,472   0%                     timer-relative-time
+          3,456   0%                   - timer-set-time
+          3,456   0%                      timer--time-setter
+          8,184   0%                  match-string-no-properties
+        644,734   0%               - seed7-beg-of-defun
+        464,398   0%                - seed7-re-search-backward
+        291,424   0%                 - run-with-timer
+        291,424   0%                  - run-at-time
+        116,592   0%                   - timer-activate
+        116,592   0%                    - timer--activate
+        116,592   0%                       timer--time-less-p
+         89,376   0%                     timer-relative-time
+         60,592   0%                   - timer-set-time
+         60,592   0%                      timer--time-setter
+         24,864   0%                     timer-create
+         99,456   0%                 - seed7-inside-string-p
+         33,152   0%                  - syntax-ppss
+         33,152   0%                     make-closure
+         37,296   0%                 - seed7-inside-comment-p
+         29,008   0%                  - syntax-ppss
+         29,008   0%                     make-closure
+         24,864   0%                   make-closure
+         11,358   0%                   re-search-backward
+         47,000   0%                - seed7-top-block-name
+         25,664   0%                 - seed7--to-top
+         20,816   0%                  - seed7-re-search-backward
+          8,288   0%                     seed7-inside-string-p
+          6,720   0%                     re-search-backward
+          5,808   0%                   - run-with-timer
+          5,808   0%                    - run-at-time
+          2,832   0%                     - timer-activate
+          2,832   0%                      - timer--activate
+          2,832   0%                         timer--time-less-p
+          1,824   0%                       timer-relative-time
+          1,152   0%                     - timer-set-time
+          1,152   0%                        timer--time-setter
+          4,848   0%                  - run-with-timer
+          4,848   0%                   - run-at-time
+          1,872   0%                    - timer-activate
+          1,872   0%                     - timer--activate
+          1,872   0%                        timer--time-less-p
+          1,824   0%                      timer-relative-time
+          1,152   0%                    - timer-set-time
+          1,152   0%                       timer--time-setter
+         21,336   0%                 - seed7--block-name
+         21,336   0%                    seed7-re-search-forward
+         35,412   0%                - seed7-re-search-backward-closest
+         31,268   0%                 - seed7-re-search-backward
+         17,428   0%                    re-search-backward
+         13,840   0%                  - run-with-timer
+         13,840   0%                   - run-at-time
+          7,888   0%                    - timer-activate
+          7,888   0%                     - timer--activate
+          7,888   0%                        timer--time-less-p
+          3,648   0%                      timer-relative-time
+          2,304   0%                    - timer-set-time
+          2,304   0%                       timer--time-setter
+          4,144   0%                 - seq-filter
+          4,144   0%                    make-closure
+         16,368   0%                  match-string-no-properties
+         16,368   0%                  match-string
+         48,367   0%               - seed7-line-starts-with-any
+         48,367   0%                  seed7-line-starts-with
+         17,456   0%               - seed7-move-to-line
+         17,456   0%                  seed7-to-previous-non-empty-line
+         16,576   0%               - seed7--current-line-nth-word
+         16,576   0%                - thing-at-point
+         16,576   0%                 - bounds-of-thing-at-point
+          8,288   0%                  - seq-some
+          8,288   0%                     make-closure
+        149,838   0%              - seed7-line-inside-a-block-cached
+        149,838   0%               - seed7-line-inside-a-block
+         90,568   0%                - seed7--safe-enclosing-block-bounds
+         45,544   0%                 - seed7--block-end-pos-for
+         45,544   0%                  - seed7-to-block-forward
+         22,872   0%                   - seed7--current-line-nth-word
+         18,728   0%                    - thing-at-point
+         18,728   0%                     - bounds-of-thing-at-point
+          8,184   0%                      - #<byte-code-function CDF>
+          8,184   0%                       - forward-thing
+          8,184   0%                          format
+          6,400   0%                        re-search-forward
+         14,384   0%                   - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          4,144   0%                      seed7-inside-line-indent-before-comment-p
+          4,144   0%                   - seed7-re-search-forward
+          4,144   0%                      seed7-inside-string-p
+          4,144   0%                     seed7-inside-comment-p
+         45,024   0%                 - seed7-to-block-backward
+         36,736   0%                  - seed7-re-search-backward
+         17,776   0%                   - run-with-timer
+         17,776   0%                    - run-at-time
+          6,864   0%                     - timer-activate
+          6,864   0%                      - timer--activate
+          6,864   0%                         timer--time-less-p
+          6,688   0%                       timer-relative-time
+          4,224   0%                     - timer-set-time
+          4,224   0%                        timer--time-setter
+          8,288   0%                   - seed7-inside-string-p
+          4,144   0%                    - syntax-ppss
+          4,144   0%                       make-closure
+          6,528   0%                     re-search-backward
+          4,144   0%                     seed7-inside-comment-p
+          8,288   0%                  - seed7--current-line-nth-word
+          8,288   0%                   - thing-at-point
+          8,288   0%                    - bounds-of-thing-at-point
+          8,288   0%                       make-closure
+         44,502   0%                - seed7-re-search-backward
+         22,478   0%                   re-search-backward
+         13,736   0%                 - run-with-timer
+         13,736   0%                  - run-at-time
+          5,304   0%                   - timer-activate
+          5,304   0%                    - timer--activate
+          5,304   0%                       timer--time-less-p
+          5,168   0%                     timer-relative-time
+          3,264   0%                   - timer-set-time
+          3,264   0%                      timer--time-setter
+          4,144   0%                   seed7-inside-string-p
+          4,144   0%                   make-closure
+         10,624   0%                  replace-regexp-in-string
+        104,106   0%              - seed7-line-at-endof-array-definition-block
+         51,098   0%               - backward-sexp
+         51,098   0%                - forward-sexp
+         51,098   0%                 - seed7--forward-sexp-function
+         27,834   0%                  - seed7--at-array-definition-end-line-p
+         22,128   0%                   - seed7-line-code-ends-with
+         22,128   0%                    - seed7-re-search-backward
+         17,984   0%                     - run-with-timer
+         17,984   0%                      - run-at-time
+          7,888   0%                       - timer-activate
+          7,888   0%                        - timer--activate
+          7,888   0%                           timer--time-less-p
+          4,144   0%                         timer-create
+          3,648   0%                         timer-relative-time
+          2,304   0%                       - timer-set-time
+          2,304   0%                          timer--time-setter
+          4,144   0%                       seed7-inside-string-p
+          5,706   0%                     looking-at
+          9,696   0%                  - seed7--at-set-definition-end-line-p
+          9,696   0%                   - seed7-line-code-ends-with
+          9,696   0%                    - seed7-re-search-backward
+          9,696   0%                     - run-with-timer
+          9,696   0%                      - run-at-time
+          3,744   0%                       - timer-activate
+          3,744   0%                        - timer--activate
+          3,744   0%                           timer--time-less-p
+          3,648   0%                         timer-relative-time
+          2,304   0%                       - timer-set-time
+          2,304   0%                          timer--time-setter
+         38,848   0%               - seed7-line-code-ends-with
+         38,848   0%                - seed7-re-search-backward
+         21,008   0%                 - run-with-timer
+         21,008   0%                  - run-at-time
+          8,112   0%                   - timer-activate
+          8,112   0%                    - timer--activate
+          8,112   0%                       timer--time-less-p
+          7,904   0%                     timer-relative-time
+          4,992   0%                   - timer-set-time
+          4,992   0%                      timer--time-setter
+         13,696   0%                   re-search-backward
+          4,144   0%                   make-closure
+          8,992   0%               - seed7-re-search-backward
+          4,848   0%                - run-with-timer
+          4,848   0%                 - run-at-time
+          1,872   0%                  - timer-activate
+          1,872   0%                   - timer--activate
+          1,872   0%                      timer--time-less-p
+          1,824   0%                    timer-relative-time
+          1,152   0%                  - timer-set-time
+          1,152   0%                     timer--time-setter
+          4,144   0%                  make-closure
+          4,144   0%               - seed7-move-to-line
+          4,144   0%                  seed7-to-previous-non-empty-line
+          1,024   0%                 looking-at
+         80,376   0%              - seed7-line-inside-array-definition-block
+         45,560   0%               - seed7-re-search-backward
+         19,392   0%                  re-search-backward
+         13,736   0%                - run-with-timer
+         13,736   0%                 - run-at-time
+          5,304   0%                  - timer-activate
+          5,304   0%                   - timer--activate
+          5,304   0%                      timer--time-less-p
+          5,168   0%                    timer-relative-time
+          3,264   0%                  - timer-set-time
+          3,264   0%                     timer--time-setter
+          8,288   0%                  seed7-inside-string-p
+          4,144   0%                  seed7-inside-comment-p
+         34,816   0%               - forward-sexp
+         34,816   0%                  seed7--forward-sexp-function
+         45,164   0%              - seed7-line-inside-assign-statement-continuation
+         36,696   0%               - seed7-assign-op-pos
+         36,696   0%                - seed7-re-search-backward
+         18,816   0%                   re-search-backward
+         13,736   0%                 - run-with-timer
+         13,736   0%                  - run-at-time
+          5,304   0%                   - timer-activate
+          5,304   0%                    - timer--activate
+          5,304   0%                       timer--time-less-p
+          5,168   0%                     timer-relative-time
+          3,264   0%                   - timer-set-time
+          3,264   0%                      timer--time-setter
+          4,144   0%                   make-closure
+          8,468   0%               - seed7-statement-end-pos
+          8,468   0%                - seed7-forward-char-pos
+          8,468   0%                 - seed7-re-search-forward
+          4,324   0%                  - seed7-inside-string-p
+          4,324   0%                   - syntax-ppss
+          4,144   0%                      make-closure
+            180   0%                      #<byte-code-function B3B>
+          4,144   0%                    seed7-inside-comment-p
+         44,496   0%              - seed7-line-inside-set-definition-block
+         44,496   0%               - seed7-re-search-backward
+         26,616   0%                  re-search-backward
+         17,880   0%                - run-with-timer
+         17,880   0%                 - run-at-time
+          5,304   0%                  - timer-activate
+          5,304   0%                   - timer--activate
+          5,304   0%                      timer--time-less-p
+          5,168   0%                    timer-relative-time
+          4,144   0%                    timer-create
+          3,264   0%                  - timer-set-time
+          3,264   0%                     timer--time-setter
+         29,682   0%              - seed7-line-inside-argument-list-section
+         22,722   0%               - seed7-re-search-backward
+         15,346   0%                  re-search-backward
+          7,376   0%                - run-with-timer
+          7,376   0%                 - run-at-time
+          5,392   0%                  - timer-activate
+          5,392   0%                   - timer--activate
+          5,392   0%                      timer--time-less-p
+          1,216   0%                    timer-relative-time
+            768   0%                  - timer-set-time
+            768   0%                     timer--time-setter
+          6,960   0%               - seed7-line-is-procfunc-beg-of-decl
+          6,960   0%                  seed7-line-starts-with
+         29,296   0%              - seed7-line-at-endof-set-definition-block
+         29,296   0%               - seed7-line-code-ends-with
+         29,296   0%                - seed7-re-search-backward
+         25,152   0%                 - run-with-timer
+         25,152   0%                  - run-at-time
+         12,256   0%                   - timer-activate
+         12,256   0%                    - timer--activate
+         12,256   0%                       timer--time-less-p
+          7,904   0%                     timer-relative-time
+          4,992   0%                   - timer-set-time
+          4,992   0%                      timer--time-setter
+          4,144   0%                 - seed7-inside-string-p
+          4,144   0%                  - syntax-ppss
+          4,144   0%                     make-closure
+         23,680   0%              - seed7-line-after-func-return-logic-operator-column
+          6,144   0%               - seed7-move-to-line
+          6,144   0%                  seed7-to-previous-non-empty-line
+         18,560   0%                seed7-line-starts-with
+         17,408   0%              - seed7-line-isa-string
+         17,408   0%                 seed7-line-starts-with
+         13,568   0%                seed7-line-indent-step
+         13,312   0%              - seed7-line-starts-with-open-paren-after-logic-operator
+         13,312   0%                 seed7-line-starts-with
+         12,328   0%              - seed7--current-line-nth-word
+         12,328   0%               - thing-at-point
+         12,328   0%                - bounds-of-thing-at-point
+          8,184   0%                 - #<byte-code-function 041>
+          8,184   0%                  - forward-thing
+          8,184   0%                     format
+          4,144   0%                   make-closure
+         11,856   0%              - seed7-line-inside-logic-check-expression
+          7,712   0%               - seed7-to-previous-line-starts-with
+          7,712   0%                - seed7-re-search-backward
+          4,480   0%                   re-search-backward
+          3,232   0%                 - run-with-timer
+          3,232   0%                  - run-at-time
+          1,248   0%                   - timer-activate
+          1,248   0%                    - timer--activate
+          1,248   0%                       timer--time-less-p
+          1,216   0%                     timer-relative-time
+            768   0%                   - timer-set-time
+            768   0%                      timer--time-setter
+          7,328   0%              - seed7-line-inside-until-logic-expression
+          7,328   0%               - seed7-re-search-backward
+          4,096   0%                  re-search-backward
+          3,232   0%                - run-with-timer
+          3,232   0%                 - run-at-time
+          1,248   0%                  - timer-activate
+          1,248   0%                   - timer--activate
+          1,248   0%                      timer--time-less-p
+          1,216   0%                    timer-relative-time
+            768   0%                  - timer-set-time
+            768   0%                     timer--time-setter
+          7,328   0%              - seed7-line-inside-func-return-statement
+          7,328   0%               - seed7-re-search-backward
+          4,096   0%                  re-search-backward
+          3,232   0%                - run-with-timer
+          3,232   0%                 - run-at-time
+          1,248   0%                  - timer-activate
+          1,248   0%                   - timer--activate
+          1,248   0%                      timer--time-less-p
+          1,216   0%                    timer-relative-time
+            768   0%                  - timer-set-time
+            768   0%                     timer--time-setter
+     25,831,879   0%             - replace-regexp-in-string
+        865,367   0%                concat
+      1,781,504   0%               match-string
+        932,400   0%               seed7--on-lineof
+         35,840   0%               seed7--indent-offset-for
+            952   0%               #<byte-code-function 418>
+        422,688   0%              seed7--cache-block-spec
+    126,827,178   1%           - seed7--indent-search-boundary
+    126,354,762   1%            - seed7--indent-search-boundary-uncached
+    126,005,792   1%             - syntax-ppss
+    122,977,344   1%                make-closure
+      2,688,944   0%                parse-partial-sexp
+        161,531   0%                #<byte-code-function 7DC>
+         46,805   0%                syntax-table
+         24,834   0%               seed7-to-indent
+     51,795,201   0%           - seed7--current-line-nth-word
+     51,529,985   0%            - thing-at-point
+     51,346,793   0%             - bounds-of-thing-at-point
+     49,327,401   0%              - #<byte-code-function 5CC>
+     49,327,401   0%               - forward-thing
+     49,079,785   0%                - forward-word
+     49,079,785   0%                 - internal--syntax-propertize
+     48,180,537   0%                  - syntax-propertize
+     46,840,331   0%                   - seed7-mode-syntax-propertize
+          2,857   0%                      #<byte-code-function 2FA>
+         32,792   0%                     syntax-ppss-flush-cache
+          4,421   0%                     #<byte-code-function E5E>
+        247,616   0%                  format
+      1,027,712   0%                make-closure
+        422,688   0%              - seq-some
+        422,688   0%                 make-closure
+         74,704   0%              - #<byte-code-function 241>
+         74,704   0%               - forward-thing
+         74,704   0%                  format
+          1,152   0%                re-search-forward
+     23,661,238   0%           - seed7-line-inside-argument-list-section
+     13,878,741   0%            - seed7-re-search-backward
+      8,259,615   0%               re-search-backward
+      5,363,688   0%             - run-with-timer
+      5,363,688   0%              - run-at-time
+      2,167,752   0%               - timer-activate
+      2,167,752   0%                - timer--activate
+      2,167,752   0%                   timer--time-less-p
+      1,712,432   0%                 timer-relative-time
+      1,131,264   0%               - timer-set-time
+      1,131,264   0%                  timer--time-setter
+        352,240   0%                 timer-create
+        243,006   0%               make-closure
+          8,288   0%               seed7-inside-comment-p
+          4,144   0%               seed7-inside-string-p
+      9,503,377   0%            - seed7-line-is-procfunc-beg-of-decl
+      9,503,377   0%               seed7-line-starts-with
+         51,200   0%            - forward-sexp
+         51,200   0%               seed7--forward-sexp-function
+         20,720   0%            - seed7-forward-char-pos
+         16,576   0%             - seed7-re-search-forward
+         16,576   0%                seed7-inside-string-p
+     20,394,821   0%           - seed7-line-inside-logic-check-expression
+     15,902,453   0%            - seed7-to-previous-line-starts-with
+     15,214,869   0%             - seed7-re-search-backward
+      6,938,091   0%              - run-with-timer
+      6,938,091   0%               - run-at-time
+      2,731,147   0%                - timer-activate
+      2,731,147   0%                 - timer--activate
+      2,731,147   0%                  - timer--time-less-p
+          7,979   0%                     timer--time
+      2,293,984   0%                  timer-relative-time
+      1,535,856   0%                - timer-set-time
+      1,535,856   0%                   timer--time-setter
+        377,104   0%                  timer-create
+      6,502,040   0%                re-search-backward
+        915,824   0%              - seed7-inside-string-p
+        261,072   0%               - syntax-ppss
+        261,072   0%                  make-closure
+        497,280   0%              - seed7-inside-comment-p
+        290,080   0%               - syntax-ppss
+        290,080   0%                  make-closure
+        360,528   0%                make-closure
+      2,669,368   0%            - seed7--current-line-nth-word
+      2,420,728   0%             - thing-at-point
+      2,264,496   0%              - bounds-of-thing-at-point
+      1,189,328   0%                 make-closure
+        368,816   0%               - seq-some
+        368,816   0%                  make-closure
+        246,568   0%               - #<byte-code-function BB9>
+        246,568   0%                - forward-thing
+        246,568   0%                   format
+         99,256   0%               - #<byte-code-function 11D>
+         99,256   0%                - forward-thing
+         99,256   0%                   format
+      1,632,376   0%            - seed7-re-search-forward
+      1,015,280   0%             - seed7-inside-string-p
+        397,824   0%              - syntax-ppss
+        397,824   0%                 make-closure
+        617,096   0%             - seed7-inside-comment-p
+        380,888   0%              - syntax-ppss
+        348,096   0%                 make-closure
+         32,792   0%                 parse-partial-sexp
+     19,037,836   0%           - seed7-line-inside-assign-statement-continuation
+     16,396,382   0%            - seed7-assign-op-pos
+     16,114,590   0%             - seed7-re-search-backward
+      7,375,274   0%              - run-with-timer
+      7,375,274   0%               - run-at-time
+      2,995,928   0%                - timer-activate
+      2,995,928   0%                 - timer--activate
+      2,995,928   0%                  - timer--time-less-p
+         32,792   0%                     timer--time
+      2,382,752   0%                  timer-relative-time
+      1,558,768   0%                - timer-set-time
+      1,558,768   0%                   timer--time-setter
+        435,120   0%                  timer-create
+          2,706   0%                  timer-set-function
+      6,501,856   0%                re-search-backward
+      1,300,773   0%              - seed7-inside-string-p
+        430,533   0%               - syntax-ppss
+        389,536   0%                  make-closure
+         32,792   0%                  parse-partial-sexp
+          4,815   0%                  syntax-table
+          3,390   0%                  #<byte-code-function D04>
+        630,031   0%              - seed7-inside-comment-p
+        385,535   0%               - syntax-ppss
+        385,392   0%                  make-closure
+            143   0%                  #<byte-code-function F235>
+        306,656   0%                make-closure
+      2,446,686   0%            - seed7-statement-end-pos
+      2,202,190   0%             - seed7-forward-char-pos
+      1,957,694   0%              - seed7-re-search-forward
+      1,419,334   0%               - seed7-inside-string-p
+        491,438   0%                - syntax-ppss
+        488,992   0%                   make-closure
+          2,446   0%                   syntax-table
+        538,360   0%               - seed7-inside-comment-p
+        347,736   0%                - syntax-ppss
+        314,944   0%                   make-closure
+         32,792   0%                   parse-partial-sexp
+     17,487,821   0%           - seed7-line-inside-array-definition-block
+     16,379,709   0%            - seed7-re-search-backward
+      7,428,184   0%             - run-with-timer
+      7,428,184   0%              - run-at-time
+      2,921,656   0%               - timer-activate
+      2,921,656   0%                - timer--activate
+      2,921,656   0%                   timer--time-less-p
+      2,398,864   0%                 timer-relative-time
+      1,668,400   0%               - timer-set-time
+      1,668,400   0%                  timer--time-setter
+        439,264   0%                 timer-create
+      6,925,109   0%               re-search-backward
+      1,152,032   0%             - seed7-inside-string-p
+        335,664   0%              - syntax-ppss
+        335,664   0%                 make-closure
+        584,304   0%             - seed7-inside-comment-p
+        223,776   0%              - syntax-ppss
+        223,776   0%                 make-closure
+        290,080   0%               make-closure
+        851,184   0%            - forward-sexp
+        851,184   0%               seed7--forward-sexp-function
+     15,093,521   0%           - seed7-line-inside-set-definition-block
+     14,807,585   0%            - seed7-re-search-backward
+      7,329,439   0%             - run-with-timer
+      7,329,439   0%              - run-at-time
+      2,919,327   0%               - timer-activate
+      2,919,327   0%                - timer--activate
+      2,886,535   0%                   timer--time-less-p
+      2,385,488   0%                 timer-relative-time
+      1,581,216   0%               - timer-set-time
+      1,581,216   0%                  timer--time-setter
+        443,408   0%                 timer-create
+      7,130,050   0%               re-search-backward
+        348,096   0%               make-closure
+     11,928,480   0%           - seed7-line-inside-until-logic-expression
+     11,762,720   0%            - seed7-re-search-backward
+      6,206,928   0%               re-search-backward
+      5,311,296   0%             - run-with-timer
+      5,311,296   0%              - run-at-time
+      2,158,656   0%               - timer-activate
+      2,158,656   0%                - timer--activate
+      2,158,656   0%                 - timer--time-less-p
+         65,584   0%                    timer--time
+      1,716,368   0%                 timer-relative-time
+      1,150,336   0%               - timer-set-time
+      1,150,336   0%                  timer--time-setter
+        285,936   0%                 timer-create
+        244,496   0%               make-closure
+     11,833,896   0%           - seed7-line-inside-func-return-statement
+     11,585,256   0%            - seed7-re-search-backward
+      6,066,024   0%               re-search-backward
+      5,274,736   0%             - run-with-timer
+      5,274,736   0%              - run-at-time
+      2,084,784   0%               - timer-activate
+      2,084,784   0%                - timer--activate
+      2,084,784   0%                   timer--time-less-p
+      1,716,384   0%                 timer-relative-time
+      1,133,760   0%               - timer-set-time
+      1,133,760   0%                  timer--time-setter
+        339,808   0%                 timer-create
+        244,496   0%               make-closure
+      9,059,742   0%           - seed7-line-after-func-return-logic-operator-column
+      2,226,078   0%            - seed7-move-to-line
+      2,226,078   0%             - seed7-to-previous-non-empty-line
+        576,558   0%              - seed7-inside-comment-p
+        394,222   0%               - syntax-ppss
+        360,528   0%                  make-closure
+         32,792   0%                  parse-partial-sexp
+            902   0%                  syntax-table
+      6,797,904   0%             seed7-line-starts-with
+      6,600,944   0%           - seed7-line-isa-string
+      6,600,944   0%              seed7-line-starts-with
+      2,378,769   0%           - seed7-line-indent-step
+      2,038,145   0%            - seed7-move-to-line
+      2,038,145   0%             - seed7-to-previous-non-empty-line
+      2,014,401   0%              - seed7-inside-comment-p
+      1,993,681   0%               - syntax-ppss
+      1,972,961   0%                - syntax-propertize
+      1,943,953   0%                 - seed7-mode-syntax-propertize
+          2,058   0%                    #<byte-code-function 1C7>
+         20,720   0%                  make-closure
+        949,632   0%           - seed7-line-at-endof-array-definition-block
+        552,888   0%            - seed7-line-code-ends-with
+        544,600   0%             - seed7-re-search-backward
+        321,504   0%              - run-with-timer
+        321,504   0%               - run-at-time
+        125,376   0%                - timer-activate
+        125,376   0%                 - timer--activate
+        125,376   0%                    timer--time-less-p
+        110,048   0%                  timer-relative-time
+         73,648   0%                - timer-set-time
+         73,648   0%                   timer--time-setter
+         12,432   0%                  timer-create
+        156,792   0%                re-search-backward
+         29,008   0%              - seed7-inside-comment-p
+         29,008   0%               - syntax-ppss
+         29,008   0%                  make-closure
+         29,008   0%              - seed7-inside-string-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+          8,288   0%                make-closure
+        344,168   0%            - backward-sexp
+        344,168   0%             - forward-sexp
+        344,168   0%              - seed7--forward-sexp-function
+        140,072   0%               - seed7--at-array-definition-end-line-p
+         90,416   0%                - seed7-line-code-ends-with
+         82,128   0%                 - seed7-re-search-backward
+         73,840   0%                  - run-with-timer
+         73,840   0%                   - run-at-time
+         32,000   0%                    - timer-activate
+         32,000   0%                     - timer--activate
+         32,000   0%                        timer--time-less-p
+         23,104   0%                      timer-relative-time
+         18,736   0%                    - timer-set-time
+         18,736   0%                       timer--time-setter
+          4,144   0%                    seed7-inside-string-p
+          4,144   0%                    seed7-inside-comment-p
+         49,656   0%                  looking-at
+         84,160   0%               - seed7--at-set-definition-end-line-p
+         80,016   0%                - seed7-line-code-ends-with
+         75,872   0%                 - seed7-re-search-backward
+         55,152   0%                  - run-with-timer
+         55,152   0%                   - run-at-time
+         22,240   0%                    - timer-activate
+         22,240   0%                     - timer--activate
+         22,240   0%                        timer--time-less-p
+         17,632   0%                      timer-relative-time
+         15,280   0%                    - timer-set-time
+         15,280   0%                       timer--time-setter
+         16,576   0%                  - seed7-inside-comment-p
+         16,576   0%                   - syntax-ppss
+         16,576   0%                      make-closure
+          4,144   0%                    make-closure
+         18,688   0%               - seed7--safe-to-block-backward
+         18,688   0%                - seed7-to-block-backward
+         14,544   0%                 - seed7-line-code-ends-with
+         14,544   0%                  - seed7-re-search-backward
+         14,544   0%                   - run-with-timer
+         14,544   0%                    - run-at-time
+          5,616   0%                     - timer-activate
+          5,616   0%                      - timer--activate
+          5,616   0%                         timer--time-less-p
+          5,472   0%                       timer-relative-time
+          3,456   0%                     - timer-set-time
+          3,456   0%                        timer--time-setter
+          4,144   0%                   seed7-inside-comment-p
+         34,848   0%            - seed7-re-search-backward
+         30,704   0%             - run-with-timer
+         30,704   0%              - run-at-time
+         11,856   0%               - timer-activate
+         11,856   0%                - timer--activate
+         11,856   0%                   timer--time-less-p
+         11,552   0%                 timer-relative-time
+          7,296   0%               - timer-set-time
+          7,296   0%                  timer--time-setter
+          4,144   0%               seed7-inside-comment-p
+         16,576   0%            - seed7-move-to-line
+         16,576   0%             - seed7-to-previous-non-empty-line
+         12,432   0%              - seed7-inside-comment-p
+          4,144   0%               - syntax-ppss
+          4,144   0%                  make-closure
+          1,152   0%              looking-at
+        918,158   0%           - seed7-comment-column
+        804,318   0%            - seed7-calc-indent
+        163,960   0%             - seed7-line-at-endof-array-definition-block
+        163,960   0%              - seed7-move-to-line
+        163,960   0%               - seed7-to-previous-non-empty-line
+        163,960   0%                - seed7-inside-comment-p
+        163,960   0%                 - syntax-ppss
+        163,960   0%                    parse-partial-sexp
+        143,538   0%             - seed7-line-is-defun-end
+        131,168   0%              - seed7-move-to-line
+        131,168   0%               - seed7-to-previous-non-empty-line
+        131,168   0%                - seed7-inside-comment-p
+        131,168   0%                 - syntax-ppss
+        131,168   0%                    parse-partial-sexp
+         11,346   0%              - seed7--safe-current-line-defun-start-indent
+         11,346   0%               - seed7-to-block-backward
+          8,184   0%                - seed7--current-line-nth-word
+          8,184   0%                 - thing-at-point
+          8,184   0%                  - bounds-of-thing-at-point
+          8,184   0%                   - #<byte-code-function 2B8>
+          8,184   0%                    - forward-thing
+          8,184   0%                       format
+          3,162   0%                - seed7-re-search-backward
+          2,354   0%                   re-search-backward
+            808   0%                 - run-with-timer
+            808   0%                  - run-at-time
+            312   0%                   - timer-activate
+            312   0%                    - timer--activate
+            312   0%                       timer--time-less-p
+            304   0%                     timer-relative-time
+            192   0%                   - timer-set-time
+            192   0%                      timer--time-setter
+          1,024   0%              - seed7-line-starts-with-any
+          1,024   0%                 seed7-line-starts-with
+        121,144   0%             - seed7-line-inside-parens-pair-column
+        121,144   0%              - seed7-line-inside-parens-pair
+        121,144   0%               - seed7-re-search-backward
+         98,376   0%                - seed7-inside-comment-p
+         98,376   0%                 - syntax-ppss
+         98,376   0%                    parse-partial-sexp
+         17,648   0%                - run-with-timer
+         17,648   0%                 - run-at-time
+          7,904   0%                    timer-relative-time
+          4,992   0%                  - timer-set-time
+          4,992   0%                     timer--time-setter
+          4,752   0%                  - timer-activate
+          4,752   0%                   - timer--activate
+          4,752   0%                      timer--time-less-p
+          5,120   0%                  re-search-backward
+         92,098   0%             - seed7-line-inside-a-block-cached
+         92,098   0%              - seed7-line-inside-a-block
+         49,090   0%               - seed7--safe-enclosing-block-bounds
+         28,104   0%                - seed7-to-block-backward
+         15,776   0%                 - seed7-re-search-backward
+          8,288   0%                  - seed7-inside-string-p
+          4,144   0%                   - syntax-ppss
+          4,144   0%                      make-closure
+          6,464   0%                  - run-with-timer
+          6,464   0%                   - run-at-time
+          2,496   0%                    - timer-activate
+          2,496   0%                     - timer--activate
+          2,496   0%                        timer--time-less-p
+          2,432   0%                      timer-relative-time
+          1,536   0%                    - timer-set-time
+          1,536   0%                       timer--time-setter
+          1,024   0%                    re-search-backward
+         12,328   0%                 - seed7--current-line-nth-word
+         12,328   0%                  - thing-at-point
+          4,144   0%                     bounds-of-thing-at-point
+         20,986   0%                - seed7--block-end-pos-for
+         20,986   0%                 - seed7-to-block-forward
+         20,986   0%                  - seed7-re-search-forward
+          4,144   0%                   - seed7-inside-comment-p
+          4,144   0%                    - syntax-ppss
+          4,144   0%                       make-closure
+         34,768   0%               - seed7-re-search-backward
+         16,840   0%                - run-with-timer
+         16,840   0%                 - run-at-time
+          7,600   0%                    timer-relative-time
+          4,800   0%                  - timer-set-time
+          4,800   0%                     timer--time-setter
+          4,440   0%                  - timer-activate
+          4,440   0%                   - timer--activate
+          4,440   0%                      timer--time-less-p
+         13,784   0%                  re-search-backward
+          4,144   0%                - seed7-inside-comment-p
+          4,144   0%                 - syntax-ppss
+          4,144   0%                    make-closure
+          8,240   0%                 replace-regexp-in-string
+         73,824   0%             - seed7-line-after-func-return-logic-operator-column
+         69,728   0%              - seed7-move-to-line
+         69,728   0%               - seed7-to-previous-non-empty-line
+         65,584   0%                - seed7-inside-comment-p
+         65,584   0%                 - syntax-ppss
+         65,584   0%                    parse-partial-sexp
+         34,912   0%             - seed7-line-inside-array-definition-block
+         28,768   0%              - seed7-re-search-backward
+         17,648   0%               - run-with-timer
+         17,648   0%                - run-at-time
+          7,904   0%                   timer-relative-time
+          4,992   0%                 - timer-set-time
+          4,992   0%                    timer--time-setter
+          4,752   0%                 - timer-activate
+          4,752   0%                  - timer--activate
+          4,752   0%                     timer--time-less-p
+          6,976   0%                 re-search-backward
+          4,144   0%                 seed7-inside-string-p
+          6,144   0%              - forward-sexp
+          6,144   0%                 seed7--forward-sexp-function
+         33,816   0%             - seed7-line-starts-with-open-paren-after-logic-operator
+         32,792   0%              - seed7-move-to-line
+         32,792   0%               - seed7-to-previous-non-empty-line
+         32,792   0%                - seed7-inside-comment-p
+         32,792   0%                 - syntax-ppss
+         32,792   0%                    parse-partial-sexp
+          1,024   0%                seed7-line-starts-with
+         32,792   0%             - seed7-line-at-endof-set-definition-block
+         32,792   0%              - seed7-move-to-line
+         32,792   0%               - seed7-to-previous-non-empty-line
+         32,792   0%                - seed7-inside-comment-p
+         32,792   0%                 - syntax-ppss
+         32,792   0%                    parse-partial-sexp
+         28,064   0%             - seed7-line-inside-assign-statement-continuation
+         28,064   0%              - seed7-assign-op-pos
+         23,920   0%               - seed7-re-search-backward
+         17,648   0%                - run-with-timer
+         17,648   0%                 - run-at-time
+          7,904   0%                    timer-relative-time
+          4,992   0%                  - timer-set-time
+          4,992   0%                     timer--time-setter
+          4,752   0%                  - timer-activate
+          4,752   0%                   - timer--activate
+          4,752   0%                      timer--time-less-p
+          6,272   0%                  re-search-backward
+         24,112   0%             - seed7-line-inside-set-definition-block
+         24,112   0%              - seed7-re-search-backward
+         17,648   0%               - run-with-timer
+         17,648   0%                - run-at-time
+          7,904   0%                   timer-relative-time
+          4,992   0%                 - timer-set-time
+          4,992   0%                    timer--time-setter
+          4,752   0%                 - timer-activate
+          4,752   0%                  - timer--activate
+          4,752   0%                     timer--time-less-p
+          6,464   0%                 re-search-backward
+         13,370   0%             - seed7-line-inside-argument-list-section
+          9,274   0%              - seed7-re-search-backward
+          6,042   0%                 re-search-backward
+          3,232   0%               - run-with-timer
+          3,232   0%                - run-at-time
+          1,248   0%                 - timer-activate
+          1,248   0%                  - timer--activate
+          1,248   0%                     timer--time-less-p
+          1,216   0%                   timer-relative-time
+            768   0%                 - timer-set-time
+            768   0%                    timer--time-setter
+          4,096   0%              - seed7-line-is-procfunc-beg-of-decl
+          4,096   0%                 seed7-line-starts-with
+         11,472   0%             - seed7-line-inside-until-logic-expression
+         11,472   0%              - seed7-re-search-backward
+          4,144   0%                 make-closure
+          4,096   0%                 re-search-backward
+          3,232   0%               - run-with-timer
+          3,232   0%                - run-at-time
+          1,248   0%                 - timer-activate
+          1,248   0%                  - timer--activate
+          1,248   0%                     timer--time-less-p
+          1,216   0%                   timer-relative-time
+            768   0%                 - timer-set-time
+            768   0%                    timer--time-setter
+          7,328   0%             - seed7-line-inside-logic-check-expression
+          7,328   0%              - seed7-to-previous-line-starts-with
+          7,328   0%               - seed7-re-search-backward
+          4,096   0%                  re-search-backward
+          3,232   0%                - run-with-timer
+          3,232   0%                 - run-at-time
+          1,248   0%                  - timer-activate
+          1,248   0%                   - timer--activate
+          1,248   0%                      timer--time-less-p
+          1,216   0%                    timer-relative-time
+            768   0%                  - timer-set-time
+            768   0%                     timer--time-setter
+          7,328   0%             - seed7-line-inside-func-return-statement
+          7,328   0%              - seed7-re-search-backward
+          4,096   0%                 re-search-backward
+          3,232   0%               - run-with-timer
+          3,232   0%                - run-at-time
+          1,248   0%                 - timer-activate
+          1,248   0%                  - timer--activate
+          1,248   0%                     timer--time-less-p
+          1,216   0%                   timer-relative-time
+            768   0%                 - timer-set-time
+            768   0%                    timer--time-setter
+          6,272   0%               seed7-line-starts-with
+          6,144   0%             - seed7-line-isa-string
+          6,144   0%                seed7-line-starts-with
+          4,144   0%             - seed7--current-line-nth-word
+          4,144   0%              - thing-at-point
+          4,144   0%               - bounds-of-thing-at-point
+          4,144   0%                  make-closure
+         79,808   0%            - seed7-line-code-ends-with
+         66,608   0%             - seed7-move-to-line
+         66,608   0%              - seed7-to-previous-non-empty-line
+         65,584   0%               - seed7-inside-comment-p
+         65,584   0%                - syntax-ppss
+         65,584   0%                   parse-partial-sexp
+         13,200   0%             - seed7-re-search-backward
+          8,080   0%              - run-with-timer
+          8,080   0%               - run-at-time
+          3,120   0%                - timer-activate
+          3,120   0%                 - timer--activate
+          3,120   0%                    timer--time-less-p
+          3,040   0%                  timer-relative-time
+          1,920   0%                - timer-set-time
+          1,920   0%                   timer--time-setter
+          5,120   0%                re-search-backward
+         16,432   0%              seed7-line-starts-with
+          4,144   0%            - seed7-inside-comment-p
+          4,144   0%             - syntax-ppss
+          4,144   0%                make-closure
+          1,024   0%              looking-at
+        877,808   0%           - seed7-current-line-start-inside-comment-p
+        587,728   0%            - seed7-inside-comment-p
+        372,240   0%             - syntax-ppss
+        306,656   0%                make-closure
+         65,584   0%                parse-partial-sexp
+        441,680   0%           - seed7-line-at-endof-set-definition-block
+        416,816   0%            - seed7-line-code-ends-with
+        412,672   0%             - seed7-re-search-backward
+        350,512   0%              - run-with-timer
+        350,512   0%               - run-at-time
+        146,096   0%                - timer-activate
+        146,096   0%                 - timer--activate
+        146,096   0%                    timer--time-less-p
+        110,048   0%                  timer-relative-time
+         69,504   0%                - timer-set-time
+         69,504   0%                   timer--time-setter
+         24,864   0%                  timer-create
+         37,296   0%              - seed7-inside-string-p
+         12,432   0%               - syntax-ppss
+         12,432   0%                  make-closure
+         12,432   0%                make-closure
+         12,432   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+         16,576   0%            - seed7-move-to-line
+         16,576   0%             - seed7-to-previous-non-empty-line
+         12,432   0%              - seed7-inside-comment-p
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+        104,024   0%           - seed7-line-starts-with-open-paren-after-logic-operator
+         99,880   0%              seed7-line-starts-with
+         95,968   0%           - seed7-line-inside-nested-parens-pairs-column
+         95,968   0%            - seed7-line-inside-nested-parens-pairs
+         95,968   0%             - seed7-line-inside-parens-pair
+         83,536   0%              - seed7-re-search-backward
+         79,392   0%               - run-with-timer
+         79,392   0%                - run-at-time
+         31,600   0%                 - timer-activate
+         31,600   0%                  - timer--activate
+         31,600   0%                     timer--time-less-p
+         26,752   0%                   timer-relative-time
+         16,896   0%                 - timer-set-time
+         16,896   0%                    timer--time-setter
+          4,144   0%                   timer-create
+          4,144   0%               - seed7-inside-comment-p
+          4,144   0%                - syntax-ppss
+          4,144   0%                   make-closure
+         12,432   0%              - seed7-line-inside-syntax-parens-pair
+          8,288   0%               - syntax-ppss
+          8,288   0%                  make-closure
+         13,464   0%           - seed7-line-ends-with
+          8,296   0%            - seed7-re-search-backward
+          7,272   0%             - run-with-timer
+          7,272   0%              - run-at-time
+          2,808   0%               - timer-activate
+          2,808   0%                - timer--activate
+          2,808   0%                   timer--time-less-p
+          2,736   0%                 timer-relative-time
+          1,728   0%               - timer-set-time
+          1,728   0%                  timer--time-setter
+          1,024   0%               re-search-backward
+          1,024   0%            - seed7-move-to-line
+          1,024   0%               seed7-to-previous-non-empty-line
+         10,016   0%           - seed7-position-of-end-of-statement
+          5,872   0%            - seed7-line-code-ends-with
+          5,872   0%             - seed7-re-search-backward
+          4,848   0%              - run-with-timer
+          4,848   0%               - run-at-time
+          1,872   0%                - timer-activate
+          1,872   0%                 - timer--activate
+          1,872   0%                    timer--time-less-p
+          1,824   0%                  timer-relative-time
+          1,152   0%                - timer-set-time
+          1,152   0%                   timer--time-setter
+          1,024   0%                re-search-backward
+        815,944   0%          - #<byte-code-function 2AE>
+        815,944   0%           - filter-buffer-substring
+        815,944   0%            - buffer-substring--filter
+        815,944   0%             - #<byte-code-function C14>
+        815,944   0%              - apply
+        815,944   0%                 #<byte-code-function 554>
+        645,904   0%          - jit-lock-after-change
+        232,064   0%             font-lock-extend-jit-lock-region-after-change
+        143,720   0%          - delete-horizontal-space
+        143,720   0%           - delete-space--internal
+         32,056   0%            - jit-lock-after-change
+          8,288   0%               font-lock-extend-jit-lock-region-after-change
+            648   0%          - undo-auto--undoable-change
+            648   0%           - undo-auto--boundary-ensure-timer
+            648   0%            - run-at-time
+            304   0%               timer-relative-time
+            192   0%             - timer-set-time
+            192   0%                timer--time-setter
+            152   0%             - timer-activate
+            152   0%              - timer--activate
+            152   0%                 timer--time-less-p
+      5,606,430   0%       - smex
+      5,606,430   0%        - smex-read-and-run
+      3,824,802   0%         - smex-completing-read
+      3,824,802   0%          - ido-completing-read
+      3,824,802   0%           - apply
+      3,824,802   0%            - ido-completing-read@ido-cr+-replace
+      3,824,802   0%             - #<native-comp-function ido-completing-read>
+      3,824,802   0%              - ido-read-internal
+      3,824,802   0%               - apply
+      3,824,802   0%                - ad-Advice-ido-read-internal
+      3,824,802   0%                 - #<native-comp-function ido-read-internal>
+      3,824,802   0%                  - read-from-minibuffer
+      2,598,829   0%                     redisplay_internal (C function)
+         72,649   0%                   - ido-exhibit
+         72,649   0%                    - apply
+         72,649   0%                     - #<native-comp-function ido-exhibit>
+         55,377   0%                      - ido-completions
+         55,377   0%                       - apply
+         55,377   0%                        - ido-grid--completions
+         37,385   0%                         - ido-grid--grid-ensure-visible
+         37,385   0%                          - ido-grid--grid
+         14,896   0%                             buffer-string
+          6,066   0%                             move-to-column
+          2,048   0%                           - ido-final-slash
+          1,024   0%                              ido-is-tramp-root
+          1,024   0%                             string-match
+             63   0%                             generate-new-buffer
+          1,024   0%                     minibuffer--regexp-setup
+            648   0%                   - undo-auto--undoable-change
+            648   0%                    - undo-auto--boundary-ensure-timer
+            648   0%                     - run-at-time
+            304   0%                        timer-relative-time
+            192   0%                      - timer-set-time
+            192   0%                         timer--time-setter
+            152   0%                      - timer-activate
+            152   0%                       - timer--activate
+            152   0%                          timer--time-less-p
+            560   0%                   - timer-event-handler
+            560   0%                    - timer-activate-when-idle
+            560   0%                     - timer--activate
+            560   0%                        timer--time-less-p
+             48   0%                   - command-execute
+             48   0%                    - call-interactively
+             48   0%                     - apply
+             48   0%                      - call-interactively@ido-cr+-record-current-command
+             48   0%                       - #<primitive-function call-interactively>
+             48   0%                          funcall-interactively
+      1,781,628   0%         - execute-extended-command
+      1,603,340   0%          - command-execute
+      1,603,340   0%           - call-interactively
+      1,603,340   0%            - apply
+      1,603,340   0%             - call-interactively@ido-cr+-record-current-command
+      1,603,340   0%              - #<primitive-function call-interactively>
+      1,603,340   0%               - funcall-interactively
+      1,603,324   0%                  profiler-stop
+      9,127,735   0%   Automatic GC
+      2,871,013   0% + redisplay_internal (C function)
+          9,296   0% + timer-event-handler
+          5,120   0% + flyspell-post-command-hook
+              0   0%   ...

--- a/reports/19.1/bas7.sd7-perf-cpu.txt
+++ b/reports/19.1/bas7.sd7-perf-cpu.txt
@@ -1,0 +1,1623 @@
+      371354  96% - ...
+      371354  96%  - smex-read-and-run
+      371354  96%   - execute-extended-command
+      371354  96%    - command-execute
+      371354  96%     - call-interactively
+      371354  96%      - apply
+      371354  96%       - call-interactively@ido-cr+-record-current-command
+      371354  96%        - #<primitive-function call-interactively>
+      371354  96%         - funcall-interactively
+      371354  96%          - pel-profile
+      371354  96%           - call-interactively
+      371354  96%            - apply
+      371354  96%             - call-interactively@ido-cr+-record-current-command
+      371354  96%              - #<primitive-function call-interactively>
+      371354  96%               - funcall-interactively
+      371354  96%                - seed7-complete-statement-or-indent
+      371354  96%                 - seed7-indent-region
+      371351  96%                  - seed7--indent-one-line
+      371282  96%                   - seed7-calc-indent
+      146118  37%                    - seed7-line-inside-a-block-cached
+      146114  37%                     - seed7-line-inside-a-block
+      134951  34%                      - seed7--safe-enclosing-block-bounds
+      123985  32%                       - seed7--block-end-pos-for
+      123973  32%                        - seed7-to-block-forward
+      119195  30%                         - seed7-end-of-defun
+      115443  29%                          - seed7-re-search-forward
+         470   0%                           - seed7-inside-comment-p
+         469   0%                            - syntax-ppss
+         331   0%                               parse-partial-sexp
+         131   0%                             - syntax-propertize
+         129   0%                                seed7-mode-syntax-propertize
+           3   0%                             - #<byte-code-function AAA>
+           1   0%                                set-syntax-table
+           1   0%                               make-closure
+           1   0%                               syntax-ppss--data
+          34   0%                           - seed7-inside-string-p
+          34   0%                            - syntax-ppss
+          33   0%                               parse-partial-sexp
+        3567   0%                          - seed7-top-block-name
+        3431   0%                           - seed7--to-top
+        3198   0%                            - seed7-re-search-backward
+        2317   0%                             - seed7-inside-comment-p
+        2315   0%                              - syntax-ppss
+        2306   0%                                 parse-partial-sexp
+           2   0%                                 syntax-ppss-toplevel-pos
+           1   0%                                 make-closure
+           1   0%                                 syntax-ppss--data
+         444   0%                               re-search-backward
+         408   0%                             - run-with-timer
+         408   0%                              - run-at-time
+         267   0%                               - timer-activate
+         267   0%                                - timer--activate
+         263   0%                                   timer--time-less-p
+          94   0%                               - timer-set-time
+          94   0%                                  timer--time-setter
+          45   0%                                 timer-relative-time
+           1   0%                               - timer-set-function
+           1   0%                                  timerp
+          18   0%                             - seed7-inside-string-p
+          13   0%                              - syntax-ppss
+          10   0%                                 parse-partial-sexp
+           1   0%                                 syntax-table
+           1   0%                                 syntax-ppss--update-stats
+           1   0%                               - #<byte-code-function 1D5>
+           1   0%                                  set-syntax-table
+           2   0%                              - #<byte-code-function 6B1>
+           2   0%                                 set-match-data
+           2   0%                             - #<byte-code-function 8BE>
+           2   0%                                cancel-timer
+          60   0%                            - run-with-timer
+          59   0%                             - run-at-time
+          40   0%                              - timer-activate
+          40   0%                               - timer--activate
+          38   0%                                  timer--time-less-p
+           1   0%                                  timerp
+          12   0%                              - timer-set-time
+          12   0%                                 timer--time-setter
+           7   0%                                timer-relative-time
+          10   0%                              seed7-to-indent
+         136   0%                           - seed7--block-name
+         134   0%                            - seed7-re-search-forward
+          47   0%                             - seed7-inside-comment-p
+          47   0%                              - syntax-ppss
+          43   0%                                 parse-partial-sexp
+           1   0%                                 syntax-table
+           1   0%                                 make-closure
+           7   0%                             - seed7-inside-string-p
+           6   0%                              - syntax-ppss
+           6   0%                                 parse-partial-sexp
+           1   0%                              match-string
+         180   0%                          - seed7-re-search-backward
+          63   0%                           - seed7-inside-comment-p
+          63   0%                            - syntax-ppss
+          63   0%                               parse-partial-sexp
+          59   0%                             re-search-backward
+          53   0%                           - run-with-timer
+          53   0%                            - run-at-time
+          28   0%                             - timer-activate
+          28   0%                              - timer--activate
+          28   0%                               - timer--time-less-p
+           1   0%                                  timer--time
+          18   0%                             - timer-set-time
+          18   0%                                timer--time-setter
+           6   0%                               timer-relative-time
+           3   0%                           - seed7-inside-string-p
+           1   0%                            - #<byte-code-function 724>
+           1   0%                               set-match-data
+           1   0%                            - syntax-ppss
+           1   0%                               make-closure
+           1   0%                           - #<byte-code-function E25>
+           1   0%                              cancel-timer
+           1   0%                            match-string
+        3967   1%                         - seed7-re-search-forward
+        1021   0%                          - seed7-inside-comment-p
+        1016   0%                           - syntax-ppss
+         944   0%                              parse-partial-sexp
+          54   0%                            - syntax-propertize
+          53   0%                               seed7-mode-syntax-propertize
+           6   0%                              #<byte-code-function 25B>
+           2   0%                              syntax-ppss--data
+           1   0%                              syntax-ppss--update-stats
+           1   0%                              make-closure
+         636   0%                          - seed7-inside-string-p
+         616   0%                           - syntax-ppss
+         599   0%                              parse-partial-sexp
+           4   0%                              #<byte-code-function A58>
+           2   0%                              syntax-ppss--data
+           2   0%                              make-closure
+           1   0%                              syntax-propertize
+           1   0%                              syntax-table
+           1   0%                              set-syntax-table
+           1   0%                              syntax-ppss--update-stats
+           5   0%                           - #<byte-code-function 7FF>
+           4   0%                              set-match-data
+         499   0%                         - seed7--current-line-nth-word
+         314   0%                          - thing-at-point
+         293   0%                           - bounds-of-thing-at-point
+         146   0%                            - #<byte-code-function FDC>
+         143   0%                             - forward-thing
+         105   0%                                forward-word
+          22   0%                                format
+           8   0%                                intern-soft
+           1   0%                                functionp
+          59   0%                            - #<byte-code-function C26>
+          57   0%                             - forward-thing
+          42   0%                                forward-word
+           9   0%                                format
+           1   0%                                functionp
+           1   0%                                intern-soft
+          20   0%                              make-closure
+          19   0%                              re-search-forward
+          11   0%                            - seq-some
+           6   0%                               make-closure
+         140   0%                         - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          97   0%                          - seed7-inside-comment-p
+          96   0%                           - syntax-ppss
+          88   0%                              parse-partial-sexp
+           2   0%                              syntax-ppss--update-stats
+           1   0%                              syntax-ppss--data
+           1   0%                              #<byte-code-function C85>
+          32   0%                          - seed7-inside-line-indent-before-comment-p
+          18   0%                             seed7-to-indent
+           5   0%                           - seed7-inside-comment-p
+           5   0%                            - syntax-ppss
+           5   0%                               parse-partial-sexp
+         107   0%                         - seed7-inside-comment-p
+         107   0%                          - syntax-ppss
+          97   0%                             parse-partial-sexp
+           2   0%                             set-syntax-table
+           1   0%                             #<byte-code-function AD6>
+           1   0%                             syntax-propertize
+          30   0%                         - seed7-inside-line-indent-before-comment-p
+          13   0%                            seed7-to-indent
+           5   0%                          - seed7-inside-comment-p
+           5   0%                           - syntax-ppss
+           5   0%                              parse-partial-sexp
+          11   0%                           seed7--end-regexp-for
+           6   0%                        - seed7-to-next-line-starts-with
+           6   0%                         - seed7-re-search-forward
+           3   0%                          - seed7-inside-comment-p
+           3   0%                           - syntax-ppss
+           3   0%                              parse-partial-sexp
+           2   0%                          - seed7-inside-string-p
+           2   0%                           - syntax-ppss
+           2   0%                              parse-partial-sexp
+       10960   2%                       - seed7-to-block-backward
+        9370   2%                        - seed7-re-search-backward
+        4414   1%                         - seed7-inside-comment-p
+        4407   1%                          - syntax-ppss
+        4379   1%                             parse-partial-sexp
+           7   0%                             make-closure
+           4   0%                             syntax-table
+           4   0%                             #<byte-code-function 207>
+           2   0%                             syntax-propertize
+           2   0%                             syntax-ppss--data
+           1   0%                             set-syntax-table
+           1   0%                             syntax-ppss--update-stats
+        2660   0%                           re-search-backward
+        2060   0%                         - run-with-timer
+        2057   0%                          - run-at-time
+        1335   0%                           - timer-activate
+        1333   0%                            - timer--activate
+        1330   0%                             - timer--time-less-p
+          21   0%                                timer--time
+         519   0%                           - timer-set-time
+         518   0%                            - timer--time-setter
+           1   0%                               timerp
+         200   0%                             timer-relative-time
+           3   0%                             timer-create
+         217   0%                         - seed7-inside-string-p
+         187   0%                          - syntax-ppss
+         164   0%                             parse-partial-sexp
+           5   0%                             make-closure
+           4   0%                             #<byte-code-function 329>
+           3   0%                             set-syntax-table
+           2   0%                             syntax-ppss--data
+           1   0%                             syntax-table
+          10   0%                          - #<byte-code-function FA0>
+           8   0%                             set-match-data
+           3   0%                         - #<byte-code-function C6D>
+           3   0%                            cancel-timer
+           1   0%                           make-closure
+         746   0%                        - seed7-beg-of-defun
+         409   0%                         - seed7-re-search-backward-closest
+         409   0%                          - seed7-re-search-backward
+         404   0%                             re-search-backward
+           4   0%                           - run-with-timer
+           4   0%                            - run-at-time
+           3   0%                             - timer-activate
+           3   0%                              - timer--activate
+           3   0%                                 timer--time-less-p
+           1   0%                             - timer-set-time
+           1   0%                                timer--time-setter
+           1   0%                           - seed7-inside-comment-p
+           1   0%                            - syntax-ppss
+           1   0%                               parse-partial-sexp
+         252   0%                         - seed7-top-block-name
+         248   0%                          - seed7--to-top
+         239   0%                           - seed7-re-search-backward
+         162   0%                            - seed7-inside-comment-p
+         162   0%                             - syntax-ppss
+         162   0%                                parse-partial-sexp
+          50   0%                            - run-with-timer
+          50   0%                             - run-at-time
+          40   0%                              - timer-activate
+          40   0%                               - timer--activate
+          40   0%                                  timer--time-less-p
+           7   0%                              - timer-set-time
+           7   0%                                 timer--time-setter
+           3   0%                                timer-relative-time
+          24   0%                              re-search-backward
+           2   0%                            - seed7-inside-string-p
+           1   0%                             - syntax-ppss
+           1   0%                                parse-partial-sexp
+           1   0%                             - #<byte-code-function 5CF>
+           1   0%                                set-match-data
+           3   0%                           - run-with-timer
+           3   0%                            - run-at-time
+           3   0%                             - timer-activate
+           3   0%                              - timer--activate
+           3   0%                                 timer--time-less-p
+           4   0%                          - seed7--block-name
+           4   0%                           - seed7-re-search-forward
+           3   0%                            - seed7-inside-comment-p
+           3   0%                             - syntax-ppss
+           3   0%                                parse-partial-sexp
+          84   0%                         - seed7-re-search-backward
+          39   0%                            re-search-backward
+          36   0%                          - seed7-inside-comment-p
+          36   0%                           - syntax-ppss
+          36   0%                              parse-partial-sexp
+           9   0%                          - run-with-timer
+           9   0%                           - run-at-time
+           5   0%                            - timer-activate
+           5   0%                             - timer--activate
+           5   0%                                timer--time-less-p
+           3   0%                              timer-relative-time
+           1   0%                            - timer-set-time
+           1   0%                               timer--time-setter
+         383   0%                        - seed7-inside-comment-p
+         383   0%                         - syntax-ppss
+         372   0%                            parse-partial-sexp
+           2   0%                            #<byte-code-function 795>
+           2   0%                            syntax-ppss--update-stats
+           1   0%                            syntax-table
+           1   0%                            make-closure
+           1   0%                            set-syntax-table
+         270   0%                        - seed7--current-line-nth-word
+         198   0%                         - thing-at-point
+         185   0%                          - bounds-of-thing-at-point
+          94   0%                           - #<byte-code-function 9AA>
+          91   0%                            - forward-thing
+          63   0%                               forward-word
+          22   0%                               format
+           2   0%                               intern-soft
+           1   0%                               functionp
+          42   0%                           - #<byte-code-function D6C>
+          42   0%                            - forward-thing
+          31   0%                               forward-word
+           8   0%                               format
+           1   0%                               intern-soft
+          13   0%                             re-search-forward
+          11   0%                             make-closure
+           3   0%                           - seq-some
+           1   0%                              seq-do
+           1   0%                              make-closure
+         157   0%                        - seed7-inside-line-indent-before-comment-p
+         107   0%                         - seed7-inside-comment-p
+         105   0%                          - syntax-ppss
+          97   0%                             parse-partial-sexp
+           1   0%                             make-closure
+           1   0%                             #<byte-code-function 297>
+           1   0%                             syntax-ppss--update-stats
+          27   0%                           seed7-to-indent
+           7   0%                        - seed7-line-code-ends-with
+           7   0%                         - seed7-re-search-backward
+           3   0%                          - run-with-timer
+           3   0%                           - run-at-time
+           2   0%                            - timer-activate
+           2   0%                             - timer--activate
+           2   0%                                timer--time-less-p
+           1   0%                            - timer-set-time
+           1   0%                               timer--time-setter
+           2   0%                          - seed7-inside-string-p
+           2   0%                           - syntax-ppss
+           2   0%                              parse-partial-sexp
+           2   0%                          - seed7-inside-comment-p
+           2   0%                           - syntax-ppss
+           2   0%                              parse-partial-sexp
+           6   0%                          seed7--start-regexp-for
+           6   0%                        - backward-sexp
+           6   0%                         - forward-sexp
+           6   0%                          - seed7--forward-sexp-function
+           3   0%                           - seed7--at-set-definition-end-line-p
+           3   0%                            - seed7-line-code-ends-with
+           3   0%                             - seed7-re-search-backward
+           2   0%                              - run-with-timer
+           2   0%                               - run-at-time
+           1   0%                                - timer-set-time
+           1   0%                                   timer--time-setter
+           1   0%                                - timer-activate
+           1   0%                                 - timer--activate
+           1   0%                                    timer--time-less-p
+           1   0%                              - seed7-inside-comment-p
+           1   0%                               - syntax-ppss
+           1   0%                                  parse-partial-sexp
+           3   0%                           - seed7--at-array-definition-end-line-p
+           3   0%                            - seed7-line-code-ends-with
+           3   0%                             - seed7-re-search-backward
+           2   0%                              - run-with-timer
+           2   0%                               - run-at-time
+           1   0%                                  timer-relative-time
+           1   0%                                - timer-activate
+           1   0%                                 - timer--activate
+           1   0%                                    timer--time-less-p
+           1   0%                              - seed7-inside-string-p
+           1   0%                               - syntax-ppss
+           1   0%                                  parse-partial-sexp
+        5459   1%                      - seed7-re-search-backward
+        2188   0%                         re-search-backward
+        2102   0%                       - seed7-inside-comment-p
+        2097   0%                        - syntax-ppss
+        2082   0%                           parse-partial-sexp
+           2   0%                           make-closure
+           2   0%                           syntax-ppss--update-stats
+           1   0%                           syntax-table
+           1   0%                           #<byte-code-function 252>
+           1   0%                           syntax-propertize
+           1   0%                           syntax-ppss--data
+        1075   0%                       - run-with-timer
+        1075   0%                        - run-at-time
+         711   0%                         - timer-activate
+         708   0%                          - timer--activate
+         703   0%                           - timer--time-less-p
+          13   0%                              timer--time
+         273   0%                         - timer-set-time
+         273   0%                            timer--time-setter
+          90   0%                           timer-relative-time
+          80   0%                       - seed7-inside-string-p
+          66   0%                        - syntax-ppss
+          55   0%                           parse-partial-sexp
+           3   0%                           make-closure
+           3   0%                         - #<byte-code-function BA9>
+           1   0%                            set-syntax-table
+           3   0%                        - #<byte-code-function 2F2>
+           1   0%                           set-match-data
+           2   0%                       - #<byte-code-function 9CF8>
+           2   0%                          cancel-timer
+           1   0%                         make-closure
+        5213   1%                      - seed7-calc-indent
+        3925   1%                       - seed7-line-inside-a-block-cached
+        3925   1%                        - seed7-line-inside-a-block
+        3852   0%                         - seed7--safe-enclosing-block-bounds
+        3417   0%                          - seed7--block-end-pos-for
+        3415   0%                           - seed7-to-block-forward
+        3346   0%                            - seed7-end-of-defun
+        3029   0%                             - seed7-re-search-forward
+          28   0%                              - seed7-inside-comment-p
+          28   0%                               - syntax-ppss
+          28   0%                                  parse-partial-sexp
+           6   0%                              - seed7-inside-string-p
+           5   0%                               - syntax-ppss
+           5   0%                                  parse-partial-sexp
+         297   0%                             - seed7-top-block-name
+         272   0%                              - seed7--to-top
+         251   0%                               - seed7-re-search-backward
+         163   0%                                - seed7-inside-comment-p
+         163   0%                                 - syntax-ppss
+         163   0%                                    parse-partial-sexp
+          53   0%                                - run-with-timer
+          53   0%                                 - run-at-time
+          39   0%                                  - timer-activate
+          39   0%                                   - timer--activate
+          39   0%                                    - timer--time-less-p
+          11   0%                                       timer--time
+          12   0%                                  - timer-set-time
+          12   0%                                     timer--time-setter
+           2   0%                                    timer-relative-time
+          34   0%                                  re-search-backward
+           1   0%                                - seed7-inside-string-p
+           1   0%                                   syntax-ppss
+           9   0%                               - run-with-timer
+           9   0%                                - run-at-time
+           5   0%                                 - timer-set-time
+           5   0%                                    timer--time-setter
+           4   0%                                 - timer-activate
+           4   0%                                  - timer--activate
+           4   0%                                     timer--time-less-p
+           1   0%                                 seed7-to-indent
+          25   0%                              - seed7--block-name
+          25   0%                               - seed7-re-search-forward
+           8   0%                                - seed7-inside-comment-p
+           8   0%                                 - syntax-ppss
+           8   0%                                    parse-partial-sexp
+           2   0%                                - seed7-inside-string-p
+           2   0%                                 - syntax-ppss
+           2   0%                                    parse-partial-sexp
+          20   0%                             - seed7-re-search-backward
+          11   0%                                re-search-backward
+           5   0%                              - run-with-timer
+           5   0%                               - run-at-time
+           4   0%                                - timer-activate
+           4   0%                                 - timer--activate
+           4   0%                                    timer--time-less-p
+           1   0%                                  timer-relative-time
+           4   0%                              - seed7-inside-comment-p
+           4   0%                               - syntax-ppss
+           4   0%                                  parse-partial-sexp
+          62   0%                            - seed7-re-search-forward
+          12   0%                             - seed7-inside-comment-p
+          11   0%                              - syntax-ppss
+          11   0%                                 parse-partial-sexp
+          10   0%                             - seed7-inside-string-p
+          10   0%                              - syntax-ppss
+          10   0%                                 parse-partial-sexp
+           3   0%                            - seed7--current-line-nth-word
+           3   0%                             - thing-at-point
+           3   0%                              - bounds-of-thing-at-point
+           2   0%                               - #<byte-code-function AFE>
+           2   0%                                - forward-thing
+           1   0%                                   format
+           1   0%                                   forward-word
+           1   0%                               - seq-some
+           1   0%                                  make-closure
+           2   0%                            - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+           1   0%                             - seed7-inside-comment-p
+           1   0%                              - syntax-ppss
+           1   0%                                 #<byte-code-function FF2>
+           1   0%                               seed7-inside-line-indent-before-comment-p
+           2   0%                            - seed7-inside-comment-p
+           2   0%                             - syntax-ppss
+           2   0%                                parse-partial-sexp
+           1   0%                           - seed7-re-search-forward-closest
+           1   0%                              seed7-re-search-forward
+         435   0%                          - seed7-to-block-backward
+         273   0%                           - seed7-beg-of-defun
+         173   0%                            - seed7-re-search-backward-closest
+         173   0%                             - seed7-re-search-backward
+         169   0%                                re-search-backward
+           4   0%                              - run-with-timer
+           4   0%                               - run-at-time
+           4   0%                                - timer-activate
+           4   0%                                 - timer--activate
+           4   0%                                    timer--time-less-p
+          95   0%                            - seed7-re-search-backward
+          55   0%                               re-search-backward
+          30   0%                             - seed7-inside-comment-p
+          30   0%                              - syntax-ppss
+          30   0%                                 parse-partial-sexp
+          10   0%                             - run-with-timer
+          10   0%                              - run-at-time
+           7   0%                               - timer-activate
+           7   0%                                - timer--activate
+           7   0%                                   timer--time-less-p
+           3   0%                               - timer-set-time
+           3   0%                                  timer--time-setter
+           4   0%                            - seed7-top-block-name
+           2   0%                             - seed7--to-top
+           1   0%                              - seed7-re-search-backward
+           1   0%                               - seed7-inside-comment-p
+           1   0%                                - syntax-ppss
+           1   0%                                   parse-partial-sexp
+           2   0%                             - seed7--block-name
+           2   0%                                seed7-re-search-forward
+           1   0%                              match-string
+         146   0%                           - seed7-re-search-backward
+          65   0%                            - seed7-inside-comment-p
+          65   0%                             - syntax-ppss
+          65   0%                                parse-partial-sexp
+          54   0%                              re-search-backward
+          23   0%                            - run-with-timer
+          23   0%                             - run-at-time
+          12   0%                              - timer-activate
+          12   0%                               - timer--activate
+          10   0%                                  timer--time-less-p
+          10   0%                              - timer-set-time
+          10   0%                                 timer--time-setter
+           1   0%                                timer-relative-time
+           4   0%                            - seed7-inside-string-p
+           3   0%                             - syntax-ppss
+           3   0%                                parse-partial-sexp
+           6   0%                           - seed7--current-line-nth-word
+           6   0%                            - thing-at-point
+           6   0%                             - bounds-of-thing-at-point
+           3   0%                              - #<byte-code-function 2A9>
+           3   0%                               - forward-thing
+           3   0%                                  forward-word
+           1   0%                                make-closure
+           1   0%                              - #<byte-code-function 328>
+           1   0%                               - forward-thing
+           1   0%                                  forward-word
+           5   0%                           - seed7-inside-comment-p
+           5   0%                            - syntax-ppss
+           5   0%                               parse-partial-sexp
+           3   0%                           - seed7-line-code-ends-with
+           3   0%                            - seed7-re-search-backward
+           2   0%                             - seed7-inside-comment-p
+           2   0%                              - syntax-ppss
+           2   0%                                 parse-partial-sexp
+           1   0%                             - run-with-timer
+           1   0%                              - run-at-time
+           1   0%                               - timer-activate
+           1   0%                                - timer--activate
+           1   0%                                   timer--time-less-p
+           2   0%                           - seed7-inside-line-indent-before-comment-p
+           1   0%                            - seed7-inside-comment-p
+           1   0%                             - syntax-ppss
+           1   0%                                parse-partial-sexp
+          69   0%                         - seed7-re-search-backward
+          28   0%                            re-search-backward
+          27   0%                          - seed7-inside-comment-p
+          27   0%                           - syntax-ppss
+          27   0%                              parse-partial-sexp
+          12   0%                          - run-with-timer
+          12   0%                           - run-at-time
+           7   0%                            - timer-activate
+           7   0%                             - timer--activate
+           7   0%                              - timer--time-less-p
+           1   0%                                 timer--time
+           4   0%                            - timer-set-time
+           4   0%                               timer--time-setter
+           1   0%                              timer-relative-time
+           1   0%                          - seed7-inside-string-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           1   0%                            #<byte-code-function 2DD>
+         816   0%                       - seed7-line-inside-parens-pair-column
+         816   0%                        - seed7-line-inside-parens-pair
+         742   0%                         - seed7-re-search-backward
+         567   0%                          - seed7-inside-comment-p
+         567   0%                           - syntax-ppss
+         565   0%                              parse-partial-sexp
+           2   0%                              make-closure
+         155   0%                          - run-with-timer
+         155   0%                           - run-at-time
+         110   0%                            - timer-activate
+         110   0%                             - timer--activate
+         109   0%                                timer--time-less-p
+          33   0%                            - timer-set-time
+          33   0%                               timer--time-setter
+          11   0%                              timer-relative-time
+           1   0%                              timer-set-function
+          11   0%                            re-search-backward
+           8   0%                          - seed7-inside-string-p
+           6   0%                           - syntax-ppss
+           5   0%                              parse-partial-sexp
+          10   0%                         - forward-sexp
+          10   0%                            seed7--forward-sexp-function
+         249   0%                       - seed7--indent-search-boundary
+         247   0%                        - seed7--indent-search-boundary-uncached
+         215   0%                         - syntax-ppss
+         213   0%                            parse-partial-sexp
+           1   0%                          - #<byte-code-function 4CA>
+           1   0%                             set-syntax-table
+           2   0%                           seed7-to-indent
+         182   0%                       - seed7-line-is-defun-end
+          84   0%                        - seed7-beg-of-defun
+          70   0%                         - seed7-re-search-backward
+          50   0%                            re-search-backward
+          17   0%                          - seed7-inside-comment-p
+          17   0%                           - syntax-ppss
+          17   0%                              parse-partial-sexp
+           3   0%                          - run-with-timer
+           3   0%                           - run-at-time
+           2   0%                            - timer-activate
+           2   0%                             - timer--activate
+           2   0%                                timer--time-less-p
+           1   0%                            - timer-set-time
+           1   0%                               timer--time-setter
+          14   0%                         - seed7-re-search-backward-closest
+          14   0%                          - seed7-re-search-backward
+          13   0%                             re-search-backward
+           1   0%                           - seed7-inside-comment-p
+           1   0%                            - syntax-ppss
+           1   0%                               parse-partial-sexp
+          56   0%                        - seed7-end-of-defun
+          37   0%                         - seed7-re-search-forward
+           2   0%                          - seed7-inside-comment-p
+           2   0%                           - syntax-ppss
+           2   0%                              parse-partial-sexp
+          19   0%                         - seed7-top-block-name
+          19   0%                          - seed7--to-top
+          19   0%                           - seed7-re-search-backward
+          16   0%                            - seed7-inside-comment-p
+          16   0%                             - syntax-ppss
+          16   0%                                parse-partial-sexp
+           2   0%                              re-search-backward
+           1   0%                            - run-with-timer
+           1   0%                             - run-at-time
+           1   0%                                timer-relative-time
+          41   0%                        - seed7--safe-current-line-defun-start-indent
+          41   0%                         - seed7-to-block-backward
+          41   0%                          - seed7-re-search-backward
+          34   0%                             re-search-backward
+           6   0%                           - seed7-inside-comment-p
+           6   0%                            - syntax-ppss
+           6   0%                               parse-partial-sexp
+           1   0%                           - run-with-timer
+           1   0%                            - run-at-time
+           1   0%                             - timer-activate
+           1   0%                              - timer--activate
+           1   0%                                 timer--time-less-p
+           1   0%                        - seed7-line-starts-with-any
+           1   0%                           seed7-line-starts-with
+          16   0%                       - seed7-line-inside-set-definition-block
+          16   0%                        - seed7-re-search-backward
+          14   0%                           re-search-backward
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+          14   0%                       - seed7-line-inside-array-definition-block
+          14   0%                        - seed7-re-search-backward
+          13   0%                           re-search-backward
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           4   0%                       - seed7-line-at-endof-array-definition-block
+           3   0%                        - backward-sexp
+           3   0%                         - forward-sexp
+           3   0%                          - seed7--forward-sexp-function
+           2   0%                           - seed7--at-set-definition-end-line-p
+           2   0%                            - seed7-line-code-ends-with
+           2   0%                             - seed7-re-search-backward
+           1   0%                              - seed7-inside-comment-p
+           1   0%                               - syntax-ppss
+           1   0%                                  parse-partial-sexp
+           1   0%                              - run-with-timer
+           1   0%                               - run-at-time
+           1   0%                                  timer-relative-time
+           1   0%                           - seed7--safe-to-block-backward
+           1   0%                            - seed7-to-block-backward
+           1   0%                             - seed7-line-code-ends-with
+           1   0%                              - seed7-re-search-backward
+           1   0%                               - run-with-timer
+           1   0%                                - run-at-time
+           1   0%                                 - timer-set-time
+           1   0%                                    timer--time-setter
+           1   0%                        - seed7-line-code-ends-with
+           1   0%                         - seed7-re-search-backward
+           1   0%                          - seed7-inside-string-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           2   0%                       - seed7-line-inside-assign-statement-continuation
+           2   0%                        - seed7-assign-op-pos
+           2   0%                         - seed7-re-search-backward
+           2   0%                            re-search-backward
+           2   0%                       - seed7-line-at-endof-set-definition-block
+           2   0%                        - seed7-line-code-ends-with
+           2   0%                         - seed7-re-search-backward
+           1   0%                          - seed7-inside-comment-p
+           1   0%                             syntax-ppss
+           1   0%                          - run-with-timer
+           1   0%                           - run-at-time
+           1   0%                            - timer-set-time
+           1   0%                               timer--time-setter
+           2   0%                       - seed7-line-after-func-return-logic-operator-column
+           2   0%                        - seed7-move-to-line
+           2   0%                         - seed7-to-previous-non-empty-line
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           1   0%                       - seed7-line-after-short-func-end
+           1   0%                        - seed7-move-to-line
+           1   0%                         - seed7-to-previous-non-empty-line
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+          47   0%                      - replace-regexp-in-string
+           5   0%                       - #<byte-code-function 443>
+           2   0%                          set-match-data
+           4   0%                         concat
+          12   0%                        match-string
+           7   0%                        seed7--on-lineof
+           1   0%                      - seed7--indent-offset-for
+           1   0%                         string-prefix-p
+           1   0%                        seed7-move-to-line
+       89164  23%                    - seed7-line-is-defun-end
+       57601  14%                     - seed7-end-of-defun
+       32092   8%                      - seed7-re-search-forward
+        4022   1%                       - seed7-inside-comment-p
+        4016   1%                        - syntax-ppss
+        2606   0%                           parse-partial-sexp
+        1394   0%                         - syntax-propertize
+        1338   0%                          - seed7-mode-syntax-propertize
+           4   0%                             #<byte-code-function 086>
+           1   0%                             #<byte-code-function 478>
+           8   0%                          - #<byte-code-function B2F>
+           8   0%                           - syntax-propertize-wholelines
+           6   0%                              syntax--lbp
+           3   0%                            #<byte-code-function 5C9>
+           1   0%                            syntax-ppss-flush-cache
+           2   0%                           make-closure
+           1   0%                           syntax-ppss--update-stats
+           1   0%                           #<byte-code-function 6E2>
+           1   0%                           syntax-ppss--data
+           1   0%                           syntax-table
+           1   0%                           syntax-ppss-toplevel-pos
+         529   0%                       - seed7-inside-string-p
+         515   0%                        - syntax-ppss
+         500   0%                           parse-partial-sexp
+           2   0%                           make-closure
+           2   0%                           set-syntax-table
+           1   0%                           syntax-ppss--update-stats
+           2   0%                        - #<byte-code-function C5F>
+           2   0%                           set-match-data
+       25019   6%                      - seed7-top-block-name
+       24937   6%                       - seed7--to-top
+       23728   6%                        - seed7-re-search-backward
+       15889   4%                         - seed7-inside-comment-p
+       15880   4%                          - syntax-ppss
+       15757   4%                             parse-partial-sexp
+          29   0%                           - syntax-propertize
+          25   0%                              seed7-mode-syntax-propertize
+           9   0%                           - #<byte-code-function 69E>
+           3   0%                              set-syntax-table
+           5   0%                             make-closure
+           3   0%                             syntax-ppss--update-stats
+           3   0%                             syntax-table
+           2   0%                             syntax-ppss--data
+           2   0%                             set-syntax-table
+           1   0%                             syntax-ppss-toplevel-pos
+        4078   1%                         - run-with-timer
+        4075   1%                          - run-at-time
+        2599   0%                           - timer-activate
+        2597   0%                            - timer--activate
+        2590   0%                             - timer--time-less-p
+          48   0%                                timer--time
+        1065   0%                           - timer-set-time
+        1061   0%                            - timer--time-setter
+           1   0%                               timerp
+         398   0%                             timer-relative-time
+           3   0%                           - timer-set-function
+           1   0%                              timerp
+           2   0%                             timer-create
+        3529   0%                           re-search-backward
+         138   0%                         - seed7-inside-string-p
+          86   0%                          - syntax-ppss
+          56   0%                           - parse-partial-sexp
+           5   0%                            - internal--syntax-propertize
+           5   0%                             - syntax-propertize
+           5   0%                                seed7-mode-syntax-propertize
+           8   0%                             make-closure
+           5   0%                           - #<byte-code-function 6F8F>
+           2   0%                              set-syntax-table
+           3   0%                             syntax-ppss--update-stats
+           2   0%                             syntax-table
+           1   0%                             set-syntax-table
+           1   0%                             syntax-propertize
+           1   0%                             syntax-ppss--data
+           5   0%                          - #<byte-code-function A8A>
+           3   0%                             set-match-data
+          15   0%                         - #<byte-code-function 882>
+          13   0%                          - cancel-timer
+           1   0%                             timerp
+           5   0%                           make-closure
+          74   0%                          seed7-to-indent
+          70   0%                        - run-with-timer
+          70   0%                         - run-at-time
+          44   0%                          - timer-activate
+          44   0%                           - timer--activate
+          44   0%                            - timer--time-less-p
+           1   0%                               timer--time
+          20   0%                          - timer-set-time
+          20   0%                             timer--time-setter
+           6   0%                            timer-relative-time
+           1   0%                          #<byte-code-function F8F>
+          81   0%                       - seed7--block-name
+          81   0%                        - seed7-re-search-forward
+          43   0%                         - seed7-inside-comment-p
+          42   0%                          - syntax-ppss
+          42   0%                             parse-partial-sexp
+          11   0%                         - seed7-inside-string-p
+           8   0%                          - syntax-ppss
+           7   0%                             parse-partial-sexp
+           1   0%                             syntax-table
+           1   0%                            #<byte-code-function 260>
+         443   0%                      - seed7-re-search-backward
+         293   0%                         re-search-backward
+          79   0%                       - run-with-timer
+          79   0%                        - run-at-time
+          45   0%                         - timer-activate
+          45   0%                          - timer--activate
+          44   0%                           - timer--time-less-p
+           1   0%                              timer--time
+          21   0%                         - timer-set-time
+          21   0%                            timer--time-setter
+          13   0%                           timer-relative-time
+          67   0%                       - seed7-inside-comment-p
+          67   0%                        - syntax-ppss
+          66   0%                           parse-partial-sexp
+           1   0%                         seed7-inside-string-p
+           3   0%                        match-string
+           2   0%                        match-string-no-properties
+       31197   8%                     - seed7-beg-of-defun
+       15061   3%                      - seed7-re-search-backward-closest
+       15061   3%                       - seed7-re-search-backward
+       14843   3%                          re-search-backward
+         170   0%                        - seed7-inside-comment-p
+         170   0%                         - syntax-ppss
+         167   0%                            parse-partial-sexp
+          42   0%                        - run-with-timer
+          42   0%                         - run-at-time
+          27   0%                          - timer-activate
+          27   0%                           - timer--activate
+          26   0%                            - timer--time-less-p
+           1   0%                               timer--time
+          10   0%                          - timer-set-time
+          10   0%                             timer--time-setter
+           4   0%                            timer-relative-time
+           2   0%                        - seed7-inside-string-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+        8140   2%                      - seed7-re-search-backward
+        5543   1%                         re-search-backward
+        2074   0%                       - seed7-inside-comment-p
+        2073   0%                        - syntax-ppss
+        2069   0%                           parse-partial-sexp
+           1   0%                           syntax-ppss--update-stats
+           1   0%                           make-closure
+         487   0%                       - run-with-timer
+         487   0%                        - run-at-time
+         282   0%                         - timer-activate
+         282   0%                          - timer--activate
+         279   0%                           - timer--time-less-p
+           5   0%                              timer--time
+           1   0%                             timerp
+         131   0%                         - timer-set-time
+         131   0%                            timer--time-setter
+          74   0%                           timer-relative-time
+          20   0%                       - seed7-inside-string-p
+          14   0%                        - syntax-ppss
+          11   0%                           parse-partial-sexp
+           1   0%                           syntax-ppss--data
+           1   0%                         make-closure
+           1   0%                       - #<byte-code-function C09D>
+           1   0%                        - cancel-timer
+           1   0%                           timerp
+        7962   2%                      - seed7-top-block-name
+        7807   2%                       - seed7--to-top
+        7408   1%                        - seed7-re-search-backward
+        4895   1%                         - seed7-inside-comment-p
+        4893   1%                          - syntax-ppss
+        4874   1%                             parse-partial-sexp
+           2   0%                             syntax-ppss--update-stats
+           1   0%                             syntax-ppss-toplevel-pos
+           1   0%                             make-closure
+        1259   0%                           re-search-backward
+        1173   0%                         - run-with-timer
+        1173   0%                          - run-at-time
+         748   0%                           - timer-activate
+         747   0%                            - timer--activate
+         745   0%                             - timer--time-less-p
+          17   0%                                timer--time
+         305   0%                           - timer-set-time
+         305   0%                              timer--time-setter
+         118   0%                             timer-relative-time
+           1   0%                             timer-create
+          51   0%                         - seed7-inside-string-p
+          37   0%                          - syntax-ppss
+          23   0%                             parse-partial-sexp
+           4   0%                             make-closure
+           3   0%                             #<byte-code-function 528>
+           1   0%                             syntax-table
+           1   0%                             syntax-propertize
+           1   0%                             syntax-ppss--data
+           4   0%                          - #<byte-code-function 9BB>
+           2   0%                             set-match-data
+           4   0%                           make-closure
+           2   0%                         - #<byte-code-function B3E>
+           2   0%                          - cancel-timer
+           1   0%                             timerp
+          25   0%                          seed7-to-indent
+          23   0%                        - run-with-timer
+          23   0%                         - run-at-time
+          16   0%                          - timer-activate
+          16   0%                           - timer--activate
+          16   0%                            - timer--time-less-p
+           1   0%                               timer--time
+           6   0%                          - timer-set-time
+           6   0%                             timer--time-setter
+           1   0%                            timer-relative-time
+         155   0%                       - seed7--block-name
+         155   0%                        - seed7-re-search-forward
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             syntax-propertize
+           4   0%                        match-string
+           1   0%                        match-string-no-properties
+           1   0%                        seed7--move-and-mark
+         153   0%                     - seed7-move-to-line
+         152   0%                      - seed7-to-previous-non-empty-line
+         115   0%                       - seed7-inside-comment-p
+         115   0%                        - syntax-ppss
+         113   0%                           parse-partial-sexp
+           1   0%                           syntax-table
+           1   0%                           make-closure
+         151   0%                     - seed7--safe-current-line-defun-start-indent
+         150   0%                      - seed7-to-block-backward
+         148   0%                       - seed7-re-search-backward
+         109   0%                          re-search-backward
+          31   0%                        - seed7-inside-comment-p
+          31   0%                         - syntax-ppss
+          31   0%                            parse-partial-sexp
+           6   0%                        - run-with-timer
+           6   0%                         - run-at-time
+           5   0%                          - timer-activate
+           5   0%                           - timer--activate
+           5   0%                              timer--time-less-p
+           1   0%                            timer-relative-time
+           2   0%                        - seed7-inside-string-p
+           1   0%                         - #<byte-code-function D78>
+           1   0%                            set-match-data
+           2   0%                       - seed7--current-line-nth-word
+           2   0%                        - thing-at-point
+           2   0%                         - bounds-of-thing-at-point
+           1   0%                          - #<byte-code-function F9A>
+           1   0%                           - forward-thing
+           1   0%                              forward-word
+           1   0%                          - #<byte-code-function 3C9>
+           1   0%                           - forward-thing
+           1   0%                              functionp
+           1   0%                        seed7-current-line-indent
+          47   0%                     - seed7--current-line-nth-word
+          42   0%                      - thing-at-point
+          41   0%                       - bounds-of-thing-at-point
+          19   0%                        - #<byte-code-function 9B8>
+          19   0%                         - forward-thing
+          11   0%                            forward-word
+           3   0%                            intern-soft
+           2   0%                            format
+           8   0%                        - #<byte-code-function 39A>
+           8   0%                         - forward-thing
+           6   0%                            forward-word
+           2   0%                            format
+           4   0%                        - seq-some
+           3   0%                           make-closure
+           4   0%                          re-search-forward
+           2   0%                          make-closure
+          10   0%                     - seed7-line-starts-with-any
+          10   0%                        seed7-line-starts-with
+           2   0%                       line-end-position
+       56003  14%                    - seed7--indent-search-boundary
+       55996  14%                     - seed7--indent-search-boundary-uncached
+       50962  13%                      - syntax-ppss
+       50680  13%                         parse-partial-sexp
+          34   0%                       - #<byte-code-function 4CF>
+          11   0%                          set-syntax-table
+          26   0%                         make-closure
+          15   0%                         syntax-propertize
+          13   0%                         syntax-ppss-toplevel-pos
+          13   0%                         syntax-ppss--update-stats
+          10   0%                         syntax-table
+           9   0%                         set-syntax-table
+           7   0%                         syntax-ppss--data
+         196   0%                        seed7-to-indent
+           1   0%                       seed7--indent-search-boundary-valid-p
+           1   0%                       seed7-to-indent
+       32885   8%                    - seed7-line-inside-array-definition-block
+       32839   8%                     - seed7-re-search-backward
+       32068   8%                        re-search-backward
+         707   0%                      - seed7-inside-comment-p
+         705   0%                       - syntax-ppss
+         698   0%                          parse-partial-sexp
+           2   0%                          syntax-ppss-toplevel-pos
+           1   0%                          syntax-ppss--update-stats
+          55   0%                      - run-with-timer
+          55   0%                       - run-at-time
+          44   0%                        - timer-activate
+          44   0%                         - timer--activate
+          43   0%                          - timer--time-less-p
+           1   0%                             timer--time
+           8   0%                          timer-relative-time
+           3   0%                        - timer-set-time
+           3   0%                           timer--time-setter
+           7   0%                      - seed7-inside-string-p
+           5   0%                       - syntax-ppss
+           2   0%                          parse-partial-sexp
+           1   0%                          syntax-ppss--update-stats
+           1   0%                        make-closure
+          34   0%                     - forward-sexp
+          34   0%                        seed7--forward-sexp-function
+       29530   7%                    - seed7-line-inside-set-definition-block
+       29470   7%                     - seed7-re-search-backward
+       28656   7%                        re-search-backward
+         718   0%                      - seed7-inside-comment-p
+         718   0%                       - syntax-ppss
+         710   0%                          parse-partial-sexp
+           1   0%                          syntax-table
+           1   0%                          syntax-ppss--update-stats
+           1   0%                          make-closure
+           1   0%                          syntax-ppss-toplevel-pos
+          92   0%                      - run-with-timer
+          92   0%                       - run-at-time
+          55   0%                        - timer-activate
+          55   0%                         - timer--activate
+          55   0%                            timer--time-less-p
+          24   0%                        - timer-set-time
+          24   0%                           timer--time-setter
+          13   0%                          timer-relative-time
+           3   0%                      - seed7-inside-string-p
+           3   0%                       - syntax-ppss
+           2   0%                          parse-partial-sexp
+           1   0%                          make-closure
+           1   0%                      - #<byte-code-function 38A>
+           1   0%                       - cancel-timer
+           1   0%                          timerp
+          38   0%                     - forward-sexp
+          37   0%                      - seed7--forward-sexp-function
+           1   0%                         seed7--at-line-comment-start-p
+           3   0%                       seed7-move-to-line
+       14128   3%                    - seed7-line-inside-parens-pair-column
+       14127   3%                     - seed7-line-inside-parens-pair
+       12558   3%                      - seed7-re-search-backward
+        9072   2%                       - seed7-inside-comment-p
+        9065   2%                        - syntax-ppss
+        9024   2%                           parse-partial-sexp
+          10   0%                         - #<byte-code-function 056>
+           2   0%                            set-syntax-table
+           4   0%                           syntax-table
+           3   0%                           make-closure
+           3   0%                           syntax-ppss--update-stats
+           3   0%                           syntax-ppss-toplevel-pos
+           1   0%                           set-syntax-table
+           1   0%                           syntax-propertize
+           1   0%                           syntax-ppss--data
+        3128   0%                       - run-with-timer
+        3124   0%                        - run-at-time
+        2024   0%                         - timer-activate
+        2023   0%                          - timer--activate
+        2009   0%                           - timer--time-less-p
+          24   0%                              timer--time
+           1   0%                             timerp
+         815   0%                         - timer-set-time
+         814   0%                          - timer--time-setter
+           1   0%                             timerp
+         274   0%                           timer-relative-time
+           6   0%                           timer-create
+           3   0%                         - timer-set-function
+           1   0%                            timerp
+         179   0%                         re-search-backward
+         156   0%                       - seed7-inside-string-p
+         128   0%                        - syntax-ppss
+          79   0%                           parse-partial-sexp
+          11   0%                           make-closure
+           7   0%                         - #<byte-code-function D3D>
+           1   0%                            set-syntax-table
+           6   0%                           syntax-ppss--data
+           4   0%                           syntax-propertize
+           4   0%                           syntax-ppss--update-stats
+           3   0%                           syntax-table
+           2   0%                           set-syntax-table
+           7   0%                        - #<byte-code-function A9E>
+           3   0%                           set-match-data
+           2   0%                       - #<byte-code-function A0D>
+           1   0%                          cancel-timer
+           1   0%                         make-closure
+         167   0%                      - forward-sexp
+         165   0%                       - seed7--forward-sexp-function
+           2   0%                          seed7--at-line-comment-start-p
+          61   0%                      - seed7-line-inside-syntax-parens-pair
+          57   0%                       - syntax-ppss
+          56   0%                          parse-partial-sexp
+           1   0%                         seed7-move-to-line
+           3   0%                        seed7--paren-pair-string
+        1091   0%                    - seed7-comment-column
+        1071   0%                     - seed7-calc-indent
+         341   0%                      - seed7-line-inside-array-definition-block
+         340   0%                       - seed7-re-search-backward
+         328   0%                          re-search-backward
+          12   0%                        - seed7-inside-comment-p
+          12   0%                         - syntax-ppss
+          12   0%                            parse-partial-sexp
+         240   0%                      - seed7--indent-search-boundary
+         240   0%                       - seed7--indent-search-boundary-uncached
+         218   0%                        - syntax-ppss
+         217   0%                           parse-partial-sexp
+         213   0%                      - seed7-line-inside-set-definition-block
+         213   0%                       - seed7-re-search-backward
+         204   0%                          re-search-backward
+           8   0%                        - seed7-inside-comment-p
+           8   0%                         - syntax-ppss
+           8   0%                            parse-partial-sexp
+           1   0%                        - seed7-inside-string-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+          95   0%                      - seed7-line-inside-a-block-cached
+          95   0%                       - seed7-line-inside-a-block
+          73   0%                        - seed7--safe-enclosing-block-bounds
+          53   0%                         - seed7-to-block-backward
+          46   0%                          - seed7-re-search-backward
+          31   0%                           - seed7-inside-comment-p
+          31   0%                            - syntax-ppss
+          31   0%                               parse-partial-sexp
+           6   0%                           - run-with-timer
+           6   0%                            - run-at-time
+           5   0%                             - timer-activate
+           5   0%                              - timer--activate
+           5   0%                               - timer--time-less-p
+           1   0%                                  timer--time
+           1   0%                             - timer-set-time
+           1   0%                                timer--time-setter
+           5   0%                             re-search-backward
+           4   0%                           - seed7-inside-string-p
+           4   0%                            - syntax-ppss
+           4   0%                               parse-partial-sexp
+           3   0%                          - seed7--current-line-nth-word
+           3   0%                           - thing-at-point
+           3   0%                            - bounds-of-thing-at-point
+           1   0%                             - seq-some
+           1   0%                                make-closure
+           1   0%                             - #<byte-code-function 021>
+           1   0%                              - forward-thing
+           1   0%                                 format
+           1   0%                             - #<byte-code-function F0E>
+           1   0%                              - forward-thing
+           1   0%                                 forward-word
+           2   0%                          - seed7-inside-comment-p
+           2   0%                           - syntax-ppss
+           2   0%                              parse-partial-sexp
+           1   0%                            seed7-inside-line-indent-before-comment-p
+          20   0%                         - seed7--block-end-pos-for
+          20   0%                          - seed7-to-block-forward
+          17   0%                           - seed7-re-search-forward
+           8   0%                            - seed7-inside-string-p
+           8   0%                             - syntax-ppss
+           8   0%                                parse-partial-sexp
+           6   0%                            - seed7-inside-comment-p
+           6   0%                             - syntax-ppss
+           6   0%                                parse-partial-sexp
+           2   0%                           - seed7-inside-comment-p
+           2   0%                            - syntax-ppss
+           2   0%                               parse-partial-sexp
+           1   0%                           - seed7--current-line-nth-word
+           1   0%                            - thing-at-point
+           1   0%                             - bounds-of-thing-at-point
+           1   0%                              - #<byte-code-function 516>
+           1   0%                               - forward-thing
+           1   0%                                  forward-word
+          22   0%                        - seed7-re-search-backward
+          15   0%                         - seed7-inside-comment-p
+          15   0%                          - syntax-ppss
+          15   0%                             parse-partial-sexp
+           3   0%                         - run-with-timer
+           3   0%                          - run-at-time
+           2   0%                           - timer-activate
+           2   0%                            - timer--activate
+           2   0%                               timer--time-less-p
+           1   0%                             timer-relative-time
+           2   0%                         - seed7-inside-string-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           2   0%                           re-search-backward
+          88   0%                      - seed7-line-is-defun-end
+          51   0%                       - seed7-end-of-defun
+          27   0%                        - seed7-top-block-name
+          27   0%                         - seed7--to-top
+          25   0%                          - seed7-re-search-backward
+          15   0%                           - seed7-inside-comment-p
+          15   0%                            - syntax-ppss
+          15   0%                               parse-partial-sexp
+           5   0%                           - run-with-timer
+           5   0%                            - run-at-time
+           2   0%                             - timer-activate
+           2   0%                              - timer--activate
+           2   0%                                 timer--time-less-p
+           2   0%                             - timer-set-time
+           2   0%                                timer--time-setter
+           1   0%                               timer-relative-time
+           4   0%                             re-search-backward
+          22   0%                        - seed7-re-search-forward
+           4   0%                         - seed7-inside-comment-p
+           4   0%                          - syntax-ppss
+           2   0%                           - syntax-propertize
+           2   0%                              seed7-mode-syntax-propertize
+           2   0%                             parse-partial-sexp
+           1   0%                        - seed7-re-search-backward
+           1   0%                           re-search-backward
+          28   0%                       - seed7-beg-of-defun
+          24   0%                        - seed7-re-search-backward-closest
+          24   0%                         - seed7-re-search-backward
+          24   0%                            re-search-backward
+           3   0%                        - seed7-re-search-backward
+           3   0%                           re-search-backward
+           1   0%                        - seed7-top-block-name
+           1   0%                         - seed7--to-top
+           1   0%                          - seed7-re-search-backward
+           1   0%                             re-search-backward
+           7   0%                       - seed7-move-to-line
+           7   0%                        - seed7-to-previous-non-empty-line
+           7   0%                         - seed7-inside-comment-p
+           7   0%                          - syntax-ppss
+           5   0%                             parse-partial-sexp
+           1   0%                             make-closure
+           2   0%                       - seed7--safe-current-line-defun-start-indent
+           2   0%                        - seed7-to-block-backward
+           1   0%                         - seed7-re-search-backward
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           1   0%                         - seed7--current-line-nth-word
+           1   0%                          - thing-at-point
+           1   0%                           - bounds-of-thing-at-point
+           1   0%                              re-search-forward
+          40   0%                      - seed7-line-inside-parens-pair-column
+          40   0%                       - seed7-line-inside-parens-pair
+          37   0%                        - seed7-re-search-backward
+          29   0%                         - seed7-inside-comment-p
+          28   0%                          - syntax-ppss
+          28   0%                             parse-partial-sexp
+           7   0%                         - run-with-timer
+           7   0%                          - run-at-time
+           4   0%                           - timer-activate
+           4   0%                            - timer--activate
+           4   0%                             - timer--time-less-p
+           1   0%                                timer--time
+           2   0%                             timer-relative-time
+           1   0%                           - timer-set-time
+           1   0%                              timer--time-setter
+           2   0%                        - seed7-line-inside-syntax-parens-pair
+           2   0%                         - syntax-ppss
+           2   0%                            parse-partial-sexp
+           1   0%                        - forward-sexp
+           1   0%                           seed7--forward-sexp-function
+          11   0%                      - seed7-line-after-func-return-logic-operator-column
+          11   0%                       - seed7-move-to-line
+          11   0%                        - seed7-to-previous-non-empty-line
+          11   0%                         - seed7-inside-comment-p
+          11   0%                          - syntax-ppss
+          11   0%                             parse-partial-sexp
+          11   0%                      - seed7-line-after-short-func-end
+          11   0%                       - seed7-move-to-line
+          11   0%                        - seed7-to-previous-non-empty-line
+          11   0%                         - seed7-inside-comment-p
+          11   0%                          - syntax-ppss
+          10   0%                             parse-partial-sexp
+          11   0%                      - seed7-line-at-endof-set-definition-block
+          11   0%                       - seed7-move-to-line
+          11   0%                        - seed7-to-previous-non-empty-line
+          11   0%                         - seed7-inside-comment-p
+          11   0%                          - syntax-ppss
+          11   0%                             parse-partial-sexp
+           7   0%                      - seed7-line-at-endof-array-definition-block
+           7   0%                       - seed7-move-to-line
+           7   0%                        - seed7-to-previous-non-empty-line
+           7   0%                         - seed7-inside-comment-p
+           7   0%                          - syntax-ppss
+           7   0%                             parse-partial-sexp
+           7   0%                      - seed7-line-starts-with-open-paren-after-logic-operator
+           7   0%                       - seed7-move-to-line
+           7   0%                        - seed7-to-previous-non-empty-line
+           7   0%                         - seed7-inside-comment-p
+           7   0%                          - syntax-ppss
+           7   0%                             parse-partial-sexp
+           3   0%                      - seed7-line-inside-logic-check-expression
+           3   0%                       - seed7-to-previous-line-starts-with
+           3   0%                        - seed7-re-search-backward
+           2   0%                           re-search-backward
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             make-closure
+           1   0%                      - seed7-line-inside-argument-list-section
+           1   0%                       - seed7-re-search-backward
+           1   0%                          re-search-backward
+           1   0%                      - seed7-line-inside-assign-statement-continuation
+           1   0%                       - seed7-assign-op-pos
+           1   0%                        - seed7-re-search-backward
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                      - seed7-current-line-start-inside-comment-p
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           1   0%                      - seed7-line-inside-until-logic-expression
+           1   0%                       - seed7-re-search-backward
+           1   0%                        - run-with-timer
+           1   0%                         - run-at-time
+           1   0%                          - timer-activate
+           1   0%                           - timer--activate
+           1   0%                              timer--time-less-p
+          11   0%                     - seed7-line-code-ends-with
+           7   0%                      - seed7-move-to-line
+           7   0%                       - seed7-to-previous-non-empty-line
+           7   0%                        - seed7-inside-comment-p
+           7   0%                         - syntax-ppss
+           6   0%                            parse-partial-sexp
+           1   0%                          - #<byte-code-function 721>
+           1   0%                             set-syntax-table
+           4   0%                      - seed7-re-search-backward
+           3   0%                       - run-with-timer
+           3   0%                        - run-at-time
+           2   0%                         - timer-activate
+           2   0%                          - timer--activate
+           2   0%                             timer--time-less-p
+           1   0%                         - timer-set-time
+           1   0%                            timer--time-setter
+           1   0%                       - seed7-inside-string-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           7   0%                     - seed7-line-inside-a-block
+           5   0%                      - seed7-re-search-backward
+           3   0%                         re-search-backward
+           2   0%                       - seed7-inside-comment-p
+           2   0%                        - syntax-ppss
+           2   0%                           parse-partial-sexp
+           2   0%                      - seed7--safe-enclosing-block-bounds
+           1   0%                       - seed7-to-block-backward
+           1   0%                        - seed7-re-search-backward
+           1   0%                           re-search-backward
+           1   0%                       - seed7--block-end-pos-for
+           1   0%                        - seed7-to-block-forward
+           1   0%                           seed7-re-search-forward
+           1   0%                     - seed7-line-starts-with
+           1   0%                      - seed7-move-to-line
+           1   0%                       - seed7-to-previous-non-empty-line
+           1   0%                        - seed7-inside-comment-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+         507   0%                    - seed7-line-inside-argument-list-section
+         486   0%                     - seed7-re-search-backward
+         396   0%                        re-search-backward
+          90   0%                      - run-with-timer
+          90   0%                       - run-at-time
+          52   0%                        - timer-activate
+          52   0%                         - timer--activate
+          51   0%                          - timer--time-less-p
+           1   0%                             timer--time
+           1   0%                            timerp
+          28   0%                        - timer-set-time
+          28   0%                           timer--time-setter
+          10   0%                          timer-relative-time
+          19   0%                     - seed7-line-is-procfunc-beg-of-decl
+          19   0%                        seed7-line-starts-with
+         455   0%                    - seed7-line-inside-assign-statement-continuation
+         445   0%                     - seed7-assign-op-pos
+         444   0%                      - seed7-re-search-backward
+         334   0%                       - seed7-inside-comment-p
+         334   0%                        - syntax-ppss
+         333   0%                           parse-partial-sexp
+           1   0%                           #<byte-code-function 23E>
+          88   0%                       - run-with-timer
+          87   0%                        - run-at-time
+          46   0%                         - timer-activate
+          46   0%                          - timer--activate
+          46   0%                           - timer--time-less-p
+           1   0%                              timer--time
+          30   0%                         - timer-set-time
+          30   0%                            timer--time-setter
+          10   0%                           timer-relative-time
+           1   0%                           timer-create
+          21   0%                         re-search-backward
+           1   0%                       - seed7-inside-string-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+          10   0%                     - seed7-statement-end-pos
+          10   0%                      - seed7-forward-char-pos
+           8   0%                       - seed7-re-search-forward
+           2   0%                        - seed7-inside-comment-p
+           2   0%                         - syntax-ppss
+           1   0%                            set-syntax-table
+           1   0%                            make-closure
+           2   0%                        - seed7-inside-string-p
+           2   0%                         - syntax-ppss
+           2   0%                            parse-partial-sexp
+         391   0%                    - seed7-line-inside-func-return-statement
+         388   0%                     - seed7-re-search-backward
+         306   0%                        re-search-backward
+          78   0%                      - run-with-timer
+          78   0%                       - run-at-time
+          49   0%                        - timer-activate
+          49   0%                         - timer--activate
+          49   0%                            timer--time-less-p
+          21   0%                        - timer-set-time
+          21   0%                           timer--time-setter
+           8   0%                          timer-relative-time
+           2   0%                       seed7-move-to-line
+         260   0%                    - seed7-line-inside-until-logic-expression
+         235   0%                     - seed7-re-search-backward
+         149   0%                        re-search-backward
+          70   0%                      - run-with-timer
+          70   0%                       - run-at-time
+          41   0%                        - timer-activate
+          41   0%                         - timer--activate
+          39   0%                            timer--time-less-p
+          19   0%                        - timer-set-time
+          19   0%                           timer--time-setter
+          10   0%                          timer-relative-time
+          13   0%                      - seed7-inside-comment-p
+          13   0%                       - syntax-ppss
+          13   0%                          parse-partial-sexp
+           1   0%                        make-closure
+          24   0%                     - seed7-line-code-ends-with
+          23   0%                      - seed7-re-search-backward
+          16   0%                       - run-with-timer
+          16   0%                        - run-at-time
+          11   0%                         - timer-activate
+          10   0%                          - timer--activate
+          10   0%                             timer--time-less-p
+           3   0%                           timer-relative-time
+           2   0%                         - timer-set-time
+           2   0%                            timer--time-setter
+           2   0%                       - seed7-inside-comment-p
+           2   0%                        - syntax-ppss
+           2   0%                           parse-partial-sexp
+           2   0%                       - seed7-inside-string-p
+           2   0%                        - syntax-ppss
+           2   0%                           parse-partial-sexp
+           2   0%                         re-search-backward
+           1   0%                        seed7-move-to-line
+           1   0%                       seed7-move-to-line
+         239   0%                    - seed7--current-line-nth-word
+         236   0%                     - thing-at-point
+         235   0%                      - bounds-of-thing-at-point
+         225   0%                       - #<byte-code-function 286>
+         225   0%                        - forward-thing
+         224   0%                         - forward-word
+         221   0%                          - internal--syntax-propertize
+         221   0%                           - syntax-propertize
+         208   0%                              seed7-mode-syntax-propertize
+           3   0%                            - #<byte-code-function CCA>
+           2   0%                             - syntax-propertize-wholelines
+           1   0%                                syntax--lbp
+           1   0%                           intern-soft
+           5   0%                       - #<byte-code-function D75>
+           5   0%                        - forward-thing
+           4   0%                           forward-word
+           1   0%                           intern-soft
+           2   0%                         make-closure
+           2   0%                         re-search-forward
+         234   0%                    - seed7-line-inside-logic-check-expression
+         200   0%                     - seed7-to-previous-line-starts-with
+         198   0%                      - seed7-re-search-backward
+          86   0%                       - run-with-timer
+          86   0%                        - run-at-time
+          46   0%                         - timer-activate
+          46   0%                          - timer--activate
+          46   0%                           - timer--time-less-p
+           1   0%                              timer--time
+          24   0%                         - timer-set-time
+          24   0%                            timer--time-setter
+          15   0%                           timer-relative-time
+          56   0%                         re-search-backward
+          48   0%                       - seed7-inside-comment-p
+          48   0%                        - syntax-ppss
+          48   0%                           parse-partial-sexp
+           6   0%                       - seed7-inside-string-p
+           6   0%                        - syntax-ppss
+           6   0%                           parse-partial-sexp
+           1   0%                         make-closure
+           1   0%                        seed7-to-indent
+          24   0%                     - seed7-re-search-forward
+          15   0%                      - seed7-inside-string-p
+          14   0%                       - syntax-ppss
+          13   0%                          parse-partial-sexp
+           1   0%                          syntax-ppss--update-stats
+           7   0%                      - seed7-inside-comment-p
+           6   0%                       - syntax-ppss
+           6   0%                          parse-partial-sexp
+           7   0%                     - seed7--current-line-nth-word
+           4   0%                      - thing-at-point
+           4   0%                       - bounds-of-thing-at-point
+           2   0%                        - #<byte-code-function A7B>
+           2   0%                         - forward-thing
+           2   0%                            forward-word
+           2   0%                       seed7-move-to-line
+         133   0%                    - seed7-line-after-func-return-logic-operator-column
+         114   0%                     - seed7-move-to-line
+         113   0%                      - seed7-to-previous-non-empty-line
+          72   0%                       - seed7-inside-comment-p
+          72   0%                        - syntax-ppss
+          70   0%                           parse-partial-sexp
+          58   0%                    - seed7-current-line-start-inside-comment-p
+          57   0%                     - seed7-inside-comment-p
+          57   0%                      - syntax-ppss
+          53   0%                         parse-partial-sexp
+           2   0%                         make-closure
+           1   0%                         #<byte-code-function D01>
+           1   0%                       seed7-to-indent
+          26   0%                    - seed7-line-at-endof-array-definition-block
+          24   0%                     - backward-sexp
+          24   0%                      - forward-sexp
+          24   0%                       - seed7--forward-sexp-function
+          23   0%                        - seed7-beg-of-defun
+          23   0%                         - seed7-re-search-backward-closest
+          23   0%                          - seed7-re-search-backward
+          23   0%                             re-search-backward
+           1   0%                        - seed7--at-array-definition-end-line-p
+           1   0%                         - seed7-line-code-ends-with
+           1   0%                          - seed7-re-search-backward
+           1   0%                           - seed7-inside-comment-p
+           1   0%                            - syntax-ppss
+           1   0%                               parse-partial-sexp
+           2   0%                     - seed7-line-code-ends-with
+           2   0%                      - seed7-re-search-backward
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           1   0%                       - run-with-timer
+           1   0%                        - run-at-time
+           1   0%                         - timer-set-time
+           1   0%                            timer--time-setter
+          24   0%                    - seed7-line-after-short-func-end
+          13   0%                     - seed7-to-block-backward
+          13   0%                      - seed7-beg-of-defun
+          13   0%                       - seed7-re-search-backward-closest
+          13   0%                        - seed7-re-search-backward
+          12   0%                           re-search-backward
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+          11   0%                     - seed7-move-to-line
+          11   0%                      - seed7-to-previous-non-empty-line
+          11   0%                       - seed7-inside-comment-p
+          11   0%                        - syntax-ppss
+           9   0%                           parse-partial-sexp
+           1   0%                           make-closure
+           1   0%                         - syntax-propertize
+           1   0%                            seed7-mode-syntax-propertize
+          13   0%                    - seed7-line-isa-string
+          11   0%                     - seed7-line-starts-with
+           5   0%                        seed7-move-to-line
+           8   0%                    - seed7-line-starts-with
+           1   0%                     - seed7-move-to-line
+           1   0%                      - seed7-to-previous-non-empty-line
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           5   0%                    - seed7-line-at-endof-set-definition-block
+           5   0%                     - seed7-line-code-ends-with
+           5   0%                      - seed7-re-search-backward
+           3   0%                       - run-with-timer
+           3   0%                        - run-at-time
+           2   0%                           timer-relative-time
+           1   0%                         - timer-set-time
+           1   0%                            timer--time-setter
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           1   0%                       - seed7-inside-string-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           3   0%                    - seed7-line-inside-nested-parens-pairs-column
+           3   0%                     - seed7-line-inside-nested-parens-pairs
+           3   0%                      - seed7-line-inside-parens-pair
+           1   0%                       - seed7-re-search-backward
+           1   0%                        - run-with-timer
+           1   0%                         - run-at-time
+           1   0%                          - timer-activate
+           1   0%                           - timer--activate
+           1   0%                              timer--time-less-p
+           1   0%                       - seed7-line-inside-syntax-parens-pair
+           1   0%                        - forward-sexp
+           1   0%                           seed7--forward-sexp-function
+           3   0%                    - seed7-line-ends-with
+           2   0%                     - seed7-move-to-line
+           2   0%                      - seed7-to-previous-non-empty-line
+           2   0%                       - seed7-inside-comment-p
+           2   0%                        - syntax-ppss
+           2   0%                           parse-partial-sexp
+           1   0%                     - seed7-re-search-backward
+           1   0%                        re-search-backward
+           2   0%                    - seed7-position-of-end-of-statement
+           2   0%                     - seed7-line-code-ends-with
+           2   0%                      - seed7-re-search-backward
+           2   0%                       - run-with-timer
+           2   0%                        - run-at-time
+           1   0%                         - timer-activate
+           1   0%                          - timer--activate
+           1   0%                             timer--time-less-p
+           1   0%                         - timer-set-time
+           1   0%                            timer--time-setter
+           1   0%                    - seed7-line-indent-step
+           1   0%                     - seed7-move-to-line
+           1   0%                      - seed7-to-previous-non-empty-line
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+          10   0%                   - jit-lock-after-change
+           5   0%                      font-lock-extend-jit-lock-region-after-change
+           2   0%                   - undo-auto--undoable-change
+           1   0%                      undo-auto--boundary-ensure-timer
+           1   0%                     delete-horizontal-space
+       14365   3%   Automatic GC

--- a/reports/19.1/bas7.sd7-perf-mem.txt
+++ b/reports/19.1/bas7.sd7-perf-mem.txt
@@ -1,0 +1,2444 @@
+  3,451,468,430  99% - ...
+  3,451,468,430  99%  - call-interactively
+  3,451,468,430  99%   - apply
+  3,451,468,430  99%    - call-interactively@ido-cr+-record-current-command
+  3,451,468,430  99%     - #<primitive-function call-interactively>
+  3,451,468,430  99%      - funcall-interactively
+  3,451,468,430  99%       - smex
+  3,451,468,430  99%        - smex-read-and-run
+  3,451,468,430  99%         - execute-extended-command
+  3,451,468,430  99%          - command-execute
+  3,451,468,430  99%           - call-interactively
+  3,451,468,430  99%            - apply
+  3,451,468,430  99%             - call-interactively@ido-cr+-record-current-command
+  3,451,468,430  99%              - #<primitive-function call-interactively>
+  3,451,468,430  99%               - funcall-interactively
+  3,451,468,430  99%                - pel-profile
+  3,449,687,442  99%                 - call-interactively
+  3,449,687,442  99%                  - apply
+  3,449,687,442  99%                   - call-interactively@ido-cr+-record-current-command
+  3,449,687,442  99%                    - #<primitive-function call-interactively>
+  3,449,687,442  99%                     - funcall-interactively
+  3,449,687,426  99%                      - seed7-complete-statement-or-indent
+  3,449,687,426  99%                       - seed7-indent-region
+  3,449,687,426  99%                        - seed7--indent-one-line
+  3,374,370,997  97%                         - seed7-calc-indent
+  1,243,174,550  35%                          - seed7-line-inside-a-block-cached
+  1,242,660,694  35%                           - seed7-line-inside-a-block
+    937,455,505  27%                            - seed7--safe-enclosing-block-bounds
+    531,996,209  15%                             - seed7-to-block-backward
+    378,502,410  10%                              - seed7-re-search-backward
+    286,734,368   8%                               - run-with-timer
+    286,734,368   8%                                - run-at-time
+    141,839,845   4%                                 - timer-activate
+    141,839,845   4%                                  - timer--activate
+    141,839,845   4%                                   - timer--time-less-p
+        132,605   0%                                      timer--time
+     77,910,416   2%                                   timer-relative-time
+     51,995,632   1%                                 - timer-set-time
+     51,995,632   1%                                    timer--time-setter
+     14,984,704   0%                                   timer-create
+          3,771   0%                                   timer-set-function
+     50,525,024   1%                               - seed7-inside-string-p
+     10,639,024   0%                                - syntax-ppss
+     10,604,496   0%                                   make-closure
+         32,792   0%                                   parse-partial-sexp
+          1,736   0%                                   #<byte-code-function 690>
+     17,921,326   0%                               - seed7-inside-comment-p
+     10,089,166   0%                                - syntax-ppss
+     10,086,496   0%                                   make-closure
+          2,670   0%                                   #<byte-code-function 98F>
+     13,980,499   0%                                 re-search-backward
+      9,341,193   0%                                 make-closure
+     95,738,573   2%                              - seed7--current-line-nth-word
+     87,719,373   2%                               - thing-at-point
+     82,554,110   2%                                - bounds-of-thing-at-point
+     37,707,236   1%                                   make-closure
+     13,737,469   0%                                 - #<byte-code-function 3FF>
+     13,737,469   0%                                  - forward-thing
+     13,730,320   0%                                     format
+          7,149   0%                                     intern-soft
+     10,343,443   0%                                 - seq-some
+     10,343,424   0%                                    make-closure
+             19   0%                                    seq-do
+      7,405,770   0%                                 - #<byte-code-function E44>
+      7,405,328   0%                                  - forward-thing
+      7,405,328   0%                                     format
+         16,512   0%                                   re-search-forward
+     23,598,123   0%                              - seed7-inside-line-indent-before-comment-p
+      7,908,819   0%                               - seed7-inside-comment-p
+      4,664,067   0%                                - syntax-ppss
+      4,662,000   0%                                   make-closure
+          2,067   0%                                   #<byte-code-function 0A74>
+            120   0%                                 seed7-to-indent
+     12,760,162   0%                              - seed7-beg-of-defun
+      8,599,941   0%                               - seed7-top-block-name
+      8,430,264   0%                                - seed7--to-top
+      8,284,792   0%                                 - seed7-re-search-backward
+      6,584,936   0%                                  - run-with-timer
+      6,584,936   0%                                   - run-at-time
+      3,250,024   0%                                    - timer-activate
+      3,250,024   0%                                     - timer--activate
+      3,250,024   0%                                        timer--time-less-p
+      1,810,304   0%                                      timer-relative-time
+      1,234,528   0%                                    - timer-set-time
+      1,234,528   0%                                       timer--time-setter
+        290,080   0%                                      timer-create
+      1,094,016   0%                                  - seed7-inside-string-p
+        165,760   0%                                   - syntax-ppss
+        165,760   0%                                      make-closure
+        339,808   0%                                  - seed7-inside-comment-p
+        153,328   0%                                   - syntax-ppss
+        153,328   0%                                      make-closure
+        203,056   0%                                    make-closure
+         62,976   0%                                    re-search-backward
+        141,328   0%                                 - run-with-timer
+        141,328   0%                                  - run-at-time
+         68,912   0%                                   - timer-activate
+         68,912   0%                                    - timer--activate
+         68,912   0%                                       timer--time-less-p
+         44,384   0%                                     timer-relative-time
+         28,032   0%                                   - timer-set-time
+         28,032   0%                                      timer--time-setter
+          4,144   0%                                   make-closure
+        169,677   0%                                - seed7--block-name
+        163,501   0%                                 - seed7-re-search-forward
+         12,432   0%                                  - seed7-inside-string-p
+          4,144   0%                                   - syntax-ppss
+          4,144   0%                                      make-closure
+          2,032   0%                                   match-string
+      2,554,472   0%                               - seed7-re-search-backward
+      1,951,678   0%                                - run-with-timer
+      1,951,678   0%                                 - run-at-time
+        963,808   0%                                  - timer-activate
+        963,808   0%                                   - timer--activate
+        963,808   0%                                      timer--time-less-p
+        511,328   0%                                    timer-relative-time
+        339,790   0%                                  - timer-set-time
+        339,520   0%                                     timer--time-setter
+        136,752   0%                                    timer-create
+        356,384   0%                                - seed7-inside-string-p
+         53,872   0%                                 - syntax-ppss
+         53,872   0%                                    make-closure
+        140,896   0%                                - seed7-inside-comment-p
+         82,880   0%                                 - syntax-ppss
+         82,880   0%                                    make-closure
+         62,160   0%                                  make-closure
+         43,354   0%                                  re-search-backward
+        600,099   0%                               - seed7-re-search-backward-closest
+        562,803   0%                                - seed7-re-search-backward
+        311,664   0%                                 - run-with-timer
+        311,664   0%                                  - run-at-time
+        162,688   0%                                   - timer-activate
+        162,688   0%                                    - timer--activate
+        162,688   0%                                       timer--time-less-p
+         88,768   0%                                     timer-relative-time
+         56,064   0%                                   - timer-set-time
+         56,064   0%                                      timer--time-setter
+          4,144   0%                                     timer-create
+        217,987   0%                                   re-search-backward
+         20,720   0%                                 - seed7-inside-string-p
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+         12,432   0%                                   make-closure
+         20,720   0%                                - seq-filter
+         20,720   0%                                   make-closure
+         90,024   0%                                 match-string-no-properties
+         42,872   0%                                 match-string
+      9,351,907   0%                              - seed7-inside-comment-p
+      5,004,851   0%                               - syntax-ppss
+      5,001,808   0%                                  make-closure
+          3,043   0%                                  syntax-table
+      7,013,064   0%                                seed7--start-regexp-for
+        752,624   0%                              - backward-sexp
+        752,624   0%                               - forward-sexp
+        752,624   0%                                - seed7--forward-sexp-function
+        393,952   0%                                 - seed7--at-array-definition-end-line-p
+        389,808   0%                                  - seed7-line-code-ends-with
+        377,376   0%                                   - seed7-re-search-backward
+        327,648   0%                                    - run-with-timer
+        327,648   0%                                     - run-at-time
+        202,128   0%                                      - timer-activate
+        202,128   0%                                       - timer--activate
+        202,128   0%                                          timer--time-less-p
+         69,312   0%                                        timer-relative-time
+         43,776   0%                                      - timer-set-time
+         43,776   0%                                         timer--time-setter
+         12,432   0%                                        timer-create
+         29,008   0%                                    - seed7-inside-string-p
+          8,288   0%                                     - syntax-ppss
+          8,288   0%                                        make-closure
+         12,432   0%                                    - seed7-inside-comment-p
+          8,288   0%                                     - syntax-ppss
+          8,288   0%                                        make-closure
+          8,288   0%                                      make-closure
+        352,496   0%                                 - seed7--at-set-definition-end-line-p
+        348,352   0%                                  - seed7-line-code-ends-with
+        348,352   0%                                   - seed7-re-search-backward
+        306,912   0%                                    - run-with-timer
+        306,912   0%                                     - run-at-time
+        189,696   0%                                      - timer-activate
+        189,696   0%                                       - timer--activate
+        189,696   0%                                          timer--time-less-p
+         69,296   0%                                        timer-relative-time
+         43,776   0%                                      - timer-set-time
+         43,776   0%                                         timer--time-setter
+          4,144   0%                                        timer-create
+         20,720   0%                                      make-closure
+         16,576   0%                                    - seed7-inside-string-p
+          8,288   0%                                     - syntax-ppss
+          8,288   0%                                        make-closure
+          4,144   0%                                      seed7-inside-comment-p
+          4,144   0%                                   seed7--line-comment-hash
+        549,280   0%                              - seed7-line-code-ends-with
+        536,848   0%                               - seed7-re-search-backward
+        370,832   0%                                - run-with-timer
+        370,832   0%                                 - run-at-time
+        171,024   0%                                  - timer-activate
+        171,024   0%                                   - timer--activate
+        171,024   0%                                      timer--time-less-p
+        102,144   0%                                    timer-relative-time
+         76,944   0%                                  - timer-set-time
+         76,944   0%                                     timer--time-setter
+         20,720   0%                                    timer-create
+         99,712   0%                                  re-search-backward
+         37,296   0%                                - seed7-inside-string-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+         16,576   0%                                - seed7-inside-comment-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+         12,432   0%                                  make-closure
+         87,490   0%                                looking-at
+    401,360,880  11%                             - seed7--block-end-pos-for
+    400,065,102  11%                              - seed7-to-block-forward
+    136,406,739   3%                               - seed7--current-line-nth-word
+    124,053,707   3%                                - thing-at-point
+    116,636,189   3%                                 - bounds-of-thing-at-point
+     50,841,008   1%                                    make-closure
+     19,366,565   0%                                  - #<byte-code-function 8D0>
+     19,366,280   0%                                   - forward-thing
+     19,366,280   0%                                      format
+     16,223,266   0%                                  - seq-some
+     16,219,616   0%                                     make-closure
+          3,650   0%                                     seq-do
+      9,745,317   0%                                  - #<byte-code-function 738>
+      9,744,920   0%                                   - forward-thing
+      9,744,920   0%                                      format
+      1,310,609   0%                                    re-search-forward
+    119,153,556   3%                               - seed7-end-of-defun
+     97,736,349   2%                                - seed7-top-block-name
+     93,422,184   2%                                 - seed7--to-top
+     84,713,653   2%                                  - seed7-re-search-backward
+     69,501,531   2%                                   - run-with-timer
+     69,501,531   2%                                    - run-at-time
+     34,138,219   0%                                     - timer-activate
+     34,138,219   0%                                      - timer--activate
+     34,138,219   0%                                         timer--time-less-p
+     19,523,008   0%                                       timer-relative-time
+     13,204,720   0%                                     - timer-set-time
+     13,204,720   0%                                        timer--time-setter
+      2,635,584   0%                                       timer-create
+      9,871,008   0%                                   - seed7-inside-string-p
+      1,694,896   0%                                    - syntax-ppss
+      1,694,896   0%                                       make-closure
+      3,115,389   0%                                   - seed7-inside-comment-p
+      1,606,973   0%                                    - syntax-ppss
+      1,574,720   0%                                       make-closure
+         32,253   0%                                     - syntax-propertize
+         32,253   0%                                        seed7-mode-syntax-propertize
+      2,009,840   0%                                     make-closure
+        215,885   0%                                     re-search-backward
+      8,430,359   0%                                  - run-with-timer
+      8,430,359   0%                                   - run-at-time
+      4,267,344   0%                                    - timer-activate
+      4,267,344   0%                                     - timer--activate
+      4,267,344   0%                                        timer--time-less-p
+      2,300,064   0%                                      timer-relative-time
+      1,531,431   0%                                    - timer-set-time
+      1,531,408   0%                                       timer--time-setter
+        331,520   0%                                      timer-create
+        277,648   0%                                    make-closure
+      4,094,533   0%                                 - seed7--block-name
+      3,389,245   0%                                  - seed7-re-search-forward
+      2,449,104   0%                                   - seed7-inside-string-p
+        252,784   0%                                    - syntax-ppss
+        252,784   0%                                       make-closure
+        455,840   0%                                   - seed7-inside-comment-p
+        248,640   0%                                    - syntax-ppss
+        248,640   0%                                       make-closure
+        241,896   0%                                    match-string
+     11,894,720   0%                                - seed7-re-search-backward
+      8,451,056   0%                                 - run-with-timer
+      8,451,056   0%                                  - run-at-time
+      4,138,880   0%                                   - timer-activate
+      4,138,880   0%                                    - timer--activate
+      4,138,880   0%                                       timer--time-less-p
+      2,300,064   0%                                     timer-relative-time
+      1,502,400   0%                                   - timer-set-time
+      1,502,400   0%                                      timer--time-setter
+        509,712   0%                                     timer-create
+      2,635,584   0%                                 - seed7-inside-string-p
+        368,816   0%                                  - syntax-ppss
+        368,816   0%                                     make-closure
+        505,568   0%                                 - seed7-inside-comment-p
+        290,080   0%                                  - syntax-ppss
+        290,080   0%                                     make-closure
+        302,512   0%                                   make-closure
+      7,154,430   0%                                - seed7-re-search-forward
+      3,393,936   0%                                 - seed7-inside-string-p
+        650,608   0%                                  - syntax-ppss
+        650,608   0%                                     make-closure
+      2,497,173   0%                                 - seed7-inside-comment-p
+      1,817,557   0%                                  - syntax-ppss
+      1,108,933   0%                                   - syntax-propertize
+      1,067,493   0%                                      seed7-mode-syntax-propertize
+        708,624   0%                                     make-closure
+        680,512   0%                                  match-string
+        310,992   0%                                  match-string-no-properties
+     90,280,378   2%                               - seed7-re-search-forward
+     44,988,489   1%                                - seed7-inside-string-p
+      9,640,529   0%                                 - syntax-ppss
+      9,638,944   0%                                    make-closure
+     24,185,750   0%                                - seed7-inside-comment-p
+     16,423,259   0%                                 - syntax-ppss
+      9,042,208   0%                                    make-closure
+      7,346,250   0%                                  - syntax-propertize
+      6,857,258   0%                                     seed7-mode-syntax-propertize
+         32,792   0%                                    parse-partial-sexp
+          1,646   0%                                    #<byte-code-function C01>
+         54,800   0%                                - internal--syntax-propertize
+         54,800   0%                                 - syntax-propertize
+         54,800   0%                                    seed7-mode-syntax-propertize
+     30,322,224   0%                               - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+      8,490,616   0%                                - seed7-inside-comment-p
+      4,926,776   0%                                 - syntax-ppss
+      4,856,768   0%                                    make-closure
+         65,584   0%                                    parse-partial-sexp
+      7,392,896   0%                                - seed7-inside-line-indent-before-comment-p
+        132,608   0%                                 - seed7-inside-comment-p
+         74,592   0%                                  - syntax-ppss
+         74,592   0%                                     make-closure
+      8,321,152   0%                               - seed7-inside-comment-p
+      4,902,352   0%                                - syntax-ppss
+      4,902,352   0%                                   make-closure
+      7,896,617   0%                               - seed7-inside-line-indent-before-comment-p
+        149,184   0%                                - seed7-inside-comment-p
+        103,600   0%                                 - syntax-ppss
+        103,600   0%                                    make-closure
+          2,297   0%                                  seed7-to-indent
+      3,934,116   0%                               - seed7--end-regexp-for
+          8,184   0%                                  seed7--type-regexp
+        539,408   0%                              - seed7-to-next-line-starts-with
+        453,912   0%                               - seed7-re-search-forward
+        116,032   0%                                - seed7-inside-string-p
+         24,864   0%                                 - syntax-ppss
+         24,864   0%                                    make-closure
+         70,448   0%                                - seed7-inside-comment-p
+         41,440   0%                                 - syntax-ppss
+         41,440   0%                                    make-closure
+        106,280   0%                              - seed7-re-search-forward-closest
+         81,416   0%                               - seed7-re-search-forward
+         37,296   0%                                - seed7-inside-string-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+          8,288   0%                                  seed7-inside-comment-p
+    196,738,315   5%                            - seed7-re-search-backward
+    141,972,159   4%                             - run-with-timer
+    141,972,159   4%                              - run-at-time
+     70,169,201   2%                               - timer-activate
+     70,169,201   2%                                - timer--activate
+     70,169,201   2%                                   timer--time-less-p
+     38,595,525   1%                                 timer-relative-time
+     25,495,008   0%                               - timer-set-time
+     25,495,008   0%                                  timer--time-setter
+      7,711,984   0%                                 timer-create
+            441   0%                                 timer-set-function
+     27,969,808   0%                             - seed7-inside-string-p
+      5,612,928   0%                              - syntax-ppss
+      5,577,824   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+     13,007,374   0%                               re-search-backward
+      9,153,736   0%                             - seed7-inside-comment-p
+      4,939,288   0%                              - syntax-ppss
+      4,906,496   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+      4,635,238   0%                               make-closure
+     56,798,764   1%                            - seed7-calc-indent
+     29,209,617   0%                             - seed7-line-inside-a-block-cached
+     29,209,617   0%                              - seed7-line-inside-a-block
+     26,146,950   0%                               - seed7--safe-enclosing-block-bounds
+     15,987,561   0%                                - seed7--block-end-pos-for
+     15,836,081   0%                                 - seed7-to-block-forward
+     12,605,119   0%                                  - seed7-end-of-defun
+     10,032,891   0%                                   - seed7-top-block-name
+      9,504,311   0%                                    - seed7--to-top
+      8,445,511   0%                                     - seed7-re-search-backward
+      6,730,583   0%                                      - run-with-timer
+      6,730,583   0%                                       - run-at-time
+      3,313,328   0%                                        - timer-activate
+      3,313,328   0%                                         - timer--activate
+      3,313,328   0%                                            timer--time-less-p
+      1,840,416   0%                                          timer-relative-time
+      1,278,471   0%                                        - timer-set-time
+      1,278,400   0%                                           timer--time-setter
+        298,368   0%                                          timer-create
+      1,123,024   0%                                      - seed7-inside-string-p
+        149,184   0%                                       - syntax-ppss
+        149,184   0%                                          make-closure
+        356,384   0%                                      - seed7-inside-comment-p
+        157,472   0%                                       - syntax-ppss
+        157,472   0%                                          make-closure
+        232,064   0%                                        make-closure
+          3,456   0%                                        re-search-backward
+      1,038,080   0%                                     - run-with-timer
+      1,038,080   0%                                      - run-at-time
+        530,864   0%                                       - timer-activate
+        530,864   0%                                        - timer--activate
+        530,864   0%                                           timer--time-less-p
+        277,856   0%                                         timer-relative-time
+        192,064   0%                                       - timer-set-time
+        192,064   0%                                          timer--time-setter
+         37,296   0%                                         timer-create
+         20,720   0%                                       make-closure
+        499,572   0%                                    - seed7--block-name
+        391,124   0%                                     - seed7-re-search-forward
+        314,944   0%                                      - seed7-inside-string-p
+         62,160   0%                                       - syntax-ppss
+         62,160   0%                                          make-closure
+         70,448   0%                                      - seed7-inside-comment-p
+         41,440   0%                                       - syntax-ppss
+         41,440   0%                                          make-closure
+         33,928   0%                                       match-string
+      1,348,880   0%                                   - seed7-re-search-backward
+        992,496   0%                                    - run-with-timer
+        992,496   0%                                     - run-at-time
+        514,288   0%                                      - timer-activate
+        514,288   0%                                       - timer--activate
+        514,288   0%                                          timer--time-less-p
+        277,856   0%                                        timer-relative-time
+        183,776   0%                                      - timer-set-time
+        183,776   0%                                         timer--time-setter
+         16,576   0%                                        timer-create
+        281,792   0%                                    - seed7-inside-string-p
+         24,864   0%                                     - syntax-ppss
+         24,864   0%                                        make-closure
+         41,440   0%                                      make-closure
+         33,152   0%                                    - seed7-inside-comment-p
+         20,720   0%                                     - syntax-ppss
+         20,720   0%                                        make-closure
+        819,101   0%                                   - seed7-re-search-forward
+        522,144   0%                                    - seed7-inside-string-p
+        120,176   0%                                     - syntax-ppss
+        120,176   0%                                        make-closure
+        254,020   0%                                    - seed7-inside-comment-p
+        154,564   0%                                     - syntax-ppss
+        145,040   0%                                        make-closure
+          9,524   0%                                      - syntax-propertize
+          9,524   0%                                         seed7-mode-syntax-propertize
+        187,024   0%                                     match-string
+         46,160   0%                                     match-string-no-properties
+      1,814,504   0%                                  - seed7--current-line-nth-word
+      1,710,904   0%                                   - thing-at-point
+      1,583,488   0%                                    - bounds-of-thing-at-point
+        642,320   0%                                       make-closure
+        335,248   0%                                     - #<byte-code-function B76>
+        335,248   0%                                      - forward-thing
+        335,248   0%                                         format
+        219,632   0%                                     - seq-some
+        219,632   0%                                        make-closure
+        159,440   0%                                     - #<byte-code-function 18D>
+        159,440   0%                                      - forward-thing
+        159,440   0%                                         format
+          3,072   0%                                       re-search-forward
+        904,034   0%                                  - seed7-re-search-forward
+        580,160   0%                                   - seed7-inside-string-p
+        132,608   0%                                    - syntax-ppss
+        132,608   0%                                       make-closure
+        194,768   0%                                   - seed7-inside-comment-p
+        120,176   0%                                    - syntax-ppss
+        120,176   0%                                       make-closure
+        226,704   0%                                  - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+         95,312   0%                                   - seed7-inside-comment-p
+         45,584   0%                                    - syntax-ppss
+         45,584   0%                                       make-closure
+         87,024   0%                                     seed7-inside-line-indent-before-comment-p
+        103,600   0%                                  - seed7-inside-line-indent-before-comment-p
+          4,144   0%                                   - seed7-inside-comment-p
+          4,144   0%                                    - syntax-ppss
+          4,144   0%                                       make-closure
+         87,024   0%                                  - seed7-inside-comment-p
+         37,296   0%                                   - syntax-ppss
+         37,296   0%                                      make-closure
+         32,936   0%                                    seed7--end-regexp-for
+         59,072   0%                                 - seed7-re-search-forward-closest
+         38,352   0%                                  - seed7-re-search-forward
+         20,720   0%                                     seed7-inside-string-p
+          8,288   0%                                     seed7-inside-comment-p
+          2,048   0%                                 - seed7-to-next-line-starts-with
+          2,048   0%                                    seed7-re-search-forward
+     10,084,797   0%                                - seed7-to-block-backward
+      4,757,984   0%                                 - seed7-re-search-backward
+      3,656,136   0%                                  - run-with-timer
+      3,656,136   0%                                   - run-at-time
+      1,820,040   0%                                    - timer-activate
+      1,820,040   0%                                     - timer--activate
+      1,820,040   0%                                        timer--time-less-p
+        990,736   0%                                      timer-relative-time
+        671,312   0%                                    - timer-set-time
+        671,312   0%                                       timer--time-setter
+        174,048   0%                                      timer-create
+        621,600   0%                                  - seed7-inside-string-p
+        161,616   0%                                   - syntax-ppss
+        161,616   0%                                      make-closure
+        277,648   0%                                  - seed7-inside-comment-p
+        169,904   0%                                   - syntax-ppss
+        169,904   0%                                      make-closure
+        120,176   0%                                    make-closure
+         82,424   0%                                    re-search-backward
+      2,867,419   0%                                 - seed7-beg-of-defun
+      2,065,949   0%                                  - seed7-re-search-backward
+      1,460,088   0%                                   - run-with-timer
+      1,460,088   0%                                    - run-at-time
+        719,992   0%                                     - timer-activate
+        719,992   0%                                      - timer--activate
+        719,992   0%                                         timer--time-less-p
+        359,632   0%                                       timer-relative-time
+        264,432   0%                                     - timer-set-time
+        264,432   0%                                        timer--time-setter
+        116,032   0%                                       timer-create
+        406,112   0%                                   - seed7-inside-string-p
+         45,584   0%                                    - syntax-ppss
+         45,584   0%                                       make-closure
+        107,744   0%                                   - seed7-inside-comment-p
+         45,584   0%                                    - syntax-ppss
+         45,584   0%                                       make-closure
+         82,880   0%                                     make-closure
+          9,125   0%                                     re-search-backward
+        251,222   0%                                  - seed7-re-search-backward-closest
+        238,790   0%                                   - seed7-re-search-backward
+        174,208   0%                                    - run-with-timer
+        174,208   0%                                     - run-at-time
+         87,376   0%                                      - timer-activate
+         87,376   0%                                       - timer--activate
+         87,376   0%                                          timer--time-less-p
+         45,600   0%                                        timer-relative-time
+         32,944   0%                                      - timer-set-time
+         32,944   0%                                         timer--time-setter
+          8,288   0%                                        timer-create
+         52,150   0%                                      re-search-backward
+          8,288   0%                                    - seed7-inside-comment-p
+          8,288   0%                                     - syntax-ppss
+          8,288   0%                                        make-closure
+          4,144   0%                                      make-closure
+         12,432   0%                                   - seq-filter
+         12,432   0%                                      make-closure
+        218,153   0%                                  - seed7-top-block-name
+        194,080   0%                                   - seed7--to-top
+        117,336   0%                                    - seed7-re-search-backward
+         72,600   0%                                     - run-with-timer
+         72,600   0%                                      - run-at-time
+         35,400   0%                                       - timer-activate
+         35,400   0%                                        - timer--activate
+         35,400   0%                                           timer--time-less-p
+         22,800   0%                                         timer-relative-time
+         14,400   0%                                       - timer-set-time
+         14,400   0%                                          timer--time-setter
+         20,720   0%                                     - seed7-inside-string-p
+          4,144   0%                                      - syntax-ppss
+          4,144   0%                                         make-closure
+         12,432   0%                                     - seed7-inside-comment-p
+          8,288   0%                                      - syntax-ppss
+          8,288   0%                                         make-closure
+         11,584   0%                                       re-search-backward
+         76,744   0%                                    - run-with-timer
+         76,744   0%                                     - run-at-time
+         39,544   0%                                      - timer-activate
+         39,544   0%                                       - timer--activate
+         39,544   0%                                          timer--time-less-p
+         22,800   0%                                        timer-relative-time
+         14,400   0%                                      - timer-set-time
+         14,400   0%                                         timer--time-setter
+         24,073   0%                                   - seed7--block-name
+         24,073   0%                                    - seed7-re-search-forward
+          4,144   0%                                       seed7-inside-string-p
+         74,704   0%                                    match-string-no-properties
+         41,920   0%                                    match-string
+      1,417,680   0%                                 - seed7--current-line-nth-word
+      1,326,512   0%                                  - thing-at-point
+      1,201,168   0%                                   - bounds-of-thing-at-point
+        505,568   0%                                      make-closure
+        271,672   0%                                    - #<byte-code-function 7D5>
+        271,672   0%                                     - forward-thing
+        271,672   0%                                        format
+        145,040   0%                                    - seq-some
+        145,040   0%                                       make-closure
+        117,272   0%                                    - #<byte-code-function A34>
+        117,272   0%                                     - forward-thing
+        117,272   0%                                        format
+        310,800   0%                                 - seed7-inside-line-indent-before-comment-p
+         62,160   0%                                  - seed7-inside-comment-p
+         24,864   0%                                   - syntax-ppss
+         24,864   0%                                      make-closure
+        248,768   0%                                 - seed7-line-code-ends-with
+        236,336   0%                                  - seed7-re-search-backward
+        177,536   0%                                   - run-with-timer
+        177,536   0%                                    - run-at-time
+         88,896   0%                                     - timer-activate
+         88,896   0%                                      - timer--activate
+         88,896   0%                                         timer--time-less-p
+         49,248   0%                                       timer-relative-time
+         35,248   0%                                     - timer-set-time
+         35,248   0%                                        timer--time-setter
+          4,144   0%                                       timer-create
+         25,648   0%                                     re-search-backward
+         16,576   0%                                   - seed7-inside-string-p
+          4,144   0%                                    - syntax-ppss
+          4,144   0%                                       make-closure
+          8,288   0%                                     make-closure
+          8,288   0%                                   - seed7-inside-comment-p
+          8,288   0%                                    - syntax-ppss
+          8,288   0%                                       make-closure
+        207,600   0%                                 - backward-sexp
+        207,600   0%                                  - forward-sexp
+        207,600   0%                                   - seed7--forward-sexp-function
+        105,920   0%                                    - seed7--at-array-definition-end-line-p
+        101,776   0%                                     - seed7-line-code-ends-with
+        101,776   0%                                      - seed7-re-search-backward
+         72,768   0%                                       - run-with-timer
+         72,768   0%                                        - run-at-time
+         39,520   0%                                           timer-relative-time
+         24,960   0%                                         - timer-set-time
+         24,960   0%                                            timer--time-setter
+          8,288   0%                                           timer-create
+         16,576   0%                                       - seed7-inside-string-p
+          4,144   0%                                        - syntax-ppss
+          4,144   0%                                           make-closure
+          8,288   0%                                         seed7-inside-comment-p
+          4,144   0%                                         make-closure
+         93,488   0%                                    - seed7--at-set-definition-end-line-p
+         93,488   0%                                     - seed7-line-code-ends-with
+         89,344   0%                                      - seed7-re-search-backward
+         68,624   0%                                       - run-with-timer
+         68,624   0%                                        - run-at-time
+         39,520   0%                                           timer-relative-time
+         24,960   0%                                         - timer-set-time
+         24,960   0%                                            timer--time-setter
+          4,144   0%                                           timer-create
+          8,288   0%                                         make-closure
+          8,288   0%                                       - seed7-inside-string-p
+          4,144   0%                                        - syntax-ppss
+          4,144   0%                                           make-closure
+          4,144   0%                                       - seed7-inside-comment-p
+          4,144   0%                                        - syntax-ppss
+          4,144   0%                                           make-closure
+        140,896   0%                                 - seed7-inside-comment-p
+         78,736   0%                                  - syntax-ppss
+         78,736   0%                                     make-closure
+         70,712   0%                                   seed7--start-regexp-for
+         33,930   0%                                   looking-at
+      2,521,747   0%                               - seed7-re-search-backward
+      1,991,128   0%                                - run-with-timer
+      1,991,128   0%                                 - run-at-time
+      1,005,608   0%                                  - timer-activate
+      1,005,608   0%                                   - timer--activate
+      1,005,608   0%                                      timer--time-less-p
+        532,912   0%                                    timer-relative-time
+        340,720   0%                                  - timer-set-time
+        340,720   0%                                     timer--time-setter
+        111,888   0%                                    timer-create
+        364,672   0%                                - seed7-inside-string-p
+         87,024   0%                                 - syntax-ppss
+         87,024   0%                                    make-closure
+         70,448   0%                                - seed7-inside-comment-p
+         33,152   0%                                 - syntax-ppss
+         33,152   0%                                    make-closure
+         62,160   0%                                  make-closure
+         33,339   0%                                  re-search-backward
+        405,272   0%                               - replace-regexp-in-string
+         33,136   0%                                  concat
+        105,656   0%                                 match-string
+     25,048,774   0%                             - seed7-line-inside-parens-pair-column
+     25,048,774   0%                              - seed7-line-inside-parens-pair
+     25,011,734   0%                               - seed7-re-search-backward
+     19,660,664   0%                                - run-with-timer
+     19,660,664   0%                                 - run-at-time
+      9,564,632   0%                                  - timer-activate
+      9,564,632   0%                                   - timer--activate
+      9,564,632   0%                                    - timer--time-less-p
+          1,216   0%                                       timer--time
+      5,486,880   0%                                    timer-relative-time
+      3,660,176   0%                                  - timer-set-time
+      3,660,176   0%                                     timer--time-setter
+        948,976   0%                                    timer-create
+      2,421,196   0%                                - seed7-inside-comment-p
+      1,592,396   0%                                 - syntax-ppss
+      1,591,296   0%                                    make-closure
+          1,100   0%                                    syntax-table
+      2,375,754   0%                                - seed7-inside-string-p
+        593,834   0%                                 - syntax-ppss
+        592,592   0%                                    make-closure
+          1,242   0%                                    syntax-table
+        518,000   0%                                  make-closure
+         36,120   0%                                  re-search-backward
+         32,896   0%                               - forward-sexp
+         32,896   0%                                  seed7--forward-sexp-function
+          4,144   0%                                 seed7-line-inside-syntax-parens-pair
+      1,409,181   0%                             - seed7-line-is-defun-end
+        500,977   0%                              - seed7-beg-of-defun
+        378,988   0%                               - seed7-re-search-backward
+        373,920   0%                                - run-with-timer
+        373,920   0%                                 - run-at-time
+        180,304   0%                                  - timer-activate
+        180,304   0%                                   - timer--activate
+        180,304   0%                                      timer--time-less-p
+        116,128   0%                                    timer-relative-time
+         77,488   0%                                  - timer-set-time
+         77,488   0%                                     timer--time-setter
+          5,068   0%                                  re-search-backward
+         41,960   0%                               - seed7-re-search-backward-closest
+         41,960   0%                                - seed7-re-search-backward
+         30,344   0%                                   re-search-backward
+         11,616   0%                                 - run-with-timer
+         11,616   0%                                  - run-at-time
+          5,664   0%                                   - timer-activate
+          5,664   0%                                    - timer--activate
+          5,664   0%                                       timer--time-less-p
+          3,648   0%                                     timer-relative-time
+          2,304   0%                                   - timer-set-time
+          2,304   0%                                      timer--time-setter
+         16,368   0%                                 match-string
+         15,732   0%                               - seed7-top-block-name
+          9,200   0%                                - seed7--to-top
+          6,296   0%                                 - seed7-re-search-backward
+          3,392   0%                                    re-search-backward
+          2,904   0%                                  - run-with-timer
+          2,904   0%                                   - run-at-time
+          1,416   0%                                    - timer-activate
+          1,416   0%                                     - timer--activate
+          1,416   0%                                        timer--time-less-p
+            912   0%                                      timer-relative-time
+            576   0%                                    - timer-set-time
+            576   0%                                       timer--time-setter
+          2,904   0%                                 - run-with-timer
+          2,904   0%                                  - run-at-time
+          1,416   0%                                   - timer-activate
+          1,416   0%                                    - timer--activate
+          1,416   0%                                       timer--time-less-p
+            912   0%                                     timer-relative-time
+            576   0%                                   - timer-set-time
+            576   0%                                      timer--time-setter
+          6,532   0%                                - seed7--block-name
+          6,532   0%                                   seed7-re-search-forward
+          8,184   0%                                 match-string-no-properties
+        435,032   0%                              - seed7--safe-current-line-defun-start-indent
+        435,032   0%                               - seed7-to-block-backward
+        425,848   0%                                - seed7-re-search-backward
+        293,240   0%                                 - run-with-timer
+        293,240   0%                                  - run-at-time
+        143,704   0%                                   - timer-activate
+        143,704   0%                                    - timer--activate
+        143,704   0%                                       timer--time-less-p
+         73,872   0%                                     timer-relative-time
+         54,944   0%                                   - timer-set-time
+         54,944   0%                                      timer--time-setter
+         20,720   0%                                     timer-create
+         87,024   0%                                 - seed7-inside-string-p
+         16,576   0%                                  - syntax-ppss
+         16,576   0%                                     make-closure
+         24,864   0%                                 - seed7-inside-comment-p
+         12,432   0%                                  - syntax-ppss
+         12,432   0%                                     make-closure
+         20,720   0%                                   make-closure
+          9,184   0%                                - user-error
+          9,184   0%                                   format-message
+        347,162   0%                              - seed7-end-of-defun
+        284,712   0%                               - seed7-top-block-name
+        272,280   0%                                - seed7--to-top
+        258,456   0%                                 - seed7-re-search-backward
+        258,456   0%                                  - run-with-timer
+        258,456   0%                                   - run-at-time
+        126,024   0%                                    - timer-activate
+        126,024   0%                                     - timer--activate
+        126,024   0%                                        timer--time-less-p
+         81,168   0%                                      timer-relative-time
+         51,264   0%                                    - timer-set-time
+         51,264   0%                                       timer--time-setter
+          9,680   0%                                 - run-with-timer
+          9,680   0%                                  - run-at-time
+          4,720   0%                                   - timer-activate
+          4,720   0%                                    - timer--activate
+          4,720   0%                                       timer--time-less-p
+          3,040   0%                                     timer-relative-time
+          1,920   0%                                   - timer-set-time
+          1,920   0%                                      timer--time-setter
+          4,144   0%                                   make-closure
+         12,432   0%                                - seed7--block-name
+          8,288   0%                                 - seed7-re-search-forward
+          8,288   0%                                  - seed7-inside-string-p
+          4,144   0%                                   - syntax-ppss
+          4,144   0%                                      make-closure
+         22,186   0%                               - seed7-re-search-forward
+         15,018   0%                                - seed7-inside-comment-p
+         15,018   0%                                 - syntax-ppss
+         15,018   0%                                  - syntax-propertize
+         15,018   0%                                     seed7-mode-syntax-propertize
+         16,368   0%                                 match-string-no-properties
+          9,680   0%                               - seed7-re-search-backward
+          9,680   0%                                - run-with-timer
+          9,680   0%                                 - run-at-time
+          4,720   0%                                  - timer-activate
+          4,720   0%                                   - timer--activate
+          4,720   0%                                      timer--time-less-p
+          3,040   0%                                    timer-relative-time
+          1,920   0%                                  - timer-set-time
+          1,920   0%                                     timer--time-setter
+         51,770   0%                              - seed7-line-starts-with-any
+         51,770   0%                                 seed7-line-starts-with
+         41,280   0%                              - seed7--current-line-nth-word
+         37,136   0%                               - thing-at-point
+         35,040   0%                                - bounds-of-thing-at-point
+         10,280   0%                                 - #<byte-code-function 6D1>
+         10,280   0%                                  - forward-thing
+         10,280   0%                                     format
+          8,288   0%                                   make-closure
+          8,184   0%                                 - #<byte-code-function 63B>
+          8,184   0%                                  - forward-thing
+          8,184   0%                                     format
+         28,816   0%                              - seed7-move-to-line
+         28,816   0%                               - seed7-to-previous-non-empty-line
+          8,288   0%                                - seed7-inside-comment-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+        231,032   0%                             - seed7-line-at-endof-array-definition-block
+        138,376   0%                              - seed7-line-code-ends-with
+        138,376   0%                               - seed7-re-search-backward
+         83,792   0%                                - run-with-timer
+         83,792   0%                                 - run-at-time
+         40,960   0%                                  - timer-activate
+         40,960   0%                                   - timer--activate
+         40,960   0%                                      timer--time-less-p
+         23,712   0%                                    timer-relative-time
+         14,976   0%                                  - timer-set-time
+         14,976   0%                                     timer--time-setter
+          4,144   0%                                    timer-create
+         29,720   0%                                  re-search-backward
+         12,432   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         12,432   0%                                - seed7-inside-string-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         64,496   0%                              - backward-sexp
+         64,496   0%                               - forward-sexp
+         64,496   0%                                - seed7--forward-sexp-function
+         30,880   0%                                 - seed7--at-array-definition-end-line-p
+         29,856   0%                                  - seed7-line-code-ends-with
+         29,856   0%                                   - seed7-re-search-backward
+         17,424   0%                                    - run-with-timer
+         17,424   0%                                     - run-at-time
+          8,496   0%                                      - timer-activate
+          8,496   0%                                       - timer--activate
+          8,496   0%                                          timer--time-less-p
+          5,472   0%                                        timer-relative-time
+          3,456   0%                                      - timer-set-time
+          3,456   0%                                         timer--time-setter
+          8,288   0%                                    - seed7-inside-string-p
+          4,144   0%                                     - syntax-ppss
+          4,144   0%                                        make-closure
+          4,144   0%                                      make-closure
+          1,024   0%                                    looking-at
+         19,632   0%                                 - seed7--at-set-definition-end-line-p
+         19,632   0%                                  - seed7-line-code-ends-with
+         19,632   0%                                   - seed7-re-search-backward
+         15,488   0%                                    - run-with-timer
+         15,488   0%                                     - run-at-time
+          7,552   0%                                      - timer-activate
+          7,552   0%                                       - timer--activate
+          7,552   0%                                          timer--time-less-p
+          4,864   0%                                        timer-relative-time
+          3,072   0%                                      - timer-set-time
+          3,072   0%                                         timer--time-setter
+          4,144   0%                                      seed7-inside-string-p
+          4,840   0%                                 - seed7-beg-of-defun
+          1,936   0%                                  - seed7-re-search-backward-closest
+          1,936   0%                                   - seed7-re-search-backward
+          1,936   0%                                    - run-with-timer
+          1,936   0%                                     - run-at-time
+            944   0%                                      - timer-activate
+            944   0%                                       - timer--activate
+            944   0%                                          timer--time-less-p
+            608   0%                                        timer-relative-time
+            384   0%                                      - timer-set-time
+            384   0%                                         timer--time-setter
+          1,936   0%                                  - seed7-top-block-name
+          1,936   0%                                   - seed7--to-top
+            968   0%                                    - run-with-timer
+            968   0%                                     - run-at-time
+            472   0%                                      - timer-activate
+            472   0%                                       - timer--activate
+            472   0%                                          timer--time-less-p
+            304   0%                                        timer-relative-time
+            192   0%                                      - timer-set-time
+            192   0%                                         timer--time-setter
+            968   0%                                    - seed7-re-search-backward
+            968   0%                                     - run-with-timer
+            968   0%                                      - run-at-time
+            472   0%                                       - timer-activate
+            472   0%                                        - timer--activate
+            472   0%                                           timer--time-less-p
+            304   0%                                         timer-relative-time
+            192   0%                                       - timer-set-time
+            192   0%                                          timer--time-setter
+            968   0%                                  - seed7-re-search-backward
+            968   0%                                   - run-with-timer
+            968   0%                                    - run-at-time
+            472   0%                                     - timer-activate
+            472   0%                                      - timer--activate
+            472   0%                                         timer--time-less-p
+            304   0%                                       timer-relative-time
+            192   0%                                     - timer-set-time
+            192   0%                                        timer--time-setter
+          1,936   0%                                 - seed7--safe-to-block-backward
+          1,936   0%                                  - seed7-to-block-backward
+          1,936   0%                                   - seed7-line-code-ends-with
+          1,936   0%                                    - seed7-re-search-backward
+          1,936   0%                                     - run-with-timer
+          1,936   0%                                      - run-at-time
+            944   0%                                       - timer-activate
+            944   0%                                        - timer--activate
+            944   0%                                           timer--time-less-p
+            608   0%                                         timer-relative-time
+            384   0%                                       - timer-set-time
+            384   0%                                          timer--time-setter
+         18,480   0%                              - seed7-move-to-line
+         18,480   0%                               - seed7-to-previous-non-empty-line
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          9,680   0%                              - seed7-re-search-backward
+          9,680   0%                               - run-with-timer
+          9,680   0%                                - run-at-time
+          4,720   0%                                 - timer-activate
+          4,720   0%                                  - timer--activate
+          4,720   0%                                     timer--time-less-p
+          3,040   0%                                   timer-relative-time
+          1,920   0%                                 - timer-set-time
+          1,920   0%                                    timer--time-setter
+        186,480   0%                             - seed7--indent-search-boundary
+        186,480   0%                              - seed7--indent-search-boundary-uncached
+        186,480   0%                               - syntax-ppss
+        186,480   0%                                  make-closure
+        136,736   0%                             - seed7-line-inside-set-definition-block
+         90,632   0%                              - seed7-re-search-backward
+         46,040   0%                               - run-with-timer
+         46,040   0%                                - run-at-time
+         22,552   0%                                 - timer-activate
+         22,552   0%                                  - timer--activate
+         22,552   0%                                     timer--time-less-p
+         11,856   0%                                   timer-relative-time
+          7,488   0%                                 - timer-set-time
+          7,488   0%                                    timer--time-setter
+          4,144   0%                                   timer-create
+         40,448   0%                                 re-search-backward
+          4,144   0%                               - seed7-inside-comment-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+         46,104   0%                              - forward-sexp
+         46,104   0%                                 seed7--forward-sexp-function
+        122,352   0%                             - seed7-line-inside-array-definition-block
+         87,536   0%                              - seed7-re-search-backward
+         41,896   0%                               - run-with-timer
+         41,896   0%                                - run-at-time
+         18,408   0%                                 - timer-activate
+         18,408   0%                                  - timer--activate
+         18,408   0%                                     timer--time-less-p
+         11,856   0%                                   timer-relative-time
+          7,488   0%                                 - timer-set-time
+          7,488   0%                                    timer--time-setter
+          4,144   0%                                   timer-create
+         41,496   0%                                 re-search-backward
+          4,144   0%                               - seed7-inside-string-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+         34,816   0%                              - forward-sexp
+         34,816   0%                                 seed7--forward-sexp-function
+        108,608   0%                             - seed7-line-at-endof-set-definition-block
+         86,000   0%                              - seed7-line-code-ends-with
+         86,000   0%                               - seed7-re-search-backward
+         81,856   0%                                - run-with-timer
+         81,856   0%                                 - run-at-time
+         35,872   0%                                  - timer-activate
+         35,872   0%                                   - timer--activate
+         35,872   0%                                      timer--time-less-p
+         23,104   0%                                    timer-relative-time
+         14,592   0%                                  - timer-set-time
+         14,592   0%                                     timer--time-setter
+          8,288   0%                                    timer-create
+          4,144   0%                                  make-closure
+          9,208   0%                                looking-at
+          8,288   0%                              - seed7-move-to-line
+          8,288   0%                               - seed7-to-previous-non-empty-line
+          4,144   0%                                  seed7-inside-comment-p
+            968   0%                              - seed7-re-search-backward
+            968   0%                               - run-with-timer
+            968   0%                                - run-at-time
+            472   0%                                 - timer-activate
+            472   0%                                  - timer--activate
+            472   0%                                     timer--time-less-p
+            304   0%                                   timer-relative-time
+            192   0%                                 - timer-set-time
+            192   0%                                    timer--time-setter
+        100,528   0%                             - seed7-line-inside-assign-statement-continuation
+         96,384   0%                              - seed7-assign-op-pos
+         92,240   0%                               - seed7-re-search-backward
+         50,344   0%                                  re-search-backward
+         37,752   0%                                - run-with-timer
+         37,752   0%                                 - run-at-time
+         18,408   0%                                  - timer-activate
+         18,408   0%                                   - timer--activate
+         18,408   0%                                      timer--time-less-p
+         11,856   0%                                    timer-relative-time
+          7,488   0%                                  - timer-set-time
+          7,488   0%                                     timer--time-setter
+          4,144   0%                                  seed7-inside-string-p
+          4,144   0%                              - seed7-statement-end-pos
+          4,144   0%                               - seed7-forward-char-pos
+          4,144   0%                                - seed7-re-search-forward
+          4,144   0%                                 - seed7-inside-string-p
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+         49,424   0%                               seed7-line-starts-with
+         40,984   0%                             - seed7-line-isa-string
+         40,984   0%                                seed7-line-starts-with
+         38,960   0%                             - seed7-line-indent-step
+          4,144   0%                              - seed7-move-to-line
+          4,144   0%                               - seed7-to-previous-non-empty-line
+          4,144   0%                                  seed7-inside-comment-p
+         35,864   0%                             - seed7-line-starts-with-open-paren-after-logic-operator
+         35,864   0%                                seed7-line-starts-with
+         32,992   0%                             - seed7-line-after-func-return-logic-operator-column
+         10,336   0%                              - seed7-move-to-line
+         10,336   0%                                 seed7-to-previous-non-empty-line
+         25,704   0%                             - seed7--current-line-nth-word
+         25,704   0%                              - thing-at-point
+         16,472   0%                               - bounds-of-thing-at-point
+          8,288   0%                                  make-closure
+          8,184   0%                                - #<byte-code-function E8F>
+          8,184   0%                                 - forward-thing
+          8,184   0%                                    format
+         21,528   0%                             - seed7-line-after-short-func-end
+         10,168   0%                              - seed7-to-block-backward
+          8,072   0%                               - seed7-re-search-backward
+          4,144   0%                                  seed7-inside-string-p
+          2,904   0%                                - run-with-timer
+          2,904   0%                                 - run-at-time
+          1,416   0%                                  - timer-activate
+          1,416   0%                                   - timer--activate
+          1,416   0%                                      timer--time-less-p
+            912   0%                                    timer-relative-time
+            576   0%                                  - timer-set-time
+            576   0%                                     timer--time-setter
+          1,024   0%                                  re-search-backward
+          2,096   0%                               - seed7--current-line-nth-word
+          2,096   0%                                - thing-at-point
+          2,096   0%                                 - bounds-of-thing-at-point
+          2,096   0%                                  - #<byte-code-function 863>
+          2,096   0%                                   - forward-thing
+          2,096   0%                                      format
+          4,144   0%                              - seed7-move-to-line
+          4,144   0%                                 seed7-to-previous-non-empty-line
+     41,455,870   1%                            - replace-regexp-in-string
+      2,583,404   0%                               concat
+      3,153,800   0%                              match-string
+      2,099,048   0%                              seed7--indent-offset-for
+      1,288,784   0%                              seed7--on-lineof
+          2,808   0%                              #<byte-code-function 363>
+        513,856   0%                             seed7--cache-block-spec
+  1,177,931,591  34%                          - seed7-line-is-defun-end
+    782,229,669  22%                           - seed7-end-of-defun
+    677,259,735  19%                            - seed7-top-block-name
+    672,232,007  19%                             - seed7--to-top
+    660,815,759  19%                              - seed7-re-search-backward
+    522,591,336  15%                               - run-with-timer
+    522,591,336  15%                                - run-at-time
+    256,438,256   7%                                 - timer-activate
+    256,438,256   7%                                  - timer--activate
+    256,438,256   7%                                   - timer--time-less-p
+        229,544   0%                                      timer--time
+    143,828,160   4%                                   timer-relative-time
+     99,172,392   2%                                 - timer-set-time
+     99,172,392   2%                                    timer--time-setter
+     23,152,528   0%                                   timer-create
+     93,576,180   2%                               - seed7-inside-string-p
+     20,360,348   0%                                - syntax-ppss
+     11,789,680   0%                                   make-closure
+        367,016   0%                                 - parse-partial-sexp
+        203,056   0%                                  - internal--syntax-propertize
+        149,184   0%                                   - syntax-propertize
+         91,168   0%                                      seed7-mode-syntax-propertize
+     27,272,451   0%                               - seed7-inside-comment-p
+     12,436,931   0%                                - syntax-ppss
+     11,425,008   0%                                   make-closure
+        847,963   0%                                 - syntax-propertize
+        802,379   0%                                    seed7-mode-syntax-propertize
+        163,960   0%                                   parse-partial-sexp
+     17,375,792   0%                                 make-closure
+     11,035,360   0%                              - run-with-timer
+     11,035,360   0%                               - run-at-time
+      5,451,600   0%                                - timer-activate
+      5,451,600   0%                                 - timer--activate
+      5,451,600   0%                                    timer--time-less-p
+      3,038,784   0%                                  timer-relative-time
+      2,060,128   0%                                - timer-set-time
+      2,060,128   0%                                   timer--time-setter
+        484,848   0%                                  timer-create
+        348,096   0%                                make-closure
+      4,729,360   0%                             - seed7--block-name
+      3,816,624   0%                              - seed7-re-search-forward
+      3,228,176   0%                               - seed7-inside-string-p
+        319,088   0%                                - syntax-ppss
+        319,088   0%                                   make-closure
+        588,448   0%                               - seed7-inside-comment-p
+        348,096   0%                                - syntax-ppss
+        348,096   0%                                   make-closure
+        335,272   0%                                match-string
+     72,513,011   2%                            - seed7-re-search-forward
+     42,932,907   1%                             - seed7-inside-comment-p
+     37,802,635   1%                              - syntax-ppss
+     33,824,755   0%                               - syntax-propertize
+     23,402,595   0%                                  seed7-mode-syntax-propertize
+      3,945,088   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+     23,980,968   0%                             - seed7-inside-string-p
+      4,570,472   0%                              - syntax-ppss
+      4,537,680   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+     15,522,952   0%                            - seed7-re-search-backward
+     11,093,016   0%                             - run-with-timer
+     11,093,016   0%                              - run-at-time
+      5,497,184   0%                               - timer-activate
+      5,497,184   0%                                - timer--activate
+      5,497,184   0%                                   timer--time-less-p
+      3,071,576   0%                                 timer-relative-time
+      2,006,256   0%                               - timer-set-time
+      2,006,256   0%                                  timer--time-setter
+        518,000   0%                                 timer-create
+      3,327,632   0%                             - seed7-inside-string-p
+        414,400   0%                              - syntax-ppss
+        414,400   0%                                 make-closure
+        642,320   0%                             - seed7-inside-comment-p
+        430,976   0%                              - syntax-ppss
+        430,976   0%                                 make-closure
+        459,984   0%                               make-closure
+      6,162,480   0%                              match-string-no-properties
+      3,261,560   0%                              match-string
+    350,590,225  10%                           - seed7-beg-of-defun
+    223,977,197   6%                            - seed7-top-block-name
+    217,636,587   6%                             - seed7--to-top
+    214,628,979   6%                              - seed7-re-search-backward
+    168,360,560   4%                               - run-with-timer
+    168,360,560   4%                                - run-at-time
+     82,930,392   2%                                 - timer-activate
+     82,930,392   2%                                  - timer--activate
+     82,930,392   2%                                   - timer--time-less-p
+        163,960   0%                                      timer--time
+     46,176,232   1%                                   timer-relative-time
+     31,827,888   0%                                 - timer-set-time
+     31,827,888   0%                                    timer--time-setter
+      7,426,048   0%                                   timer-create
+     28,625,312   0%                               - seed7-inside-string-p
+      4,540,744   0%                                - syntax-ppss
+      4,442,368   0%                                   make-closure
+         98,376   0%                                   parse-partial-sexp
+      9,070,496   0%                               - seed7-inside-comment-p
+      4,325,616   0%                                - syntax-ppss
+      4,260,032   0%                                   make-closure
+         65,584   0%                                   parse-partial-sexp
+      5,756,016   0%                                 make-closure
+      2,816,595   0%                                 re-search-backward
+      2,883,648   0%                              - run-with-timer
+      2,883,648   0%                               - run-at-time
+      1,425,168   0%                                - timer-activate
+      1,425,168   0%                                 - timer--activate
+      1,425,168   0%                                    timer--time-less-p
+        789,760   0%                                  timer-relative-time
+        523,680   0%                                - timer-set-time
+        523,680   0%                                   timer--time-setter
+        145,040   0%                                  timer-create
+         91,168   0%                                make-closure
+      6,299,170   0%                             - seed7--block-name
+      6,193,522   0%                              - seed7-re-search-forward
+        567,728   0%                               - seed7-inside-string-p
+         29,008   0%                                - syntax-ppss
+         29,008   0%                                   make-closure
+         74,592   0%                               - seed7-inside-comment-p
+         29,008   0%                                - syntax-ppss
+         29,008   0%                                   make-closure
+         25,872   0%                                match-string
+     86,672,020   2%                            - seed7-re-search-backward
+     65,993,832   1%                             - run-with-timer
+     65,993,832   1%                              - run-at-time
+     32,604,072   0%                               - timer-activate
+     32,604,072   0%                                - timer--activate
+     32,604,072   0%                                   timer--time-less-p
+     18,194,016   0%                                 timer-relative-time
+     12,439,984   0%                               - timer-set-time
+     12,439,984   0%                                  timer--time-setter
+      2,755,760   0%                                 timer-create
+     10,936,016   0%                             - seed7-inside-string-p
+      1,844,080   0%                              - syntax-ppss
+      1,844,080   0%                                 make-closure
+      4,122,908   0%                               re-search-backward
+      3,501,680   0%                             - seed7-inside-comment-p
+      1,678,320   0%                              - syntax-ppss
+      1,678,320   0%                                 make-closure
+      2,117,584   0%                               make-closure
+     15,778,305   0%                            - seed7-re-search-backward-closest
+     14,939,089   0%                             - seed7-re-search-backward
+      7,505,177   0%                                re-search-backward
+      5,938,288   0%                              - run-with-timer
+      5,938,288   0%                               - run-at-time
+      2,898,208   0%                                - timer-activate
+      2,898,208   0%                                 - timer--activate
+      2,898,208   0%                                    timer--time-less-p
+      1,639,760   0%                                  timer-relative-time
+      1,159,968   0%                                - timer-set-time
+      1,159,968   0%                                   timer--time-setter
+        240,352   0%                                  timer-create
+        932,400   0%                              - seed7-inside-string-p
+        124,320   0%                               - syntax-ppss
+        124,320   0%                                  make-closure
+        347,736   0%                              - seed7-inside-comment-p
+        239,992   0%                               - syntax-ppss
+        207,200   0%                                  make-closure
+         32,792   0%                                  parse-partial-sexp
+        215,488   0%                                make-closure
+         72,576   0%                             - seq-filter
+         70,448   0%                                make-closure
+          2,128   0%                                make-symbol
+      4,025,336   0%                              match-string-no-properties
+      1,298,968   0%                              match-string
+         10,280   0%                              seed7--no-defun-found-msg-for
+          2,096   0%                            - user-error
+          2,096   0%                               format-message
+     20,321,540   0%                           - seed7-line-starts-with-any
+     20,321,540   0%                              seed7-line-starts-with
+     11,770,840   0%                           - seed7-move-to-line
+     11,770,840   0%                            - seed7-to-previous-non-empty-line
+        613,312   0%                             - seed7-inside-comment-p
+        343,952   0%                              - syntax-ppss
+        343,952   0%                                 make-closure
+     10,507,976   0%                           - seed7--current-line-nth-word
+      9,786,920   0%                            - thing-at-point
+      9,171,568   0%                             - bounds-of-thing-at-point
+      3,282,048   0%                                make-closure
+      1,676,440   0%                              - #<byte-code-function B8E>
+      1,676,440   0%                               - forward-thing
+      1,676,440   0%                                  format
+      1,427,848   0%                                re-search-forward
+        974,304   0%                              - #<byte-code-function 4483>
+        974,304   0%                               - forward-thing
+        974,304   0%                                  format
+        745,920   0%                              - seq-some
+        745,920   0%                                 make-closure
+      1,922,893   0%                           - seed7--safe-current-line-defun-start-indent
+      1,902,173   0%                            - seed7-to-block-backward
+      1,462,653   0%                             - seed7-re-search-backward
+        971,320   0%                              - run-with-timer
+        971,320   0%                               - run-at-time
+        479,304   0%                                - timer-activate
+        479,304   0%                                 - timer--activate
+        479,304   0%                                    timer--time-less-p
+        266,000   0%                                  timer-relative-time
+        180,432   0%                                - timer-set-time
+        180,432   0%                                   timer--time-setter
+         45,584   0%                                  timer-create
+        263,413   0%                                re-search-backward
+        145,040   0%                              - seed7-inside-string-p
+         33,152   0%                               - syntax-ppss
+         33,152   0%                                  make-closure
+         62,160   0%                              - seed7-inside-comment-p
+         24,864   0%                               - syntax-ppss
+         24,864   0%                                  make-closure
+         20,720   0%                                make-closure
+        317,448   0%                             - seed7--current-line-nth-word
+        288,440   0%                              - thing-at-point
+        275,008   0%                               - bounds-of-thing-at-point
+        145,040   0%                                  make-closure
+         56,640   0%                                - #<byte-code-function 600>
+         56,640   0%                                 - forward-thing
+         56,640   0%                                    format
+         31,888   0%                                - #<byte-code-function 8E8>
+         31,888   0%                                 - forward-thing
+         31,888   0%                                    format
+         16,576   0%                                - seq-some
+         16,576   0%                                   make-closure
+         78,736   0%                             - seed7-inside-line-indent-before-comment-p
+         33,152   0%                              - seed7-inside-comment-p
+         29,008   0%                               - syntax-ppss
+         29,008   0%                                  make-closure
+         20,720   0%                             - seed7-inside-comment-p
+         16,576   0%                              - syntax-ppss
+         16,576   0%                                 make-closure
+         10,184   0%                             - user-error
+         10,184   0%                                format-message
+         12,432   0%                              seed7-current-line-indent
+    564,536,193  16%                          - seed7-line-inside-parens-pair-column
+    564,536,193  16%                           - seed7-line-inside-parens-pair
+    557,554,641  16%                            - seed7-re-search-backward
+    438,133,329  12%                             - run-with-timer
+    438,133,329  12%                              - run-at-time
+    216,841,328   6%                               - timer-activate
+    216,841,328   6%                                - timer--activate
+    216,841,328   6%                                 - timer--time-less-p
+        196,808   0%                                    timer--time
+    117,543,200   3%                                 timer-relative-time
+     78,959,270   2%                               - timer-set-time
+     78,957,800   2%                                  timer--time-setter
+     24,789,408   0%                                 timer-create
+            123   0%                                 timer-set-function
+     59,953,822   1%                             - seed7-inside-string-p
+     15,932,110   0%                              - syntax-ppss
+     15,821,792   0%                                 make-closure
+         98,376   0%                                 parse-partial-sexp
+          4,130   0%                                 #<byte-code-function 95B>
+          3,306   0%                                 syntax-table
+     32,948,395   0%                             - seed7-inside-comment-p
+     20,334,059   0%                              - syntax-ppss
+     20,330,464   0%                                 make-closure
+          1,087   0%                                 syntax-table
+     15,928,839   0%                               make-closure
+     10,590,256   0%                               re-search-backward
+      5,808,600   0%                            - forward-sexp
+      5,808,600   0%                               seed7--forward-sexp-function
+        799,992   0%                            - seed7-line-inside-syntax-parens-pair
+        426,832   0%                             - syntax-ppss
+        426,832   0%                                make-closure
+         95,512   0%                             - forward-sexp
+         95,512   0%                                seed7--forward-sexp-function
+     69,015,110   1%                          - seed7--indent-search-boundary
+     68,546,838   1%                           - seed7--indent-search-boundary-uncached
+     68,144,344   1%                            - syntax-ppss
+     67,518,192   1%                               make-closure
+        623,048   0%                               parse-partial-sexp
+          1,695   0%                               syntax-table
+          1,409   0%                               #<byte-code-function E7E1>
+            702   0%                              seed7-to-indent
+     63,185,326   1%                          - seed7--current-line-nth-word
+     62,874,526   1%                           - thing-at-point
+     62,544,990   1%                            - bounds-of-thing-at-point
+     59,430,454   1%                             - #<byte-code-function 538>
+     59,430,454   1%                              - forward-thing
+     58,607,854   1%                               - forward-word
+     58,607,854   1%                                - internal--syntax-propertize
+     57,625,726   1%                                 - syntax-propertize
+     55,719,486   1%                                    seed7-mode-syntax-propertize
+        822,600   0%                                 format
+      1,520,848   0%                               make-closure
+        444,136   0%                             - #<byte-code-function 678>
+        444,136   0%                              - forward-thing
+        444,136   0%                                 format
+        393,680   0%                             - seq-some
+        393,680   0%                                make-closure
+         72,112   0%                               re-search-forward
+     38,420,132   1%                          - seed7-line-inside-argument-list-section
+     24,908,859   0%                           - seed7-re-search-backward
+     13,260,875   0%                              re-search-backward
+     11,212,864   0%                            - run-with-timer
+     11,212,864   0%                             - run-at-time
+      5,593,072   0%                              - timer-activate
+      5,593,072   0%                               - timer--activate
+      5,593,072   0%                                - timer--time-less-p
+         32,792   0%                                   timer--time
+      3,063,408   0%                                timer-relative-time
+      2,030,096   0%                              - timer-set-time
+      2,030,096   0%                                 timer--time-setter
+        526,288   0%                                timer-create
+        422,688   0%                              make-closure
+          8,288   0%                            - seed7-inside-string-p
+          4,144   0%                             - syntax-ppss
+          4,144   0%                                make-closure
+          4,144   0%                            - seed7-inside-comment-p
+          4,144   0%                             - syntax-ppss
+          4,144   0%                                make-closure
+     13,182,137   0%                           - seed7-line-is-procfunc-beg-of-decl
+     13,182,137   0%                              seed7-line-starts-with
+         49,728   0%                           - seed7-forward-char-pos
+         33,152   0%                            - seed7-re-search-forward
+         20,720   0%                               seed7-inside-string-p
+         12,432   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+         26,624   0%                           - forward-sexp
+         26,624   0%                              seed7--forward-sexp-function
+     33,540,931   0%                          - seed7-line-inside-array-definition-block
+     26,121,267   0%                           - seed7-re-search-backward
+     11,842,576   0%                            - run-with-timer
+     11,842,576   0%                             - run-at-time
+      5,848,352   0%                              - timer-activate
+      5,848,352   0%                               - timer--activate
+      5,848,352   0%                                  timer--time-less-p
+      3,264,960   0%                                timer-relative-time
+      2,169,824   0%                              - timer-set-time
+      2,169,824   0%                                 timer--time-setter
+        559,440   0%                                timer-create
+     11,749,813   0%                              re-search-backward
+      1,433,464   0%                            - seed7-inside-string-p
+        467,912   0%                             - syntax-ppss
+        435,120   0%                                make-closure
+         32,792   0%                                parse-partial-sexp
+        712,768   0%                            - seed7-inside-comment-p
+        426,832   0%                             - syntax-ppss
+        426,832   0%                                make-closure
+        382,646   0%                              make-closure
+      7,183,456   0%                           - forward-sexp
+      7,183,456   0%                              seed7--forward-sexp-function
+     29,231,490   0%                          - seed7-line-inside-logic-check-expression
+     24,947,346   0%                           - seed7-to-previous-line-starts-with
+     24,071,994   0%                            - seed7-re-search-backward
+     11,251,112   0%                             - run-with-timer
+     11,251,112   0%                              - run-at-time
+      5,584,824   0%                               - timer-activate
+      5,584,824   0%                                - timer--activate
+      5,584,824   0%                                   timer--time-less-p
+      3,079,200   0%                                 timer-relative-time
+      2,114,672   0%                               - timer-set-time
+      2,114,672   0%                                  timer--time-setter
+        472,416   0%                                 timer-create
+     11,109,770   0%                               re-search-backward
+        890,960   0%                             - seed7-inside-string-p
+        240,352   0%                              - syntax-ppss
+        240,352   0%                                 make-closure
+        480,344   0%                             - seed7-inside-comment-p
+        244,136   0%                              - syntax-ppss
+        211,344   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+        339,808   0%                               make-closure
+      2,667,984   0%                           - seed7--current-line-nth-word
+      2,423,488   0%                            - thing-at-point
+      2,268,008   0%                             - bounds-of-thing-at-point
+      1,081,584   0%                                make-closure
+        441,192   0%                              - #<byte-code-function E1D>
+        441,192   0%                               - forward-thing
+        441,192   0%                                  format
+        219,632   0%                              - seq-some
+        219,632   0%                                 make-closure
+        181,648   0%                              - #<byte-code-function AF0>
+        181,648   0%                               - forward-thing
+        181,648   0%                                  format
+      1,317,792   0%                           - seed7-re-search-forward
+        915,824   0%                            - seed7-inside-string-p
+        298,368   0%                             - syntax-ppss
+        298,368   0%                                make-closure
+        401,968   0%                            - seed7-inside-comment-p
+        211,344   0%                             - syntax-ppss
+        211,344   0%                                make-closure
+     28,863,144   0%                          - seed7-line-inside-assign-statement-continuation
+     25,792,440   0%                           - seed7-assign-op-pos
+     25,514,792   0%                            - seed7-re-search-backward
+     11,830,848   0%                             - run-with-timer
+     11,830,848   0%                              - run-at-time
+      5,833,792   0%                               - timer-activate
+      5,833,792   0%                                - timer--activate
+      5,833,792   0%                                 - timer--time-less-p
+         32,792   0%                                    timer--time
+      3,218,432   0%                                 timer-relative-time
+      2,132,160   0%                               - timer-set-time
+      2,132,160   0%                                  timer--time-setter
+        646,464   0%                                 timer-create
+     11,247,272   0%                               re-search-backward
+      1,487,696   0%                             - seed7-inside-string-p
+        410,256   0%                              - syntax-ppss
+        410,256   0%                                 make-closure
+        592,592   0%                             - seed7-inside-comment-p
+        368,816   0%                              - syntax-ppss
+        368,816   0%                                 make-closure
+        356,384   0%                               make-closure
+      2,751,616   0%                           - seed7-statement-end-pos
+      2,457,392   0%                            - seed7-forward-char-pos
+      2,229,472   0%                             - seed7-re-search-forward
+      1,549,856   0%                              - seed7-inside-string-p
+        459,984   0%                               - syntax-ppss
+        459,984   0%                                  make-closure
+        679,616   0%                              - seed7-inside-comment-p
+        290,080   0%                               - syntax-ppss
+        290,080   0%                                  make-closure
+     26,360,076   0%                          - seed7-line-inside-set-definition-block
+     25,985,932   0%                           - seed7-re-search-backward
+     11,951,936   0%                            - run-with-timer
+     11,951,936   0%                             - run-at-time
+      5,895,040   0%                              - timer-activate
+      5,895,040   0%                               - timer--activate
+      5,895,040   0%                                  timer--time-less-p
+      3,257,648   0%                                timer-relative-time
+      2,227,376   0%                              - timer-set-time
+      2,227,376   0%                                 timer--time-setter
+        571,872   0%                                timer-create
+     11,603,242   0%                              re-search-backward
+      1,359,232   0%                            - seed7-inside-string-p
+        480,704   0%                             - syntax-ppss
+        480,704   0%                                make-closure
+        687,904   0%                            - seed7-inside-comment-p
+        368,816   0%                             - syntax-ppss
+        368,816   0%                                make-closure
+        383,618   0%                              make-closure
+         79,920   0%                           - forward-sexp
+         79,920   0%                              seed7--forward-sexp-function
+     25,642,483   0%                          - seed7-line-inside-until-logic-expression
+     22,535,576   0%                           - seed7-re-search-backward
+     11,138,512   0%                            - run-with-timer
+     11,138,512   0%                             - run-at-time
+      5,485,424   0%                              - timer-activate
+      5,485,424   0%                               - timer--activate
+      5,485,424   0%                                  timer--time-less-p
+      3,068,576   0%                                timer-relative-time
+      2,074,800   0%                              - timer-set-time
+      2,074,800   0%                                 timer--time-setter
+        509,712   0%                                timer-create
+     10,887,352   0%                              re-search-backward
+        339,808   0%                              make-closure
+        120,176   0%                            - seed7-inside-string-p
+         62,160   0%                             - syntax-ppss
+         62,160   0%                                make-closure
+         49,728   0%                            - seed7-inside-comment-p
+         24,864   0%                             - syntax-ppss
+         24,864   0%                                make-closure
+      2,804,395   0%                           - seed7-line-code-ends-with
+      2,767,099   0%                            - seed7-re-search-backward
+      1,621,872   0%                             - run-with-timer
+      1,621,872   0%                              - run-at-time
+        847,168   0%                               - timer-activate
+        847,168   0%                                - timer--activate
+        847,168   0%                                   timer--time-less-p
+        446,880   0%                                 timer-relative-time
+        290,528   0%                               - timer-set-time
+        290,528   0%                                  timer--time-setter
+         37,296   0%                                 timer-create
+        756,040   0%                               re-search-backward
+        235,848   0%                             - seed7-inside-string-p
+         45,584   0%                              - syntax-ppss
+         45,584   0%                                 make-closure
+        111,899   0%                             - seed7-inside-comment-p
+         49,739   0%                              - syntax-ppss
+         49,728   0%                                 make-closure
+         41,440   0%                               make-closure
+     22,627,176   0%                          - seed7-line-inside-func-return-statement
+     22,292,728   0%                           - seed7-re-search-backward
+     11,161,440   0%                            - run-with-timer
+     11,161,440   0%                             - run-at-time
+      5,571,504   0%                              - timer-activate
+      5,571,504   0%                               - timer--activate
+      5,571,504   0%                                  timer--time-less-p
+      3,067,968   0%                                timer-relative-time
+      2,020,544   0%                              - timer-set-time
+      2,020,544   0%                                 timer--time-setter
+        501,424   0%                                timer-create
+     10,758,328   0%                              re-search-backward
+        368,816   0%                              make-closure
+          4,144   0%                              seed7-inside-comment-p
+     14,069,688   0%                          - seed7-line-after-func-return-logic-operator-column
+      2,778,768   0%                           - seed7-move-to-line
+      2,745,976   0%                            - seed7-to-previous-non-empty-line
+        609,168   0%                             - seed7-inside-comment-p
+        406,112   0%                              - syntax-ppss
+        406,112   0%                                 make-closure
+     11,788,440   0%                          - seed7-line-starts-with
+          8,288   0%                           - seed7-move-to-line
+          8,288   0%                              seed7-to-previous-non-empty-line
+     11,361,496   0%                          - seed7-line-isa-string
+     11,361,496   0%                             seed7-line-starts-with
+     10,036,587   0%                          - seed7-comment-column
+      9,263,555   0%                           - seed7-calc-indent
+      3,867,924   0%                            - seed7-line-inside-a-block-cached
+      3,867,924   0%                             - seed7-line-inside-a-block
+      3,055,410   0%                              - seed7--safe-enclosing-block-bounds
+      2,105,296   0%                               - seed7-to-block-backward
+      1,647,048   0%                                - seed7-re-search-backward
+      1,189,784   0%                                 - run-with-timer
+      1,189,784   0%                                  - run-at-time
+        573,704   0%                                   - timer-activate
+        573,704   0%                                    - timer--activate
+        573,704   0%                                       timer--time-less-p
+        326,800   0%                                     timer-relative-time
+        231,264   0%                                   - timer-set-time
+        231,264   0%                                      timer--time-setter
+         58,016   0%                                     timer-create
+        240,352   0%                                 - seed7-inside-string-p
+         45,584   0%                                  - syntax-ppss
+         45,584   0%                                     make-closure
+         88,448   0%                                   re-search-backward
+         70,448   0%                                 - seed7-inside-comment-p
+         33,152   0%                                  - syntax-ppss
+         33,152   0%                                     make-closure
+         58,016   0%                                   make-closure
+        326,216   0%                                - seed7--current-line-nth-word
+        305,496   0%                                 - thing-at-point
+        280,824   0%                                  - bounds-of-thing-at-point
+         95,664   0%                                   - #<byte-code-function FAEC>
+         95,664   0%                                    - forward-thing
+         95,664   0%                                       format
+         82,880   0%                                     make-closure
+         44,264   0%                                   - #<byte-code-function 74D>
+         44,264   0%                                    - forward-thing
+         44,264   0%                                       format
+          4,144   0%                                   - seq-some
+          4,144   0%                                      make-closure
+         53,296   0%                                  seed7--start-regexp-for
+         37,296   0%                                - seed7-inside-line-indent-before-comment-p
+         12,432   0%                                 - seed7-inside-comment-p
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+         29,008   0%                                - seed7-inside-comment-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+        933,538   0%                               - seed7--block-end-pos-for
+        933,538   0%                                - seed7-to-block-forward
+        413,544   0%                                 - seed7--current-line-nth-word
+        363,816   0%                                  - thing-at-point
+        314,544   0%                                   - bounds-of-thing-at-point
+        124,320   0%                                      make-closure
+         78,448   0%                                    - #<byte-code-function EFE>
+         78,448   0%                                     - forward-thing
+         78,448   0%                                        format
+         28,944   0%                                    - #<byte-code-function DEA>
+         28,944   0%                                     - forward-thing
+         28,944   0%                                        format
+          8,288   0%                                    - seq-some
+          8,288   0%                                       make-closure
+          4,096   0%                                      re-search-forward
+        389,586   0%                                 - seed7-re-search-forward
+        161,616   0%                                  - seed7-inside-string-p
+         24,864   0%                                   - syntax-ppss
+         24,864   0%                                      make-closure
+        102,639   0%                                  - seed7-inside-comment-p
+         57,055   0%                                   - syntax-ppss
+         33,152   0%                                      make-closure
+         23,903   0%                                    - syntax-propertize
+         23,903   0%                                       seed7-mode-syntax-propertize
+         62,112   0%                                 - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+         29,008   0%                                  - seed7-inside-comment-p
+         16,576   0%                                   - syntax-ppss
+         16,576   0%                                      make-closure
+         20,720   0%                                    seed7-inside-line-indent-before-comment-p
+         20,720   0%                                   seed7-inside-line-indent-before-comment-p
+         20,720   0%                                 - seed7-inside-comment-p
+         12,432   0%                                  - syntax-ppss
+         12,432   0%                                     make-closure
+         10,280   0%                                   seed7--end-regexp-for
+        577,338   0%                              - seed7-re-search-backward
+        402,232   0%                               - run-with-timer
+        402,232   0%                                - run-at-time
+        202,808   0%                                 - timer-activate
+        202,808   0%                                  - timer--activate
+        202,808   0%                                     timer--time-less-p
+        114,608   0%                                   timer-relative-time
+         72,384   0%                                 - timer-set-time
+         72,384   0%                                    timer--time-setter
+         12,432   0%                                   timer-create
+         96,370   0%                                 re-search-backward
+         53,872   0%                               - seed7-inside-string-p
+         16,576   0%                                - syntax-ppss
+         16,576   0%                                   make-closure
+         20,720   0%                               - seed7-inside-comment-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+          4,144   0%                                 make-closure
+        171,280   0%                              - replace-regexp-in-string
+          7,336   0%                                 concat
+         23,560   0%                                match-string
+          8,288   0%                                seed7--on-lineof
+          5,248   0%                                seed7--indent-offset-for
+      1,171,149   0%                            - seed7-line-is-defun-end
+        786,313   0%                             - seed7-end-of-defun
+        679,248   0%                              - seed7-top-block-name
+        679,248   0%                               - seed7--to-top
+        659,616   0%                                - seed7-re-search-backward
+        477,280   0%                                 - run-with-timer
+        477,280   0%                                  - run-at-time
+        241,936   0%                                   - timer-activate
+        241,936   0%                                    - timer--activate
+        241,936   0%                                       timer--time-less-p
+        126,464   0%                                     timer-relative-time
+         88,160   0%                                   - timer-set-time
+         88,160   0%                                      timer--time-setter
+         20,720   0%                                     timer-create
+        120,176   0%                                 - seed7-inside-string-p
+         29,008   0%                                  - syntax-ppss
+         29,008   0%                                     make-closure
+         41,440   0%                                 - seed7-inside-comment-p
+         20,720   0%                                  - syntax-ppss
+         20,720   0%                                     make-closure
+         20,720   0%                                   make-closure
+         19,632   0%                                - run-with-timer
+         19,632   0%                                 - run-at-time
+         11,696   0%                                  - timer-activate
+         11,696   0%                                   - timer--activate
+         11,696   0%                                      timer--time-less-p
+          4,864   0%                                    timer-relative-time
+          3,072   0%                                  - timer-set-time
+          3,072   0%                                     timer--time-setter
+         56,928   0%                              - seed7-re-search-backward
+         32,064   0%                               - run-with-timer
+         32,064   0%                                - run-at-time
+         15,840   0%                                 - timer-activate
+         15,840   0%                                  - timer--activate
+         15,840   0%                                     timer--time-less-p
+          8,288   0%                                   timer-create
+          4,864   0%                                   timer-relative-time
+          3,072   0%                                 - timer-set-time
+          3,072   0%                                    timer--time-setter
+         24,864   0%                               - seed7-inside-string-p
+          8,288   0%                                - syntax-ppss
+          8,288   0%                                   make-closure
+         38,969   0%                              - seed7-re-search-forward
+         26,633   0%                               - seed7-inside-comment-p
+         26,633   0%                                - syntax-ppss
+         22,489   0%                                 - syntax-propertize
+         22,489   0%                                    seed7-mode-syntax-propertize
+          4,144   0%                                   make-closure
+          4,144   0%                                 seed7-inside-string-p
+          1,016   0%                                match-string
+        124,320   0%                             - seed7-move-to-line
+        124,320   0%                              - seed7-to-previous-non-empty-line
+         91,168   0%                               - seed7-inside-comment-p
+         58,016   0%                                - syntax-ppss
+         58,016   0%                                   make-closure
+        101,270   0%                             - seed7-beg-of-defun
+         27,972   0%                              - seed7-top-block-name
+         20,320   0%                               - seed7--to-top
+         12,304   0%                                - seed7-re-search-backward
+          4,288   0%                                   re-search-backward
+          4,144   0%                                   seed7-inside-string-p
+          3,872   0%                                 - run-with-timer
+          3,872   0%                                  - run-at-time
+          1,888   0%                                   - timer-activate
+          1,888   0%                                    - timer--activate
+          1,888   0%                                       timer--time-less-p
+          1,216   0%                                     timer-relative-time
+            768   0%                                   - timer-set-time
+            768   0%                                      timer--time-setter
+          8,016   0%                                - run-with-timer
+          8,016   0%                                 - run-at-time
+          6,032   0%                                  - timer-activate
+          6,032   0%                                   - timer--activate
+          6,032   0%                                      timer--time-less-p
+          1,216   0%                                    timer-relative-time
+            768   0%                                  - timer-set-time
+            768   0%                                     timer--time-setter
+          7,652   0%                               - seed7--block-name
+          7,652   0%                                  seed7-re-search-forward
+         22,962   0%                              - seed7-re-search-backward-closest
+         22,962   0%                               - seed7-re-search-backward
+         11,888   0%                                - run-with-timer
+         11,888   0%                                 - run-at-time
+          7,920   0%                                  - timer-activate
+          7,920   0%                                   - timer--activate
+          7,920   0%                                      timer--time-less-p
+          2,432   0%                                    timer-relative-time
+          1,536   0%                                  - timer-set-time
+          1,536   0%                                     timer--time-setter
+         11,074   0%                                  re-search-backward
+         20,304   0%                              - seed7-re-search-backward
+         16,432   0%                                 re-search-backward
+          3,872   0%                               - run-with-timer
+          3,872   0%                                - run-at-time
+          1,888   0%                                 - timer-activate
+          1,888   0%                                  - timer--activate
+          1,888   0%                                     timer--time-less-p
+          1,216   0%                                   timer-relative-time
+            768   0%                                 - timer-set-time
+            768   0%                                    timer--time-setter
+          1,048   0%                                match-string
+         93,000   0%                             - seed7--current-line-nth-word
+         88,856   0%                              - thing-at-point
+         88,856   0%                               - bounds-of-thing-at-point
+         45,584   0%                                  make-closure
+         19,512   0%                                - #<byte-code-function 871>
+         19,512   0%                                 - forward-thing
+         19,512   0%                                    format
+         11,328   0%                                - #<byte-code-function AF7>
+         11,328   0%                                 - forward-thing
+         11,328   0%                                    format
+          8,288   0%                                - seq-some
+          8,288   0%                                   make-closure
+         40,464   0%                             - seed7-line-starts-with-any
+         40,464   0%                                seed7-line-starts-with
+         21,638   0%                             - seed7--safe-current-line-defun-start-indent
+         21,638   0%                              - seed7-to-block-backward
+         17,494   0%                               - seed7-re-search-backward
+         11,686   0%                                  re-search-backward
+          5,808   0%                                - run-with-timer
+          5,808   0%                                 - run-at-time
+          2,832   0%                                  - timer-activate
+          2,832   0%                                   - timer--activate
+          2,832   0%                                      timer--time-less-p
+          1,824   0%                                    timer-relative-time
+          1,152   0%                                  - timer-set-time
+          1,152   0%                                     timer--time-setter
+      1,015,008   0%                            - seed7-line-inside-parens-pair-column
+      1,015,008   0%                             - seed7-line-inside-parens-pair
+        990,288   0%                              - seed7-re-search-backward
+        677,352   0%                               - run-with-timer
+        677,352   0%                                - run-at-time
+        314,936   0%                                 - timer-activate
+        314,936   0%                                  - timer--activate
+        314,936   0%                                     timer--time-less-p
+        181,488   0%                                   timer-relative-time
+        114,624   0%                                 - timer-set-time
+        114,624   0%                                    timer--time-setter
+         66,304   0%                                   timer-create
+        107,744   0%                               - seed7-inside-comment-p
+         70,448   0%                                - syntax-ppss
+         70,448   0%                                   make-closure
+        103,600   0%                               - seed7-inside-string-p
+          8,288   0%                                - syntax-ppss
+          8,288   0%                                   make-closure
+         93,304   0%                                 re-search-backward
+          8,288   0%                                 make-closure
+         12,432   0%                              - seed7-line-inside-syntax-parens-pair
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+         12,288   0%                              - forward-sexp
+         12,288   0%                                 seed7--forward-sexp-function
+        513,856   0%                            - seed7--indent-search-boundary
+        513,856   0%                             - seed7--indent-search-boundary-uncached
+        513,856   0%                              - syntax-ppss
+        513,856   0%                                 make-closure
+        315,672   0%                            - seed7-line-inside-array-definition-block
+        274,712   0%                             - seed7-re-search-backward
+        150,160   0%                              - run-with-timer
+        150,160   0%                               - run-at-time
+         73,424   0%                                - timer-activate
+         73,424   0%                                 - timer--activate
+         73,424   0%                                    timer--time-less-p
+         41,952   0%                                  timer-relative-time
+         30,640   0%                                - timer-set-time
+         30,640   0%                                   timer--time-setter
+          4,144   0%                                  timer-create
+        116,264   0%                                re-search-backward
+          8,288   0%                                seed7-inside-string-p
+         40,960   0%                             - forward-sexp
+         40,960   0%                                seed7--forward-sexp-function
+        314,130   0%                            - seed7-line-inside-argument-list-section
+        191,522   0%                             - seed7-re-search-backward
+        108,002   0%                                re-search-backward
+         83,520   0%                              - run-with-timer
+         83,520   0%                               - run-at-time
+         42,848   0%                                - timer-activate
+         42,848   0%                                 - timer--activate
+         42,848   0%                                    timer--time-less-p
+         24,928   0%                                  timer-relative-time
+         15,744   0%                                - timer-set-time
+         15,744   0%                                   timer--time-setter
+        122,608   0%                             - seed7-line-is-procfunc-beg-of-decl
+        122,608   0%                                seed7-line-starts-with
+        299,464   0%                            - seed7-line-inside-assign-statement-continuation
+        266,312   0%                             - seed7-assign-op-pos
+        266,312   0%                              - seed7-re-search-backward
+        158,448   0%                               - run-with-timer
+        158,448   0%                                - run-at-time
+         65,136   0%                                 - timer-activate
+         65,136   0%                                  - timer--activate
+         65,136   0%                                     timer--time-less-p
+         41,952   0%                                   timer-relative-time
+         30,640   0%                                 - timer-set-time
+         30,640   0%                                    timer--time-setter
+         20,720   0%                                   timer-create
+         91,288   0%                                 re-search-backward
+          8,288   0%                                 seed7-inside-string-p
+          8,288   0%                                 seed7-inside-comment-p
+         33,152   0%                             - seed7-statement-end-pos
+         33,152   0%                              - seed7-forward-char-pos
+         29,008   0%                               - seed7-re-search-forward
+         20,720   0%                                - seed7-inside-string-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          8,288   0%                                - seed7-inside-comment-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+        258,496   0%                            - seed7-line-inside-set-definition-block
+        254,352   0%                             - seed7-re-search-backward
+        133,584   0%                              - run-with-timer
+        133,584   0%                               - run-at-time
+         65,136   0%                                - timer-activate
+         65,136   0%                                 - timer--activate
+         65,136   0%                                    timer--time-less-p
+         41,952   0%                                  timer-relative-time
+         26,496   0%                                - timer-set-time
+         26,496   0%                                   timer--time-setter
+        100,048   0%                                re-search-backward
+         12,432   0%                              - seed7-inside-string-p
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+          4,144   0%                              - seed7-inside-comment-p
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+          4,144   0%                                make-closure
+        245,472   0%                            - seed7-line-inside-logic-check-expression
+        201,968   0%                             - seed7-to-previous-line-starts-with
+        193,784   0%                              - seed7-re-search-backward
+         91,808   0%                               - run-with-timer
+         91,808   0%                                - run-at-time
+         46,992   0%                                 - timer-activate
+         46,992   0%                                  - timer--activate
+         46,992   0%                                     timer--time-less-p
+         24,928   0%                                   timer-relative-time
+         19,888   0%                                 - timer-set-time
+         19,888   0%                                    timer--time-setter
+         85,400   0%                                 re-search-backward
+          8,288   0%                                 seed7-inside-comment-p
+          8,288   0%                               - seed7-inside-string-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+         22,784   0%                             - seed7--current-line-nth-word
+         22,784   0%                              - thing-at-point
+         20,720   0%                               - bounds-of-thing-at-point
+          8,288   0%                                  make-closure
+          4,144   0%                                - seq-some
+          4,144   0%                                   make-closure
+         16,576   0%                             - seed7-re-search-forward
+         16,576   0%                              - seed7-inside-string-p
+          8,288   0%                               - syntax-ppss
+          8,288   0%                                  make-closure
+        209,904   0%                            - seed7-line-inside-until-logic-expression
+        188,592   0%                             - seed7-re-search-backward
+         87,664   0%                              - run-with-timer
+         87,664   0%                               - run-at-time
+         46,992   0%                                - timer-activate
+         46,992   0%                                 - timer--activate
+         46,992   0%                                    timer--time-less-p
+         24,928   0%                                  timer-relative-time
+         15,744   0%                                - timer-set-time
+         15,744   0%                                   timer--time-setter
+         84,352   0%                                re-search-backward
+         12,432   0%                                make-closure
+          4,144   0%                                seed7-inside-comment-p
+         13,024   0%                             - seed7-line-code-ends-with
+          8,880   0%                              - seed7-re-search-backward
+          5,808   0%                               - run-with-timer
+          5,808   0%                                - run-at-time
+          2,832   0%                                 - timer-activate
+          2,832   0%                                  - timer--activate
+          2,832   0%                                     timer--time-less-p
+          1,824   0%                                   timer-relative-time
+          1,152   0%                                 - timer-set-time
+          1,152   0%                                    timer--time-setter
+          3,072   0%                                 re-search-backward
+        194,784   0%                            - seed7-line-after-func-return-logic-operator-column
+        107,696   0%                             - seed7-move-to-line
+        107,696   0%                              - seed7-to-previous-non-empty-line
+         62,160   0%                               - seed7-inside-comment-p
+         41,440   0%                                - syntax-ppss
+         41,440   0%                                   make-closure
+        185,240   0%                            - seed7-line-inside-func-return-statement
+        181,096   0%                             - seed7-re-search-backward
+         91,808   0%                              - run-with-timer
+         91,808   0%                               - run-at-time
+         42,848   0%                                - timer-activate
+         42,848   0%                                 - timer--activate
+         42,848   0%                                    timer--time-less-p
+         24,928   0%                                  timer-relative-time
+         15,744   0%                                - timer-set-time
+         15,744   0%                                   timer--time-setter
+          8,288   0%                                  timer-create
+         85,144   0%                                re-search-backward
+          4,144   0%                                make-closure
+        108,768   0%                            - seed7-line-starts-with-open-paren-after-logic-operator
+        107,744   0%                             - seed7-move-to-line
+        107,744   0%                              - seed7-to-previous-non-empty-line
+         78,736   0%                               - seed7-inside-comment-p
+         45,584   0%                                - syntax-ppss
+         45,584   0%                                   make-closure
+          1,024   0%                               seed7-line-starts-with
+        105,816   0%                              seed7-line-starts-with
+        103,600   0%                            - seed7-line-after-short-func-end
+         99,456   0%                             - seed7-move-to-line
+         99,456   0%                              - seed7-to-previous-non-empty-line
+         53,872   0%                               - seed7-inside-comment-p
+         20,720   0%                                - syntax-ppss
+         20,720   0%                                   make-closure
+         99,456   0%                            - seed7-line-at-endof-set-definition-block
+         99,456   0%                             - seed7-move-to-line
+         99,456   0%                              - seed7-to-previous-non-empty-line
+         70,448   0%                               - seed7-inside-comment-p
+         37,296   0%                                - syntax-ppss
+         37,296   0%                                   make-closure
+         99,448   0%                            - seed7-line-isa-string
+         99,448   0%                               seed7-line-starts-with
+         91,168   0%                            - seed7-line-at-endof-array-definition-block
+         91,168   0%                             - seed7-move-to-line
+         91,168   0%                              - seed7-to-previous-non-empty-line
+         62,160   0%                               - seed7-inside-comment-p
+         37,296   0%                                - syntax-ppss
+         37,296   0%                                   make-closure
+         50,720   0%                            - seed7--current-line-nth-word
+         50,720   0%                             - thing-at-point
+         50,720   0%                              - bounds-of-thing-at-point
+         29,008   0%                                 make-closure
+         12,376   0%                               - #<byte-code-function 956>
+         12,376   0%                                - forward-thing
+         12,376   0%                                   format
+          1,048   0%                               - #<byte-code-function E9F>
+          1,048   0%                                - forward-thing
+          1,048   0%                                   format
+         12,432   0%                            - seed7-current-line-start-inside-comment-p
+         12,432   0%                               seed7-inside-comment-p
+          1,048   0%                            - error
+          1,048   0%                               format-message
+        557,776   0%                           - seed7-line-code-ends-with
+        404,688   0%                            - seed7-re-search-backward
+        253,464   0%                             - run-with-timer
+        253,464   0%                              - run-at-time
+        146,968   0%                               - timer-activate
+        146,968   0%                                - timer--activate
+        146,968   0%                                 - timer--time-less-p
+         32,792   0%                                    timer--time
+         60,192   0%                                 timer-relative-time
+         42,160   0%                               - timer-set-time
+         42,160   0%                                  timer--time-setter
+          4,144   0%                                 timer-create
+         93,208   0%                               re-search-backward
+         24,864   0%                               seed7-inside-string-p
+         16,576   0%                               seed7-inside-comment-p
+         16,576   0%                               make-closure
+        148,944   0%                            - seed7-move-to-line
+        148,944   0%                             - seed7-to-previous-non-empty-line
+         87,024   0%                              - seed7-inside-comment-p
+         53,872   0%                               - syntax-ppss
+         53,872   0%                                  make-closure
+        120,712   0%                           - seed7-line-inside-a-block
+         88,288   0%                            - seed7--safe-enclosing-block-bounds
+         47,480   0%                             - seed7--block-end-pos-for
+         47,480   0%                              - seed7-to-block-forward
+         28,952   0%                               - seed7--current-line-nth-word
+         24,808   0%                                - thing-at-point
+         24,808   0%                                 - bounds-of-thing-at-point
+          9,232   0%                                  - #<byte-code-function D69>
+          9,232   0%                                   - forward-thing
+          9,232   0%                                      format
+          8,288   0%                                    make-closure
+          4,144   0%                                  - seq-some
+          4,144   0%                                     make-closure
+          3,144   0%                                  - #<byte-code-function 19E>
+          3,144   0%                                   - forward-thing
+          3,144   0%                                      format
+         14,384   0%                               - seed7-re-search-forward
+          6,144   0%                                - seed7-inside-comment-p
+          6,144   0%                                 - syntax-ppss
+          6,144   0%                                  - syntax-propertize
+          6,144   0%                                     seed7-mode-syntax-propertize
+          4,144   0%                                  seed7-inside-string-p
+          4,144   0%                               - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          4,144   0%                                  seed7-inside-line-indent-before-comment-p
+         40,808   0%                             - seed7-to-block-backward
+         17,992   0%                              - seed7-re-search-backward
+         14,792   0%                               - run-with-timer
+         14,792   0%                                - run-at-time
+          9,336   0%                                 - timer-activate
+          9,336   0%                                  - timer--activate
+          9,336   0%                                     timer--time-less-p
+          3,344   0%                                   timer-relative-time
+          2,112   0%                                 - timer-set-time
+          2,112   0%                                    timer--time-setter
+          3,200   0%                                 re-search-backward
+         12,432   0%                              - seed7-inside-line-indent-before-comment-p
+          4,144   0%                                 seed7-inside-comment-p
+          9,336   0%                              - seed7--current-line-nth-word
+          5,192   0%                               - thing-at-point
+          4,144   0%                                - bounds-of-thing-at-point
+          4,144   0%                                   make-closure
+          1,048   0%                                seed7--start-regexp-for
+         18,888   0%                            - seed7-re-search-backward
+         14,792   0%                             - run-with-timer
+         14,792   0%                              - run-at-time
+          9,336   0%                               - timer-activate
+          9,336   0%                                - timer--activate
+          9,336   0%                                   timer--time-less-p
+          3,344   0%                                 timer-relative-time
+          2,112   0%                               - timer-set-time
+          2,112   0%                                  timer--time-setter
+          4,096   0%                               re-search-backward
+          5,144   0%                              replace-regexp-in-string
+          4,144   0%                            - seed7-move-to-line
+          4,144   0%                               seed7-to-previous-non-empty-line
+          3,200   0%                              seed7--indent-offset-for
+         83,184   0%                           - seed7-line-starts-with
+          8,288   0%                            - seed7-move-to-line
+          8,288   0%                             - seed7-to-previous-non-empty-line
+          8,288   0%                              - seed7-inside-comment-p
+          8,288   0%                               - syntax-ppss
+          8,288   0%                                  make-closure
+          3,072   0%                             looking-at
+      1,702,116   0%                          - seed7-line-after-short-func-end
+      1,421,900   0%                           - seed7-move-to-line
+      1,421,900   0%                            - seed7-to-previous-non-empty-line
+      1,306,636   0%                             - seed7-inside-comment-p
+      1,285,916   0%                              - syntax-ppss
+      1,252,764   0%                               - syntax-propertize
+      1,236,188   0%                                  seed7-mode-syntax-propertize
+         33,152   0%                                 make-closure
+         34,048   0%                           - seed7-to-block-backward
+         14,096   0%                            - seed7-re-search-backward
+          8,288   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+          5,808   0%                             - run-with-timer
+          5,808   0%                              - run-at-time
+          2,832   0%                               - timer-activate
+          2,832   0%                                - timer--activate
+          2,832   0%                                   timer--time-less-p
+          1,824   0%                                 timer-relative-time
+          1,152   0%                               - timer-set-time
+          1,152   0%                                  timer--time-setter
+          5,160   0%                            - seed7--current-line-nth-word
+          5,160   0%                             - thing-at-point
+          4,144   0%                              - bounds-of-thing-at-point
+          4,144   0%                                 make-closure
+          4,840   0%                            - seed7-beg-of-defun
+          1,936   0%                             - seed7-re-search-backward-closest
+          1,936   0%                              - seed7-re-search-backward
+          1,936   0%                               - run-with-timer
+          1,936   0%                                - run-at-time
+            944   0%                                 - timer-activate
+            944   0%                                  - timer--activate
+            944   0%                                     timer--time-less-p
+            608   0%                                   timer-relative-time
+            384   0%                                 - timer-set-time
+            384   0%                                    timer--time-setter
+          1,936   0%                             - seed7-top-block-name
+          1,936   0%                              - seed7--to-top
+            968   0%                               - run-with-timer
+            968   0%                                - run-at-time
+            472   0%                                 - timer-activate
+            472   0%                                  - timer--activate
+            472   0%                                     timer--time-less-p
+            304   0%                                   timer-relative-time
+            192   0%                                 - timer-set-time
+            192   0%                                    timer--time-setter
+            968   0%                               - seed7-re-search-backward
+            968   0%                                - run-with-timer
+            968   0%                                 - run-at-time
+            472   0%                                  - timer-activate
+            472   0%                                   - timer--activate
+            472   0%                                      timer--time-less-p
+            304   0%                                    timer-relative-time
+            192   0%                                  - timer-set-time
+            192   0%                                     timer--time-setter
+            968   0%                             - seed7-re-search-backward
+            968   0%                              - run-with-timer
+            968   0%                               - run-at-time
+            472   0%                                - timer-activate
+            472   0%                                 - timer--activate
+            472   0%                                    timer--time-less-p
+            304   0%                                  timer-relative-time
+            192   0%                                - timer-set-time
+            192   0%                                   timer--time-setter
+          3,872   0%                            - backward-sexp
+          3,872   0%                             - forward-sexp
+          3,872   0%                              - seed7--forward-sexp-function
+          1,936   0%                               - seed7--at-array-definition-end-line-p
+          1,936   0%                                - seed7-line-code-ends-with
+          1,936   0%                                 - seed7-re-search-backward
+          1,936   0%                                  - run-with-timer
+          1,936   0%                                   - run-at-time
+            944   0%                                    - timer-activate
+            944   0%                                     - timer--activate
+            944   0%                                        timer--time-less-p
+            608   0%                                      timer-relative-time
+            384   0%                                    - timer-set-time
+            384   0%                                       timer--time-setter
+          1,936   0%                               - seed7--at-set-definition-end-line-p
+          1,936   0%                                - seed7-line-code-ends-with
+          1,936   0%                                 - seed7-re-search-backward
+          1,936   0%                                  - run-with-timer
+          1,936   0%                                   - run-at-time
+            944   0%                                    - timer-activate
+            944   0%                                     - timer--activate
+            944   0%                                        timer--time-less-p
+            608   0%                                      timer-relative-time
+            384   0%                                    - timer-set-time
+            384   0%                                       timer--time-setter
+          1,936   0%                            - seed7-line-code-ends-with
+          1,936   0%                             - seed7-re-search-backward
+          1,936   0%                              - run-with-timer
+          1,936   0%                               - run-at-time
+            944   0%                                - timer-activate
+            944   0%                                 - timer--activate
+            944   0%                                    timer--time-less-p
+            608   0%                                  timer-relative-time
+            384   0%                                - timer-set-time
+            384   0%                                   timer--time-setter
+      1,156,940   0%                          - seed7-current-line-start-inside-comment-p
+        837,852   0%                           - seed7-inside-comment-p
+        435,884   0%                            - syntax-ppss
+        435,120   0%                               make-closure
+            764   0%                               syntax-table
+        378,560   0%                          - seed7-line-at-endof-array-definition-block
+        274,784   0%                           - seed7-line-code-ends-with
+        270,640   0%                            - seed7-re-search-backward
+        214,000   0%                             - run-with-timer
+        214,000   0%                              - run-at-time
+         98,704   0%                               - timer-activate
+         98,704   0%                                - timer--activate
+         98,704   0%                                   timer--time-less-p
+         52,880   0%                                 timer-relative-time
+         45,840   0%                               - timer-set-time
+         45,840   0%                                  timer--time-setter
+         16,576   0%                                 timer-create
+         40,064   0%                               re-search-backward
+          8,288   0%                               make-closure
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+          4,144   0%                               seed7-inside-string-p
+         65,992   0%                           - backward-sexp
+         65,992   0%                            - forward-sexp
+         65,992   0%                             - seed7--forward-sexp-function
+         29,080   0%                              - seed7--at-array-definition-end-line-p
+         25,984   0%                               - seed7-line-code-ends-with
+         25,984   0%                                - seed7-re-search-backward
+         17,696   0%                                 - run-with-timer
+         17,696   0%                                  - run-at-time
+         10,752   0%                                   - timer-activate
+         10,752   0%                                    - timer--activate
+         10,752   0%                                       timer--time-less-p
+          4,256   0%                                     timer-relative-time
+          2,688   0%                                   - timer-set-time
+          2,688   0%                                      timer--time-setter
+          4,144   0%                                   seed7-inside-string-p
+          4,144   0%                                   make-closure
+          3,096   0%                                 looking-at
+         19,904   0%                              - seed7--at-set-definition-end-line-p
+         19,904   0%                               - seed7-line-code-ends-with
+         19,904   0%                                - seed7-re-search-backward
+         15,760   0%                                 - run-with-timer
+         15,760   0%                                  - run-at-time
+          9,808   0%                                   - timer-activate
+          9,808   0%                                    - timer--activate
+          9,808   0%                                       timer--time-less-p
+          3,648   0%                                     timer-relative-time
+          2,304   0%                                   - timer-set-time
+          2,304   0%                                      timer--time-setter
+          4,144   0%                                   seed7-inside-string-p
+         13,024   0%                              - seed7-beg-of-defun
+          8,184   0%                                 match-string-no-properties
+          1,936   0%                               - seed7-re-search-backward-closest
+          1,936   0%                                - seed7-re-search-backward
+          1,936   0%                                 - run-with-timer
+          1,936   0%                                  - run-at-time
+            944   0%                                   - timer-activate
+            944   0%                                    - timer--activate
+            944   0%                                       timer--time-less-p
+            608   0%                                     timer-relative-time
+            384   0%                                   - timer-set-time
+            384   0%                                      timer--time-setter
+          1,936   0%                               - seed7-top-block-name
+          1,936   0%                                - seed7--to-top
+            968   0%                                 - run-with-timer
+            968   0%                                  - run-at-time
+            472   0%                                   - timer-activate
+            472   0%                                    - timer--activate
+            472   0%                                       timer--time-less-p
+            304   0%                                     timer-relative-time
+            192   0%                                   - timer-set-time
+            192   0%                                      timer--time-setter
+            968   0%                                 - seed7-re-search-backward
+            968   0%                                  - run-with-timer
+            968   0%                                   - run-at-time
+            472   0%                                    - timer-activate
+            472   0%                                     - timer--activate
+            472   0%                                        timer--time-less-p
+            304   0%                                      timer-relative-time
+            192   0%                                    - timer-set-time
+            192   0%                                       timer--time-setter
+            968   0%                               - seed7-re-search-backward
+            968   0%                                - run-with-timer
+            968   0%                                 - run-at-time
+            472   0%                                  - timer-activate
+            472   0%                                   - timer--activate
+            472   0%                                      timer--time-less-p
+            304   0%                                    timer-relative-time
+            192   0%                                  - timer-set-time
+            192   0%                                     timer--time-setter
+          1,936   0%                              - seed7--safe-to-block-backward
+          1,936   0%                               - seed7-to-block-backward
+          1,936   0%                                - seed7-line-code-ends-with
+          1,936   0%                                 - seed7-re-search-backward
+          1,936   0%                                  - run-with-timer
+          1,936   0%                                   - run-at-time
+            944   0%                                    - timer-activate
+            944   0%                                     - timer--activate
+            944   0%                                        timer--time-less-p
+            608   0%                                      timer-relative-time
+            384   0%                                    - timer-set-time
+            384   0%                                       timer--time-setter
+         18,576   0%                           - seed7-move-to-line
+         18,576   0%                            - seed7-to-previous-non-empty-line
+          8,288   0%                             - seed7-inside-comment-p
+          8,288   0%                              - syntax-ppss
+          8,288   0%                                 make-closure
+         10,920   0%                           - seed7-re-search-backward
+          6,776   0%                            - run-with-timer
+          6,776   0%                             - run-at-time
+          3,304   0%                              - timer-activate
+          3,304   0%                               - timer--activate
+          3,304   0%                                  timer--time-less-p
+          2,128   0%                                timer-relative-time
+          1,344   0%                              - timer-set-time
+          1,344   0%                                 timer--time-setter
+          4,144   0%                              seed7-inside-string-p
+        378,288   0%                          - seed7-line-ends-with
+        271,744   0%                           - seed7-re-search-backward
+        133,280   0%                            - run-with-timer
+        133,280   0%                             - run-at-time
+         69,440   0%                              - timer-activate
+         69,440   0%                               - timer--activate
+         69,440   0%                                  timer--time-less-p
+         34,048   0%                                timer-relative-time
+         21,504   0%                              - timer-set-time
+         21,504   0%                                 timer--time-setter
+          8,288   0%                                timer-create
+        130,176   0%                              re-search-backward
+          8,288   0%                              make-closure
+        106,544   0%                           - seed7-move-to-line
+        106,544   0%                            - seed7-to-previous-non-empty-line
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+        310,008   0%                          - seed7-line-indent-step
+         33,152   0%                           - seed7-move-to-line
+         33,152   0%                            - seed7-to-previous-non-empty-line
+         16,576   0%                             - seed7-inside-comment-p
+          8,288   0%                              - syntax-ppss
+          8,288   0%                                 make-closure
+        268,144   0%                          - seed7-line-at-endof-set-definition-block
+        216,224   0%                           - seed7-line-code-ends-with
+        207,936   0%                            - seed7-re-search-backward
+        183,072   0%                             - run-with-timer
+        183,072   0%                              - run-at-time
+         81,184   0%                               - timer-activate
+         81,184   0%                                - timer--activate
+         81,184   0%                                   timer--time-less-p
+         52,288   0%                                 timer-relative-time
+         33,024   0%                               - timer-set-time
+         33,024   0%                                  timer--time-setter
+         16,576   0%                                 timer-create
+         16,576   0%                             - seed7-inside-string-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+          4,144   0%                               make-closure
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+         42,880   0%                           - backward-sexp
+         42,880   0%                            - forward-sexp
+         42,880   0%                             - seed7--forward-sexp-function
+         19,904   0%                              - seed7--safe-to-block-backward
+         19,904   0%                               - seed7-to-block-backward
+         19,904   0%                                - seed7-line-code-ends-with
+         19,904   0%                                 - seed7-re-search-backward
+         11,616   0%                                  - run-with-timer
+         11,616   0%                                   - run-at-time
+          5,664   0%                                    - timer-activate
+          5,664   0%                                     - timer--activate
+          5,664   0%                                        timer--time-less-p
+          3,648   0%                                      timer-relative-time
+          2,304   0%                                    - timer-set-time
+          2,304   0%                                       timer--time-setter
+          8,288   0%                                    seed7-inside-string-p
+         13,024   0%                              - seed7--at-set-definition-end-line-p
+          9,952   0%                               - seed7-line-code-ends-with
+          9,952   0%                                - seed7-re-search-backward
+          5,808   0%                                 - run-with-timer
+          5,808   0%                                  - run-at-time
+          2,832   0%                                   - timer-activate
+          2,832   0%                                    - timer--activate
+          2,832   0%                                       timer--time-less-p
+          1,824   0%                                     timer-relative-time
+          1,152   0%                                   - timer-set-time
+          1,152   0%                                      timer--time-setter
+          4,144   0%                                   seed7-inside-string-p
+          3,072   0%                                 looking-at
+          9,952   0%                              - seed7--at-array-definition-end-line-p
+          9,952   0%                               - seed7-line-code-ends-with
+          9,952   0%                                - seed7-re-search-backward
+          5,808   0%                                 - run-with-timer
+          5,808   0%                                  - run-at-time
+          2,832   0%                                   - timer-activate
+          2,832   0%                                    - timer--activate
+          2,832   0%                                       timer--time-less-p
+          1,824   0%                                     timer-relative-time
+          1,152   0%                                   - timer-set-time
+          1,152   0%                                      timer--time-setter
+          4,144   0%                                   seed7-inside-string-p
+          4,144   0%                           - seed7-move-to-line
+          4,144   0%                              seed7-to-previous-non-empty-line
+          3,872   0%                           - seed7-re-search-backward
+          3,872   0%                            - run-with-timer
+          3,872   0%                             - run-at-time
+          1,888   0%                              - timer-activate
+          1,888   0%                               - timer--activate
+          1,888   0%                                  timer--time-less-p
+          1,216   0%                                timer-relative-time
+            768   0%                              - timer-set-time
+            768   0%                                 timer--time-setter
+          1,024   0%                             looking-at
+        213,152   0%                          - seed7-position-of-end-of-statement
+        213,152   0%                           - seed7-line-code-ends-with
+        209,008   0%                            - seed7-re-search-backward
+        146,016   0%                             - run-with-timer
+        146,016   0%                              - run-at-time
+         73,424   0%                               - timer-activate
+         73,424   0%                                - timer--activate
+         73,424   0%                                   timer--time-less-p
+         41,952   0%                                 timer-relative-time
+         26,496   0%                               - timer-set-time
+         26,496   0%                                  timer--time-setter
+          4,144   0%                                 timer-create
+         24,864   0%                             - seed7-inside-string-p
+         12,432   0%                              - syntax-ppss
+         12,432   0%                                 make-closure
+         17,408   0%                               re-search-backward
+         16,576   0%                             - seed7-inside-comment-p
+          8,288   0%                              - syntax-ppss
+          8,288   0%                                 make-closure
+          4,144   0%                               make-closure
+        111,576   0%                          - seed7-line-inside-nested-parens-pairs-column
+        111,576   0%                           - seed7-line-inside-nested-parens-pairs
+        107,432   0%                            - seed7-line-inside-parens-pair
+         99,144   0%                             - seed7-re-search-backward
+         83,640   0%                              - run-with-timer
+         83,640   0%                               - run-at-time
+         43,112   0%                                - timer-activate
+         43,112   0%                                 - timer--activate
+         43,112   0%                                    timer--time-less-p
+         19,760   0%                                  timer-relative-time
+         12,480   0%                                - timer-set-time
+         12,480   0%                                   timer--time-setter
+          8,288   0%                                  timer-create
+          4,144   0%                                seed7-inside-string-p
+          4,144   0%                                make-closure
+          4,144   0%                              - seed7-inside-comment-p
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+          3,072   0%                                re-search-backward
+          4,144   0%                             - seed7-line-inside-syntax-parens-pair
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+         52,344   0%                          - seed7-line-starts-with-open-paren-after-logic-operator
+         52,344   0%                             seed7-line-starts-with
+         11,312   0%                          - seed7-line-is-procfunc-beg-of-decl
+         11,312   0%                             seed7-line-starts-with
+        834,056   0%                         - jit-lock-after-change
+        352,240   0%                            font-lock-extend-jit-lock-region-after-change
+        682,616   0%                         - #<byte-code-function EAE>
+        682,616   0%                          - filter-buffer-substring
+        682,616   0%                           - buffer-substring--filter
+        682,616   0%                            - #<byte-code-function D87>
+        682,616   0%                             - apply
+        682,616   0%                                #<byte-code-function 954>
+            648   0%                         - delete-horizontal-space
+            648   0%                            delete-space--internal
+      1,780,988   0%                   profiler-stop
+      2,417,606   0%   Automatic GC

--- a/reports/19.1/castle.sd7-perf-cpu.txt
+++ b/reports/19.1/castle.sd7-perf-cpu.txt
@@ -1,0 +1,875 @@
+       46801  93% - ...
+       46801  93%  - smex-read-and-run
+       46801  93%   - execute-extended-command
+       46801  93%    - command-execute
+       46801  93%     - call-interactively
+       46801  93%      - apply
+       46801  93%       - call-interactively@ido-cr+-record-current-command
+       46801  93%        - #<primitive-function call-interactively>
+       46801  93%         - funcall-interactively
+       46801  93%          - pel-profile
+       46801  93%           - call-interactively
+       46801  93%            - apply
+       46801  93%             - call-interactively@ido-cr+-record-current-command
+       46801  93%              - #<primitive-function call-interactively>
+       46801  93%               - funcall-interactively
+       46801  93%                - seed7-complete-statement-or-indent
+       46801  93%                 - seed7-indent-region
+       46800  93%                  - seed7--indent-one-line
+       46782  93%                   - seed7-calc-indent
+       22352  44%                    - seed7-line-is-defun-end
+       21025  41%                     - seed7-end-of-defun
+       19475  38%                      - seed7-top-block-name
+       19450  38%                       - seed7--to-top
+       19376  38%                        - seed7-re-search-backward
+       17180  34%                         - seed7-inside-comment-p
+       17171  34%                          - syntax-ppss
+       17055  34%                             parse-partial-sexp
+          75   0%                           - syntax-propertize
+          72   0%                              seed7-mode-syntax-propertize
+           7   0%                             make-closure
+           4   0%                             syntax-ppss--update-stats
+           3   0%                           - #<byte-code-function C62>
+           1   0%                              set-syntax-table
+           3   0%                             syntax-ppss-toplevel-pos
+           2   0%                             syntax-table
+        1431   2%                         - run-with-timer
+        1428   2%                          - run-at-time
+         751   1%                           - timer-activate
+         747   1%                            - timer--activate
+         738   1%                             - timer--time-less-p
+          22   0%                                timer--time
+         383   0%                           - timer-set-time
+         381   0%                            - timer--time-setter
+           1   0%                               timerp
+         272   0%                             timer-relative-time
+          15   0%                             timer-create
+           2   0%                           - timer-set-function
+           1   0%                              timerp
+         526   1%                           re-search-backward
+         135   0%                         - seed7-inside-string-p
+          82   0%                          - syntax-ppss
+          42   0%                           - parse-partial-sexp
+           3   0%                            - internal--syntax-propertize
+           3   0%                             - syntax-propertize
+           2   0%                                seed7-mode-syntax-propertize
+          16   0%                             make-closure
+           7   0%                           - #<byte-code-function 172>
+           1   0%                              set-syntax-table
+           3   0%                             syntax-ppss--data
+           2   0%                             syntax-ppss--update-stats
+          13   0%                          - #<byte-code-function FDD>
+          10   0%                             set-match-data
+          13   0%                           make-closure
+          12   0%                         - #<byte-code-function E7A>
+          10   0%                          - cancel-timer
+           2   0%                             timerp
+          21   0%                          seed7-to-indent
+          12   0%                        - run-with-timer
+          12   0%                         - run-at-time
+           5   0%                          - timer-activate
+           5   0%                           - timer--activate
+           5   0%                              timer--time-less-p
+           5   0%                            timer-relative-time
+           2   0%                          - timer-set-time
+           2   0%                             timer--time-setter
+           1   0%                        - #<byte-code-function 69F>
+           1   0%                           cancel-timer
+          25   0%                       - seed7--block-name
+          24   0%                        - seed7-re-search-forward
+           8   0%                         - seed7-inside-comment-p
+           7   0%                          - syntax-ppss
+           4   0%                             parse-partial-sexp
+           2   0%                             syntax-ppss--data
+           1   0%                             #<byte-code-function 139>
+           6   0%                         - seed7-inside-string-p
+           5   0%                          - syntax-ppss
+           5   0%                             parse-partial-sexp
+        1335   2%                      - seed7-re-search-forward
+         448   0%                       - seed7-inside-comment-p
+         446   0%                        - syntax-ppss
+         379   0%                           parse-partial-sexp
+          58   0%                         - syntax-propertize
+          53   0%                            seed7-mode-syntax-propertize
+           2   0%                          - #<byte-code-function 3C7>
+           2   0%                           - syntax-propertize-wholelines
+           2   0%                              syntax--lbp
+           3   0%                           make-closure
+           1   0%                           #<byte-code-function 9D9>
+           1   0%                           syntax-ppss--data
+         252   0%                       - seed7-inside-string-p
+         240   0%                        - syntax-ppss
+         233   0%                           parse-partial-sexp
+           3   0%                         - #<byte-code-function 88A>
+           1   0%                            set-syntax-table
+           1   0%                           make-closure
+           1   0%                           syntax-ppss--update-stats
+           1   0%                        - #<byte-code-function DB3>
+           1   0%                           set-match-data
+         206   0%                      - seed7-re-search-backward
+         180   0%                       - seed7-inside-comment-p
+         180   0%                        - syntax-ppss
+         179   0%                           parse-partial-sexp
+          13   0%                       - run-with-timer
+          13   0%                        - run-at-time
+           7   0%                         - timer-activate
+           7   0%                          - timer--activate
+           7   0%                             timer--time-less-p
+           3   0%                         - timer-set-time
+           3   0%                            timer--time-setter
+           3   0%                           timer-relative-time
+          10   0%                         re-search-backward
+           2   0%                       - seed7-inside-string-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           1   0%                         make-closure
+           1   0%                        match-string-no-properties
+           1   0%                        match-string
+        1239   2%                     - seed7-beg-of-defun
+         718   1%                      - seed7-re-search-backward
+         607   1%                       - seed7-inside-comment-p
+         607   1%                        - syntax-ppss
+         607   1%                           parse-partial-sexp
+          53   0%                       - run-with-timer
+          53   0%                        - run-at-time
+          26   0%                         - timer-activate
+          25   0%                          - timer--activate
+          25   0%                           - timer--time-less-p
+           2   0%                              timer--time
+          19   0%                         - timer-set-time
+          19   0%                            timer--time-setter
+           7   0%                           timer-relative-time
+           1   0%                           timer-create
+          49   0%                         re-search-backward
+           5   0%                       - seed7-inside-string-p
+           5   0%                        - syntax-ppss
+           4   0%                           parse-partial-sexp
+         478   0%                      - seed7-re-search-backward-closest
+         477   0%                       - seed7-re-search-backward
+         468   0%                          re-search-backward
+           8   0%                        - run-with-timer
+           8   0%                         - run-at-time
+           3   0%                          - timer-activate
+           3   0%                           - timer--activate
+           3   0%                              timer--time-less-p
+           3   0%                            timer-relative-time
+           2   0%                          - timer-set-time
+           2   0%                             timer--time-setter
+          25   0%                      - seed7-top-block-name
+          22   0%                       - seed7--to-top
+          19   0%                        - seed7-re-search-backward
+          13   0%                         - seed7-inside-comment-p
+          13   0%                          - syntax-ppss
+          13   0%                             parse-partial-sexp
+           3   0%                         - run-with-timer
+           3   0%                          - run-at-time
+           1   0%                             timer-relative-time
+           1   0%                           - timer-activate
+           1   0%                            - timer--activate
+           1   0%                               timer--time-less-p
+           1   0%                           - timer-set-time
+           1   0%                              timer--time-setter
+           3   0%                           re-search-backward
+           2   0%                        - run-with-timer
+           2   0%                         - run-at-time
+           2   0%                            timer-relative-time
+           3   0%                       - seed7--block-name
+           2   0%                          seed7-re-search-forward
+           1   0%                          match-string
+          47   0%                     - seed7-move-to-line
+          47   0%                      - seed7-to-previous-non-empty-line
+          43   0%                       - seed7-inside-comment-p
+          43   0%                        - syntax-ppss
+          42   0%                           parse-partial-sexp
+          17   0%                     - seed7--safe-current-line-defun-start-indent
+          17   0%                      - seed7-to-block-backward
+          16   0%                       - seed7-re-search-backward
+          14   0%                        - seed7-inside-comment-p
+          14   0%                         - syntax-ppss
+          14   0%                            parse-partial-sexp
+           1   0%                        - run-with-timer
+           1   0%                         - run-at-time
+           1   0%                          - timer-activate
+           1   0%                           - timer--activate
+           1   0%                              timer--time-less-p
+           1   0%                          re-search-backward
+           1   0%                       - seed7-inside-line-indent-before-comment-p
+           1   0%                        - seed7-inside-comment-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+          13   0%                     - seed7--current-line-nth-word
+          10   0%                      - thing-at-point
+          10   0%                       - bounds-of-thing-at-point
+           3   0%                          re-search-forward
+           3   0%                        - #<byte-code-function 6C2>
+           3   0%                         - forward-thing
+           1   0%                            forward-word
+           1   0%                            functionp
+           1   0%                            format
+           2   0%                        - #<byte-code-function EB0>
+           2   0%                         - forward-thing
+           1   0%                            format
+           1   0%                            forward-word
+           7   0%                     - seed7-line-starts-with-any
+           7   0%                        seed7-line-starts-with
+           2   0%                       line-end-position
+       17039  34%                    - seed7--indent-search-boundary
+       17037  34%                     - seed7--indent-search-boundary-uncached
+       16771  33%                      - syntax-ppss
+       16703  33%                         parse-partial-sexp
+          10   0%                         make-closure
+          10   0%                       - #<byte-code-function BE5>
+           1   0%                          set-syntax-table
+           6   0%                         syntax-ppss--update-stats
+           4   0%                         syntax-propertize
+           4   0%                         syntax-table
+           3   0%                         syntax-ppss--data
+           2   0%                         set-syntax-table
+           1   0%                         syntax-ppss-toplevel-pos
+          40   0%                        seed7-to-indent
+        5201  10%                    - seed7-line-inside-a-block-cached
+        5200  10%                     - seed7-line-inside-a-block
+        4839   9%                      - seed7--safe-enclosing-block-bounds
+        4195   8%                       - seed7--block-end-pos-for
+        4193   8%                        - seed7-to-block-forward
+        3977   7%                         - seed7-end-of-defun
+        3869   7%                          - seed7-top-block-name
+        3858   7%                           - seed7--to-top
+        3841   7%                            - seed7-re-search-backward
+        3386   6%                             - seed7-inside-comment-p
+        3381   6%                              - syntax-ppss
+        3360   6%                                 parse-partial-sexp
+          14   0%                               - syntax-propertize
+          14   0%                                  seed7-mode-syntax-propertize
+           1   0%                                 make-closure
+           1   0%                                 syntax-ppss--update-stats
+         301   0%                             - run-with-timer
+         300   0%                              - run-at-time
+         154   0%                               - timer-activate
+         153   0%                                - timer--activate
+         152   0%                                 - timer--time-less-p
+           5   0%                                    timer--time
+          82   0%                               - timer-set-time
+          81   0%                                  timer--time-setter
+          64   0%                                 timer-relative-time
+         119   0%                               re-search-backward
+          18   0%                             - seed7-inside-string-p
+          10   0%                              - syntax-ppss
+           4   0%                                 parse-partial-sexp
+           2   0%                                 make-closure
+           1   0%                                 #<byte-code-function D96>
+           1   0%                                 set-syntax-table
+           1   0%                                 syntax-propertize
+           1   0%                                #<byte-code-function DC9>
+           4   0%                               make-closure
+           4   0%                            - run-with-timer
+           4   0%                             - run-at-time
+           3   0%                              - timer-activate
+           3   0%                               - timer--activate
+           3   0%                                  timer--time-less-p
+           1   0%                                timer-relative-time
+           3   0%                              seed7-to-indent
+          11   0%                           - seed7--block-name
+          11   0%                            - seed7-re-search-forward
+           4   0%                             - seed7-inside-string-p
+           4   0%                              - syntax-ppss
+           4   0%                                 parse-partial-sexp
+           4   0%                             - seed7-inside-comment-p
+           4   0%                              - syntax-ppss
+           4   0%                                 parse-partial-sexp
+          76   0%                          - seed7-re-search-forward
+           3   0%                           - seed7-inside-string-p
+           3   0%                            - syntax-ppss
+           3   0%                               parse-partial-sexp
+           1   0%                           - seed7-inside-comment-p
+           1   0%                            - syntax-ppss
+           1   0%                               parse-partial-sexp
+          32   0%                          - seed7-re-search-backward
+          28   0%                           - seed7-inside-comment-p
+          28   0%                            - syntax-ppss
+          28   0%                               parse-partial-sexp
+           4   0%                           - run-with-timer
+           4   0%                            - run-at-time
+           2   0%                             - timer-set-time
+           2   0%                                timer--time-setter
+           2   0%                             - timer-activate
+           2   0%                              - timer--activate
+           2   0%                                 timer--time-less-p
+         150   0%                         - seed7-re-search-forward
+          66   0%                          - seed7-inside-string-p
+          66   0%                           - syntax-ppss
+          66   0%                              parse-partial-sexp
+          64   0%                          - seed7-inside-comment-p
+          63   0%                           - syntax-ppss
+          59   0%                              parse-partial-sexp
+           3   0%                            - syntax-propertize
+           2   0%                               seed7-mode-syntax-propertize
+           1   0%                              syntax-ppss--update-stats
+          40   0%                         - seed7--current-line-nth-word
+          33   0%                          - thing-at-point
+          30   0%                           - bounds-of-thing-at-point
+          15   0%                            - #<byte-code-function A92>
+          15   0%                             - forward-thing
+          11   0%                                forward-word
+           2   0%                                format
+           7   0%                            - #<byte-code-function A8C>
+           7   0%                             - forward-thing
+           3   0%                                forward-word
+           2   0%                                format
+           1   0%                                functionp
+           1   0%                                intern-soft
+           2   0%                              make-closure
+           2   0%                            - seq-some
+           1   0%                             - seq-do
+           1   0%                                mapc
+           1   0%                               make-closure
+           2   0%                              re-search-forward
+          11   0%                         - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+           7   0%                          - seed7-inside-comment-p
+           7   0%                           - syntax-ppss
+           7   0%                              parse-partial-sexp
+           3   0%                          - seed7-inside-line-indent-before-comment-p
+           1   0%                             seed7-inside-comment-p
+          10   0%                         - seed7-inside-comment-p
+           9   0%                          - syntax-ppss
+           8   0%                             parse-partial-sexp
+           2   0%                         - seed7--end-regexp-for
+           1   0%                            seed7--type-regexp
+           2   0%                         - seed7-inside-line-indent-before-comment-p
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           1   0%                            seed7-to-indent
+         644   1%                       - seed7-to-block-backward
+         598   1%                        - seed7-re-search-backward
+         467   0%                         - seed7-inside-comment-p
+         466   0%                          - syntax-ppss
+         463   0%                             parse-partial-sexp
+           2   0%                             syntax-propertize
+          77   0%                         - run-with-timer
+          77   0%                          - run-at-time
+          43   0%                           - timer-activate
+          43   0%                            - timer--activate
+          43   0%                             - timer--time-less-p
+           2   0%                                timer--time
+          18   0%                           - timer-set-time
+          18   0%                              timer--time-setter
+          15   0%                             timer-relative-time
+           1   0%                             timer-create
+          27   0%                         - seed7-inside-string-p
+          27   0%                          - syntax-ppss
+          23   0%                             parse-partial-sexp
+           1   0%                             set-syntax-table
+           1   0%                             syntax-ppss--data
+          23   0%                           re-search-backward
+           1   0%                         - #<byte-code-function B48>
+           1   0%                          - cancel-timer
+           1   0%                             timerp
+          25   0%                        - seed7-inside-comment-p
+          25   0%                         - syntax-ppss
+          25   0%                            parse-partial-sexp
+          14   0%                        - seed7--current-line-nth-word
+          12   0%                         - thing-at-point
+          12   0%                          - bounds-of-thing-at-point
+           6   0%                           - #<byte-code-function 91F>
+           6   0%                            - forward-thing
+           3   0%                               forward-word
+           2   0%                               format
+           3   0%                             make-closure
+           2   0%                           - #<byte-code-function 404>
+           2   0%                            - forward-thing
+           2   0%                               forward-word
+           1   0%                           - seq-some
+           1   0%                            - seq-do
+           1   0%                               mapc
+           6   0%                        - seed7-inside-line-indent-before-comment-p
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           1   0%                          seed7--start-regexp-for
+         240   0%                      - seed7-re-search-backward
+         157   0%                       - seed7-inside-comment-p
+         156   0%                        - syntax-ppss
+         155   0%                           parse-partial-sexp
+           1   0%                           syntax-ppss-toplevel-pos
+          42   0%                       - run-with-timer
+          42   0%                        - run-at-time
+          17   0%                         - timer-activate
+          17   0%                          - timer--activate
+          17   0%                             timer--time-less-p
+          16   0%                         - timer-set-time
+          16   0%                          - timer--time-setter
+           1   0%                             timerp
+           9   0%                           timer-relative-time
+          26   0%                         re-search-backward
+          13   0%                       - seed7-inside-string-p
+          12   0%                        - syntax-ppss
+          12   0%                           parse-partial-sexp
+           1   0%                         make-closure
+           1   0%                       - #<byte-code-function 21B>
+           1   0%                        - cancel-timer
+           1   0%                           timerp
+         109   0%                      - seed7-calc-indent
+          98   0%                       - seed7-line-is-defun-end
+          96   0%                        - seed7-end-of-defun
+          86   0%                         - seed7-top-block-name
+          86   0%                          - seed7--to-top
+          86   0%                           - seed7-re-search-backward
+          78   0%                            - seed7-inside-comment-p
+          78   0%                             - syntax-ppss
+          78   0%                                parse-partial-sexp
+           5   0%                            - run-with-timer
+           5   0%                             - run-at-time
+           3   0%                                timer-relative-time
+           1   0%                              - timer-activate
+           1   0%                               - timer--activate
+           1   0%                                  timer--time-less-p
+           1   0%                              - timer-set-time
+           1   0%                                 timer--time-setter
+           2   0%                              re-search-backward
+          10   0%                         - seed7-re-search-forward
+           3   0%                          - seed7-inside-string-p
+           2   0%                           - syntax-ppss
+           2   0%                              parse-partial-sexp
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           2   0%                        - seed7-beg-of-defun
+           1   0%                         - seed7-re-search-backward-closest
+           1   0%                          - seed7-re-search-backward
+           1   0%                             re-search-backward
+           1   0%                         - seed7-re-search-backward
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+          11   0%                       - seed7-line-inside-parens-pair-column
+          11   0%                        - seed7-line-inside-parens-pair
+           9   0%                         - seed7-re-search-backward
+           9   0%                          - seed7-inside-comment-p
+           9   0%                           - syntax-ppss
+           9   0%                              parse-partial-sexp
+           5   0%                      - replace-regexp-in-string
+           2   0%                         concat
+           1   0%                        seed7--on-lineof
+           1   0%                        match-string
+         651   1%                    - seed7-line-inside-parens-pair-column
+         651   1%                     - seed7-line-inside-parens-pair
+         602   1%                      - seed7-re-search-backward
+         397   0%                       - seed7-inside-comment-p
+         395   0%                        - syntax-ppss
+         394   0%                           parse-partial-sexp
+           1   0%                           make-closure
+         129   0%                       - run-with-timer
+         129   0%                        - run-at-time
+          74   0%                         - timer-activate
+          73   0%                          - timer--activate
+          73   0%                           - timer--time-less-p
+           1   0%                              timer--time
+          34   0%                         - timer-set-time
+          34   0%                            timer--time-setter
+          18   0%                           timer-relative-time
+           1   0%                           timer-create
+          59   0%                       - seed7-inside-string-p
+          58   0%                        - syntax-ppss
+          56   0%                           parse-partial-sexp
+           1   0%                           syntax-table
+           1   0%                        - #<byte-code-function EB6>
+           1   0%                           set-match-data
+          12   0%                         re-search-backward
+           1   0%                         make-closure
+           1   0%                       - #<byte-code-function 5BC>
+           1   0%                          cancel-timer
+          14   0%                      - seed7-line-inside-syntax-parens-pair
+          12   0%                       - syntax-ppss
+          12   0%                          parse-partial-sexp
+           1   0%                         seed7-move-to-line
+          12   0%                      - forward-sexp
+          12   0%                         seed7--forward-sexp-function
+         569   1%                    - seed7-line-inside-set-definition-block
+         569   1%                     - seed7-re-search-backward
+         555   1%                        re-search-backward
+          14   0%                      - run-with-timer
+          14   0%                       - run-at-time
+           6   0%                        - timer-activate
+           6   0%                         - timer--activate
+           5   0%                          - timer--time-less-p
+           1   0%                             timer--time
+           4   0%                        - timer-set-time
+           4   0%                           timer--time-setter
+           3   0%                          timer-relative-time
+         486   0%                    - seed7-line-inside-array-definition-block
+         476   0%                     - seed7-re-search-backward
+         357   0%                        re-search-backward
+         101   0%                      - seed7-inside-comment-p
+         101   0%                       - syntax-ppss
+         100   0%                          parse-partial-sexp
+           1   0%                        - #<byte-code-function 267>
+           1   0%                           set-syntax-table
+          15   0%                      - run-with-timer
+          15   0%                       - run-at-time
+          13   0%                        - timer-activate
+          13   0%                         - timer--activate
+          13   0%                            timer--time-less-p
+           1   0%                        - timer-set-time
+           1   0%                           timer--time-setter
+           1   0%                          timer-relative-time
+           2   0%                      - seed7-inside-string-p
+           1   0%                       - syntax-ppss
+           1   0%                          parse-partial-sexp
+           1   0%                        #<byte-code-function B1E>
+           8   0%                     - forward-sexp
+           8   0%                        seed7--forward-sexp-function
+         160   0%                    - seed7-line-inside-assign-statement-continuation
+         155   0%                     - seed7-assign-op-pos
+         155   0%                      - seed7-re-search-backward
+         130   0%                       - seed7-inside-comment-p
+         130   0%                        - syntax-ppss
+         129   0%                           parse-partial-sexp
+          14   0%                       - run-with-timer
+          14   0%                        - run-at-time
+           8   0%                         - timer-activate
+           8   0%                          - timer--activate
+           7   0%                             timer--time-less-p
+           4   0%                         - timer-set-time
+           4   0%                            timer--time-setter
+           2   0%                           timer-relative-time
+           6   0%                         re-search-backward
+           3   0%                       - seed7-inside-string-p
+           3   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           5   0%                     - seed7-statement-end-pos
+           5   0%                      - seed7-forward-char-pos
+           5   0%                       - seed7-re-search-forward
+           3   0%                        - seed7-inside-comment-p
+           3   0%                         - syntax-ppss
+           2   0%                            parse-partial-sexp
+           2   0%                        - seed7-inside-string-p
+           2   0%                         - syntax-ppss
+           2   0%                            parse-partial-sexp
+          86   0%                    - seed7--current-line-nth-word
+          84   0%                     - thing-at-point
+          84   0%                      - bounds-of-thing-at-point
+          80   0%                       - #<byte-code-function 94D>
+          80   0%                        - forward-thing
+          78   0%                         - forward-word
+          75   0%                          - internal--syntax-propertize
+          75   0%                           - syntax-propertize
+          74   0%                              seed7-mode-syntax-propertize
+           2   0%                           format
+           2   0%                       - #<byte-code-function 799>
+           2   0%                        - forward-thing
+           1   0%                           forward-word
+          41   0%                    - seed7-comment-column
+          37   0%                     - seed7-calc-indent
+           8   0%                      - seed7-line-is-defun-end
+           6   0%                       - seed7-end-of-defun
+           5   0%                        - seed7-top-block-name
+           5   0%                         - seed7--to-top
+           4   0%                          - seed7-re-search-backward
+           2   0%                           - seed7-inside-comment-p
+           2   0%                            - syntax-ppss
+           2   0%                               parse-partial-sexp
+           2   0%                           - run-with-timer
+           2   0%                            - run-at-time
+           1   0%                             - timer-set-time
+           1   0%                                timer--time-setter
+           1   0%                             - timer-activate
+           1   0%                              - timer--activate
+           1   0%                                 timer--time-less-p
+           1   0%                          - run-with-timer
+           1   0%                           - run-at-time
+           1   0%                            - timer-activate
+           1   0%                             - timer--activate
+           1   0%                                timer--time-less-p
+           1   0%                        - seed7-re-search-forward
+           1   0%                         - seed7-inside-string-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           2   0%                       - seed7-move-to-line
+           2   0%                        - seed7-to-previous-non-empty-line
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           7   0%                      - seed7-line-inside-a-block-cached
+           7   0%                       - seed7-line-inside-a-block
+           6   0%                        - seed7--safe-enclosing-block-bounds
+           6   0%                         - seed7-to-block-backward
+           6   0%                          - seed7-re-search-backward
+           6   0%                           - seed7-inside-comment-p
+           6   0%                            - syntax-ppss
+           6   0%                               parse-partial-sexp
+           1   0%                        - seed7-re-search-backward
+           1   0%                         - run-with-timer
+           1   0%                          - run-at-time
+           1   0%                             timer-relative-time
+           4   0%                      - seed7-line-after-func-return-logic-operator-column
+           4   0%                       - seed7-move-to-line
+           4   0%                        - seed7-to-previous-non-empty-line
+           4   0%                         - seed7-inside-comment-p
+           4   0%                          - syntax-ppss
+           4   0%                             parse-partial-sexp
+           4   0%                      - seed7-line-at-endof-array-definition-block
+           4   0%                       - seed7-move-to-line
+           4   0%                        - seed7-to-previous-non-empty-line
+           3   0%                         - seed7-inside-comment-p
+           3   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           1   0%                             #<byte-code-function 183>
+           3   0%                      - seed7-line-inside-parens-pair-column
+           3   0%                       - seed7-line-inside-parens-pair
+           3   0%                        - seed7-re-search-backward
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                         - run-with-timer
+           1   0%                          - run-at-time
+           1   0%                           - timer-activate
+           1   0%                            - timer--activate
+           1   0%                               timer--time-less-p
+           3   0%                      - seed7-line-after-short-func-end
+           3   0%                       - seed7-move-to-line
+           3   0%                        - seed7-to-previous-non-empty-line
+           3   0%                         - seed7-inside-comment-p
+           3   0%                          - syntax-ppss
+           3   0%                             parse-partial-sexp
+           3   0%                      - seed7-line-at-endof-set-definition-block
+           3   0%                       - seed7-move-to-line
+           3   0%                        - seed7-to-previous-non-empty-line
+           3   0%                         - seed7-inside-comment-p
+           3   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           1   0%                             syntax-ppss--data
+           2   0%                      - seed7-line-inside-set-definition-block
+           2   0%                       - seed7-re-search-backward
+           1   0%                        - run-with-timer
+           1   0%                         - run-at-time
+           1   0%                          - timer-activate
+           1   0%                           - timer--activate
+           1   0%                              timer--time-less-p
+           1   0%                          re-search-backward
+           2   0%                      - seed7-line-starts-with-open-paren-after-logic-operator
+           2   0%                       - seed7-move-to-line
+           2   0%                        - seed7-to-previous-non-empty-line
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           1   0%                      - seed7--indent-search-boundary
+           1   0%                       - seed7--indent-search-boundary-uncached
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           2   0%                     - seed7-line-code-ends-with
+           2   0%                      - seed7-move-to-line
+           2   0%                       - seed7-to-previous-non-empty-line
+           2   0%                        - seed7-inside-comment-p
+           2   0%                         - syntax-ppss
+           2   0%                            parse-partial-sexp
+           1   0%                     - seed7-line-starts-with
+           1   0%                        seed7-move-to-line
+           1   0%                     - seed7-inside-comment-p
+           1   0%                      - syntax-ppss
+           1   0%                         parse-partial-sexp
+          35   0%                    - seed7-line-inside-logic-check-expression
+          25   0%                     - seed7-to-previous-line-starts-with
+          25   0%                      - seed7-re-search-backward
+          12   0%                       - run-with-timer
+          12   0%                        - run-at-time
+           7   0%                         - timer-activate
+           7   0%                          - timer--activate
+           7   0%                             timer--time-less-p
+           4   0%                           timer-relative-time
+           1   0%                         - timer-set-time
+           1   0%                            timer--time-setter
+           6   0%                       - seed7-inside-comment-p
+           6   0%                        - syntax-ppss
+           6   0%                           parse-partial-sexp
+           3   0%                         re-search-backward
+           3   0%                       - seed7-inside-string-p
+           3   0%                        - syntax-ppss
+           3   0%                           parse-partial-sexp
+           9   0%                     - seed7-re-search-forward
+           5   0%                      - seed7-inside-comment-p
+           5   0%                       - syntax-ppss
+           5   0%                          parse-partial-sexp
+           2   0%                      - seed7-inside-string-p
+           2   0%                       - syntax-ppss
+           2   0%                          parse-partial-sexp
+           1   0%                     - seed7--current-line-nth-word
+           1   0%                      - thing-at-point
+           1   0%                       - bounds-of-thing-at-point
+           1   0%                        - #<byte-code-function 4D1>
+           1   0%                         - forward-thing
+           1   0%                            forward-word
+          29   0%                    - seed7-line-inside-argument-list-section
+          19   0%                     - seed7-re-search-backward
+          14   0%                      - run-with-timer
+          14   0%                       - run-at-time
+           8   0%                        - timer-activate
+           8   0%                         - timer--activate
+           8   0%                          - timer--time-less-p
+           1   0%                             timer--time
+           4   0%                        - timer-set-time
+           4   0%                           timer--time-setter
+           2   0%                          timer-relative-time
+           5   0%                        re-search-backward
+          10   0%                     - seed7-line-is-procfunc-beg-of-decl
+          10   0%                        seed7-line-starts-with
+          25   0%                    - seed7-line-after-func-return-logic-operator-column
+          23   0%                     - seed7-move-to-line
+          23   0%                      - seed7-to-previous-non-empty-line
+          22   0%                       - seed7-inside-comment-p
+          22   0%                        - syntax-ppss
+          22   0%                           parse-partial-sexp
+          21   0%                    - seed7-line-inside-nested-parens-pairs-column
+          21   0%                     - seed7-line-inside-nested-parens-pairs
+          21   0%                      - seed7-line-inside-parens-pair
+          11   0%                       - seed7-line-inside-syntax-parens-pair
+           6   0%                        - syntax-ppss
+           5   0%                           parse-partial-sexp
+           1   0%                           syntax-ppss--data
+           4   0%                        - forward-sexp
+           4   0%                           seed7--forward-sexp-function
+           7   0%                       - seed7-re-search-backward
+           3   0%                        - run-with-timer
+           3   0%                         - run-at-time
+           2   0%                          - timer-activate
+           2   0%                           - timer--activate
+           2   0%                              timer--time-less-p
+           1   0%                            timer-relative-time
+           3   0%                        - seed7-inside-string-p
+           3   0%                         - syntax-ppss
+           3   0%                            parse-partial-sexp
+           1   0%                       - forward-sexp
+           1   0%                          seed7--forward-sexp-function
+          18   0%                    - seed7-current-line-start-inside-comment-p
+          18   0%                     - seed7-inside-comment-p
+          18   0%                      - syntax-ppss
+          18   0%                         parse-partial-sexp
+          18   0%                    - seed7-line-inside-func-return-statement
+          18   0%                     - seed7-re-search-backward
+          14   0%                      - run-with-timer
+          14   0%                       - run-at-time
+          10   0%                        - timer-activate
+          10   0%                         - timer--activate
+           9   0%                            timer--time-less-p
+           1   0%                            timerp
+           2   0%                          timer-relative-time
+           2   0%                        - timer-set-time
+           2   0%                           timer--time-setter
+           4   0%                        re-search-backward
+          13   0%                    - seed7-line-at-endof-array-definition-block
+           5   0%                     - seed7-line-code-ends-with
+           5   0%                      - seed7-re-search-backward
+           4   0%                       - seed7-inside-string-p
+           4   0%                        - syntax-ppss
+           4   0%                           parse-partial-sexp
+           1   0%                       - run-with-timer
+           1   0%                        - run-at-time
+           1   0%                         - timer-activate
+           1   0%                          - timer--activate
+           1   0%                             timer--time-less-p
+           4   0%                     - backward-sexp
+           4   0%                      - forward-sexp
+           4   0%                       - seed7--forward-sexp-function
+           4   0%                        - seed7--safe-to-block-backward
+           4   0%                         - seed7-to-block-backward
+           3   0%                          - seed7-inside-line-indent-before-comment-p
+           3   0%                           - seed7-inside-comment-p
+           3   0%                            - syntax-ppss
+           3   0%                               parse-partial-sexp
+           1   0%                          - seed7-line-code-ends-with
+           1   0%                           - seed7-re-search-backward
+           1   0%                            - run-with-timer
+           1   0%                             - run-at-time
+           1   0%                              - timer-activate
+           1   0%                               - timer--activate
+           1   0%                                  timer--time-less-p
+           3   0%                     - seed7-move-to-line
+           3   0%                      - seed7-to-previous-non-empty-line
+           3   0%                       - seed7-inside-comment-p
+           3   0%                        - syntax-ppss
+           3   0%                           parse-partial-sexp
+           1   0%                     - seed7-re-search-backward
+           1   0%                      - run-with-timer
+           1   0%                       - run-at-time
+           1   0%                        - timer-activate
+           1   0%                         - timer--activate
+           1   0%                            timer--time-less-p
+          11   0%                    - seed7-line-after-short-func-end
+          11   0%                     - seed7-move-to-line
+          11   0%                      - seed7-to-previous-non-empty-line
+          11   0%                       - seed7-inside-comment-p
+          11   0%                        - syntax-ppss
+           6   0%                           parse-partial-sexp
+           4   0%                         - syntax-propertize
+           4   0%                            seed7-mode-syntax-propertize
+           1   0%                           make-closure
+           8   0%                    - seed7-line-inside-until-logic-expression
+           6   0%                     - seed7-re-search-backward
+           5   0%                      - run-with-timer
+           5   0%                       - run-at-time
+           3   0%                        - timer-activate
+           3   0%                         - timer--activate
+           3   0%                            timer--time-less-p
+           1   0%                        - timer-set-time
+           1   0%                           timer--time-setter
+           1   0%                          timer-relative-time
+           1   0%                        re-search-backward
+           2   0%                     - seed7-line-code-ends-with
+           1   0%                      - seed7-re-search-backward
+           1   0%                         re-search-backward
+           1   0%                        seed7-move-to-line
+           5   0%                    - seed7-line-indent-step
+           5   0%                     - seed7-move-to-line
+           5   0%                      - seed7-to-previous-non-empty-line
+           5   0%                       - seed7-inside-comment-p
+           5   0%                        - syntax-ppss
+           5   0%                           parse-partial-sexp
+           5   0%                    - seed7-line-at-endof-set-definition-block
+           4   0%                     - seed7-line-code-ends-with
+           4   0%                      - seed7-re-search-backward
+           2   0%                       - seed7-inside-string-p
+           2   0%                        - syntax-ppss
+           2   0%                           parse-partial-sexp
+           2   0%                       - run-with-timer
+           2   0%                        - run-at-time
+           1   0%                         - timer-activate
+           1   0%                          - timer--activate
+           1   0%                             timer--time-less-p
+           1   0%                           timer-relative-time
+           1   0%                     - seed7-move-to-line
+           1   0%                      - seed7-to-previous-non-empty-line
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           5   0%                    - seed7-line-ends-with
+           4   0%                     - seed7-move-to-line
+           4   0%                      - seed7-to-previous-non-empty-line
+           4   0%                       - seed7-inside-comment-p
+           4   0%                        - syntax-ppss
+           4   0%                           parse-partial-sexp
+           1   0%                     - seed7-re-search-backward
+           1   0%                      - run-with-timer
+           1   0%                       - run-at-time
+           1   0%                        - timer-activate
+           1   0%                         - timer--activate
+           1   0%                            timer--time-less-p
+           2   0%                    - seed7-line-isa-string
+           2   0%                       seed7-line-starts-with
+           2   0%                    - seed7-line-starts-with
+           1   0%                     - seed7-move-to-line
+           1   0%                      - seed7-to-previous-non-empty-line
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           3   0%                   - jit-lock-after-change
+           2   0%                      font-lock-extend-jit-lock-region-after-change
+           1   0%                   - #<byte-code-function EAE>
+           1   0%                    - filter-buffer-substring
+           1   0%                     - buffer-substring--filter
+           1   0%                      - #<byte-code-function 2A6>
+           1   0%                       - apply
+           1   0%                          #<byte-code-function 954>
+           1   0%                     seed7-to-indent
+           1   0%                   - delete-horizontal-space
+           1   0%                      delete-space--internal
+        3302   6%   Automatic GC

--- a/reports/19.1/castle.sd7-perf-mem.txt
+++ b/reports/19.1/castle.sd7-perf-mem.txt
@@ -1,0 +1,1607 @@
+    595,275,979  99% - ...
+    595,275,979  99%  - call-interactively
+    595,275,979  99%   - apply
+    595,275,979  99%    - call-interactively@ido-cr+-record-current-command
+    595,275,979  99%     - #<primitive-function call-interactively>
+    595,275,979  99%      - funcall-interactively
+    595,275,979  99%       - smex
+    595,275,979  99%        - smex-read-and-run
+    595,275,979  99%         - execute-extended-command
+    595,275,979  99%          - command-execute
+    595,275,979  99%           - call-interactively
+    595,275,979  99%            - apply
+    595,275,979  99%             - call-interactively@ido-cr+-record-current-command
+    595,275,979  99%              - #<primitive-function call-interactively>
+    595,275,979  99%               - funcall-interactively
+    595,275,979  99%                - pel-profile
+    593,610,495  99%                 - call-interactively
+    593,610,495  99%                  - apply
+    593,610,495  99%                   - call-interactively@ido-cr+-record-current-command
+    593,610,495  99%                    - #<primitive-function call-interactively>
+    593,610,495  99%                     - funcall-interactively
+    593,610,479  99%                      - seed7-complete-statement-or-indent
+    593,610,479  99%                       - seed7-indent-region
+    593,610,479  99%                        - seed7--indent-one-line
+    592,793,191  99%                         - seed7-calc-indent
+    361,982,499  60%                          - seed7-line-is-defun-end
+    326,841,966  54%                           - seed7-end-of-defun
+    302,670,629  50%                            - seed7-top-block-name
+    301,346,717  50%                             - seed7--to-top
+    298,335,509  50%                              - seed7-re-search-backward
+    224,547,284  37%                               - run-with-timer
+    224,547,284  37%                                - run-at-time
+     96,338,844  16%                                 - timer-activate
+     96,338,844  16%                                  - timer--activate
+     96,240,468  16%                                   - timer--time-less-p
+      1,810,804   0%                                      timer--time
+     66,736,848  11%                                   timer-relative-time
+     45,691,240   7%                                 - timer-set-time
+     45,691,240   7%                                    timer--time-setter
+     15,780,352   2%                                   timer-create
+     40,990,840   6%                               - seed7-inside-string-p
+      6,880,672   1%                                - syntax-ppss
+      5,681,424   0%                                   make-closure
+      1,199,248   0%                                 - parse-partial-sexp
+        215,488   0%                                  - internal--syntax-propertize
+        153,328   0%                                   - syntax-propertize
+         95,312   0%                                      seed7-mode-syntax-propertize
+     27,291,964   4%                               - seed7-inside-comment-p
+      8,556,940   1%                                - syntax-ppss
+      5,507,376   0%                                   make-closure
+      1,639,508   0%                                 - syntax-propertize
+      1,573,204   0%                                    seed7-mode-syntax-propertize
+      1,344,472   0%                                   parse-partial-sexp
+      5,308,669   0%                                 make-closure
+      2,399,872   0%                              - run-with-timer
+      2,399,872   0%                               - run-at-time
+      1,081,472   0%                                - timer-activate
+      1,081,472   0%                                 - timer--activate
+      1,081,472   0%                                    timer--time-less-p
+        721,696   0%                                  timer-relative-time
+        464,096   0%                                - timer-set-time
+        464,096   0%                                   timer--time-setter
+        132,608   0%                                  timer-create
+         53,872   0%                                make-closure
+      1,257,608   0%                             - seed7--block-name
+        977,984   0%                              - seed7-re-search-forward
+        820,512   0%                               - seed7-inside-string-p
+         70,448   0%                                - syntax-ppss
+         70,448   0%                                   make-closure
+        157,472   0%                               - seed7-inside-comment-p
+         91,168   0%                                - syntax-ppss
+         91,168   0%                                   make-closure
+         64,344   0%                                match-string
+     16,710,872   2%                            - seed7-re-search-forward
+      7,709,268   1%                             - seed7-inside-string-p
+      1,216,700   0%                              - syntax-ppss
+      1,019,424   0%                                 make-closure
+        196,752   0%                                 parse-partial-sexp
+      7,614,740   1%                             - seed7-inside-comment-p
+      4,854,836   0%                              - syntax-ppss
+      3,516,500   0%                               - syntax-propertize
+      2,170,780   0%                                  seed7-mode-syntax-propertize
+        944,832   0%                                 make-closure
+        393,504   0%                                 parse-partial-sexp
+      3,565,576   0%                            - seed7-re-search-backward
+      2,410,120   0%                             - run-with-timer
+      2,410,120   0%                              - run-at-time
+      1,062,712   0%                               - timer-activate
+      1,062,712   0%                                - timer--activate
+      1,062,712   0%                                 - timer--time-less-p
+         32,792   0%                                    timer--time
+        721,696   0%                                 timer-relative-time
+        455,808   0%                               - timer-set-time
+        455,808   0%                                  timer--time-setter
+        169,904   0%                                 timer-create
+        840,872   0%                             - seed7-inside-string-p
+         86,664   0%                              - syntax-ppss
+         53,872   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+        227,560   0%                             - seed7-inside-comment-p
+         78,376   0%                              - syntax-ppss
+         45,584   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+         87,024   0%                               make-closure
+      1,293,072   0%                              match-string-no-properties
+        773,592   0%                              match-string
+     24,833,333   4%                           - seed7-beg-of-defun
+     11,417,292   1%                            - seed7-re-search-backward
+      8,197,888   1%                             - run-with-timer
+      8,197,888   1%                              - run-at-time
+      3,610,464   0%                               - timer-activate
+      3,610,464   0%                                - timer--activate
+      3,610,464   0%                                 - timer--time-less-p
+         98,376   0%                                    timer--time
+      2,397,648   0%                                 timer-relative-time
+      1,617,904   0%                               - timer-set-time
+      1,617,904   0%                                  timer--time-setter
+        571,872   0%                                 timer-create
+      1,350,944   0%                             - seed7-inside-string-p
+        207,200   0%                              - syntax-ppss
+        207,200   0%                                 make-closure
+        915,340   0%                               re-search-backward
+        741,776   0%                             - seed7-inside-comment-p
+        211,344   0%                              - syntax-ppss
+        211,344   0%                                 make-closure
+        211,344   0%                               make-closure
+      3,943,436   0%                            - seed7-top-block-name
+      2,228,629   0%                             - seed7--to-top
+      1,553,725   0%                              - seed7-re-search-backward
+        690,304   0%                               - run-with-timer
+        690,304   0%                                - run-at-time
+        318,032   0%                                 - timer-activate
+        318,032   0%                                  - timer--activate
+        318,032   0%                                   - timer--time-less-p
+         32,792   0%                                      timer--time
+        202,768   0%                                   timer-relative-time
+        132,208   0%                                 - timer-set-time
+        132,208   0%                                    timer--time-setter
+         37,296   0%                                   timer-create
+        635,501   0%                                 re-search-backward
+        145,040   0%                               - seed7-inside-string-p
+         29,008   0%                                - syntax-ppss
+         29,008   0%                                   make-closure
+         70,448   0%                               - seed7-inside-comment-p
+         16,576   0%                                - syntax-ppss
+         16,576   0%                                   make-closure
+         12,432   0%                                 make-closure
+        654,184   0%                              - run-with-timer
+        654,184   0%                               - run-at-time
+        277,768   0%                                - timer-activate
+        277,768   0%                                 - timer--activate
+        277,768   0%                                    timer--time-less-p
+        202,768   0%                                  timer-relative-time
+        132,208   0%                                - timer-set-time
+        132,208   0%                                   timer--time-setter
+         41,440   0%                                  timer-create
+         20,720   0%                                make-closure
+      1,706,519   0%                             - seed7--block-name
+      1,681,759   0%                              - seed7-re-search-forward
+        145,040   0%                                 seed7-inside-string-p
+         41,440   0%                               - seed7-inside-comment-p
+         16,576   0%                                - syntax-ppss
+         16,576   0%                                   make-closure
+      3,634,197   0%                            - seed7-re-search-backward-closest
+      3,517,101   0%                             - seed7-re-search-backward
+      2,010,605   0%                                re-search-backward
+      1,473,344   0%                              - run-with-timer
+      1,473,344   0%                               - run-at-time
+        613,264   0%                                - timer-activate
+        613,264   0%                                 - timer--activate
+        613,264   0%                                    timer--time-less-p
+        463,864   0%                                  timer-relative-time
+        313,336   0%                                - timer-set-time
+        313,336   0%                                   timer--time-setter
+         82,880   0%                                  timer-create
+         33,152   0%                                make-closure
+         50,792   0%                             - seq-filter
+         49,728   0%                                make-closure
+          1,064   0%                                make-symbol
+        286,952   0%                              match-string
+        278,256   0%                              match-string-no-properties
+          8,184   0%                            - user-error
+          8,184   0%                               format-message
+      5,279,863   0%                           - seed7-line-starts-with-any
+      5,279,863   0%                              seed7-line-starts-with
+      2,229,338   0%                           - seed7--current-line-nth-word
+      2,084,298   0%                            - thing-at-point
+      1,953,466   0%                             - bounds-of-thing-at-point
+        625,744   0%                                make-closure
+        382,976   0%                                re-search-forward
+        312,274   0%                              - #<byte-code-function DF7>
+        310,992   0%                               - forward-thing
+        310,992   0%                                  format
+        252,784   0%                              - seq-some
+        252,784   0%                                 make-closure
+        122,760   0%                              - #<byte-code-function F2E>
+        122,760   0%                               - forward-thing
+        122,760   0%                                  format
+      2,127,488   0%                           - seed7-move-to-line
+      2,127,488   0%                            - seed7-to-previous-non-empty-line
+        152,968   0%                             - seed7-inside-comment-p
+         82,520   0%                              - syntax-ppss
+         49,728   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+        434,303   0%                           - seed7--safe-current-line-defun-start-indent
+        426,015   0%                            - seed7-to-block-backward
+        307,951   0%                             - seed7-re-search-backward
+        139,320   0%                              - run-with-timer
+        139,320   0%                               - run-at-time
+         55,960   0%                                - timer-activate
+         55,960   0%                                 - timer--activate
+         55,960   0%                                    timer--time-less-p
+         43,472   0%                                  timer-relative-time
+         35,744   0%                                - timer-set-time
+         35,744   0%                                   timer--time-setter
+          4,144   0%                                  timer-create
+        127,191   0%                                re-search-backward
+         24,864   0%                                seed7-inside-string-p
+         12,432   0%                              - seed7-inside-comment-p
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+          4,144   0%                                make-closure
+         80,768   0%                             - seed7--current-line-nth-word
+         76,624   0%                              - thing-at-point
+         74,592   0%                               - bounds-of-thing-at-point
+         41,440   0%                                  make-closure
+         12,432   0%                                - seq-some
+         12,432   0%                                   make-closure
+         29,008   0%                             - seed7-inside-line-indent-before-comment-p
+          4,144   0%                                seed7-inside-comment-p
+          8,288   0%                               seed7-inside-comment-p
+          8,288   0%                              seed7-current-line-indent
+    118,001,334  19%                          - seed7-line-inside-a-block-cached
+    117,922,598  19%                           - seed7-line-inside-a-block
+    102,952,619  17%                            - seed7--safe-enclosing-block-bounds
+     81,093,774  13%                             - seed7--block-end-pos-for
+     81,008,206  13%                              - seed7-to-block-forward
+     65,334,733  10%                               - seed7-end-of-defun
+     64,112,862  10%                                - seed7-top-block-name
+     63,634,599  10%                                 - seed7--to-top
+     63,061,663  10%                                  - seed7-re-search-backward
+     46,950,888   7%                                   - run-with-timer
+     46,950,888   7%                                    - run-at-time
+     20,789,312   3%                                     - timer-activate
+     20,789,312   3%                                      - timer--activate
+     20,756,520   3%                                       - timer--time-less-p
+        163,960   0%                                          timer--time
+     13,870,736   2%                                       timer-relative-time
+      9,149,688   1%                                     - timer-set-time
+      9,149,688   1%                                        timer--time-setter
+      3,141,152   0%                                       timer-create
+     10,532,968   1%                                   - seed7-inside-string-p
+      2,037,768   0%                                    - syntax-ppss
+      1,910,384   0%                                       make-closure
+        127,384   0%                                     - parse-partial-sexp
+         29,008   0%                                      - internal--syntax-propertize
+         24,864   0%                                       - syntax-propertize
+         12,432   0%                                          seed7-mode-syntax-propertize
+      3,902,309   0%                                   - seed7-inside-comment-p
+      2,248,853   0%                                    - syntax-ppss
+      1,835,792   0%                                       make-closure
+        249,101   0%                                     - syntax-propertize
+        236,669   0%                                        seed7-mode-syntax-propertize
+        163,960   0%                                       parse-partial-sexp
+      1,587,152   0%                                     make-closure
+         53,735   0%                                     re-search-backward
+        506,992   0%                                  - run-with-timer
+        506,992   0%                                   - run-at-time
+        233,952   0%                                    - timer-activate
+        233,952   0%                                     - timer--activate
+        233,952   0%                                        timer--time-less-p
+        149,568   0%                                      timer-relative-time
+         98,608   0%                                    - timer-set-time
+         98,608   0%                                       timer--time-setter
+         24,864   0%                                      timer-create
+         33,152   0%                                    make-closure
+        457,543   0%                                 - seed7--block-name
+        378,519   0%                                  - seed7-re-search-forward
+        211,344   0%                                   - seed7-inside-string-p
+         41,440   0%                                    - syntax-ppss
+         41,440   0%                                       make-closure
+         53,872   0%                                   - seed7-inside-comment-p
+         33,152   0%                                    - syntax-ppss
+         33,152   0%                                       make-closure
+         41,936   0%                                    match-string
+        709,712   0%                                - seed7-re-search-backward
+        490,080   0%                                 - run-with-timer
+        490,080   0%                                  - run-at-time
+        221,184   0%                                   - timer-activate
+        221,184   0%                                    - timer--activate
+        221,184   0%                                       timer--time-less-p
+        149,568   0%                                     timer-relative-time
+         94,464   0%                                   - timer-set-time
+         94,464   0%                                      timer--time-setter
+         24,864   0%                                     timer-create
+        186,480   0%                                 - seed7-inside-string-p
+         24,864   0%                                  - syntax-ppss
+         24,864   0%                                     make-closure
+         24,864   0%                                 - seed7-inside-comment-p
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+          8,288   0%                                   make-closure
+        338,193   0%                                - seed7-re-search-forward
+         74,884   0%                                 - seed7-inside-comment-p
+         70,740   0%                                  - syntax-ppss
+         66,596   0%                                   - syntax-propertize
+         58,308   0%                                      seed7-mode-syntax-propertize
+          4,144   0%                                     make-closure
+         37,296   0%                                 - seed7-inside-string-p
+         12,432   0%                                  - syntax-ppss
+         12,432   0%                                     make-closure
+         40,920   0%                                  match-string
+      6,662,185   1%                               - seed7-re-search-forward
+      1,653,096   0%                                - seed7-inside-string-p
+        273,504   0%                                 - syntax-ppss
+        273,504   0%                                    make-closure
+      1,501,232   0%                                - seed7-inside-comment-p
+      1,061,968   0%                                 - syntax-ppss
+        805,040   0%                                  - syntax-propertize
+        771,888   0%                                     seed7-mode-syntax-propertize
+        256,928   0%                                    make-closure
+      5,185,544   0%                               - seed7--current-line-nth-word
+      4,485,208   0%                                - thing-at-point
+      4,190,240   0%                                 - bounds-of-thing-at-point
+      1,707,328   0%                                    make-closure
+        638,176   0%                                  - seq-some
+        638,176   0%                                     make-closure
+        589,248   0%                                  - #<byte-code-function 216>
+        589,248   0%                                   - forward-thing
+        589,248   0%                                      format
+        310,992   0%                                  - #<byte-code-function 0BE>
+        310,992   0%                                   - forward-thing
+        310,992   0%                                      format
+        293,888   0%                                    re-search-forward
+      2,887,552   0%                               - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+        439,264   0%                                - seed7-inside-line-indent-before-comment-p
+         45,584   0%                                 - seed7-inside-comment-p
+         29,008   0%                                  - syntax-ppss
+         29,008   0%                                     make-closure
+        318,368   0%                                - seed7-inside-comment-p
+        194,048   0%                                 - syntax-ppss
+        128,464   0%                                    make-closure
+         65,584   0%                                    parse-partial-sexp
+        356,384   0%                               - seed7-inside-line-indent-before-comment-p
+         20,720   0%                                - seed7-inside-comment-p
+         12,432   0%                                 - syntax-ppss
+         12,432   0%                                    make-closure
+        244,496   0%                               - seed7-inside-comment-p
+        165,760   0%                                - syntax-ppss
+        165,760   0%                                   make-closure
+        196,416   0%                               - seed7--end-regexp-for
+         57,288   0%                                  seed7--type-regexp
+         15,504   0%                              - seed7-re-search-forward-closest
+         11,360   0%                               - seed7-re-search-forward
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          4,144   0%                                  seed7-inside-string-p
+          4,144   0%                               - seq-filter
+          4,144   0%                                  make-closure
+     21,668,221   3%                             - seed7-to-block-backward
+     16,141,765   2%                              - seed7-re-search-backward
+     11,252,352   1%                               - run-with-timer
+     11,252,352   1%                                - run-at-time
+      5,065,520   0%                                 - timer-activate
+      5,065,520   0%                                  - timer--activate
+      5,065,520   0%                                   - timer--time-less-p
+         98,376   0%                                      timer--time
+      3,200,128   0%                                   timer-relative-time
+      2,120,608   0%                                 - timer-set-time
+      2,120,608   0%                                    timer--time-setter
+        866,096   0%                                   timer-create
+      1,847,568   0%                                 re-search-backward
+      1,819,216   0%                               - seed7-inside-string-p
+        331,520   0%                                - syntax-ppss
+        331,520   0%                                   make-closure
+        878,677   0%                               - seed7-inside-comment-p
+        344,101   0%                                - syntax-ppss
+        277,648   0%                                   make-closure
+         65,584   0%                                   parse-partial-sexp
+            869   0%                                   #<byte-code-function 8C5>
+        343,952   0%                                 make-closure
+      3,693,888   0%                              - seed7--current-line-nth-word
+      3,283,632   0%                               - thing-at-point
+      3,084,560   0%                                - bounds-of-thing-at-point
+      1,342,656   0%                                   make-closure
+        513,856   0%                                 - seq-some
+        513,856   0%                                    make-closure
+        417,384   0%                                 - #<byte-code-function 4E7>
+        417,384   0%                                  - forward-thing
+        417,384   0%                                     format
+        261,888   0%                                 - #<byte-code-function F05>
+        261,888   0%                                  - forward-thing
+        261,888   0%                                     format
+          6,272   0%                                   re-search-forward
+      1,031,856   0%                              - seed7-inside-line-indent-before-comment-p
+        277,648   0%                               - seed7-inside-comment-p
+        111,888   0%                                - syntax-ppss
+        111,888   0%                                   make-closure
+        414,400   0%                              - seed7-inside-comment-p
+        116,032   0%                               - syntax-ppss
+        116,032   0%                                  make-closure
+        253,704   0%                              - seed7--start-regexp-for
+          8,184   0%                                 seed7--type-regexp
+      8,994,970   1%                            - seed7-re-search-backward
+      4,934,280   0%                             - run-with-timer
+      4,934,280   0%                              - run-at-time
+      2,225,864   0%                               - timer-activate
+      2,225,864   0%                                - timer--activate
+      2,225,864   0%                                   timer--time-less-p
+      1,477,120   0%                                 timer-relative-time
+        978,512   0%                               - timer-set-time
+        978,512   0%                                  timer--time-setter
+        252,784   0%                                 timer-create
+      2,436,602   0%                               re-search-backward
+      1,102,304   0%                             - seed7-inside-string-p
+        174,048   0%                              - syntax-ppss
+        174,048   0%                                 make-closure
+        372,600   0%                             - seed7-inside-comment-p
+        186,120   0%                              - syntax-ppss
+        153,328   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+        149,184   0%                               make-closure
+      3,236,152   0%                            - replace-regexp-in-string
+         90,024   0%                               concat
+      1,761,305   0%                            - seed7-calc-indent
+      1,171,173   0%                             - seed7-line-is-defun-end
+      1,030,772   0%                              - seed7-end-of-defun
+        956,656   0%                               - seed7-top-block-name
+        956,656   0%                                - seed7--to-top
+        940,392   0%                                 - seed7-re-search-backward
+        753,912   0%                                  - run-with-timer
+        753,912   0%                                   - run-at-time
+        290,376   0%                                    - timer-activate
+        290,376   0%                                     - timer--activate
+        290,376   0%                                        timer--time-less-p
+        258,704   0%                                      timer-relative-time
+        171,680   0%                                    - timer-set-time
+        171,680   0%                                       timer--time-setter
+         33,152   0%                                      timer-create
+        111,888   0%                                  - seed7-inside-string-p
+         12,432   0%                                   - syntax-ppss
+         12,432   0%                                      make-closure
+         66,304   0%                                  - seed7-inside-comment-p
+         16,576   0%                                   - syntax-ppss
+         16,576   0%                                      make-closure
+          8,288   0%                                    make-closure
+         16,264   0%                                 - run-with-timer
+         16,264   0%                                  - run-at-time
+          7,024   0%                                   - timer-set-time
+          7,024   0%                                      timer--time-setter
+          4,680   0%                                   - timer-activate
+          4,680   0%                                    - timer--activate
+          4,680   0%                                       timer--time-less-p
+          4,560   0%                                     timer-relative-time
+         35,380   0%                               - seed7-re-search-forward
+         20,720   0%                                  seed7-inside-string-p
+          6,468   0%                                - seed7-inside-comment-p
+          6,468   0%                                 - syntax-ppss
+          6,468   0%                                  - syntax-propertize
+          6,468   0%                                     seed7-mode-syntax-propertize
+         12,120   0%                               - seed7-re-search-backward
+         12,120   0%                                - run-with-timer
+         12,120   0%                                 - run-at-time
+          4,680   0%                                  - timer-activate
+          4,680   0%                                   - timer--activate
+          4,680   0%                                      timer--time-less-p
+          4,560   0%                                    timer-relative-time
+          2,880   0%                                  - timer-set-time
+          2,880   0%                                     timer--time-setter
+          9,200   0%                                 match-string
+         96,449   0%                              - seed7-beg-of-defun
+         21,659   0%                               - seed7-top-block-name
+         10,944   0%                                - seed7--to-top
+          7,712   0%                                 - seed7-re-search-backward
+          4,480   0%                                    re-search-backward
+          3,232   0%                                  - run-with-timer
+          3,232   0%                                   - run-at-time
+          1,248   0%                                    - timer-activate
+          1,248   0%                                     - timer--activate
+          1,248   0%                                        timer--time-less-p
+          1,216   0%                                      timer-relative-time
+            768   0%                                    - timer-set-time
+            768   0%                                       timer--time-setter
+          3,232   0%                                 - run-with-timer
+          3,232   0%                                  - run-at-time
+          1,248   0%                                   - timer-activate
+          1,248   0%                                    - timer--activate
+          1,248   0%                                       timer--time-less-p
+          1,216   0%                                     timer-relative-time
+            768   0%                                   - timer-set-time
+            768   0%                                      timer--time-setter
+         10,715   0%                                - seed7--block-name
+         10,715   0%                                   seed7-re-search-forward
+         20,920   0%                               - seed7-re-search-backward-closest
+         20,920   0%                                - seed7-re-search-backward
+         12,840   0%                                   re-search-backward
+          8,080   0%                                 - run-with-timer
+          8,080   0%                                  - run-at-time
+          3,120   0%                                   - timer-activate
+          3,120   0%                                    - timer--activate
+          3,120   0%                                       timer--time-less-p
+          3,040   0%                                     timer-relative-time
+          1,920   0%                                   - timer-set-time
+          1,920   0%                                      timer--time-setter
+         15,174   0%                               - seed7-re-search-backward
+          7,902   0%                                  re-search-backward
+          7,272   0%                                - run-with-timer
+          7,272   0%                                 - run-at-time
+          2,808   0%                                  - timer-activate
+          2,808   0%                                   - timer--activate
+          2,808   0%                                      timer--time-less-p
+          2,736   0%                                    timer-relative-time
+          1,728   0%                                  - timer-set-time
+          1,728   0%                                     timer--time-setter
+          1,016   0%                                 match-string
+         37,760   0%                              - seed7-line-starts-with-any
+         37,760   0%                                 seed7-line-starts-with
+          4,144   0%                              - seed7--current-line-nth-word
+          4,144   0%                               - thing-at-point
+          4,144   0%                                  bounds-of-thing-at-point
+          2,048   0%                              - seed7-move-to-line
+          2,048   0%                                 seed7-to-previous-non-empty-line
+        242,136   0%                             - seed7-line-inside-parens-pair-column
+        242,136   0%                              - seed7-line-inside-parens-pair
+        223,656   0%                               - seed7-re-search-backward
+        158,472   0%                                - run-with-timer
+        158,472   0%                                 - run-at-time
+         59,592   0%                                  - timer-activate
+         59,592   0%                                   - timer--activate
+         59,592   0%                                      timer--time-less-p
+         58,064   0%                                    timer-relative-time
+         36,672   0%                                  - timer-set-time
+         36,672   0%                                     timer--time-setter
+          4,144   0%                                    timer-create
+         24,864   0%                                - seed7-inside-comment-p
+         12,432   0%                                 - syntax-ppss
+         12,432   0%                                    make-closure
+         20,720   0%                                - seed7-inside-string-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+         12,432   0%                                  make-closure
+          7,168   0%                                  re-search-backward
+         14,336   0%                               - forward-sexp
+         14,336   0%                                  seed7--forward-sexp-function
+          4,144   0%                                 seed7-line-inside-syntax-parens-pair
+        121,588   0%                             - seed7-line-at-endof-array-definition-block
+         67,244   0%                              - backward-sexp
+         67,244   0%                               - forward-sexp
+         67,244   0%                                - seed7--forward-sexp-function
+         23,696   0%                                 - seed7--at-array-definition-end-line-p
+         19,600   0%                                  - seed7-line-code-ends-with
+         19,600   0%                                   - seed7-re-search-backward
+         11,312   0%                                    - run-with-timer
+         11,312   0%                                     - run-at-time
+          4,368   0%                                      - timer-activate
+          4,368   0%                                       - timer--activate
+          4,368   0%                                          timer--time-less-p
+          4,256   0%                                        timer-relative-time
+          2,688   0%                                      - timer-set-time
+          2,688   0%                                         timer--time-setter
+          4,144   0%                                      seed7-inside-string-p
+          4,144   0%                                      seed7-inside-comment-p
+          4,096   0%                                    looking-at
+         17,852   0%                                 - seed7-beg-of-defun
+          4,861   0%                                  - seed7-top-block-name
+          2,640   0%                                   - seed7--to-top
+          1,832   0%                                    - seed7-re-search-backward
+          1,024   0%                                       re-search-backward
+            808   0%                                     - run-with-timer
+            808   0%                                      - run-at-time
+            312   0%                                       - timer-activate
+            312   0%                                        - timer--activate
+            312   0%                                           timer--time-less-p
+            304   0%                                         timer-relative-time
+            192   0%                                       - timer-set-time
+            192   0%                                          timer--time-setter
+            808   0%                                    - run-with-timer
+            808   0%                                     - run-at-time
+            312   0%                                      - timer-activate
+            312   0%                                       - timer--activate
+            312   0%                                          timer--time-less-p
+            304   0%                                        timer-relative-time
+            192   0%                                      - timer-set-time
+            192   0%                                         timer--time-setter
+          2,221   0%                                   - seed7--block-name
+          2,221   0%                                      seed7-re-search-forward
+          4,480   0%                                  - seed7-re-search-backward-closest
+          4,480   0%                                   - seed7-re-search-backward
+          2,864   0%                                      re-search-backward
+          1,616   0%                                    - run-with-timer
+          1,616   0%                                     - run-at-time
+            624   0%                                      - timer-activate
+            624   0%                                       - timer--activate
+            624   0%                                          timer--time-less-p
+            608   0%                                        timer-relative-time
+            384   0%                                      - timer-set-time
+            384   0%                                         timer--time-setter
+          3,884   0%                                  - seed7-re-search-backward
+          3,076   0%                                     re-search-backward
+            808   0%                                   - run-with-timer
+            808   0%                                    - run-at-time
+            312   0%                                     - timer-activate
+            312   0%                                      - timer--activate
+            312   0%                                         timer--time-less-p
+            304   0%                                       timer-relative-time
+            192   0%                                     - timer-set-time
+            192   0%                                        timer--time-setter
+          9,696   0%                                 - seed7--at-set-definition-end-line-p
+          9,696   0%                                  - seed7-line-code-ends-with
+          9,696   0%                                   - seed7-re-search-backward
+          9,696   0%                                    - run-with-timer
+          9,696   0%                                     - run-at-time
+          3,744   0%                                      - timer-activate
+          3,744   0%                                       - timer--activate
+          3,744   0%                                          timer--time-less-p
+          3,648   0%                                        timer-relative-time
+          2,304   0%                                      - timer-set-time
+          2,304   0%                                         timer--time-setter
+          5,760   0%                                 - seed7--safe-to-block-backward
+          5,760   0%                                  - seed7-to-block-backward
+          4,144   0%                                     seed7-inside-line-indent-before-comment-p
+          1,616   0%                                   - seed7-line-code-ends-with
+          1,616   0%                                    - seed7-re-search-backward
+          1,616   0%                                     - run-with-timer
+          1,616   0%                                      - run-at-time
+            624   0%                                       - timer-activate
+            624   0%                                        - timer--activate
+            624   0%                                           timer--time-less-p
+            608   0%                                         timer-relative-time
+            384   0%                                       - timer-set-time
+            384   0%                                          timer--time-setter
+         37,328   0%                              - seed7-line-code-ends-with
+         37,328   0%                               - seed7-re-search-backward
+         21,920   0%                                - run-with-timer
+         21,920   0%                                 - run-at-time
+          6,864   0%                                  - timer-activate
+          6,864   0%                                   - timer--activate
+          6,864   0%                                      timer--time-less-p
+          6,688   0%                                    timer-relative-time
+          4,224   0%                                  - timer-set-time
+          4,224   0%                                     timer--time-setter
+          4,144   0%                                    timer-create
+         11,264   0%                                  re-search-backward
+          4,144   0%                                  seed7-inside-comment-p
+          9,800   0%                              - seed7-re-search-backward
+          9,800   0%                               - run-with-timer
+          9,800   0%                                - run-at-time
+          6,328   0%                                 - timer-activate
+          6,328   0%                                  - timer--activate
+          6,328   0%                                     timer--time-less-p
+          2,128   0%                                   timer-relative-time
+          1,344   0%                                 - timer-set-time
+          1,344   0%                                    timer--time-setter
+          3,072   0%                                looking-at
+         45,208   0%                             - seed7-line-inside-a-block-cached
+         45,208   0%                              - seed7-line-inside-a-block
+         19,840   0%                               - seed7--safe-enclosing-block-bounds
+         13,696   0%                                - seed7-to-block-backward
+         13,696   0%                                 - seed7-re-search-backward
+          4,144   0%                                    seed7-inside-string-p
+          4,144   0%                                  - seed7-inside-comment-p
+          4,144   0%                                   - syntax-ppss
+          4,144   0%                                      make-closure
+          3,232   0%                                  - run-with-timer
+          3,232   0%                                   - run-at-time
+          1,248   0%                                    - timer-activate
+          1,248   0%                                     - timer--activate
+          1,248   0%                                        timer--time-less-p
+          1,216   0%                                      timer-relative-time
+            768   0%                                    - timer-set-time
+            768   0%                                       timer--time-setter
+          2,176   0%                                    re-search-backward
+          6,144   0%                                - seed7--block-end-pos-for
+          2,048   0%                                 - seed7-to-block-forward
+          1,024   0%                                    seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          1,024   0%                                  - seed7--current-line-nth-word
+          1,024   0%                                   - thing-at-point
+          1,024   0%                                    - bounds-of-thing-at-point
+          1,024   0%                                       re-search-forward
+          1,024   0%                                 - seed7-re-search-forward-closest
+          1,024   0%                                    seed7-re-search-forward
+         19,176   0%                               - seed7-re-search-backward
+         13,032   0%                                - run-with-timer
+         13,032   0%                                 - run-at-time
+          4,144   0%                                    timer-create
+          3,432   0%                                  - timer-activate
+          3,432   0%                                   - timer--activate
+          3,432   0%                                      timer--time-less-p
+          3,344   0%                                    timer-relative-time
+          2,112   0%                                  - timer-set-time
+          2,112   0%                                     timer--time-setter
+          6,144   0%                                  re-search-backward
+          2,048   0%                                 replace-regexp-in-string
+         30,440   0%                             - seed7-line-inside-array-definition-block
+         24,296   0%                              - seed7-re-search-backward
+         11,264   0%                                 re-search-backward
+          8,888   0%                               - run-with-timer
+          8,888   0%                                - run-at-time
+          3,432   0%                                 - timer-activate
+          3,432   0%                                  - timer--activate
+          3,432   0%                                     timer--time-less-p
+          3,344   0%                                   timer-relative-time
+          2,112   0%                                 - timer-set-time
+          2,112   0%                                    timer--time-setter
+          4,144   0%                                 seed7-inside-string-p
+          6,144   0%                              - forward-sexp
+          6,144   0%                                 seed7--forward-sexp-function
+         24,448   0%                             - seed7-line-at-endof-set-definition-block
+         20,304   0%                              - seed7-line-code-ends-with
+         20,304   0%                               - seed7-re-search-backward
+         16,160   0%                                - run-with-timer
+         16,160   0%                                 - run-at-time
+          6,240   0%                                  - timer-activate
+          6,240   0%                                   - timer--activate
+          6,240   0%                                      timer--time-less-p
+          6,080   0%                                    timer-relative-time
+          3,840   0%                                  - timer-set-time
+          3,840   0%                                     timer--time-setter
+          4,144   0%                                  seed7-inside-string-p
+          4,144   0%                              - seed7-move-to-line
+          4,144   0%                                 seed7-to-previous-non-empty-line
+         24,424   0%                             - seed7-line-inside-assign-statement-continuation
+         24,424   0%                              - seed7-assign-op-pos
+         20,280   0%                               - seed7-re-search-backward
+         11,392   0%                                  re-search-backward
+          8,888   0%                                - run-with-timer
+          8,888   0%                                 - run-at-time
+          3,432   0%                                  - timer-activate
+          3,432   0%                                   - timer--activate
+          3,432   0%                                      timer--time-less-p
+          3,344   0%                                    timer-relative-time
+          2,112   0%                                  - timer-set-time
+          2,112   0%                                     timer--time-setter
+         24,296   0%                             - seed7-line-inside-set-definition-block
+         24,296   0%                              - seed7-re-search-backward
+         13,032   0%                               - run-with-timer
+         13,032   0%                                - run-at-time
+          7,576   0%                                 - timer-activate
+          7,576   0%                                  - timer--activate
+          7,576   0%                                     timer--time-less-p
+          3,344   0%                                   timer-relative-time
+          2,112   0%                                 - timer-set-time
+          2,112   0%                                    timer--time-setter
+         11,264   0%                                 re-search-backward
+         16,904   0%                             - seed7-line-after-short-func-end
+         10,712   0%                              - seed7-to-block-backward
+          8,288   0%                               - seed7--current-line-nth-word
+          8,288   0%                                - thing-at-point
+          8,288   0%                                 - bounds-of-thing-at-point
+          4,144   0%                                    make-closure
+          2,424   0%                               - seed7-re-search-backward
+          2,424   0%                                - run-with-timer
+          2,424   0%                                 - run-at-time
+            936   0%                                  - timer-activate
+            936   0%                                   - timer--activate
+            936   0%                                      timer--time-less-p
+            912   0%                                    timer-relative-time
+            576   0%                                  - timer-set-time
+            576   0%                                     timer--time-setter
+          4,144   0%                              - seed7-move-to-line
+          4,144   0%                               - seed7-to-previous-non-empty-line
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         15,408   0%                             - seed7-line-isa-string
+         15,408   0%                                seed7-line-starts-with
+         15,408   0%                             - seed7-line-after-func-return-logic-operator-column
+          8,240   0%                              - seed7-move-to-line
+          8,240   0%                                 seed7-to-previous-non-empty-line
+         11,392   0%                               seed7-line-starts-with
+          7,168   0%                             - seed7-line-starts-with-open-paren-after-logic-operator
+          7,168   0%                                seed7-line-starts-with
+          7,168   0%                               seed7-line-indent-step
+          4,144   0%                             - seed7--indent-search-boundary
+          4,144   0%                              - seed7--indent-search-boundary-uncached
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+        299,240   0%                              seed7--indent-offset-for
+        281,792   0%                              seed7--on-lineof
+        135,688   0%                              match-string
+          4,672   0%                              #<byte-code-function 921>
+         78,736   0%                             seed7--cache-block-spec
+     29,900,251   5%                          - seed7-line-inside-parens-pair-column
+     29,900,251   5%                           - seed7-line-inside-parens-pair
+     28,680,243   4%                            - seed7-re-search-backward
+     20,942,232   3%                             - run-with-timer
+     20,942,232   3%                              - run-at-time
+      9,020,568   1%                               - timer-activate
+      9,020,568   1%                                - timer--activate
+      9,020,568   1%                                   timer--time-less-p
+      6,199,424   1%                                 timer-relative-time
+      4,147,520   0%                               - timer-set-time
+      4,147,520   0%                                  timer--time-setter
+      1,574,720   0%                                 timer-create
+      3,110,704   0%                             - seed7-inside-string-p
+        981,048   0%                              - syntax-ppss
+        882,672   0%                                 make-closure
+         98,376   0%                                 parse-partial-sexp
+      1,964,875   0%                               re-search-backward
+      1,942,096   0%                             - seed7-inside-comment-p
+        918,528   0%                              - syntax-ppss
+        787,360   0%                                 make-closure
+        131,168   0%                                 parse-partial-sexp
+        654,752   0%                               make-closure
+        963,568   0%                            - forward-sexp
+        963,568   0%                               seed7--forward-sexp-function
+        161,488   0%                            - seed7-line-inside-syntax-parens-pair
+         78,736   0%                             - syntax-ppss
+         78,736   0%                                make-closure
+         33,024   0%                             - forward-sexp
+         33,024   0%                                seed7--forward-sexp-function
+     21,101,439   3%                          - seed7--indent-search-boundary
+     20,952,255   3%                           - seed7--indent-search-boundary-uncached
+     20,019,995   3%                            - syntax-ppss
+     16,576,000   2%                               make-closure
+      3,115,240   0%                               parse-partial-sexp
+            759   0%                               #<byte-code-function A1A>
+             76   0%                               syntax-table
+          1,652   0%                              seed7-to-indent
+     12,347,214   2%                          - seed7--current-line-nth-word
+     12,239,470   2%                           - thing-at-point
+     12,205,718   2%                            - bounds-of-thing-at-point
+     11,197,222   1%                             - #<byte-code-function 9FA6>
+     11,197,222   1%                              - forward-thing
+     11,058,094   1%                               - forward-word
+     11,058,094   1%                                - internal--syntax-propertize
+     10,826,390   1%                                 - syntax-propertize
+     10,312,534   1%                                    seed7-mode-syntax-propertize
+        139,128   0%                                 format
+        480,704   0%                               make-closure
+        165,760   0%                             - seq-some
+        165,760   0%                                make-closure
+        114,576   0%                             - #<byte-code-function D44>
+        114,576   0%                              - forward-thing
+        114,576   0%                                 format
+         23,680   0%                               re-search-forward
+      7,150,206   1%                          - seed7-line-inside-array-definition-block
+      5,769,198   0%                           - seed7-re-search-backward
+      2,865,896   0%                            - run-with-timer
+      2,865,896   0%                             - run-at-time
+      1,258,696   0%                              - timer-activate
+      1,258,696   0%                               - timer--activate
+      1,258,696   0%                                - timer--time-less-p
+         32,792   0%                                   timer--time
+        868,224   0%                                timer-relative-time
+        569,072   0%                              - timer-set-time
+        569,072   0%                                 timer--time-setter
+        169,904   0%                                timer-create
+      2,165,670   0%                              re-search-backward
+        443,408   0%                            - seed7-inside-string-p
+        116,032   0%                             - syntax-ppss
+        116,032   0%                                make-closure
+        198,912   0%                            - seed7-inside-comment-p
+         74,592   0%                             - syntax-ppss
+         74,592   0%                                make-closure
+         95,312   0%                              make-closure
+      1,249,120   0%                           - forward-sexp
+      1,249,120   0%                              seed7--forward-sexp-function
+         32,792   0%                             seed7-move-to-line
+      6,655,749   1%                          - seed7-line-inside-argument-list-section
+      4,310,579   0%                           - seed7-re-search-backward
+      2,394,083   0%                              re-search-backward
+      1,833,616   0%                            - run-with-timer
+      1,833,616   0%                             - run-at-time
+        788,832   0%                              - timer-activate
+        788,832   0%                               - timer--activate
+        788,832   0%                                  timer--time-less-p
+        551,456   0%                                timer-relative-time
+        369,008   0%                              - timer-set-time
+        369,008   0%                                 timer--time-setter
+        124,320   0%                                timer-create
+         70,448   0%                              make-closure
+          8,288   0%                              seed7-inside-comment-p
+          4,144   0%                            - seed7-inside-string-p
+          4,144   0%                             - syntax-ppss
+          4,144   0%                                make-closure
+      2,182,322   0%                           - seed7-line-is-procfunc-beg-of-decl
+      2,182,322   0%                              seed7-line-starts-with
+         71,680   0%                           - forward-sexp
+         71,680   0%                              seed7--forward-sexp-function
+         20,720   0%                           - seed7-forward-char-pos
+         12,432   0%                            - seed7-re-search-forward
+          8,288   0%                               seed7-inside-string-p
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+      5,326,542   0%                          - seed7-line-inside-assign-statement-continuation
+      4,774,872   0%                           - seed7-assign-op-pos
+      4,725,144   0%                            - seed7-re-search-backward
+      2,179,504   0%                             - run-with-timer
+      2,179,504   0%                              - run-at-time
+        962,752   0%                               - timer-activate
+        962,752   0%                                - timer--activate
+        962,752   0%                                   timer--time-less-p
+        651,776   0%                                 timer-relative-time
+        436,512   0%                               - timer-set-time
+        436,512   0%                                  timer--time-setter
+        128,464   0%                                 timer-create
+      2,093,944   0%                               re-search-backward
+        248,640   0%                             - seed7-inside-string-p
+         70,448   0%                              - syntax-ppss
+         70,448   0%                                 make-closure
+        149,184   0%                             - seed7-inside-comment-p
+         62,160   0%                              - syntax-ppss
+         62,160   0%                                 make-closure
+         53,872   0%                               make-closure
+        489,510   0%                           - seed7-statement-end-pos
+        402,486   0%                            - seed7-forward-char-pos
+        315,462   0%                             - seed7-re-search-forward
+        194,768   0%                              - seed7-inside-string-p
+         29,008   0%                               - syntax-ppss
+         29,008   0%                                  make-closure
+        120,176   0%                              - seed7-inside-comment-p
+         70,448   0%                               - syntax-ppss
+         70,448   0%                                  make-closure
+      4,944,400   0%                          - seed7-line-inside-logic-check-expression
+      4,262,096   0%                           - seed7-to-previous-line-starts-with
+      4,110,120   0%                            - seed7-re-search-backward
+      1,969,800   0%                               re-search-backward
+      1,846,096   0%                             - run-with-timer
+      1,846,096   0%                              - run-at-time
+        774,352   0%                               - timer-activate
+        774,352   0%                                - timer--activate
+        774,352   0%                                   timer--time-less-p
+        565,440   0%                                 timer-relative-time
+        381,984   0%                               - timer-set-time
+        381,984   0%                                  timer--time-setter
+        124,320   0%                                 timer-create
+        140,896   0%                             - seed7-inside-string-p
+         20,720   0%                              - syntax-ppss
+         20,720   0%                                 make-closure
+         99,456   0%                             - seed7-inside-comment-p
+         29,008   0%                              - syntax-ppss
+         29,008   0%                                 make-closure
+         53,872   0%                               make-closure
+        334,568   0%                           - seed7--current-line-nth-word
+        288,984   0%                            - thing-at-point
+        256,304   0%                             - bounds-of-thing-at-point
+        120,176   0%                                make-closure
+         40,920   0%                              - #<byte-code-function 124>
+         40,920   0%                               - forward-thing
+         40,920   0%                                  format
+         37,296   0%                              - seq-some
+         37,296   0%                                 make-closure
+          8,184   0%                              - #<byte-code-function BDC>
+          8,184   0%                               - forward-thing
+          8,184   0%                                  format
+        244,496   0%                           - seed7-re-search-forward
+        124,320   0%                            - seed7-inside-comment-p
+         37,296   0%                             - syntax-ppss
+         37,296   0%                                make-closure
+        120,176   0%                            - seed7-inside-string-p
+         24,864   0%                             - syntax-ppss
+         24,864   0%                                make-closure
+         32,792   0%                             seed7-move-to-line
+      4,754,250   0%                          - seed7-line-inside-set-definition-block
+      4,663,082   0%                           - seed7-re-search-backward
+      2,309,306   0%                              re-search-backward
+      2,279,184   0%                            - run-with-timer
+      2,279,184   0%                             - run-at-time
+        969,056   0%                              - timer-activate
+        969,056   0%                               - timer--activate
+        969,056   0%                                  timer--time-less-p
+        678,528   0%                                timer-relative-time
+        461,696   0%                              - timer-set-time
+        461,696   0%                                 timer--time-setter
+        169,904   0%                                timer-create
+         74,592   0%                              make-closure
+      4,022,344   0%                          - seed7-line-inside-until-logic-expression
+      3,883,368   0%                           - seed7-re-search-backward
+      1,933,736   0%                              re-search-backward
+      1,899,904   0%                            - run-with-timer
+      1,899,904   0%                             - run-at-time
+        835,928   0%                              - timer-activate
+        835,928   0%                               - timer--activate
+        835,928   0%                                - timer--time-less-p
+         32,792   0%                                   timer--time
+        586,072   0%                                timer-relative-time
+        390,880   0%                              - timer-set-time
+        390,880   0%                                 timer--time-setter
+         87,024   0%                                timer-create
+         49,728   0%                              make-closure
+         60,240   0%                           - seed7-line-code-ends-with
+         56,096   0%                            - seed7-re-search-backward
+         41,760   0%                             - run-with-timer
+         41,760   0%                              - run-at-time
+         16,576   0%                                 timer-create
+         11,296   0%                               - timer-activate
+         11,296   0%                                - timer--activate
+         11,296   0%                                   timer--time-less-p
+          8,512   0%                                 timer-relative-time
+          5,376   0%                               - timer-set-time
+          5,376   0%                                  timer--time-setter
+         14,336   0%                               re-search-backward
+      3,886,208   0%                          - seed7-line-inside-func-return-statement
+      3,786,752   0%                           - seed7-re-search-backward
+      1,925,416   0%                              re-search-backward
+      1,815,752   0%                            - run-with-timer
+      1,815,752   0%                             - run-at-time
+        783,896   0%                              - timer-activate
+        783,896   0%                               - timer--activate
+        783,896   0%                                  timer--time-less-p
+        551,152   0%                                timer-relative-time
+        372,960   0%                              - timer-set-time
+        372,960   0%                                 timer--time-setter
+        107,744   0%                                timer-create
+         45,584   0%                              make-closure
+      2,678,760   0%                          - seed7-line-after-func-return-logic-operator-column
+        585,000   0%                           - seed7-move-to-line
+        585,000   0%                            - seed7-to-previous-non-empty-line
+        103,600   0%                             - seed7-inside-comment-p
+         70,448   0%                              - syntax-ppss
+         70,448   0%                                 make-closure
+      2,228,360   0%                            seed7-line-starts-with
+      2,131,888   0%                          - seed7-line-isa-string
+      2,131,888   0%                             seed7-line-starts-with
+      1,654,704   0%                          - seed7-line-inside-nested-parens-pairs-column
+      1,654,704   0%                           - seed7-line-inside-nested-parens-pairs
+      1,642,272   0%                            - seed7-line-inside-parens-pair
+      1,452,008   0%                             - seed7-re-search-backward
+      1,211,064   0%                              - run-with-timer
+      1,211,064   0%                               - run-at-time
+        500,904   0%                                - timer-activate
+        500,904   0%                                 - timer--activate
+        500,904   0%                                  - timer--time-less-p
+         32,792   0%                                     timer--time
+        379,376   0%                                  timer-relative-time
+        247,904   0%                                - timer-set-time
+        247,904   0%                                   timer--time-setter
+         82,880   0%                                  timer-create
+         82,880   0%                              - seed7-inside-string-p
+         16,576   0%                               - syntax-ppss
+         16,576   0%                                  make-closure
+         66,304   0%                              - seed7-inside-comment-p
+         62,160   0%                               - syntax-ppss
+         62,160   0%                                  make-closure
+         53,872   0%                                make-closure
+         37,888   0%                                re-search-backward
+        111,888   0%                             - seed7-line-inside-syntax-parens-pair
+         91,168   0%                              - syntax-ppss
+         91,168   0%                                 make-closure
+      1,035,120   0%                          - seed7-line-at-endof-array-definition-block
+        486,704   0%                           - seed7-line-code-ends-with
+        486,704   0%                            - seed7-re-search-backward
+        294,560   0%                             - run-with-timer
+        294,560   0%                              - run-at-time
+        107,824   0%                               - timer-activate
+        107,824   0%                                - timer--activate
+        107,824   0%                                   timer--time-less-p
+         96,672   0%                                 timer-relative-time
+         61,056   0%                               - timer-set-time
+         61,056   0%                                  timer--time-setter
+         29,008   0%                                 timer-create
+        113,408   0%                               re-search-backward
+         45,584   0%                               make-closure
+         29,008   0%                             - seed7-inside-string-p
+          8,288   0%                              - syntax-ppss
+          8,288   0%                                 make-closure
+          4,144   0%                               seed7-inside-comment-p
+        470,992   0%                           - backward-sexp
+        470,992   0%                            - forward-sexp
+        470,992   0%                             - seed7--forward-sexp-function
+        195,392   0%                              - seed7--at-array-definition-end-line-p
+        146,248   0%                               - seed7-line-code-ends-with
+        142,104   0%                                - seed7-re-search-backward
+         80,304   0%                                 - run-with-timer
+         80,304   0%                                  - run-at-time
+         38,640   0%                                   - timer-activate
+         38,640   0%                                    - timer--activate
+         38,640   0%                                       timer--time-less-p
+         25,536   0%                                     timer-relative-time
+         16,128   0%                                   - timer-set-time
+         16,128   0%                                      timer--time-setter
+         45,224   0%                                 - seed7-inside-string-p
+         36,936   0%                                  - syntax-ppss
+         32,792   0%                                     parse-partial-sexp
+          4,144   0%                                     make-closure
+         12,432   0%                                 - seed7-inside-comment-p
+          8,288   0%                                  - syntax-ppss
+          8,288   0%                                     make-closure
+          4,144   0%                                   make-closure
+         49,144   0%                                 looking-at
+        154,744   0%                              - seed7--safe-to-block-backward
+        154,744   0%                               - seed7-to-block-backward
+        113,304   0%                                - seed7-line-code-ends-with
+        113,304   0%                                 - seed7-re-search-backward
+         92,584   0%                                  - run-with-timer
+         92,584   0%                                   - run-at-time
+         55,880   0%                                    - timer-activate
+         55,880   0%                                     - timer--activate
+         55,880   0%                                      - timer--time-less-p
+         32,792   0%                                         timer--time
+         22,496   0%                                      timer-relative-time
+         14,208   0%                                    - timer-set-time
+         14,208   0%                                       timer--time-setter
+         12,432   0%                                  - seed7-inside-string-p
+          8,288   0%                                   - syntax-ppss
+          8,288   0%                                      make-closure
+          4,144   0%                                    make-closure
+          4,144   0%                                  - seed7-inside-comment-p
+          4,144   0%                                   - syntax-ppss
+          4,144   0%                                      make-closure
+         29,008   0%                                - seed7--current-line-nth-word
+         24,864   0%                                 - thing-at-point
+         24,864   0%                                  - bounds-of-thing-at-point
+         12,432   0%                                     make-closure
+          4,144   0%                                   - seq-some
+          4,144   0%                                      make-closure
+          8,288   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          4,144   0%                                  seed7-inside-line-indent-before-comment-p
+         16,376   0%                              - seed7-beg-of-defun
+          7,808   0%                               - seed7-top-block-name
+          6,784   0%                                - seed7--to-top
+          5,976   0%                                 - seed7-re-search-backward
+          4,952   0%                                  - run-with-timer
+          4,952   0%                                   - run-at-time
+          4,336   0%                                    - timer-set-time
+          4,336   0%                                       timer--time-setter
+            312   0%                                    - timer-activate
+            312   0%                                     - timer--activate
+            312   0%                                        timer--time-less-p
+            304   0%                                      timer-relative-time
+          1,024   0%                                    re-search-backward
+            808   0%                                 - run-with-timer
+            808   0%                                  - run-at-time
+            312   0%                                   - timer-activate
+            312   0%                                    - timer--activate
+            312   0%                                       timer--time-less-p
+            304   0%                                     timer-relative-time
+            192   0%                                   - timer-set-time
+            192   0%                                      timer--time-setter
+          1,024   0%                                - seed7--block-name
+          1,024   0%                                   seed7-re-search-forward
+          3,664   0%                               - seed7-re-search-backward-closest
+          3,664   0%                                - seed7-re-search-backward
+          2,048   0%                                   re-search-backward
+          1,616   0%                                 - run-with-timer
+          1,616   0%                                  - run-at-time
+            624   0%                                   - timer-activate
+            624   0%                                    - timer--activate
+            624   0%                                       timer--time-less-p
+            608   0%                                     timer-relative-time
+            384   0%                                   - timer-set-time
+            384   0%                                      timer--time-setter
+          1,832   0%                               - seed7-re-search-backward
+          1,024   0%                                  re-search-backward
+            808   0%                                - run-with-timer
+            808   0%                                 - run-at-time
+            312   0%                                  - timer-activate
+            312   0%                                   - timer--activate
+            312   0%                                      timer--time-less-p
+            304   0%                                    timer-relative-time
+            192   0%                                  - timer-set-time
+            192   0%                                     timer--time-setter
+         12,224   0%                              - seed7--at-set-definition-end-line-p
+         12,224   0%                               - seed7-line-code-ends-with
+         12,224   0%                                - seed7-re-search-backward
+          8,080   0%                                 - run-with-timer
+          8,080   0%                                  - run-at-time
+          3,120   0%                                   - timer-activate
+          3,120   0%                                    - timer--activate
+          3,120   0%                                       timer--time-less-p
+          3,040   0%                                     timer-relative-time
+          1,920   0%                                   - timer-set-time
+          1,920   0%                                      timer--time-setter
+          4,144   0%                                   make-closure
+          4,144   0%                                seed7--line-comment-hash
+         38,080   0%                           - seed7-re-search-backward
+         33,936   0%                            - run-with-timer
+         33,936   0%                             - run-at-time
+         13,104   0%                              - timer-activate
+         13,104   0%                               - timer--activate
+         13,104   0%                                  timer--time-less-p
+         12,768   0%                                timer-relative-time
+          8,064   0%                              - timer-set-time
+          8,064   0%                                 timer--time-setter
+          4,144   0%                              seed7-inside-comment-p
+         33,152   0%                           - seed7-move-to-line
+         33,152   0%                            - seed7-to-previous-non-empty-line
+         12,432   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+          2,048   0%                             looking-at
+        949,780   0%                          - seed7-line-after-short-func-end
+        650,884   0%                           - seed7-move-to-line
+        650,884   0%                            - seed7-to-previous-non-empty-line
+        598,180   0%                             - seed7-inside-comment-p
+        585,748   0%                              - syntax-ppss
+        565,028   0%                               - syntax-propertize
+        540,164   0%                                  seed7-mode-syntax-propertize
+         20,720   0%                                 make-closure
+         34,768   0%                           - seed7-to-block-backward
+         17,592   0%                            - seed7--current-line-nth-word
+         13,448   0%                             - thing-at-point
+         12,432   0%                              - bounds-of-thing-at-point
+          8,288   0%                               - seq-some
+          8,288   0%                                  make-closure
+          4,144   0%                                 make-closure
+         13,032   0%                            - seed7-re-search-backward
+          8,888   0%                             - run-with-timer
+          8,888   0%                              - run-at-time
+          3,432   0%                               - timer-activate
+          3,432   0%                                - timer--activate
+          3,432   0%                                   timer--time-less-p
+          3,344   0%                                 timer-relative-time
+          2,112   0%                               - timer-set-time
+          2,112   0%                                  timer--time-setter
+          4,144   0%                               seed7-inside-string-p
+          4,144   0%                            - seed7-inside-line-indent-before-comment-p
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+        839,164   0%                          - seed7-comment-column
+        821,180   0%                           - seed7-calc-indent
+        526,548   0%                            - seed7-line-is-defun-end
+        483,744   0%                             - seed7-end-of-defun
+        400,704   0%                              - seed7-top-block-name
+        396,560   0%                               - seed7--to-top
+        394,136   0%                                - seed7-re-search-backward
+        269,816   0%                                 - run-with-timer
+        269,816   0%                                  - run-at-time
+        113,336   0%                                   - timer-activate
+        113,336   0%                                    - timer--activate
+        113,336   0%                                       timer--time-less-p
+         78,128   0%                                     timer-relative-time
+         49,344   0%                                   - timer-set-time
+         49,344   0%                                      timer--time-setter
+         29,008   0%                                     timer-create
+         87,024   0%                                 - seed7-inside-string-p
+         16,576   0%                                  - syntax-ppss
+         16,576   0%                                     make-closure
+         29,008   0%                                 - seed7-inside-comment-p
+         16,576   0%                                  - syntax-ppss
+         16,576   0%                                     make-closure
+          8,288   0%                                   make-closure
+          2,424   0%                                - run-with-timer
+          2,424   0%                                 - run-at-time
+            936   0%                                  - timer-activate
+            936   0%                                   - timer--activate
+            936   0%                                      timer--time-less-p
+            912   0%                                    timer-relative-time
+            576   0%                                  - timer-set-time
+            576   0%                                     timer--time-setter
+          4,144   0%                               - seed7--block-name
+          4,144   0%                                - seed7-re-search-forward
+          4,144   0%                                 - seed7-inside-string-p
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+         68,352   0%                              - seed7-re-search-forward
+         49,728   0%                               - seed7-inside-string-p
+         12,432   0%                                - syntax-ppss
+         12,432   0%                                   make-closure
+         16,576   0%                               - seed7-inside-comment-p
+          8,288   0%                                - syntax-ppss
+          8,288   0%                                   make-closure
+          8,184   0%                                match-string-no-properties
+          2,424   0%                              - seed7-re-search-backward
+          2,424   0%                               - run-with-timer
+          2,424   0%                                - run-at-time
+            936   0%                                 - timer-activate
+            936   0%                                  - timer--activate
+            936   0%                                     timer--time-less-p
+            912   0%                                   timer-relative-time
+            576   0%                                 - timer-set-time
+            576   0%                                    timer--time-setter
+          2,032   0%                                match-string
+         24,332   0%                             - seed7-beg-of-defun
+          9,888   0%                              - seed7-top-block-name
+          7,248   0%                               - seed7--block-name
+          3,104   0%                                  seed7-re-search-forward
+          2,640   0%                               - seed7--to-top
+          1,832   0%                                - seed7-re-search-backward
+          1,024   0%                                   re-search-backward
+            808   0%                                 - run-with-timer
+            808   0%                                  - run-at-time
+            312   0%                                   - timer-activate
+            312   0%                                    - timer--activate
+            312   0%                                       timer--time-less-p
+            304   0%                                     timer-relative-time
+            192   0%                                   - timer-set-time
+            192   0%                                      timer--time-setter
+            808   0%                                - run-with-timer
+            808   0%                                 - run-at-time
+            312   0%                                  - timer-activate
+            312   0%                                   - timer--activate
+            312   0%                                      timer--time-less-p
+            304   0%                                    timer-relative-time
+            192   0%                                  - timer-set-time
+            192   0%                                     timer--time-setter
+          3,664   0%                              - seed7-re-search-backward-closest
+          3,664   0%                               - seed7-re-search-backward
+          2,048   0%                                  re-search-backward
+          1,616   0%                                - run-with-timer
+          1,616   0%                                 - run-at-time
+            624   0%                                  - timer-activate
+            624   0%                                   - timer--activate
+            624   0%                                      timer--time-less-p
+            608   0%                                    timer-relative-time
+            384   0%                                  - timer-set-time
+            384   0%                                     timer--time-setter
+          3,612   0%                              - seed7-re-search-backward
+          1,996   0%                                 re-search-backward
+          1,616   0%                               - run-with-timer
+          1,616   0%                                - run-at-time
+            624   0%                                 - timer-activate
+            624   0%                                  - timer--activate
+            624   0%                                     timer--time-less-p
+            608   0%                                   timer-relative-time
+            384   0%                                 - timer-set-time
+            384   0%                                    timer--time-setter
+         12,328   0%                             - seed7--current-line-nth-word
+         12,328   0%                              - thing-at-point
+         12,328   0%                               - bounds-of-thing-at-point
+          8,184   0%                                - #<byte-code-function D12>
+          8,184   0%                                 - forward-thing
+          8,184   0%                                    format
+          6,144   0%                             - seed7-line-starts-with-any
+          6,144   0%                                seed7-line-starts-with
+        117,136   0%                            - seed7-line-inside-a-block-cached
+        117,136   0%                             - seed7-line-inside-a-block
+         91,856   0%                              - seed7--safe-enclosing-block-bounds
+         56,704   0%                               - seed7-to-block-backward
+         56,704   0%                                - seed7-re-search-backward
+         34,960   0%                                 - run-with-timer
+         34,960   0%                                  - run-at-time
+         19,088   0%                                   - timer-activate
+         19,088   0%                                    - timer--activate
+         19,088   0%                                       timer--time-less-p
+          9,728   0%                                     timer-relative-time
+          6,144   0%                                   - timer-set-time
+          6,144   0%                                      timer--time-setter
+         12,432   0%                                 - seed7-inside-string-p
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+          4,144   0%                                   make-closure
+          4,144   0%                                   seed7-inside-comment-p
+          1,024   0%                                   re-search-backward
+         35,152   0%                               - seed7--block-end-pos-for
+         35,152   0%                                - seed7-to-block-forward
+         24,816   0%                                 - seed7-re-search-forward
+         14,480   0%                                  - seed7-inside-comment-p
+          6,192   0%                                   - syntax-ppss
+          6,192   0%                                    - syntax-propertize
+          2,048   0%                                       seed7-mode-syntax-propertize
+          8,288   0%                                  - seed7-inside-string-p
+          4,144   0%                                   - syntax-ppss
+          4,144   0%                                      make-closure
+          5,168   0%                                   seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          5,168   0%                                 - seed7--current-line-nth-word
+          1,024   0%                                  - thing-at-point
+          1,024   0%                                   - bounds-of-thing-at-point
+          1,024   0%                                      re-search-forward
+         23,232   0%                              - seed7-re-search-backward
+         19,552   0%                               - run-with-timer
+         19,552   0%                                - run-at-time
+          7,648   0%                                 - timer-activate
+          7,648   0%                                  - timer--activate
+          7,648   0%                                     timer--time-less-p
+          7,296   0%                                   timer-relative-time
+          4,608   0%                                 - timer-set-time
+          4,608   0%                                    timer--time-setter
+          3,680   0%                                 re-search-backward
+          2,048   0%                                replace-regexp-in-string
+         52,688   0%                            - seed7-line-inside-parens-pair-column
+         52,688   0%                             - seed7-line-inside-parens-pair
+         50,640   0%                              - seed7-re-search-backward
+         35,008   0%                               - run-with-timer
+         35,008   0%                                - run-at-time
+         12,016   0%                                 - timer-activate
+         12,016   0%                                  - timer--activate
+         12,016   0%                                     timer--time-less-p
+         11,552   0%                                   timer-relative-time
+          7,296   0%                                 - timer-set-time
+          7,296   0%                                    timer--time-setter
+          4,144   0%                                   timer-create
+         12,432   0%                               - seed7-inside-comment-p
+         12,432   0%                                - syntax-ppss
+         12,432   0%                                   make-closure
+          3,200   0%                                 re-search-backward
+          2,048   0%                              - forward-sexp
+          2,048   0%                                 seed7--forward-sexp-function
+         26,896   0%                            - seed7-line-inside-assign-statement-continuation
+         26,896   0%                             - seed7-assign-op-pos
+         26,896   0%                              - seed7-re-search-backward
+         19,552   0%                               - run-with-timer
+         19,552   0%                                - run-at-time
+          7,648   0%                                 - timer-activate
+          7,648   0%                                  - timer--activate
+          7,648   0%                                     timer--time-less-p
+          7,296   0%                                   timer-relative-time
+          4,608   0%                                 - timer-set-time
+          4,608   0%                                    timer--time-setter
+          4,144   0%                                 make-closure
+          3,200   0%                                 re-search-backward
+         23,968   0%                            - seed7-line-inside-array-definition-block
+         22,944   0%                             - seed7-re-search-backward
+         19,552   0%                              - run-with-timer
+         19,552   0%                               - run-at-time
+          7,648   0%                                - timer-activate
+          7,648   0%                                 - timer--activate
+          7,648   0%                                    timer--time-less-p
+          7,296   0%                                  timer-relative-time
+          4,608   0%                                - timer-set-time
+          4,608   0%                                   timer--time-setter
+          3,392   0%                                re-search-backward
+          1,024   0%                             - forward-sexp
+          1,024   0%                                seed7--forward-sexp-function
+         22,624   0%                            - seed7-line-inside-set-definition-block
+         22,624   0%                             - seed7-re-search-backward
+         19,552   0%                              - run-with-timer
+         19,552   0%                               - run-at-time
+          7,648   0%                                - timer-activate
+          7,648   0%                                 - timer--activate
+          7,648   0%                                    timer--time-less-p
+          7,296   0%                                  timer-relative-time
+          4,608   0%                                - timer-set-time
+          4,608   0%                                   timer--time-setter
+          3,072   0%                                re-search-backward
+          8,288   0%                            - seed7--indent-search-boundary
+          8,288   0%                             - seed7--indent-search-boundary-uncached
+          8,288   0%                              - syntax-ppss
+          8,288   0%                                 make-closure
+          8,184   0%                            - seed7--current-line-nth-word
+          8,184   0%                             - thing-at-point
+          8,184   0%                              - bounds-of-thing-at-point
+          8,184   0%                               - #<byte-code-function 827>
+          8,184   0%                                - forward-thing
+          8,184   0%                                   format
+          6,784   0%                            - seed7-line-at-endof-array-definition-block
+          6,784   0%                             - seed7-line-code-ends-with
+          6,784   0%                              - seed7-re-search-backward
+          5,760   0%                               - run-with-timer
+          5,760   0%                                - run-at-time
+          4,144   0%                                   timer-create
+            624   0%                                 - timer-activate
+            624   0%                                  - timer--activate
+            624   0%                                     timer--time-less-p
+            608   0%                                   timer-relative-time
+            384   0%                                 - timer-set-time
+            384   0%                                    timer--time-setter
+          1,024   0%                                 re-search-backward
+          6,136   0%                            - seed7-line-inside-logic-check-expression
+          4,144   0%                             - seed7-re-search-forward
+          4,144   0%                                seed7-inside-comment-p
+          1,992   0%                             - seed7-to-previous-line-starts-with
+          1,992   0%                              - seed7-re-search-backward
+          1,024   0%                                 re-search-backward
+            968   0%                               - run-with-timer
+            968   0%                                - run-at-time
+            472   0%                                 - timer-activate
+            472   0%                                  - timer--activate
+            472   0%                                     timer--time-less-p
+            304   0%                                   timer-relative-time
+            192   0%                                 - timer-set-time
+            192   0%                                    timer--time-setter
+          3,072   0%                            - seed7-line-isa-string
+          3,072   0%                               seed7-line-starts-with
+          3,072   0%                              seed7-line-starts-with
+          3,072   0%                            - seed7-line-starts-with-open-paren-after-logic-operator
+          2,048   0%                               seed7-line-starts-with
+          3,072   0%                            - seed7-line-after-func-return-logic-operator-column
+          1,024   0%                             - seed7-move-to-line
+          1,024   0%                                seed7-to-previous-non-empty-line
+          3,016   0%                            - seed7-line-inside-argument-list-section
+          1,992   0%                             - seed7-re-search-backward
+          1,024   0%                                re-search-backward
+            968   0%                              - run-with-timer
+            968   0%                               - run-at-time
+            472   0%                                - timer-activate
+            472   0%                                 - timer--activate
+            472   0%                                    timer--time-less-p
+            304   0%                                  timer-relative-time
+            192   0%                                - timer-set-time
+            192   0%                                   timer--time-setter
+          1,024   0%                             - seed7-line-is-procfunc-beg-of-decl
+          1,024   0%                                seed7-line-starts-with
+          1,992   0%                            - seed7-line-inside-until-logic-expression
+          1,992   0%                             - seed7-re-search-backward
+          1,024   0%                                re-search-backward
+            968   0%                              - run-with-timer
+            968   0%                               - run-at-time
+            472   0%                                - timer-activate
+            472   0%                                 - timer--activate
+            472   0%                                    timer--time-less-p
+            304   0%                                  timer-relative-time
+            192   0%                                - timer-set-time
+            192   0%                                   timer--time-setter
+          1,992   0%                            - seed7-line-inside-func-return-statement
+          1,992   0%                             - seed7-re-search-backward
+          1,024   0%                                re-search-backward
+            968   0%                              - run-with-timer
+            968   0%                               - run-at-time
+            472   0%                                - timer-activate
+            472   0%                                 - timer--activate
+            472   0%                                    timer--time-less-p
+            304   0%                                  timer-relative-time
+            192   0%                                - timer-set-time
+            192   0%                                   timer--time-setter
+          1,616   0%                            - seed7-line-at-endof-set-definition-block
+          1,616   0%                             - seed7-line-code-ends-with
+          1,616   0%                              - seed7-re-search-backward
+          1,616   0%                               - run-with-timer
+          1,616   0%                                - run-at-time
+            624   0%                                 - timer-activate
+            624   0%                                  - timer--activate
+            624   0%                                     timer--time-less-p
+            608   0%                                   timer-relative-time
+            384   0%                                 - timer-set-time
+            384   0%                                    timer--time-setter
+          1,024   0%                              seed7-line-after-short-func-end
+          9,744   0%                           - seed7-line-code-ends-with
+          8,720   0%                            - seed7-re-search-backward
+          7,696   0%                             - run-with-timer
+          7,696   0%                              - run-at-time
+          5,712   0%                               - timer-activate
+          5,712   0%                                - timer--activate
+          5,712   0%                                   timer--time-less-p
+          1,216   0%                                 timer-relative-time
+            768   0%                               - timer-set-time
+            768   0%                                  timer--time-setter
+          1,024   0%                               re-search-backward
+          1,024   0%                            - seed7-move-to-line
+          1,024   0%                               seed7-to-previous-non-empty-line
+          3,072   0%                             seed7-line-starts-with
+          1,024   0%                             looking-at
+        298,368   0%                          - seed7-current-line-start-inside-comment-p
+        132,608   0%                           - seed7-inside-comment-p
+         62,160   0%                            - syntax-ppss
+         62,160   0%                               make-closure
+        296,624   0%                          - seed7-line-ends-with
+        204,368   0%                           - seed7-re-search-backward
+         91,392   0%                            - run-with-timer
+         91,392   0%                             - run-at-time
+         43,600   0%                              - timer-activate
+         43,600   0%                               - timer--activate
+         43,600   0%                                  timer--time-less-p
+         26,752   0%                                timer-relative-time
+         16,896   0%                              - timer-set-time
+         16,896   0%                                 timer--time-setter
+          4,144   0%                                timer-create
+         83,968   0%                              re-search-backward
+         12,432   0%                              make-closure
+         12,432   0%                              seed7-inside-string-p
+          4,144   0%                            - seed7-inside-comment-p
+          4,144   0%                             - syntax-ppss
+          4,144   0%                                make-closure
+         88,112   0%                           - seed7-move-to-line
+         88,112   0%                              seed7-to-previous-non-empty-line
+        261,872   0%                          - seed7-line-indent-step
+         49,728   0%                           - seed7-move-to-line
+         49,728   0%                            - seed7-to-previous-non-empty-line
+         33,152   0%                             - seed7-inside-comment-p
+         12,432   0%                              - syntax-ppss
+         12,432   0%                                 make-closure
+        239,387   0%                          - seed7-line-at-endof-set-definition-block
+        231,099   0%                           - seed7-line-code-ends-with
+        222,811   0%                            - seed7-re-search-backward
+        214,048   0%                             - run-with-timer
+        214,048   0%                              - run-at-time
+         84,736   0%                               - timer-activate
+         84,736   0%                                - timer--activate
+         84,736   0%                                   timer--time-less-p
+         74,176   0%                                 timer-relative-time
+         50,992   0%                               - timer-set-time
+         50,992   0%                                  timer--time-setter
+          4,144   0%                                 timer-create
+          4,619   0%                             - seed7-inside-string-p
+          4,619   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+            475   0%                                 #<byte-code-function 7BF>
+          4,144   0%                               seed7-inside-comment-p
+          4,144   0%                           - seed7-move-to-line
+          4,144   0%                            - seed7-to-previous-non-empty-line
+          4,144   0%                               seed7-inside-comment-p
+         79,864   0%                          - seed7-line-starts-with-open-paren-after-logic-operator
+         79,864   0%                             seed7-line-starts-with
+         22,720   0%                          - seed7-position-of-end-of-statement
+         22,720   0%                           - seed7-line-code-ends-with
+         18,576   0%                            - seed7-re-search-backward
+         15,504   0%                             - run-with-timer
+         15,504   0%                              - run-at-time
+          6,576   0%                               - timer-activate
+          6,576   0%                                - timer--activate
+          6,576   0%                                   timer--time-less-p
+          5,472   0%                                 timer-relative-time
+          3,456   0%                               - timer-set-time
+          3,456   0%                                  timer--time-setter
+          3,072   0%                               re-search-backward
+        271,688   0%                         - jit-lock-after-change
+        124,320   0%                            font-lock-extend-jit-lock-region-after-change
+         87,872   0%                         - #<byte-code-function EAE>
+         87,872   0%                          - filter-buffer-substring
+         87,872   0%                           - buffer-substring--filter
+         87,872   0%                            - #<byte-code-function 2A6>
+         87,872   0%                             - apply
+         87,872   0%                                #<byte-code-function 954>
+         32,792   0%                           flyspell-after-change-function
+         32,792   0%                           syntax-ppss-flush-cache
+         17,328   0%                         - delete-horizontal-space
+         17,328   0%                          - delete-space--internal
+          8,288   0%                           - jit-lock-after-change
+          4,144   0%                              font-lock-extend-jit-lock-region-after-change
+      1,665,484   0%                   profiler-stop
+        687,557   0%   Automatic GC

--- a/reports/19.1/chkarr.sd7-perf-cpu.txt
+++ b/reports/19.1/chkarr.sd7-perf-cpu.txt
@@ -1,0 +1,1043 @@
+      285912  93% - ...
+      285912  93%  - smex-read-and-run
+      285912  93%   - execute-extended-command
+      285912  93%    - command-execute
+      285912  93%     - call-interactively
+      285912  93%      - apply
+      285912  93%       - call-interactively@ido-cr+-record-current-command
+      285912  93%        - #<primitive-function call-interactively>
+      285912  93%         - funcall-interactively
+      285912  93%          - pel-profile
+      285912  93%           - call-interactively
+      285912  93%            - apply
+      285912  93%             - call-interactively@ido-cr+-record-current-command
+      285912  93%              - #<primitive-function call-interactively>
+      285912  93%               - funcall-interactively
+      285912  93%                - seed7-complete-statement-or-indent
+      285912  93%                 - seed7-indent-region
+      285909  93%                  - seed7--indent-one-line
+      285844  93%                   - seed7-calc-indent
+      179884  58%                    - seed7-line-is-defun-end
+      177685  57%                     - seed7-end-of-defun
+      171748  55%                      - seed7-top-block-name
+      171546  55%                       - seed7--to-top
+      170739  55%                        - seed7-re-search-backward
+      143578  46%                         - seed7-inside-comment-p
+      143515  46%                          - syntax-ppss
+      139285  45%                             parse-partial-sexp
+        3932   1%                           - syntax-propertize
+        3023   0%                              seed7-mode-syntax-propertize
+          35   0%                           - #<byte-code-function 7A2>
+           8   0%                              set-syntax-table
+          32   0%                             make-closure
+          20   0%                             syntax-ppss--update-stats
+          12   0%                             syntax-ppss--data
+          11   0%                             syntax-ppss-toplevel-pos
+           9   0%                             syntax-table
+           4   0%                             set-syntax-table
+       22342   7%                         - run-with-timer
+       22331   7%                          - run-at-time
+       14463   4%                           - timer-activate
+       14451   4%                            - timer--activate
+       14403   4%                             - timer--time-less-p
+         194   0%                                timer--time
+           3   0%                               timerp
+        5870   1%                           - timer-set-time
+        5852   1%                            - timer--time-setter
+           7   0%                               timerp
+        1926   0%                             timer-relative-time
+          29   0%                             timer-create
+          22   0%                           - timer-set-function
+           9   0%                              timerp
+        3515   1%                           re-search-backward
+         748   0%                         - seed7-inside-string-p
+         506   0%                          - syntax-ppss
+         307   0%                           - parse-partial-sexp
+           7   0%                            - internal--syntax-propertize
+           7   0%                             - syntax-propertize
+           4   0%                                seed7-mode-syntax-propertize
+          35   0%                             make-closure
+          24   0%                           - #<byte-code-function 94A>
+           2   0%                              set-syntax-table
+          20   0%                             syntax-ppss--data
+          19   0%                             syntax-ppss--update-stats
+          14   0%                             syntax-propertize
+          12   0%                             syntax-table
+           3   0%                             set-syntax-table
+          45   0%                          - #<byte-code-function 278>
+          34   0%                             set-match-data
+          79   0%                         - #<byte-code-function 4E1>
+          58   0%                          - cancel-timer
+           9   0%                             timerp
+          38   0%                           make-closure
+         187   0%                          seed7-to-indent
+          93   0%                        - run-with-timer
+          92   0%                         - run-at-time
+          53   0%                          - timer-activate
+          53   0%                           - timer--activate
+          52   0%                            - timer--time-less-p
+           1   0%                               timer--time
+          30   0%                          - timer-set-time
+          29   0%                             timer--time-setter
+           9   0%                            timer-relative-time
+         202   0%                       - seed7--block-name
+         201   0%                        - seed7-re-search-forward
+         112   0%                         - seed7-inside-comment-p
+         112   0%                          - syntax-ppss
+          89   0%                             parse-partial-sexp
+          22   0%                           - syntax-propertize
+          18   0%                              seed7-mode-syntax-propertize
+          24   0%                         - seed7-inside-string-p
+          22   0%                          - syntax-ppss
+          22   0%                             parse-partial-sexp
+           1   0%                          - #<byte-code-function C5A>
+           1   0%                             set-match-data
+           1   0%                          match-string
+        5309   1%                      - seed7-re-search-forward
+        1291   0%                       - seed7-inside-comment-p
+        1290   0%                        - syntax-ppss
+         659   0%                           parse-partial-sexp
+         631   0%                         - syntax-propertize
+         490   0%                            seed7-mode-syntax-propertize
+           2   0%                          - #<byte-code-function 0E84>
+           2   0%                             syntax-propertize-wholelines
+           1   0%                            syntax-ppss-flush-cache
+          33   0%                       - seed7-inside-string-p
+          32   0%                        - syntax-ppss
+          30   0%                           parse-partial-sexp
+           1   0%                           make-closure
+           1   0%                           syntax-ppss--update-stats
+         616   0%                      - seed7-re-search-backward
+         466   0%                       - seed7-inside-comment-p
+         465   0%                        - syntax-ppss
+         465   0%                           parse-partial-sexp
+          76   0%                       - run-with-timer
+          76   0%                        - run-at-time
+          57   0%                         - timer-activate
+          57   0%                          - timer--activate
+          57   0%                           - timer--time-less-p
+           1   0%                              timer--time
+          12   0%                         - timer-set-time
+          12   0%                            timer--time-setter
+           7   0%                           timer-relative-time
+          66   0%                         re-search-backward
+           5   0%                       - seed7-inside-string-p
+           4   0%                        - syntax-ppss
+           4   0%                           parse-partial-sexp
+           1   0%                        - #<byte-code-function C9C>
+           1   0%                           set-match-data
+           1   0%                       - #<byte-code-function 118>
+           1   0%                          cancel-timer
+           4   0%                        match-string
+           1   0%                        match-string-no-properties
+        2023   0%                     - seed7-beg-of-defun
+        1411   0%                      - seed7-re-search-backward-closest
+        1408   0%                       - seed7-re-search-backward
+        1359   0%                          re-search-backward
+          45   0%                        - run-with-timer
+          45   0%                         - run-at-time
+          31   0%                          - timer-activate
+          31   0%                           - timer--activate
+          30   0%                              timer--time-less-p
+           7   0%                          - timer-set-time
+           7   0%                             timer--time-setter
+           7   0%                            timer-relative-time
+           3   0%                       - seq-filter
+           2   0%                        - seq-map
+           1   0%                         - apply
+           1   0%                          - #<byte-code-function D07>
+           1   0%                             mapcar
+           1   0%                           cl-type-of
+           1   0%                          make-symbol
+         423   0%                      - seed7-re-search-backward
+         248   0%                       - seed7-inside-comment-p
+         248   0%                        - syntax-ppss
+         247   0%                           parse-partial-sexp
+           1   0%                           #<byte-code-function E9A>
+         123   0%                         re-search-backward
+          46   0%                       - run-with-timer
+          46   0%                        - run-at-time
+          28   0%                         - timer-activate
+          28   0%                          - timer--activate
+          27   0%                           - timer--time-less-p
+           1   0%                              timer--time
+          12   0%                         - timer-set-time
+          12   0%                            timer--time-setter
+           6   0%                           timer-relative-time
+           5   0%                       - seed7-inside-string-p
+           3   0%                        - syntax-ppss
+           3   0%                           parse-partial-sexp
+           1   0%                       - #<byte-code-function F9D>
+           1   0%                          cancel-timer
+         162   0%                      - seed7-top-block-name
+         123   0%                       - seed7--to-top
+          97   0%                        - seed7-re-search-backward
+          31   0%                           re-search-backward
+          24   0%                         - run-with-timer
+          24   0%                          - run-at-time
+          17   0%                           - timer-activate
+          17   0%                            - timer--activate
+          17   0%                               timer--time-less-p
+           5   0%                           - timer-set-time
+           5   0%                              timer--time-setter
+           2   0%                             timer-relative-time
+          22   0%                         - seed7-inside-comment-p
+          22   0%                          - syntax-ppss
+          21   0%                             parse-partial-sexp
+          20   0%                         - seed7-inside-string-p
+          20   0%                          - syntax-ppss
+          18   0%                             parse-partial-sexp
+           2   0%                             #<byte-code-function 691>
+          24   0%                        - run-with-timer
+          24   0%                         - run-at-time
+          17   0%                          - timer-activate
+          17   0%                           - timer--activate
+          17   0%                              timer--time-less-p
+           4   0%                          - timer-set-time
+           4   0%                             timer--time-setter
+           3   0%                            timer-relative-time
+           1   0%                          seed7-to-indent
+           1   0%                          make-closure
+          39   0%                       - seed7--block-name
+          39   0%                        - seed7-re-search-forward
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           1   0%                        match-string-no-properties
+           1   0%                        seed7--move-and-mark
+           1   0%                        seed7-to-indent
+         107   0%                     - seed7-move-to-line
+         107   0%                      - seed7-to-previous-non-empty-line
+          99   0%                       - seed7-inside-comment-p
+          99   0%                        - syntax-ppss
+          99   0%                           parse-partial-sexp
+          36   0%                     - seed7--current-line-nth-word
+          27   0%                      - thing-at-point
+          24   0%                       - bounds-of-thing-at-point
+          15   0%                        - #<byte-code-function 5C6>
+          15   0%                         - forward-thing
+          12   0%                            forward-word
+           2   0%                            format
+           1   0%                            functionp
+           5   0%                        - #<byte-code-function 2C8>
+           5   0%                         - forward-thing
+           4   0%                            forward-word
+           1   0%                            format
+           1   0%                        - seq-some
+           1   0%                           make-closure
+          17   0%                     - seed7-line-starts-with-any
+          17   0%                        seed7-line-starts-with
+          10   0%                     - seed7--safe-current-line-defun-start-indent
+          10   0%                      - seed7-to-block-backward
+          10   0%                       - seed7-re-search-backward
+           5   0%                        - seed7-inside-comment-p
+           5   0%                         - syntax-ppss
+           5   0%                            parse-partial-sexp
+           4   0%                          re-search-backward
+           1   0%                        - run-with-timer
+           1   0%                         - run-at-time
+           1   0%                            timer-relative-time
+           5   0%                       line-end-position
+       43136  14%                    - seed7--indent-search-boundary
+       43128  14%                     - seed7--indent-search-boundary-uncached
+       42588  13%                      - syntax-ppss
+       42465  13%                         parse-partial-sexp
+          16   0%                         make-closure
+          11   0%                       - #<byte-code-function F78>
+           3   0%                          set-syntax-table
+           6   0%                         syntax-table
+           4   0%                         syntax-propertize
+           4   0%                         syntax-ppss-toplevel-pos
+           4   0%                         syntax-ppss--data
+           4   0%                         syntax-ppss--update-stats
+           2   0%                         set-syntax-table
+          55   0%                        seed7-to-indent
+           1   0%                       seed7-to-indent
+       33518  10%                    - seed7-line-inside-parens-pair-column
+       33518  10%                     - seed7-line-inside-parens-pair
+       32224  10%                      - seed7-re-search-backward
+       24049   7%                       - seed7-inside-comment-p
+       24034   7%                        - syntax-ppss
+       23960   7%                           parse-partial-sexp
+          11   0%                           make-closure
+           8   0%                           syntax-ppss--data
+           7   0%                         - #<byte-code-function 4BC>
+           3   0%                            set-syntax-table
+           6   0%                           syntax-table
+           4   0%                           syntax-ppss-toplevel-pos
+           3   0%                           set-syntax-table
+           2   0%                           syntax-ppss--update-stats
+           1   0%                           syntax-propertize
+        7528   2%                       - run-with-timer
+        7524   2%                        - run-at-time
+        4977   1%                         - timer-activate
+        4970   1%                          - timer--activate
+        4956   1%                           - timer--time-less-p
+          58   0%                              timer--time
+        2018   0%                         - timer-set-time
+        2017   0%                          - timer--time-setter
+           4   0%                             timerp
+         508   0%                           timer-relative-time
+           8   0%                           timer-create
+           4   0%                         - timer-set-function
+           1   0%                            timerp
+         423   0%                       - seed7-inside-string-p
+         381   0%                        - syntax-ppss
+         321   0%                           parse-partial-sexp
+          13   0%                         - #<byte-code-function 307>
+           2   0%                            set-syntax-table
+           8   0%                           make-closure
+           6   0%                           syntax-propertize
+           5   0%                           syntax-ppss--update-stats
+           2   0%                           syntax-ppss--data
+           2   0%                           syntax-table
+           1   0%                           set-syntax-table
+           7   0%                        - #<byte-code-function 4A0>
+           3   0%                           set-match-data
+         138   0%                         re-search-backward
+          12   0%                       - #<byte-code-function 9A92>
+          10   0%                        - cancel-timer
+           1   0%                           timerp
+           6   0%                         make-closure
+         306   0%                      - forward-sexp
+         297   0%                         seed7--forward-sexp-function
+          92   0%                      - seed7-line-inside-syntax-parens-pair
+          89   0%                       - syntax-ppss
+          89   0%                          parse-partial-sexp
+           1   0%                         seed7-move-to-line
+           1   0%                       - forward-sexp
+           1   0%                          seed7--forward-sexp-function
+           1   0%                        seed7--paren-pair-string
+       25179   8%                    - seed7-line-inside-a-block-cached
+       25175   8%                     - seed7-line-inside-a-block
+       18411   5%                      - seed7--safe-enclosing-block-bounds
+       16809   5%                       - seed7--block-end-pos-for
+       16804   5%                        - seed7-to-block-forward
+       15570   5%                         - seed7-end-of-defun
+       14809   4%                          - seed7-top-block-name
+       14783   4%                           - seed7--to-top
+       14716   4%                            - seed7-re-search-backward
+       12702   4%                             - seed7-inside-comment-p
+       12689   4%                              - syntax-ppss
+       12523   4%                                 parse-partial-sexp
+         134   0%                               - syntax-propertize
+         102   0%                                  seed7-mode-syntax-propertize
+           5   0%                                 syntax-ppss--update-stats
+           5   0%                                 make-closure
+           4   0%                                 #<byte-code-function F34>
+           4   0%                                 syntax-ppss--data
+           2   0%                                 syntax-table
+           2   0%                                 syntax-ppss-toplevel-pos
+           2   0%                                 set-syntax-table
+        1509   0%                             - run-with-timer
+        1508   0%                              - run-at-time
+         927   0%                               - timer-activate
+         925   0%                                - timer--activate
+         920   0%                                 - timer--time-less-p
+          17   0%                                    timer--time
+         390   0%                               - timer-set-time
+         389   0%                                - timer--time-setter
+           2   0%                                   timerp
+         186   0%                                 timer-relative-time
+           4   0%                                 timer-create
+         363   0%                               re-search-backward
+          85   0%                             - seed7-inside-string-p
+          64   0%                              - syntax-ppss
+          32   0%                                 parse-partial-sexp
+           7   0%                                 syntax-ppss--data
+           5   0%                               - #<byte-code-function AE7>
+           1   0%                                  set-syntax-table
+           4   0%                                 make-closure
+           3   0%                                 syntax-propertize
+           2   0%                                 syntax-table
+           2   0%                                 syntax-ppss--update-stats
+           2   0%                              - #<byte-code-function E7B>
+           1   0%                                 set-match-data
+           6   0%                             - #<byte-code-function 8E7>
+           5   0%                              - cancel-timer
+           1   0%                                 timerp
+           5   0%                               make-closure
+          14   0%                              seed7-to-indent
+           8   0%                            - run-with-timer
+           8   0%                             - run-at-time
+           3   0%                                timer-relative-time
+           3   0%                              - timer-set-time
+           3   0%                                 timer--time-setter
+           2   0%                              - timer-activate
+           2   0%                               - timer--activate
+           2   0%                                  timer--time-less-p
+          26   0%                           - seed7--block-name
+          25   0%                            - seed7-re-search-forward
+           9   0%                             - seed7-inside-comment-p
+           9   0%                              - syntax-ppss
+           9   0%                                 parse-partial-sexp
+           6   0%                             - seed7-inside-string-p
+           6   0%                              - syntax-ppss
+           6   0%                                 parse-partial-sexp
+         712   0%                          - seed7-re-search-forward
+          59   0%                           - seed7-inside-comment-p
+          59   0%                            - syntax-ppss
+          33   0%                               parse-partial-sexp
+          26   0%                             - syntax-propertize
+          18   0%                                seed7-mode-syntax-propertize
+           2   0%                           - seed7-inside-string-p
+           2   0%                            - syntax-ppss
+           2   0%                               parse-partial-sexp
+          49   0%                          - seed7-re-search-backward
+          36   0%                           - seed7-inside-comment-p
+          36   0%                            - syntax-ppss
+          36   0%                               parse-partial-sexp
+           9   0%                           - run-with-timer
+           9   0%                            - run-at-time
+           5   0%                             - timer-activate
+           5   0%                              - timer--activate
+           5   0%                                 timer--time-less-p
+           3   0%                             - timer-set-time
+           3   0%                                timer--time-setter
+           1   0%                               timer-relative-time
+           2   0%                             re-search-backward
+           1   0%                           - seed7-inside-string-p
+           1   0%                            - syntax-ppss
+           1   0%                               syntax-ppss--update-stats
+           1   0%                           - #<byte-code-function C87>
+           1   0%                              cancel-timer
+         699   0%                         - seed7-re-search-forward
+         426   0%                          - seed7-inside-comment-p
+         422   0%                           - syntax-ppss
+         288   0%                              parse-partial-sexp
+         124   0%                            - syntax-propertize
+         101   0%                               seed7-mode-syntax-propertize
+           1   0%                               #<byte-code-function B6B>
+           4   0%                              make-closure
+           2   0%                            - #<byte-code-function ABF>
+           1   0%                               set-syntax-table
+           1   0%                              syntax-table
+           1   0%                              syntax-ppss--update-stats
+         115   0%                          - seed7-inside-string-p
+         110   0%                           - syntax-ppss
+         109   0%                              parse-partial-sexp
+         414   0%                         - seed7--current-line-nth-word
+         294   0%                          - thing-at-point
+         282   0%                           - bounds-of-thing-at-point
+         144   0%                            - #<byte-code-function 238>
+         143   0%                             - forward-thing
+         105   0%                                forward-word
+          22   0%                                format
+           5   0%                                intern-soft
+           1   0%                                functionp
+          66   0%                            - #<byte-code-function CD4>
+          66   0%                             - forward-thing
+          54   0%                                forward-word
+          10   0%                                format
+           1   0%                                intern-soft
+          18   0%                              re-search-forward
+          16   0%                              make-closure
+          10   0%                            - seq-some
+           4   0%                               make-closure
+           1   0%                               seq-do
+          49   0%                         - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          25   0%                          - seed7-inside-comment-p
+          23   0%                           - syntax-ppss
+          18   0%                              parse-partial-sexp
+           2   0%                              make-closure
+           1   0%                              set-syntax-table
+           1   0%                              #<byte-code-function 885>
+          13   0%                          - seed7-inside-line-indent-before-comment-p
+           8   0%                             seed7-to-indent
+           2   0%                           - seed7-inside-comment-p
+           2   0%                            - syntax-ppss
+           2   0%                               parse-partial-sexp
+          22   0%                         - seed7-inside-comment-p
+          20   0%                          - syntax-ppss
+          16   0%                             parse-partial-sexp
+           2   0%                             #<byte-code-function 483>
+           2   0%                             make-closure
+          15   0%                         - seed7-inside-line-indent-before-comment-p
+           4   0%                            seed7-to-indent
+          10   0%                           seed7--end-regexp-for
+           1   0%                        - seed7-re-search-forward-closest
+           1   0%                         - seq-filter
+           1   0%                            make-closure
+           1   0%                        - seed7-to-next-line-starts-with
+           1   0%                         - seed7-re-search-forward
+           1   0%                          - seed7-inside-string-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+        1598   0%                       - seed7-to-block-backward
+        1172   0%                        - seed7-re-search-backward
+         765   0%                         - run-with-timer
+         764   0%                          - run-at-time
+         516   0%                           - timer-activate
+         516   0%                            - timer--activate
+         513   0%                             - timer--time-less-p
+           3   0%                                timer--time
+           1   0%                               timerp
+         193   0%                           - timer-set-time
+         193   0%                              timer--time-setter
+          55   0%                             timer-relative-time
+         216   0%                         - seed7-inside-comment-p
+         214   0%                          - syntax-ppss
+         208   0%                             parse-partial-sexp
+           1   0%                             syntax-ppss--data
+           1   0%                             make-closure
+           1   0%                           - #<byte-code-function 949>
+           1   0%                              set-syntax-table
+           1   0%                             syntax-ppss--update-stats
+         154   0%                           re-search-backward
+          25   0%                         - seed7-inside-string-p
+          18   0%                          - syntax-ppss
+          11   0%                             parse-partial-sexp
+           3   0%                             #<byte-code-function 0BB>
+           1   0%                             syntax-ppss--update-stats
+           1   0%                             syntax-propertize
+           4   0%                         - #<byte-code-function 9FCA>
+           3   0%                            cancel-timer
+           1   0%                           make-closure
+         236   0%                        - seed7--current-line-nth-word
+         191   0%                         - thing-at-point
+         175   0%                          - bounds-of-thing-at-point
+          98   0%                           - #<byte-code-function 4A8>
+          96   0%                            - forward-thing
+          72   0%                               forward-word
+          21   0%                               format
+           2   0%                               intern-soft
+          38   0%                           - #<byte-code-function 82D>
+          38   0%                            - forward-thing
+          27   0%                               forward-word
+           7   0%                               format
+           2   0%                               intern-soft
+          11   0%                             re-search-forward
+          10   0%                             make-closure
+           4   0%                           - seq-some
+           1   0%                              seq-do
+         114   0%                        - seed7-inside-comment-p
+         114   0%                         - syntax-ppss
+         112   0%                            parse-partial-sexp
+           1   0%                            make-closure
+          55   0%                        - seed7-inside-line-indent-before-comment-p
+          30   0%                         - seed7-inside-comment-p
+          29   0%                          - syntax-ppss
+          21   0%                             parse-partial-sexp
+           2   0%                           - #<byte-code-function 3CB>
+           1   0%                              set-syntax-table
+           1   0%                             make-closure
+          11   0%                           seed7-to-indent
+          10   0%                          seed7--start-regexp-for
+        5133   1%                      - seed7-re-search-backward
+        4173   1%                       - seed7-inside-comment-p
+        4172   1%                        - syntax-ppss
+        4153   1%                           parse-partial-sexp
+           3   0%                           make-closure
+           3   0%                           syntax-ppss--update-stats
+           2   0%                           syntax-ppss-toplevel-pos
+           1   0%                           syntax-propertize
+           1   0%                           syntax-table
+         788   0%                       - run-with-timer
+         788   0%                        - run-at-time
+         519   0%                         - timer-activate
+         519   0%                          - timer--activate
+         516   0%                           - timer--time-less-p
+           7   0%                              timer--time
+           1   0%                             timerp
+         204   0%                         - timer-set-time
+         204   0%                            timer--time-setter
+          64   0%                           timer-relative-time
+           1   0%                           timer-create
+         138   0%                         re-search-backward
+          29   0%                       - seed7-inside-string-p
+          22   0%                        - syntax-ppss
+          14   0%                           parse-partial-sexp
+           2   0%                           #<byte-code-function 627>
+           2   0%                           syntax-ppss--update-stats
+           1   0%                           make-closure
+           1   0%                         make-closure
+           1   0%                       - #<byte-code-function 582>
+           1   0%                        - cancel-timer
+           1   0%                           timerp
+        1561   0%                      - seed7-calc-indent
+         950   0%                       - seed7-line-inside-parens-pair-column
+         950   0%                        - seed7-line-inside-parens-pair
+         906   0%                         - seed7-re-search-backward
+         734   0%                          - seed7-inside-comment-p
+         734   0%                           - syntax-ppss
+         730   0%                              parse-partial-sexp
+           1   0%                              #<byte-code-function 7AE>
+         151   0%                          - run-with-timer
+         151   0%                           - run-at-time
+          86   0%                            - timer-activate
+          86   0%                             - timer--activate
+          86   0%                              - timer--time-less-p
+           2   0%                                 timer--time
+          43   0%                            - timer-set-time
+          43   0%                               timer--time-setter
+          21   0%                              timer-relative-time
+           1   0%                              timer-create
+          14   0%                          - seed7-inside-string-p
+           9   0%                           - syntax-ppss
+           5   0%                              parse-partial-sexp
+           3   0%                              syntax-ppss--data
+           1   0%                              #<byte-code-function C955>
+           2   0%                           - #<byte-code-function 54A>
+           1   0%                              set-match-data
+           5   0%                            re-search-backward
+           1   0%                            make-closure
+          13   0%                         - forward-sexp
+          12   0%                            seed7--forward-sexp-function
+         597   0%                       - seed7-line-is-defun-end
+         561   0%                        - seed7-end-of-defun
+         506   0%                         - seed7-top-block-name
+         506   0%                          - seed7--to-top
+         502   0%                           - seed7-re-search-backward
+         440   0%                            - seed7-inside-comment-p
+         439   0%                             - syntax-ppss
+         439   0%                                parse-partial-sexp
+          43   0%                            - run-with-timer
+          43   0%                             - run-at-time
+          26   0%                              - timer-activate
+          26   0%                               - timer--activate
+          26   0%                                  timer--time-less-p
+          10   0%                              - timer-set-time
+          10   0%                                 timer--time-setter
+           7   0%                                timer-relative-time
+          15   0%                              re-search-backward
+           3   0%                            - seed7-inside-string-p
+           2   0%                             - syntax-ppss
+           2   0%                                parse-partial-sexp
+           1   0%                           - run-with-timer
+           1   0%                            - run-at-time
+           1   0%                             - timer-set-time
+           1   0%                                timer--time-setter
+           1   0%                             seed7-to-indent
+          54   0%                         - seed7-re-search-forward
+          13   0%                          - seed7-inside-comment-p
+          12   0%                           - syntax-ppss
+          12   0%                              parse-partial-sexp
+           4   0%                          - seed7-inside-string-p
+           4   0%                           - syntax-ppss
+           4   0%                              parse-partial-sexp
+           1   0%                         - seed7-re-search-backward
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+          36   0%                        - seed7-beg-of-defun
+          28   0%                         - seed7-re-search-backward
+          19   0%                          - seed7-inside-comment-p
+          19   0%                           - syntax-ppss
+          19   0%                              parse-partial-sexp
+           6   0%                            re-search-backward
+           2   0%                          - run-with-timer
+           2   0%                           - run-at-time
+           1   0%                              timer-relative-time
+           1   0%                            - timer-activate
+           1   0%                             - timer--activate
+           1   0%                                timer--time-less-p
+           7   0%                         - seed7-re-search-backward-closest
+           7   0%                          - seed7-re-search-backward
+           6   0%                             re-search-backward
+           1   0%                           - run-with-timer
+           1   0%                            - run-at-time
+           1   0%                             - timer-set-time
+           1   0%                                timer--time-setter
+           1   0%                         - seed7-top-block-name
+           1   0%                            seed7--to-top
+           3   0%                       - seed7-line-after-short-func-end
+           2   0%                        - seed7-move-to-line
+           2   0%                         - seed7-to-previous-non-empty-line
+           2   0%                          - seed7-inside-comment-p
+           2   0%                           - syntax-ppss
+           2   0%                              parse-partial-sexp
+           1   0%                        - seed7-to-block-backward
+           1   0%                         - seed7--current-line-nth-word
+           1   0%                          - thing-at-point
+           1   0%                           - bounds-of-thing-at-point
+           1   0%                            - #<byte-code-function 6DB>
+           1   0%                             - forward-thing
+           1   0%                                format
+           3   0%                       - seed7-line-inside-assign-statement-continuation
+           3   0%                        - seed7-assign-op-pos
+           3   0%                         - seed7-re-search-backward
+           3   0%                          - seed7-inside-comment-p
+           3   0%                           - syntax-ppss
+           3   0%                              parse-partial-sexp
+           3   0%                       - seed7-line-inside-array-definition-block
+           3   0%                        - seed7-re-search-backward
+           3   0%                         - seed7-inside-comment-p
+           3   0%                          - syntax-ppss
+           3   0%                             parse-partial-sexp
+           3   0%                       - seed7-line-inside-set-definition-block
+           3   0%                        - seed7-re-search-backward
+           3   0%                           re-search-backward
+           1   0%                       - seed7-line-at-endof-array-definition-block
+           1   0%                        - backward-sexp
+           1   0%                         - forward-sexp
+           1   0%                          - seed7--forward-sexp-function
+           1   0%                           - seed7--at-set-definition-end-line-p
+           1   0%                            - seed7-line-code-ends-with
+           1   0%                             - seed7-re-search-backward
+           1   0%                              - seed7-inside-string-p
+           1   0%                               - syntax-ppss
+           1   0%                                  parse-partial-sexp
+           1   0%                       - seed7-line-inside-logic-check-expression
+           1   0%                        - seed7-to-previous-line-starts-with
+           1   0%                         - seed7-re-search-backward
+           1   0%                          - run-with-timer
+           1   0%                           - run-at-time
+           1   0%                            - timer-activate
+           1   0%                             - timer--activate
+           1   0%                                timer--time-less-p
+          25   0%                      - replace-regexp-in-string
+           2   0%                         concat
+          10   0%                        match-string
+           2   0%                        seed7--on-lineof
+           1   0%                      - seed7--indent-offset-for
+           1   0%                         string-prefix-p
+           2   0%                       seed7--cached-block-spec-current-line
+        2290   0%                    - seed7-line-inside-set-definition-block
+        2289   0%                     - seed7-re-search-backward
+        2207   0%                        re-search-backward
+          81   0%                      - run-with-timer
+          81   0%                       - run-at-time
+          56   0%                        - timer-activate
+          56   0%                         - timer--activate
+          56   0%                            timer--time-less-p
+          21   0%                        - timer-set-time
+          21   0%                           timer--time-setter
+           4   0%                          timer-relative-time
+           1   0%                       seed7-move-to-line
+         621   0%                    - seed7-line-inside-array-definition-block
+         612   0%                     - seed7-re-search-backward
+         377   0%                      - seed7-inside-comment-p
+         377   0%                       - syntax-ppss
+         376   0%                          parse-partial-sexp
+         167   0%                        re-search-backward
+          59   0%                      - run-with-timer
+          59   0%                       - run-at-time
+          46   0%                        - timer-activate
+          45   0%                         - timer--activate
+          45   0%                            timer--time-less-p
+           9   0%                          timer-relative-time
+           4   0%                        - timer-set-time
+           4   0%                           timer--time-setter
+           8   0%                      - seed7-inside-string-p
+           6   0%                       - syntax-ppss
+           6   0%                          parse-partial-sexp
+           5   0%                     - forward-sexp
+           4   0%                        seed7--forward-sexp-function
+           1   0%                       seed7-move-to-line
+         396   0%                    - seed7-line-inside-assign-statement-continuation
+         364   0%                     - seed7-assign-op-pos
+         363   0%                      - seed7-re-search-backward
+         282   0%                       - seed7-inside-comment-p
+         282   0%                        - syntax-ppss
+         282   0%                           parse-partial-sexp
+          69   0%                       - run-with-timer
+          69   0%                        - run-at-time
+          45   0%                         - timer-activate
+          45   0%                          - timer--activate
+          45   0%                           - timer--time-less-p
+           1   0%                              timer--time
+          17   0%                         - timer-set-time
+          17   0%                            timer--time-setter
+           7   0%                           timer-relative-time
+           7   0%                         re-search-backward
+           5   0%                       - seed7-inside-string-p
+           5   0%                        - syntax-ppss
+           5   0%                           parse-partial-sexp
+          30   0%                     - seed7-statement-end-pos
+          30   0%                      - seed7-forward-char-pos
+          28   0%                       - seed7-re-search-forward
+          15   0%                        - seed7-inside-string-p
+          15   0%                         - syntax-ppss
+          14   0%                            parse-partial-sexp
+           1   0%                            syntax-propertize
+          11   0%                        - seed7-inside-comment-p
+          11   0%                         - syntax-ppss
+          11   0%                            parse-partial-sexp
+           1   0%                       seed7-move-to-line
+         192   0%                    - seed7-line-inside-logic-check-expression
+         142   0%                     - seed7-to-previous-line-starts-with
+         142   0%                      - seed7-re-search-backward
+          67   0%                       - seed7-inside-comment-p
+          67   0%                        - syntax-ppss
+          67   0%                           parse-partial-sexp
+          60   0%                       - run-with-timer
+          60   0%                        - run-at-time
+          36   0%                         - timer-activate
+          36   0%                          - timer--activate
+          36   0%                             timer--time-less-p
+          20   0%                         - timer-set-time
+          19   0%                            timer--time-setter
+           4   0%                           timer-relative-time
+           8   0%                         re-search-backward
+           6   0%                       - seed7-inside-string-p
+           6   0%                        - syntax-ppss
+           5   0%                           parse-partial-sexp
+           1   0%                           #<byte-code-function 452>
+           1   0%                       - #<byte-code-function 53C>
+           1   0%                          cancel-timer
+          41   0%                     - seed7-re-search-forward
+          22   0%                      - seed7-inside-comment-p
+          22   0%                       - syntax-ppss
+          21   0%                          parse-partial-sexp
+           1   0%                          syntax-ppss--update-stats
+          16   0%                      - seed7-inside-string-p
+          16   0%                       - syntax-ppss
+          15   0%                          parse-partial-sexp
+           1   0%                          syntax-propertize
+           7   0%                     - seed7--current-line-nth-word
+           3   0%                      - thing-at-point
+           3   0%                       - bounds-of-thing-at-point
+           3   0%                        - #<byte-code-function 170>
+           3   0%                         - forward-thing
+           2   0%                            forward-word
+           1   0%                            format
+         176   0%                    - seed7--current-line-nth-word
+         172   0%                     - thing-at-point
+         172   0%                      - bounds-of-thing-at-point
+         167   0%                       - #<byte-code-function AFC>
+         167   0%                        - forward-thing
+         167   0%                         - forward-word
+         162   0%                          - internal--syntax-propertize
+         161   0%                           - syntax-propertize
+         134   0%                              seed7-mode-syntax-propertize
+           2   0%                            - #<byte-code-function C57>
+           2   0%                               syntax-propertize-wholelines
+           4   0%                         re-search-forward
+           1   0%                       - #<byte-code-function 40B>
+           1   0%                        - forward-thing
+           1   0%                           forward-word
+         104   0%                    - seed7-line-inside-argument-list-section
+          93   0%                     - seed7-re-search-backward
+          48   0%                      - run-with-timer
+          48   0%                       - run-at-time
+          33   0%                        - timer-activate
+          33   0%                         - timer--activate
+          33   0%                          - timer--time-less-p
+           1   0%                             timer--time
+          11   0%                        - timer-set-time
+          11   0%                           timer--time-setter
+           4   0%                          timer-relative-time
+          44   0%                        re-search-backward
+           9   0%                     - seed7-line-is-procfunc-beg-of-decl
+           9   0%                        seed7-line-starts-with
+           1   0%                     - seed7-forward-char-pos
+           1   0%                      - seed7-re-search-forward
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+          97   0%                    - seed7-line-after-func-return-logic-operator-column
+          91   0%                     - seed7-move-to-line
+          91   0%                      - seed7-to-previous-non-empty-line
+          88   0%                       - seed7-inside-comment-p
+          88   0%                        - syntax-ppss
+          88   0%                           parse-partial-sexp
+          84   0%                    - seed7-line-inside-until-logic-expression
+          84   0%                     - seed7-re-search-backward
+          57   0%                      - run-with-timer
+          57   0%                       - run-at-time
+          41   0%                        - timer-activate
+          41   0%                         - timer--activate
+          41   0%                            timer--time-less-p
+          13   0%                        - timer-set-time
+          13   0%                           timer--time-setter
+           3   0%                          timer-relative-time
+          27   0%                        re-search-backward
+          76   0%                    - seed7-line-inside-func-return-statement
+          76   0%                     - seed7-re-search-backward
+          49   0%                      - run-with-timer
+          49   0%                       - run-at-time
+          33   0%                        - timer-activate
+          33   0%                         - timer--activate
+          33   0%                            timer--time-less-p
+          12   0%                        - timer-set-time
+          12   0%                           timer--time-setter
+           4   0%                          timer-relative-time
+          26   0%                        re-search-backward
+           1   0%                        make-closure
+          39   0%                    - seed7-current-line-start-inside-comment-p
+          39   0%                     - seed7-inside-comment-p
+          39   0%                      - syntax-ppss
+          36   0%                         parse-partial-sexp
+           1   0%                         make-closure
+          27   0%                    - seed7-comment-column
+          23   0%                     - seed7-calc-indent
+           6   0%                      - seed7-line-inside-parens-pair-column
+           6   0%                       - seed7-line-inside-parens-pair
+           5   0%                        - seed7-re-search-backward
+           4   0%                         - seed7-inside-comment-p
+           4   0%                          - syntax-ppss
+           4   0%                             parse-partial-sexp
+           1   0%                         - run-with-timer
+           1   0%                          - run-at-time
+           1   0%                           - timer-set-time
+           1   0%                              timer--time-setter
+           1   0%                        - seed7-line-inside-syntax-parens-pair
+           1   0%                           syntax-ppss
+           4   0%                      - seed7-line-inside-a-block-cached
+           4   0%                       - seed7-line-inside-a-block
+           2   0%                        - seed7--safe-enclosing-block-bounds
+           2   0%                         - seed7-to-block-backward
+           1   0%                          - seed7-re-search-backward
+           1   0%                           - seed7-inside-comment-p
+           1   0%                            - syntax-ppss
+           1   0%                               parse-partial-sexp
+           1   0%                            seed7--current-line-nth-word
+           1   0%                        - seed7-re-search-backward
+           1   0%                         - run-with-timer
+           1   0%                          - run-at-time
+           1   0%                           - timer-activate
+           1   0%                            - timer--activate
+           1   0%                               timer--time-less-p
+           1   0%                          seed7--on-lineof
+           3   0%                      - seed7-line-is-defun-end
+           2   0%                       - seed7-move-to-line
+           2   0%                        - seed7-to-previous-non-empty-line
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           1   0%                       - seed7--safe-current-line-defun-start-indent
+           1   0%                        - seed7-to-block-backward
+           1   0%                         - seed7-re-search-backward
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           2   0%                      - seed7-line-starts-with-open-paren-after-logic-operator
+           2   0%                       - seed7-move-to-line
+           2   0%                        - seed7-to-previous-non-empty-line
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           2   0%                      - seed7-line-after-func-return-logic-operator-column
+           2   0%                       - seed7-move-to-line
+           2   0%                        - seed7-to-previous-non-empty-line
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           2   0%                      - seed7-line-inside-set-definition-block
+           2   0%                       - seed7-re-search-backward
+           2   0%                          re-search-backward
+           1   0%                      - seed7-line-after-short-func-end
+           1   0%                       - seed7-move-to-line
+           1   0%                        - seed7-to-previous-non-empty-line
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                      - seed7-line-at-endof-set-definition-block
+           1   0%                       - seed7-move-to-line
+           1   0%                        - seed7-to-previous-non-empty-line
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                      - seed7-line-at-endof-array-definition-block
+           1   0%                       - seed7-move-to-line
+           1   0%                        - seed7-to-previous-non-empty-line
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                      - seed7-line-inside-array-definition-block
+           1   0%                       - seed7-re-search-backward
+           1   0%                        - seed7-inside-comment-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+           3   0%                     - seed7-line-code-ends-with
+           3   0%                      - seed7-move-to-line
+           3   0%                       - seed7-to-previous-non-empty-line
+           3   0%                        - seed7-inside-comment-p
+           3   0%                         - syntax-ppss
+           3   0%                            parse-partial-sexp
+           1   0%                     - seed7-inside-comment-p
+           1   0%                      - syntax-ppss
+           1   0%                         parse-partial-sexp
+           8   0%                    - seed7-line-at-endof-array-definition-block
+           5   0%                     - backward-sexp
+           5   0%                      - forward-sexp
+           5   0%                       - seed7--forward-sexp-function
+           3   0%                        - seed7--at-set-definition-end-line-p
+           3   0%                         - seed7-line-code-ends-with
+           3   0%                          - seed7-re-search-backward
+           2   0%                           - run-with-timer
+           2   0%                            - run-at-time
+           2   0%                             - timer-activate
+           2   0%                              - timer--activate
+           2   0%                                 timer--time-less-p
+           1   0%                           - seed7-inside-string-p
+           1   0%                            - syntax-ppss
+           1   0%                               parse-partial-sexp
+           1   0%                        - seed7--at-array-definition-end-line-p
+           1   0%                         - seed7-line-code-ends-with
+           1   0%                          - seed7-re-search-backward
+           1   0%                           - run-with-timer
+           1   0%                            - run-at-time
+           1   0%                             - timer-activate
+           1   0%                              - timer--activate
+           1   0%                                 timer--time-less-p
+           2   0%                     - seed7-re-search-backward
+           1   0%                      - seed7-inside-comment-p
+           1   0%                       - syntax-ppss
+           1   0%                          parse-partial-sexp
+           1   0%                      - seed7-inside-string-p
+           1   0%                       - syntax-ppss
+           1   0%                          parse-partial-sexp
+           1   0%                     - seed7-line-code-ends-with
+           1   0%                      - seed7-re-search-backward
+           1   0%                       - run-with-timer
+           1   0%                        - run-at-time
+           1   0%                         - timer-activate
+           1   0%                          - timer--activate
+           1   0%                             timer--time-less-p
+           7   0%                    - seed7-line-after-short-func-end
+           5   0%                     - seed7-move-to-line
+           5   0%                      - seed7-to-previous-non-empty-line
+           5   0%                       - seed7-inside-comment-p
+           5   0%                        - syntax-ppss
+           3   0%                           parse-partial-sexp
+           2   0%                         - syntax-propertize
+           2   0%                            seed7-mode-syntax-propertize
+           2   0%                     - seed7-to-block-backward
+           1   0%                      - seed7-inside-comment-p
+           1   0%                       - syntax-ppss
+           1   0%                          parse-partial-sexp
+           1   0%                      - seed7--current-line-nth-word
+           1   0%                       - thing-at-point
+           1   0%                        - bounds-of-thing-at-point
+           1   0%                           re-search-forward
+           3   0%                    - seed7-line-inside-nested-parens-pairs-column
+           3   0%                     - seed7-line-inside-nested-parens-pairs
+           3   0%                      - seed7-line-inside-parens-pair
+           2   0%                       - seed7-re-search-backward
+           1   0%                        - seed7-inside-comment-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+           1   0%                        - run-with-timer
+           1   0%                         - run-at-time
+           1   0%                          - timer-activate
+           1   0%                           - timer--activate
+           1   0%                              timer--time-less-p
+           1   0%                       - seed7-line-inside-syntax-parens-pair
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           3   0%                    - seed7-line-starts-with
+           1   0%                       seed7-move-to-line
+           1   0%                    - seed7-line-at-endof-set-definition-block
+           1   0%                     - seed7-line-code-ends-with
+           1   0%                      - seed7-re-search-backward
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           1   0%                    - seed7-line-isa-string
+           1   0%                     - seed7-line-starts-with
+           1   0%                        seed7-move-to-line
+           1   0%                      seed7--cached-block-bounds
+          12   0%                   - jit-lock-after-change
+           7   0%                      font-lock-extend-jit-lock-region-after-change
+           1   0%                      #<byte-code-function 6F5>
+           9   0%                   - #<byte-code-function EAE>
+           9   0%                    - filter-buffer-substring
+           9   0%                     - buffer-substring--filter
+           9   0%                      - #<byte-code-function BD8>
+           9   0%                       - apply
+           9   0%                          #<byte-code-function 954>
+           1   0%                     undo-auto--undoable-change
+           1   0%                     syntax-ppss-flush-cache
+           1   0%                     flyspell-after-change-function
+       21082   6%   Automatic GC

--- a/reports/19.1/chkarr.sd7-perf-mem.txt
+++ b/reports/19.1/chkarr.sd7-perf-mem.txt
@@ -1,0 +1,1554 @@
+  6,222,349,488  99% - ...
+  6,222,349,488  99%  - call-interactively
+  6,222,349,488  99%   - apply
+  6,222,349,488  99%    - call-interactively@ido-cr+-record-current-command
+  6,222,349,488  99%     - #<primitive-function call-interactively>
+  6,222,349,488  99%      - funcall-interactively
+  6,222,349,488  99%       - smex
+  6,222,349,488  99%        - smex-read-and-run
+  6,222,349,488  99%         - execute-extended-command
+  6,222,349,488  99%          - command-execute
+  6,222,349,488  99%           - call-interactively
+  6,222,349,488  99%            - apply
+  6,222,349,488  99%             - call-interactively@ido-cr+-record-current-command
+  6,222,349,488  99%              - #<primitive-function call-interactively>
+  6,222,349,488  99%               - funcall-interactively
+  6,222,349,488  99%                - pel-profile
+  6,220,708,868  99%                 - call-interactively
+  6,220,708,868  99%                  - apply
+  6,220,708,868  99%                   - call-interactively@ido-cr+-record-current-command
+  6,220,708,868  99%                    - #<primitive-function call-interactively>
+  6,220,708,868  99%                     - funcall-interactively
+  6,220,708,852  99%                      - seed7-complete-statement-or-indent
+  6,220,708,852  99%                       - seed7-indent-region
+  6,220,708,852  99%                        - seed7--indent-one-line
+  6,214,647,028  99%                         - seed7-calc-indent
+  3,772,104,872  60%                          - seed7-line-is-defun-end
+  3,677,067,090  59%                           - seed7-end-of-defun
+  3,632,073,759  58%                            - seed7-top-block-name
+  3,624,943,114  58%                             - seed7--to-top
+  3,613,616,362  58%                              - seed7-re-search-backward
+  2,775,400,346  44%                               - run-with-timer
+  2,775,400,346  44%                                - run-at-time
+  1,361,857,304  21%                                 - timer-activate
+  1,361,857,304  21%                                  - timer--activate
+  1,361,693,344  21%                                   - timer--time-less-p
+      3,476,116   0%                                      timer--time
+    736,713,672  11%                                   timer-relative-time
+    519,154,278   8%                                 - timer-set-time
+    519,154,168   8%                                    timer--time-setter
+    157,675,056   2%                                   timer-create
+             36   0%                                   timer-set-function
+    555,374,936   8%                               - seed7-inside-string-p
+     69,268,056   1%                                - syntax-ppss
+     66,395,168   1%                                   make-closure
+      2,872,888   0%                                 - parse-partial-sexp
+      1,462,832   0%                                  - internal--syntax-propertize
+      1,040,144   0%                                   - syntax-propertize
+        505,568   0%                                      seed7-mode-syntax-propertize
+    172,134,411   2%                               - seed7-inside-comment-p
+     67,349,227   1%                                - syntax-ppss
+     63,345,184   1%                                   make-closure
+      2,495,174   0%                                 - syntax-propertize
+      1,964,742   0%                                  - seed7-mode-syntax-propertize
+             14   0%                                     #<byte-code-function 9FF>
+      1,246,096   0%                                   parse-partial-sexp
+            437   0%                                   #<byte-code-function A31>
+    110,574,513   1%                                 make-closure
+            988   0%                                 re-search-backward
+     10,310,384   0%                              - run-with-timer
+     10,310,384   0%                               - run-at-time
+      5,131,648   0%                                - timer-activate
+      5,131,648   0%                                 - timer--activate
+      5,131,648   0%                                    timer--time-less-p
+      2,780,384   0%                                  timer-relative-time
+      1,843,056   0%                                - timer-set-time
+      1,843,056   0%                                   timer--time-setter
+        555,296   0%                                  timer-create
+        360,528   0%                                make-closure
+      6,852,997   0%                             - seed7--block-name
+      5,624,053   0%                              - seed7-re-search-forward
+      3,696,448   0%                               - seed7-inside-string-p
+        277,648   0%                                - syntax-ppss
+        277,648   0%                                   make-closure
+      1,927,605   0%                               - seed7-inside-comment-p
+      1,811,573   0%                                - syntax-ppss
+      1,074,661   0%                                 - syntax-propertize
+        846,741   0%                                    seed7-mode-syntax-propertize
+        671,328   0%                                   make-closure
+         65,584   0%                                   parse-partial-sexp
+        497,704   0%                                match-string
+     21,931,977   0%                            - seed7-re-search-forward
+     14,672,721   0%                             - seed7-inside-comment-p
+     14,150,577   0%                              - syntax-ppss
+     13,682,305   0%                               - syntax-propertize
+     12,915,665   0%                                  seed7-mode-syntax-propertize
+        468,272   0%                                 make-closure
+      2,324,784   0%                             - seed7-inside-string-p
+        401,968   0%                              - syntax-ppss
+        401,968   0%                                 make-closure
+     14,939,480   0%                            - seed7-re-search-backward
+     10,352,432   0%                             - run-with-timer
+     10,352,432   0%                              - run-at-time
+      5,082,528   0%                               - timer-activate
+      5,082,528   0%                                - timer--activate
+      5,082,528   0%                                   timer--time-less-p
+      2,780,384   0%                                 timer-relative-time
+      1,884,496   0%                               - timer-set-time
+      1,884,496   0%                                  timer--time-setter
+        605,024   0%                                 timer-create
+      3,472,672   0%                             - seed7-inside-string-p
+        215,488   0%                              - syntax-ppss
+        215,488   0%                                 make-closure
+        625,384   0%                             - seed7-inside-comment-p
+        289,720   0%                              - syntax-ppss
+        256,928   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+        488,992   0%                               make-closure
+      1,130,552   0%                              match-string
+        208,744   0%                              match-string-no-properties
+     60,157,925   0%                           - seed7-beg-of-defun
+     16,934,420   0%                            - seed7-top-block-name
+      8,829,461   0%                             - seed7--to-top
+      6,031,061   0%                              - seed7-re-search-backward
+      2,630,560   0%                               - run-with-timer
+      2,630,560   0%                                - run-at-time
+      1,301,472   0%                                 - timer-activate
+      1,301,472   0%                                  - timer--activate
+      1,301,472   0%                                     timer--time-less-p
+        702,848   0%                                   timer-relative-time
+        456,336   0%                                 - timer-set-time
+        456,336   0%                                    timer--time-setter
+        169,904   0%                                   timer-create
+      2,575,845   0%                                 re-search-backward
+        468,272   0%                               - seed7-inside-string-p
+         78,736   0%                                - syntax-ppss
+         78,736   0%                                   make-closure
+        219,632   0%                               - seed7-inside-comment-p
+        120,176   0%                                - syntax-ppss
+        120,176   0%                                   make-closure
+        136,752   0%                                 make-closure
+      2,690,656   0%                              - run-with-timer
+      2,690,656   0%                               - run-at-time
+      1,340,848   0%                                - timer-activate
+      1,340,848   0%                                 - timer--activate
+      1,340,848   0%                                    timer--time-less-p
+        702,848   0%                                  timer-relative-time
+        493,632   0%                                - timer-set-time
+        493,632   0%                                   timer--time-setter
+        153,328   0%                                  timer-create
+        107,744   0%                                make-closure
+      8,042,799   0%                             - seed7--block-name
+      7,957,775   0%                              - seed7-re-search-forward
+         91,168   0%                               - seed7-inside-string-p
+         16,576   0%                                - syntax-ppss
+         16,576   0%                                   make-closure
+         12,432   0%                               - seed7-inside-comment-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+          4,192   0%                                match-string
+     13,645,976   0%                            - seed7-re-search-backward-closest
+     13,368,328   0%                             - seed7-re-search-backward
+      7,965,696   0%                                re-search-backward
+      5,220,296   0%                              - run-with-timer
+      5,220,296   0%                               - run-at-time
+      2,587,704   0%                                - timer-activate
+      2,587,704   0%                                 - timer--activate
+      2,587,704   0%                                  - timer--time-less-p
+         32,792   0%                                     timer--time
+      1,415,408   0%                                  timer-relative-time
+        943,680   0%                                - timer-set-time
+        943,680   0%                                   timer--time-setter
+        273,504   0%                                  timer-create
+        182,336   0%                                make-closure
+        145,040   0%                             - seq-filter
+        145,040   0%                                make-closure
+     11,868,504   0%                            - seed7-re-search-backward
+      5,270,128   0%                             - run-with-timer
+      5,270,128   0%                              - run-at-time
+      2,617,408   0%                               - timer-activate
+      2,617,408   0%                                - timer--activate
+      2,617,408   0%                                   timer--time-less-p
+      1,437,904   0%                                 timer-relative-time
+        982,752   0%                               - timer-set-time
+        982,752   0%                                  timer--time-setter
+        232,064   0%                                 timer-create
+      4,998,792   0%                               re-search-backward
+      1,073,296   0%                             - seed7-inside-string-p
+        223,776   0%                              - syntax-ppss
+        223,776   0%                                 make-closure
+        352,240   0%                             - seed7-inside-comment-p
+        174,048   0%                              - syntax-ppss
+        174,048   0%                                 make-closure
+        174,048   0%                               make-closure
+        290,768   0%                              match-string
+        203,704   0%                              match-string-no-properties
+     18,422,351   0%                           - seed7-line-starts-with-any
+     18,422,351   0%                              seed7-line-starts-with
+      8,505,616   0%                           - seed7--current-line-nth-word
+      7,925,456   0%                            - thing-at-point
+      7,398,224   0%                             - bounds-of-thing-at-point
+      2,635,584   0%                                make-closure
+      1,269,288   0%                              - #<byte-code-function A74>
+      1,269,288   0%                               - forward-thing
+      1,269,288   0%                                  format
+      1,237,512   0%                                re-search-forward
+        882,672   0%                              - seq-some
+        882,672   0%                                 make-closure
+        502,928   0%                              - #<byte-code-function 621>
+        502,928   0%                               - forward-thing
+        502,928   0%                                  format
+      7,101,424   0%                           - seed7-move-to-line
+      7,101,424   0%                            - seed7-to-previous-non-empty-line
+        555,296   0%                             - seed7-inside-comment-p
+        360,528   0%                              - syntax-ppss
+        360,528   0%                                 make-closure
+        328,322   0%                           - seed7--safe-current-line-defun-start-indent
+        324,178   0%                            - seed7-to-block-backward
+        237,266   0%                             - seed7-re-search-backward
+         97,304   0%                              - run-with-timer
+         97,304   0%                               - run-at-time
+         46,216   0%                                - timer-activate
+         46,216   0%                                 - timer--activate
+         46,216   0%                                    timer--time-less-p
+         31,312   0%                                  timer-relative-time
+         19,776   0%                                - timer-set-time
+         19,776   0%                                   timer--time-setter
+         86,090   0%                                re-search-backward
+         45,584   0%                              - seed7-inside-string-p
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+          8,288   0%                                seed7-inside-comment-p
+         70,336   0%                             - seed7--current-line-nth-word
+         66,192   0%                              - thing-at-point
+         55,912   0%                               - bounds-of-thing-at-point
+         29,008   0%                                  make-closure
+         13,424   0%                                - #<byte-code-function F88>
+         13,424   0%                                 - forward-thing
+         13,424   0%                                    format
+          4,144   0%                                - seq-some
+          4,144   0%                                   make-closure
+          1,048   0%                                - #<byte-code-function 930>
+          1,048   0%                                 - forward-thing
+          1,048   0%                                    format
+         12,432   0%                               seed7-inside-line-indent-before-comment-p
+          4,144   0%                               seed7-inside-comment-p
+  1,203,046,712  19%                          - seed7-line-inside-parens-pair-column
+  1,203,046,712  19%                           - seed7-line-inside-parens-pair
+  1,197,345,990  19%                            - seed7-re-search-backward
+    942,232,506  15%                             - run-with-timer
+    942,232,506  15%                              - run-at-time
+    465,418,549   7%                               - timer-activate
+    465,418,549   7%                                - timer--activate
+    465,418,549   7%                                 - timer--time-less-p
+        571,080   0%                                    timer--time
+    251,602,076   4%                                 timer-relative-time
+    170,938,715   2%                               - timer-set-time
+    170,934,880   2%                                  timer--time-setter
+     54,265,680   0%                                 timer-create
+          7,486   0%                                 timer-set-function
+    143,310,305   2%                             - seed7-inside-string-p
+     40,378,209   0%                              - syntax-ppss
+     39,985,456   0%                                 make-closure
+        360,712   0%                                 parse-partial-sexp
+         15,846   0%                                 #<byte-code-function 0FB>
+          3,476   0%                                 syntax-table
+     69,926,621   1%                             - seed7-inside-comment-p
+     42,936,749   0%                              - syntax-ppss
+     42,703,920   0%                                 make-closure
+        196,752   0%                                 parse-partial-sexp
+         22,380   0%                                 #<byte-code-function CC5>
+         11,633   0%                                 syntax-table
+     35,592,484   0%                               make-closure
+      6,284,074   0%                               re-search-backward
+      4,555,810   0%                            - forward-sexp
+      4,552,272   0%                               seed7--forward-sexp-function
+        596,640   0%                            - seed7-line-inside-syntax-parens-pair
+        248,640   0%                             - syntax-ppss
+        248,640   0%                                make-closure
+          8,192   0%                             - forward-sexp
+          8,192   0%                                seed7--forward-sexp-function
+    981,796,087  15%                          - seed7-line-inside-a-block-cached
+    981,447,991  15%                           - seed7-line-inside-a-block
+    767,663,432  12%                            - seed7--safe-enclosing-block-bounds
+    505,206,198   8%                             - seed7--block-end-pos-for
+    504,921,342   8%                              - seed7-to-block-forward
+    292,765,814   4%                               - seed7-end-of-defun
+    289,935,775   4%                                - seed7-top-block-name
+    289,135,404   4%                                 - seed7--to-top
+    287,852,308   4%                                  - seed7-re-search-backward
+    219,588,237   3%                                   - run-with-timer
+    219,588,237   3%                                    - run-at-time
+    105,592,920   1%                                     - timer-activate
+    105,592,920   1%                                      - timer--activate
+    105,527,336   1%                                       - timer--time-less-p
+        787,064   0%                                          timer--time
+     59,341,965   0%                                       timer-relative-time
+     41,454,072   0%                                     - timer-set-time
+     41,454,072   0%                                        timer--time-setter
+     13,198,640   0%                                       timer-create
+            640   0%                                       timer-set-function
+     45,637,991   0%                                   - seed7-inside-string-p
+      6,214,135   0%                                    - syntax-ppss
+      5,867,904   0%                                       make-closure
+        344,496   0%                                     - parse-partial-sexp
+         16,576   0%                                      - internal--syntax-propertize
+         12,432   0%                                         syntax-propertize
+            379   0%                                       syntax-table
+     14,312,525   0%                                   - seed7-inside-comment-p
+      6,074,253   0%                                    - syntax-ppss
+      5,610,976   0%                                       make-closure
+        262,336   0%                                       parse-partial-sexp
+        102,532   0%                                     - syntax-propertize
+         90,100   0%                                        seed7-mode-syntax-propertize
+             33   0%                                       #<byte-code-function 1FC>
+      8,171,968   0%                                     make-closure
+        106,168   0%                                     re-search-backward
+      1,122,920   0%                                  - run-with-timer
+      1,122,920   0%                                   - run-at-time
+        512,000   0%                                    - timer-activate
+        512,000   0%                                     - timer--activate
+        512,000   0%                                        timer--time-less-p
+        285,760   0%                                      timer-relative-time
+        233,992   0%                                    - timer-set-time
+        233,992   0%                                       timer--time-setter
+         91,168   0%                                      timer-create
+         29,008   0%                                    make-closure
+        746,499   0%                                 - seed7--block-name
+        615,859   0%                                  - seed7-re-search-forward
+        252,784   0%                                   - seed7-inside-string-p
+         33,152   0%                                    - syntax-ppss
+         33,152   0%                                       make-closure
+        116,032   0%                                   - seed7-inside-comment-p
+         87,024   0%                                    - syntax-ppss
+         78,736   0%                                       make-closure
+          8,288   0%                                     - syntax-propertize
+          8,288   0%                                        seed7-mode-syntax-propertize
+         41,936   0%                                    match-string
+      1,566,480   0%                                - seed7-re-search-backward
+      1,036,048   0%                                 - run-with-timer
+      1,036,048   0%                                  - run-at-time
+        482,784   0%                                   - timer-activate
+        482,784   0%                                    - timer--activate
+        482,784   0%                                       timer--time-less-p
+        285,760   0%                                     timer-relative-time
+        201,200   0%                                   - timer-set-time
+        201,200   0%                                      timer--time-setter
+         66,304   0%                                     timer-create
+        422,688   0%                                 - seed7-inside-string-p
+         37,296   0%                                  - syntax-ppss
+         37,296   0%                                     make-closure
+         82,880   0%                                 - seed7-inside-comment-p
+         41,440   0%                                  - syntax-ppss
+         41,440   0%                                     make-closure
+         24,864   0%                                   make-closure
+        838,311   0%                                - seed7-re-search-forward
+        332,763   0%                                 - seed7-inside-comment-p
+        299,611   0%                                  - syntax-ppss
+        258,171   0%                                   - syntax-propertize
+        254,027   0%                                      seed7-mode-syntax-propertize
+         41,440   0%                                     make-closure
+        174,048   0%                                 - seed7-inside-string-p
+         45,584   0%                                  - syntax-ppss
+         45,584   0%                                     make-closure
+         68,952   0%                                  match-string
+    124,870,195   2%                               - seed7--current-line-nth-word
+    116,283,287   1%                                - thing-at-point
+    105,640,943   1%                                 - bounds-of-thing-at-point
+     43,507,856   0%                                    make-closure
+     21,171,284   0%                                  - #<byte-code-function 353>
+     21,163,056   0%                                   - forward-thing
+     21,163,056   0%                                      format
+     15,826,038   0%                                  - seq-some
+     15,821,792   0%                                     make-closure
+     10,405,895   0%                                  - #<byte-code-function CC6>
+     10,402,608   0%                                   - forward-thing
+     10,402,608   0%                                      format
+      1,166,558   0%                                    re-search-forward
+     45,625,363   0%                               - seed7-re-search-forward
+     19,493,360   0%                                - seed7-inside-string-p
+      4,914,768   0%                                 - syntax-ppss
+      4,881,632   0%                                    make-closure
+         32,792   0%                                    parse-partial-sexp
+     16,925,395   0%                                - seed7-inside-comment-p
+     13,933,427   0%                                 - syntax-ppss
+     10,012,805   0%                                  - syntax-propertize
+      9,635,701   0%                                     seed7-mode-syntax-propertize
+      3,887,072   0%                                    make-closure
+         32,792   0%                                    parse-partial-sexp
+            758   0%                                    #<byte-code-function DE1>
+     22,464,887   0%                               - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+      6,999,216   0%                                - seed7-inside-line-indent-before-comment-p
+         82,880   0%                                 - seed7-inside-comment-p
+         16,576   0%                                  - syntax-ppss
+         16,576   0%                                     make-closure
+      6,609,975   0%                                - seed7-inside-comment-p
+      3,787,911   0%                                 - syntax-ppss
+      3,779,328   0%                                    make-closure
+          8,583   0%                                    #<byte-code-function F74>
+      6,568,240   0%                               - seed7-inside-line-indent-before-comment-p
+        111,888   0%                                - seed7-inside-comment-p
+         62,160   0%                                 - syntax-ppss
+         62,160   0%                                    make-closure
+      5,611,641   0%                                 seed7--end-regexp-for
+      5,535,794   0%                               - seed7-inside-comment-p
+      3,848,376   0%                                - syntax-ppss
+      3,841,488   0%                                   make-closure
+          2,663   0%                                   #<byte-code-function 031>
+         82,608   0%                              - seed7-to-next-line-starts-with
+         78,464   0%                               - seed7-re-search-forward
+         24,864   0%                                - seed7-inside-string-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+          8,288   0%                                  seed7-inside-comment-p
+         22,768   0%                              - seed7-re-search-forward-closest
+         18,624   0%                               - seed7-re-search-forward
+         16,576   0%                                - seed7-inside-string-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+          4,144   0%                               - seq-filter
+          4,144   0%                                  make-closure
+    254,238,687   4%                             - seed7-to-block-backward
+    132,383,887   2%                              - seed7-re-search-backward
+     97,962,711   1%                               - run-with-timer
+     97,962,711   1%                                - run-at-time
+     50,166,893   0%                                 - timer-activate
+     50,166,893   0%                                  - timer--activate
+     50,166,893   0%                                   - timer--time-less-p
+            197   0%                                      timer--time
+     26,357,419   0%                                   timer-relative-time
+     18,633,922   0%                                 - timer-set-time
+     18,625,776   0%                                    timer--time-setter
+      2,801,344   0%                                   timer-create
+          3,133   0%                                   timer-set-function
+     18,328,149   0%                               - seed7-inside-string-p
+      3,268,853   0%                                - syntax-ppss
+      3,199,168   0%                                   make-closure
+         65,584   0%                                   parse-partial-sexp
+      8,693,949   0%                               - seed7-inside-comment-p
+      3,294,317   0%                                - syntax-ppss
+      3,290,336   0%                                   make-closure
+      5,832,224   0%                                 re-search-backward
+      1,566,854   0%                                 make-closure
+     86,955,448   1%                              - seed7--current-line-nth-word
+     81,028,533   1%                               - thing-at-point
+     73,575,469   1%                                - bounds-of-thing-at-point
+     32,573,962   0%                                   make-closure
+     16,698,670   0%                                 - #<byte-code-function 089>
+     16,696,979   0%                                  - forward-thing
+     16,695,664   0%                                     format
+          1,315   0%                                     intern-soft
+     12,900,309   0%                                 - seq-some
+     12,891,984   0%                                    make-closure
+      6,059,984   0%                                 - #<byte-code-function C2D>
+      6,059,984   0%                                  - forward-thing
+      6,059,984   0%                                     format
+          9,216   0%                                   re-search-forward
+     21,217,280   0%                              - seed7-inside-line-indent-before-comment-p
+      3,866,352   0%                               - seed7-inside-comment-p
+      2,366,224   0%                                - syntax-ppss
+      2,366,224   0%                                   make-closure
+      6,625,560   0%                                seed7--start-regexp-for
+      5,664,128   0%                              - seed7-inside-comment-p
+      3,268,896   0%                               - syntax-ppss
+      3,203,312   0%                                  make-closure
+         65,584   0%                                  parse-partial-sexp
+    134,588,717   2%                            - seed7-re-search-backward
+     97,829,212   1%                             - run-with-timer
+     97,829,212   1%                              - run-at-time
+     49,138,859   0%                               - timer-activate
+     49,138,859   0%                                - timer--activate
+     49,138,859   0%                                 - timer--time-less-p
+          2,515   0%                                    timer--time
+     26,208,453   0%                                 timer-relative-time
+     18,213,896   0%                               - timer-set-time
+     18,213,896   0%                                  timer--time-setter
+      4,264,176   0%                                 timer-create
+          3,828   0%                                 timer-set-function
+     18,528,545   0%                             - seed7-inside-string-p
+      2,433,249   0%                              - syntax-ppss
+      2,399,376   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+      8,004,599   0%                               re-search-backward
+      7,897,433   0%                             - seed7-inside-comment-p
+      3,318,313   0%                              - syntax-ppss
+      3,186,736   0%                                 make-closure
+         98,376   0%                                 parse-partial-sexp
+            409   0%                                 #<byte-code-function 832>
+      2,328,928   0%                               make-closure
+     36,497,247   0%                            - seed7-calc-indent
+     24,446,008   0%                             - seed7-line-inside-parens-pair-column
+     24,446,008   0%                              - seed7-line-inside-parens-pair
+     24,398,880   0%                               - seed7-re-search-backward
+     19,302,454   0%                                - run-with-timer
+     19,302,454   0%                                 - run-at-time
+      9,465,342   0%                                  - timer-activate
+      9,465,342   0%                                   - timer--activate
+      9,432,550   0%                                    - timer--time-less-p
+        163,960   0%                                       timer--time
+      5,257,280   0%                                    timer-relative-time
+      3,589,416   0%                                  - timer-set-time
+      3,589,416   0%                                     timer--time-setter
+        990,416   0%                                    timer-create
+      2,911,248   0%                                - seed7-inside-string-p
+      1,043,024   0%                                 - syntax-ppss
+        907,536   0%                                    make-closure
+        131,168   0%                                    parse-partial-sexp
+          1,642   0%                                    #<byte-code-function 86E>
+      1,422,296   0%                                - seed7-inside-comment-p
+        929,160   0%                                 - syntax-ppss
+        634,032   0%                                    make-closure
+        295,128   0%                                    parse-partial-sexp
+        745,920   0%                                  make-closure
+         16,962   0%                                  re-search-backward
+         14,336   0%                               - forward-sexp
+         14,336   0%                                  seed7--forward-sexp-function
+     11,093,708   0%                             - seed7-line-is-defun-end
+     10,196,487   0%                              - seed7-end-of-defun
+      9,776,632   0%                               - seed7-top-block-name
+      9,764,200   0%                                - seed7--to-top
+      9,731,440   0%                                 - seed7-re-search-backward
+      6,847,576   0%                                  - run-with-timer
+      6,847,576   0%                                   - run-at-time
+      3,401,000   0%                                    - timer-activate
+      3,401,000   0%                                     - timer--activate
+      3,401,000   0%                                      - timer--time-less-p
+         65,584   0%                                         timer--time
+      1,670,480   0%                                      timer-relative-time
+      1,245,664   0%                                    - timer-set-time
+      1,245,664   0%                                       timer--time-setter
+        530,432   0%                                      timer-create
+      1,922,456   0%                                  - seed7-inside-string-p
+        256,568   0%                                   - syntax-ppss
+        223,776   0%                                      make-closure
+         32,792   0%                                      parse-partial-sexp
+        576,016   0%                                  - seed7-inside-comment-p
+        227,920   0%                                   - syntax-ppss
+        227,920   0%                                      make-closure
+        385,392   0%                                    make-closure
+         28,616   0%                                 - run-with-timer
+         28,616   0%                                  - run-at-time
+          9,912   0%                                   - timer-activate
+          9,912   0%                                    - timer--activate
+          9,912   0%                                       timer--time-less-p
+          8,288   0%                                     timer-create
+          6,384   0%                                     timer-relative-time
+          4,032   0%                                   - timer-set-time
+          4,032   0%                                      timer--time-setter
+          4,144   0%                                   make-closure
+         12,432   0%                                - seed7--block-name
+         12,432   0%                                 - seed7-re-search-forward
+         12,432   0%                                    seed7-inside-string-p
+        320,799   0%                               - seed7-re-search-forward
+        182,336   0%                                - seed7-inside-string-p
+         45,584   0%                                 - syntax-ppss
+         45,584   0%                                    make-closure
+        124,127   0%                                - seed7-inside-comment-p
+         70,255   0%                                 - syntax-ppss
+         49,728   0%                                    make-closure
+         20,527   0%                                  - syntax-propertize
+         20,527   0%                                     seed7-mode-syntax-propertize
+         45,192   0%                               - seed7-re-search-backward
+         24,864   0%                                  seed7-inside-string-p
+         20,328   0%                                - run-with-timer
+         20,328   0%                                 - run-at-time
+          9,912   0%                                  - timer-activate
+          9,912   0%                                   - timer--activate
+          9,912   0%                                      timer--time-less-p
+          6,384   0%                                    timer-relative-time
+          4,032   0%                                  - timer-set-time
+          4,032   0%                                     timer--time-setter
+         17,424   0%                                 match-string
+          9,232   0%                                 match-string-no-properties
+        799,051   0%                              - seed7-beg-of-defun
+        628,255   0%                               - seed7-re-search-backward
+        405,376   0%                                - run-with-timer
+        405,376   0%                                 - run-at-time
+        204,752   0%                                  - timer-activate
+        204,752   0%                                   - timer--activate
+        204,752   0%                                      timer--time-less-p
+        105,184   0%                                    timer-relative-time
+         78,864   0%                                  - timer-set-time
+         78,864   0%                                     timer--time-setter
+         16,576   0%                                    timer-create
+        140,896   0%                                - seed7-inside-string-p
+         33,152   0%                                 - syntax-ppss
+         33,152   0%                                    make-closure
+         37,296   0%                                - seed7-inside-comment-p
+         24,864   0%                                 - syntax-ppss
+         24,864   0%                                    make-closure
+         33,152   0%                                  make-closure
+         11,535   0%                                  re-search-backward
+         64,840   0%                               - seed7-top-block-name
+         35,832   0%                                - seed7--block-name
+         35,832   0%                                   seed7-re-search-forward
+         29,008   0%                                - seed7--to-top
+         18,088   0%                                 - seed7-re-search-backward
+          7,168   0%                                    re-search-backward
+          6,776   0%                                  - run-with-timer
+          6,776   0%                                   - run-at-time
+          3,304   0%                                    - timer-activate
+          3,304   0%                                     - timer--activate
+          3,304   0%                                        timer--time-less-p
+          2,128   0%                                      timer-relative-time
+          1,344   0%                                    - timer-set-time
+          1,344   0%                                       timer--time-setter
+          4,144   0%                                  - seed7-inside-string-p
+          4,144   0%                                   - syntax-ppss
+          4,144   0%                                      make-closure
+         10,920   0%                                 - run-with-timer
+         10,920   0%                                  - run-at-time
+          4,144   0%                                     timer-create
+          3,304   0%                                   - timer-activate
+          3,304   0%                                    - timer--activate
+          3,304   0%                                       timer--time-less-p
+          2,128   0%                                     timer-relative-time
+          1,344   0%                                   - timer-set-time
+          1,344   0%                                      timer--time-setter
+         33,480   0%                               - seed7-re-search-backward-closest
+         33,480   0%                                - seed7-re-search-backward
+         19,928   0%                                   re-search-backward
+         13,552   0%                                 - run-with-timer
+         13,552   0%                                  - run-at-time
+          6,608   0%                                   - timer-activate
+          6,608   0%                                    - timer--activate
+          6,608   0%                                       timer--time-less-p
+          4,256   0%                                     timer-relative-time
+          2,688   0%                                   - timer-set-time
+          2,688   0%                                      timer--time-setter
+          8,184   0%                                 match-string-no-properties
+          2,096   0%                                 match-string
+         49,714   0%                              - seed7-line-starts-with-any
+         49,714   0%                                 seed7-line-starts-with
+         31,000   0%                              - seed7--current-line-nth-word
+         31,000   0%                               - thing-at-point
+         29,952   0%                                - bounds-of-thing-at-point
+         12,432   0%                                 - seq-some
+         12,432   0%                                    make-closure
+          8,288   0%                                   make-closure
+          8,184   0%                                 - #<byte-code-function 860>
+          8,184   0%                                  - forward-thing
+          8,184   0%                                     format
+          1,048   0%                                 - #<byte-code-function 974>
+          1,048   0%                                  - forward-thing
+          1,048   0%                                     format
+         17,456   0%                              - seed7-move-to-line
+         17,456   0%                               - seed7-to-previous-non-empty-line
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+        255,688   0%                             - seed7-line-inside-a-block-cached
+        255,688   0%                              - seed7-line-inside-a-block
+        175,736   0%                               - seed7--safe-enclosing-block-bounds
+         89,728   0%                                - seed7--block-end-pos-for
+         64,856   0%                                 - seed7-to-block-forward
+         37,016   0%                                  - seed7--current-line-nth-word
+         32,872   0%                                   - thing-at-point
+         32,872   0%                                    - bounds-of-thing-at-point
+         17,416   0%                                     - #<byte-code-function 925>
+         17,416   0%                                      - forward-thing
+         17,416   0%                                         format
+          8,288   0%                                       make-closure
+          7,168   0%                                       re-search-forward
+         12,432   0%                                  - seed7-re-search-forward
+          8,288   0%                                   - seed7-inside-comment-p
+          4,144   0%                                    - syntax-ppss
+          4,144   0%                                       make-closure
+          4,144   0%                                   - seed7-inside-string-p
+          4,144   0%                                    - syntax-ppss
+          4,144   0%                                       make-closure
+         11,264   0%                                    seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+          4,144   0%                                  - seed7-inside-line-indent-before-comment-p
+          4,144   0%                                   - seed7-inside-comment-p
+          4,144   0%                                    - syntax-ppss
+          4,144   0%                                       make-closure
+          7,344   0%                                 - seed7-re-search-forward-closest
+          7,344   0%                                  - seed7-re-search-forward
+          4,144   0%                                   - seed7-inside-comment-p
+          4,144   0%                                    - syntax-ppss
+          4,144   0%                                       make-closure
+         81,864   0%                                - seed7-to-block-backward
+         55,040   0%                                 - seed7-re-search-backward
+         28,096   0%                                  - run-with-timer
+         28,096   0%                                   - run-at-time
+         12,224   0%                                    - timer-activate
+         12,224   0%                                     - timer--activate
+         12,224   0%                                        timer--time-less-p
+          9,728   0%                                      timer-relative-time
+          6,144   0%                                    - timer-set-time
+          6,144   0%                                       timer--time-setter
+         12,432   0%                                    seed7-inside-string-p
+         10,368   0%                                    re-search-backward
+          4,144   0%                                    make-closure
+         26,824   0%                                 - seed7--current-line-nth-word
+         22,680   0%                                  - thing-at-point
+         21,664   0%                                   - bounds-of-thing-at-point
+          9,232   0%                                    - #<byte-code-function 652>
+          9,232   0%                                     - forward-thing
+          9,232   0%                                        format
+          4,144   0%                                      make-closure
+          4,144   0%                                    - seq-some
+          4,144   0%                                       make-closure
+         65,616   0%                               - seed7-re-search-backward
+         30,904   0%                                  re-search-backward
+         30,568   0%                                - run-with-timer
+         30,568   0%                                 - run-at-time
+          9,880   0%                                  - timer-activate
+          9,880   0%                                   - timer--activate
+          9,880   0%                                      timer--time-less-p
+          8,944   0%                                  - timer-set-time
+          8,944   0%                                     timer--time-setter
+          7,600   0%                                    timer-relative-time
+          4,144   0%                                    timer-create
+          4,144   0%                                  seed7-inside-string-p
+         14,336   0%                                 replace-regexp-in-string
+        160,186   0%                             - seed7-line-at-endof-array-definition-block
+         75,792   0%                              - seed7-line-code-ends-with
+         71,648   0%                               - seed7-re-search-backward
+         41,600   0%                                - run-with-timer
+         41,600   0%                                 - run-at-time
+         20,768   0%                                  - timer-activate
+         20,768   0%                                   - timer--activate
+         20,768   0%                                      timer--time-less-p
+         12,768   0%                                    timer-relative-time
+          8,064   0%                                  - timer-set-time
+          8,064   0%                                     timer--time-setter
+         21,760   0%                                  re-search-backward
+          4,144   0%                                  make-closure
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         62,810   0%                              - backward-sexp
+         62,810   0%                               - forward-sexp
+         62,810   0%                                - seed7--forward-sexp-function
+         24,954   0%                                 - seed7--at-array-definition-end-line-p
+         18,352   0%                                  - seed7-line-code-ends-with
+         18,352   0%                                   - seed7-re-search-backward
+         14,208   0%                                    - run-with-timer
+         14,208   0%                                     - run-at-time
+          6,272   0%                                      - timer-activate
+          6,272   0%                                       - timer--activate
+          6,272   0%                                          timer--time-less-p
+          4,864   0%                                        timer-relative-time
+          3,072   0%                                      - timer-set-time
+          3,072   0%                                         timer--time-setter
+          4,144   0%                                    - seed7-inside-comment-p
+          4,144   0%                                     - syntax-ppss
+          4,144   0%                                        make-closure
+          6,602   0%                                    looking-at
+         20,880   0%                                 - seed7--at-set-definition-end-line-p
+         20,880   0%                                  - seed7-line-code-ends-with
+         20,880   0%                                   - seed7-re-search-backward
+         20,880   0%                                    - run-with-timer
+         20,880   0%                                     - run-at-time
+          9,792   0%                                      - timer-activate
+          9,792   0%                                       - timer--activate
+          9,792   0%                                          timer--time-less-p
+          4,256   0%                                        timer-relative-time
+          4,144   0%                                        timer-create
+          2,688   0%                                      - timer-set-time
+          2,688   0%                                         timer--time-setter
+          1,616   0%                                 - seed7--safe-to-block-backward
+          1,616   0%                                  - seed7-to-block-backward
+          1,616   0%                                   - seed7-line-code-ends-with
+          1,616   0%                                    - seed7-re-search-backward
+          1,616   0%                                     - run-with-timer
+          1,616   0%                                      - run-at-time
+            624   0%                                       - timer-activate
+            624   0%                                        - timer--activate
+            624   0%                                           timer--time-less-p
+            608   0%                                         timer-relative-time
+            384   0%                                       - timer-set-time
+            384   0%                                          timer--time-setter
+         15,392   0%                              - seed7-re-search-backward
+          8,288   0%                                 seed7-inside-string-p
+          7,104   0%                               - run-with-timer
+          7,104   0%                                - run-at-time
+          3,136   0%                                 - timer-activate
+          3,136   0%                                  - timer--activate
+          3,136   0%                                     timer--time-less-p
+          2,432   0%                                   timer-relative-time
+          1,536   0%                                 - timer-set-time
+          1,536   0%                                    timer--time-setter
+          2,048   0%                                looking-at
+        112,088   0%                             - seed7-line-inside-array-definition-block
+         60,888   0%                              - seed7-re-search-backward
+         26,424   0%                               - run-with-timer
+         26,424   0%                                - run-at-time
+         14,024   0%                                 - timer-activate
+         14,024   0%                                  - timer--activate
+         14,024   0%                                     timer--time-less-p
+          7,600   0%                                   timer-relative-time
+          4,800   0%                                 - timer-set-time
+          4,800   0%                                    timer--time-setter
+         26,176   0%                                 re-search-backward
+          8,288   0%                                 seed7-inside-string-p
+         51,200   0%                              - forward-sexp
+         51,200   0%                                 seed7--forward-sexp-function
+         74,176   0%                             - seed7-line-inside-assign-statement-continuation
+         65,888   0%                              - seed7-assign-op-pos
+         65,888   0%                               - seed7-re-search-backward
+         27,032   0%                                  re-search-backward
+         26,424   0%                                - run-with-timer
+         26,424   0%                                 - run-at-time
+          9,880   0%                                  - timer-activate
+          9,880   0%                                   - timer--activate
+          9,880   0%                                      timer--time-less-p
+          7,600   0%                                    timer-relative-time
+          4,800   0%                                  - timer-set-time
+          4,800   0%                                     timer--time-setter
+          4,144   0%                                    timer-create
+          8,288   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          4,144   0%                                  seed7-inside-string-p
+          8,288   0%                              - seed7-statement-end-pos
+          4,144   0%                               - seed7-forward-char-pos
+          4,144   0%                                - seed7-re-search-forward
+          4,144   0%                                   seed7-inside-string-p
+         62,549   0%                             - seed7-line-inside-set-definition-block
+         58,405   0%                              - seed7-re-search-backward
+         36,125   0%                                 re-search-backward
+         22,280   0%                               - run-with-timer
+         22,280   0%                                - run-at-time
+          9,880   0%                                 - timer-activate
+          9,880   0%                                  - timer--activate
+          9,880   0%                                     timer--time-less-p
+          7,600   0%                                   timer-relative-time
+          4,800   0%                                 - timer-set-time
+          4,800   0%                                    timer--time-setter
+         58,176   0%                             - seed7-line-at-endof-set-definition-block
+         49,888   0%                              - seed7-line-code-ends-with
+         45,744   0%                               - seed7-re-search-backward
+         37,456   0%                                - run-with-timer
+         37,456   0%                                 - run-at-time
+         16,624   0%                                  - timer-activate
+         16,624   0%                                   - timer--activate
+         16,624   0%                                      timer--time-less-p
+         12,768   0%                                    timer-relative-time
+          8,064   0%                                  - timer-set-time
+          8,064   0%                                     timer--time-setter
+          4,144   0%                                - seed7-inside-string-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          8,288   0%                              - seed7-move-to-line
+          8,288   0%                               - seed7-to-previous-non-empty-line
+          4,144   0%                                  seed7-inside-comment-p
+         46,648   0%                             - seed7-line-after-short-func-end
+         31,192   0%                              - seed7-to-block-backward
+         19,616   0%                               - seed7--current-line-nth-word
+         19,616   0%                                - thing-at-point
+         19,616   0%                                 - bounds-of-thing-at-point
+          9,232   0%                                  - #<byte-code-function 89F>
+          9,232   0%                                   - forward-thing
+          9,232   0%                                      format
+          2,096   0%                                  - #<byte-code-function 42E>
+          2,096   0%                                   - forward-thing
+          2,096   0%                                      format
+         11,576   0%                               - seed7-re-search-backward
+         11,576   0%                                - run-with-timer
+         11,576   0%                                 - run-at-time
+          7,112   0%                                  - timer-activate
+          7,112   0%                                   - timer--activate
+          7,112   0%                                      timer--time-less-p
+          2,736   0%                                    timer-relative-time
+          1,728   0%                                  - timer-set-time
+          1,728   0%                                     timer--time-setter
+          8,288   0%                              - seed7-move-to-line
+          8,288   0%                               - seed7-to-previous-non-empty-line
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         30,256   0%                               seed7-line-starts-with
+         28,800   0%                             - seed7-line-after-func-return-logic-operator-column
+          7,168   0%                              - seed7-move-to-line
+          7,168   0%                                 seed7-to-previous-non-empty-line
+         25,728   0%                             - seed7-line-isa-string
+         25,728   0%                                seed7-line-starts-with
+         25,556   0%                             - seed7-line-inside-argument-list-section
+         18,836   0%                              - seed7-re-search-backward
+         15,284   0%                                 re-search-backward
+          3,552   0%                               - run-with-timer
+          3,552   0%                                - run-at-time
+          1,568   0%                                 - timer-activate
+          1,568   0%                                  - timer--activate
+          1,568   0%                                     timer--time-less-p
+          1,216   0%                                   timer-relative-time
+            768   0%                                 - timer-set-time
+            768   0%                                    timer--time-setter
+          6,720   0%                              - seed7-line-is-procfunc-beg-of-decl
+          6,720   0%                                 seed7-line-starts-with
+         21,472   0%                             - seed7-line-indent-step
+          8,288   0%                              - seed7-move-to-line
+          8,288   0%                               - seed7-to-previous-non-empty-line
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         12,432   0%                             - seed7--indent-search-boundary
+          4,144   0%                              - seed7--indent-search-boundary-uncached
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+         12,288   0%                             - seed7-line-starts-with-open-paren-after-logic-operator
+         12,288   0%                                seed7-line-starts-with
+         11,792   0%                             - seed7-line-inside-func-return-statement
+         11,792   0%                              - seed7-re-search-backward
+          7,696   0%                               - run-with-timer
+          7,696   0%                                - run-at-time
+          4,912   0%                                 - timer-set-time
+          4,912   0%                                    timer--time-setter
+          1,568   0%                                 - timer-activate
+          1,568   0%                                  - timer--activate
+          1,568   0%                                     timer--time-less-p
+          1,216   0%                                   timer-relative-time
+          4,096   0%                                 re-search-backward
+          7,904   0%                             - seed7-line-inside-logic-check-expression
+          7,904   0%                              - seed7-to-previous-line-starts-with
+          7,904   0%                               - seed7-re-search-backward
+          4,352   0%                                  re-search-backward
+          3,552   0%                                - run-with-timer
+          3,552   0%                                 - run-at-time
+          1,568   0%                                  - timer-activate
+          1,568   0%                                   - timer--activate
+          1,568   0%                                      timer--time-less-p
+          1,216   0%                                    timer-relative-time
+            768   0%                                  - timer-set-time
+            768   0%                                     timer--time-setter
+          7,648   0%                             - seed7-line-inside-until-logic-expression
+          7,648   0%                              - seed7-re-search-backward
+          4,096   0%                                 re-search-backward
+          3,552   0%                               - run-with-timer
+          3,552   0%                                - run-at-time
+          1,568   0%                                 - timer-activate
+          1,568   0%                                  - timer--activate
+          1,568   0%                                     timer--time-less-p
+          1,216   0%                                   timer-relative-time
+            768   0%                                 - timer-set-time
+            768   0%                                    timer--time-setter
+          4,144   0%                               seed7--current-line-nth-word
+     34,300,067   0%                            - replace-regexp-in-string
+      2,141,968   0%                               concat
+      4,150,376   0%                              match-string
+      1,139,600   0%                              seed7--on-lineof
+         45,056   0%                              seed7--indent-offset-for
+          6,944   0%                              #<byte-code-function 2F6>
+        348,096   0%                             seed7--cache-block-spec
+     50,384,320   0%                          - seed7--current-line-nth-word
+     50,177,120   0%                           - thing-at-point
+     49,986,536   0%                            - bounds-of-thing-at-point
+     47,450,600   0%                             - #<byte-code-function F21>
+     47,450,600   0%                              - forward-thing
+     46,677,152   0%                               - forward-word
+     46,677,152   0%                                - internal--syntax-propertize
+     45,943,664   0%                                 - syntax-propertize
+     44,368,944   0%                                    seed7-mode-syntax-propertize
+        773,448   0%                                 format
+      1,292,928   0%                               make-closure
+        381,248   0%                             - seq-some
+        381,248   0%                                make-closure
+        342,736   0%                             - #<byte-code-function 733>
+        342,736   0%                              - forward-thing
+        342,736   0%                                 format
+          1,024   0%                               re-search-forward
+     49,893,560   0%                          - seed7--indent-search-boundary
+     49,396,280   0%                           - seed7--indent-search-boundary-uncached
+     48,477,598   0%                            - syntax-ppss
+     46,574,416   0%                               make-closure
+      1,672,392   0%                               parse-partial-sexp
+            719   0%                               #<byte-code-function 469>
+            527   0%                               syntax-table
+            506   0%                              seed7-to-indent
+     24,011,408   0%                          - seed7-line-inside-argument-list-section
+     14,651,379   0%                           - seed7-re-search-backward
+      7,937,478   0%                              re-search-backward
+      6,485,981   0%                            - run-with-timer
+      6,485,981   0%                             - run-at-time
+      3,219,325   0%                              - timer-activate
+      3,219,325   0%                               - timer--activate
+      3,219,325   0%                                - timer--time-less-p
+         32,792   0%                                   timer--time
+      1,715,120   0%                                timer-relative-time
+      1,174,432   0%                              - timer-set-time
+      1,174,432   0%                                 timer--time-setter
+        377,104   0%                                timer-create
+        215,488   0%                              make-closure
+          8,288   0%                            - seed7-inside-comment-p
+          8,288   0%                             - syntax-ppss
+          8,288   0%                                make-closure
+          4,144   0%                            - seed7-inside-string-p
+          4,144   0%                             - syntax-ppss
+          4,144   0%                                make-closure
+      9,059,917   0%                           - seed7-line-is-procfunc-beg-of-decl
+      9,059,917   0%                              seed7-line-starts-with
+         72,192   0%                           - forward-sexp
+         72,192   0%                              seed7--forward-sexp-function
+         24,864   0%                           - seed7-forward-char-pos
+         24,864   0%                            - seed7-re-search-forward
+         20,720   0%                               seed7-inside-string-p
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+     22,865,633   0%                          - seed7-line-inside-logic-check-expression
+     17,880,009   0%                           - seed7-to-previous-line-starts-with
+     17,225,161   0%                            - seed7-re-search-backward
+      8,726,696   0%                             - run-with-timer
+      8,726,696   0%                              - run-at-time
+      4,324,760   0%                               - timer-activate
+      4,324,760   0%                                - timer--activate
+      4,324,760   0%                                   timer--time-less-p
+      2,311,888   0%                                 timer-relative-time
+      1,543,040   0%                               - timer-set-time
+      1,543,040   0%                                  timer--time-setter
+        547,008   0%                                 timer-create
+      6,583,280   0%                               re-search-backward
+      1,130,952   0%                             - seed7-inside-string-p
+        318,728   0%                              - syntax-ppss
+        285,936   0%                                 make-closure
+         32,792   0%                                 parse-partial-sexp
+        448,569   0%                             - seed7-inside-comment-p
+        257,945   0%                              - syntax-ppss
+        256,928   0%                                 make-closure
+          1,017   0%                                 syntax-table
+        335,664   0%                               make-closure
+      2,930,200   0%                           - seed7--current-line-nth-word
+      2,594,536   0%                            - thing-at-point
+      2,385,616   0%                             - bounds-of-thing-at-point
+      1,094,016   0%                                make-closure
+        468,280   0%                              - #<byte-code-function 1D6>
+        467,944   0%                               - forward-thing
+        467,944   0%                                  format
+        223,776   0%                              - seq-some
+        223,776   0%                                 make-closure
+        181,000   0%                              - #<byte-code-function 0BC>
+        181,000   0%                               - forward-thing
+        181,000   0%                                  format
+      1,802,640   0%                           - seed7-re-search-forward
+      1,222,480   0%                            - seed7-inside-string-p
+        236,208   0%                             - syntax-ppss
+        236,208   0%                                make-closure
+        580,160   0%                            - seed7-inside-comment-p
+        372,960   0%                             - syntax-ppss
+        372,960   0%                                make-closure
+     20,613,383   0%                          - seed7-line-inside-assign-statement-continuation
+     17,994,375   0%                           - seed7-assign-op-pos
+     17,762,311   0%                            - seed7-re-search-backward
+      9,092,072   0%                             - run-with-timer
+      9,092,072   0%                              - run-at-time
+      4,541,744   0%                               - timer-activate
+      4,541,744   0%                                - timer--activate
+      4,541,744   0%                                 - timer--time-less-p
+         65,584   0%                                    timer--time
+      2,382,752   0%                                 timer-relative-time
+      1,662,008   0%                               - timer-set-time
+      1,662,008   0%                                  timer--time-setter
+        505,568   0%                                 timer-create
+      6,550,040   0%                               re-search-backward
+      1,259,416   0%                             - seed7-inside-string-p
+        352,240   0%                              - syntax-ppss
+        352,240   0%                                 make-closure
+        588,448   0%                             - seed7-inside-comment-p
+        356,384   0%                              - syntax-ppss
+        356,384   0%                                 make-closure
+        272,335   0%                               make-closure
+      2,353,792   0%                           - seed7-statement-end-pos
+      2,150,736   0%                            - seed7-forward-char-pos
+      1,873,088   0%                             - seed7-re-search-forward
+      1,263,920   0%                              - seed7-inside-string-p
+        290,080   0%                               - syntax-ppss
+        290,080   0%                                  make-closure
+        609,168   0%                              - seed7-inside-comment-p
+        381,248   0%                               - syntax-ppss
+        381,248   0%                                  make-closure
+     18,904,002   0%                          - seed7-line-inside-array-definition-block
+     17,782,874   0%                           - seed7-re-search-backward
+      8,862,288   0%                            - run-with-timer
+      8,862,288   0%                             - run-at-time
+      4,401,360   0%                              - timer-activate
+      4,401,360   0%                               - timer--activate
+      4,401,360   0%                                - timer--time-less-p
+         32,792   0%                                   timer--time
+      2,398,848   0%                                timer-relative-time
+      1,614,528   0%                              - timer-set-time
+      1,614,528   0%                                 timer--time-setter
+        447,552   0%                                timer-create
+      6,769,869   0%                              re-search-backward
+      1,239,056   0%                            - seed7-inside-string-p
+        377,104   0%                             - syntax-ppss
+        377,104   0%                                make-closure
+        570,006   0%                            - seed7-inside-comment-p
+        294,224   0%                             - syntax-ppss
+        294,224   0%                                make-closure
+        339,808   0%                              make-closure
+        839,336   0%                           - forward-sexp
+        839,336   0%                              seed7--forward-sexp-function
+     16,520,336   0%                          - seed7-line-inside-set-definition-block
+     16,317,280   0%                           - seed7-re-search-backward
+      8,872,559   0%                            - run-with-timer
+      8,872,559   0%                             - run-at-time
+      4,508,079   0%                              - timer-activate
+      4,508,079   0%                               - timer--activate
+      4,508,079   0%                                - timer--time-less-p
+         35,959   0%                                   timer--time
+      2,385,440   0%                                timer-relative-time
+      1,643,376   0%                              - timer-set-time
+      1,643,376   0%                                 timer--time-setter
+        335,664   0%                                timer-create
+      7,092,481   0%                              re-search-backward
+        352,240   0%                              make-closure
+     13,086,408   0%                          - seed7-line-inside-func-return-statement
+     12,920,648   0%                           - seed7-re-search-backward
+      6,461,480   0%                            - run-with-timer
+      6,461,480   0%                             - run-at-time
+      3,138,776   0%                              - timer-activate
+      3,138,776   0%                               - timer--activate
+      3,138,776   0%                                  timer--time-less-p
+      1,721,552   0%                                timer-relative-time
+      1,232,336   0%                              - timer-set-time
+      1,232,336   0%                                 timer--time-setter
+        368,816   0%                                timer-create
+      6,239,536   0%                              re-search-backward
+        219,632   0%                              make-closure
+     12,994,752   0%                          - seed7-line-inside-until-logic-expression
+     12,758,544   0%                           - seed7-re-search-backward
+      6,320,584   0%                            - run-with-timer
+      6,320,584   0%                             - run-at-time
+      3,151,208   0%                              - timer-activate
+      3,151,208   0%                               - timer--activate
+      3,151,208   0%                                  timer--time-less-p
+      1,721,552   0%                                timer-relative-time
+      1,112,160   0%                              - timer-set-time
+      1,112,160   0%                                 timer--time-setter
+        335,664   0%                                timer-create
+      6,168,600   0%                              re-search-backward
+        269,360   0%                              make-closure
+      9,220,968   0%                          - seed7-line-after-func-return-logic-operator-column
+      2,239,696   0%                           - seed7-move-to-line
+      2,206,904   0%                            - seed7-to-previous-non-empty-line
+        563,584   0%                             - seed7-inside-comment-p
+        339,808   0%                              - syntax-ppss
+        339,808   0%                                 make-closure
+      7,258,040   0%                            seed7-line-starts-with
+      6,883,304   0%                          - seed7-line-isa-string
+      6,883,304   0%                             seed7-line-starts-with
+      2,448,376   0%                          - seed7-line-after-short-func-end
+      2,136,472   0%                           - seed7-move-to-line
+      2,136,472   0%                            - seed7-to-previous-non-empty-line
+      2,096,152   0%                             - seed7-inside-comment-p
+      2,092,008   0%                              - syntax-ppss
+      2,063,000   0%                               - syntax-propertize
+      2,025,704   0%                                  seed7-mode-syntax-propertize
+         29,008   0%                                 make-closure
+         44,920   0%                           - seed7-to-block-backward
+         21,768   0%                            - seed7--current-line-nth-word
+         21,768   0%                             - thing-at-point
+         21,768   0%                              - bounds-of-thing-at-point
+          4,144   0%                                 make-closure
+          4,144   0%                               - seq-some
+          4,144   0%                                  make-closure
+          1,048   0%                               - #<byte-code-function D2A>
+          1,048   0%                                - forward-thing
+          1,048   0%                                   format
+         19,008   0%                            - seed7-re-search-backward
+         19,008   0%                             - run-with-timer
+         19,008   0%                              - run-at-time
+          5,936   0%                               - timer-activate
+          5,936   0%                                - timer--activate
+          5,936   0%                                   timer--time-less-p
+          5,472   0%                                 timer-relative-time
+          4,144   0%                                 timer-create
+          3,456   0%                               - timer-set-time
+          3,456   0%                                  timer--time-setter
+          4,144   0%                            - seed7-inside-line-indent-before-comment-p
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+        953,120   0%                          - seed7-current-line-start-inside-comment-p
+        588,448   0%                           - seed7-inside-comment-p
+        397,824   0%                            - syntax-ppss
+        397,824   0%                               make-closure
+        518,700   0%                          - seed7-line-at-endof-array-definition-block
+        318,988   0%                           - backward-sexp
+        318,988   0%                            - forward-sexp
+        318,988   0%                             - seed7--forward-sexp-function
+        125,616   0%                              - seed7--at-array-definition-end-line-p
+         86,576   0%                               - seed7-line-code-ends-with
+         86,576   0%                                - seed7-re-search-backward
+         78,288   0%                                 - run-with-timer
+         78,288   0%                                  - run-at-time
+         42,576   0%                                   - timer-activate
+         42,576   0%                                    - timer--activate
+         42,576   0%                                       timer--time-less-p
+         21,888   0%                                     timer-relative-time
+         13,824   0%                                   - timer-set-time
+         13,824   0%                                      timer--time-setter
+          4,144   0%                                   seed7-inside-comment-p
+          4,144   0%                                   seed7-inside-string-p
+         39,040   0%                                 looking-at
+         81,936   0%                              - seed7--at-set-definition-end-line-p
+         81,936   0%                               - seed7-line-code-ends-with
+         81,936   0%                                - seed7-re-search-backward
+         69,504   0%                                 - run-with-timer
+         69,504   0%                                  - run-at-time
+         37,584   0%                                   - timer-activate
+         37,584   0%                                    - timer--activate
+         37,584   0%                                       timer--time-less-p
+         17,024   0%                                     timer-relative-time
+         14,896   0%                                   - timer-set-time
+         14,896   0%                                      timer--time-setter
+          8,288   0%                                 - seed7-inside-comment-p
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+          4,144   0%                                   seed7-inside-string-p
+         12,928   0%                              - seed7--safe-to-block-backward
+         12,928   0%                               - seed7-to-block-backward
+         12,928   0%                                - seed7-line-code-ends-with
+         12,928   0%                                 - seed7-re-search-backward
+         12,928   0%                                  - run-with-timer
+         12,928   0%                                   - run-at-time
+          4,992   0%                                    - timer-activate
+          4,992   0%                                     - timer--activate
+          4,992   0%                                        timer--time-less-p
+          4,864   0%                                      timer-relative-time
+          3,072   0%                                    - timer-set-time
+          3,072   0%                                       timer--time-setter
+        139,872   0%                           - seed7-line-code-ends-with
+        135,728   0%                            - seed7-re-search-backward
+         81,520   0%                             - run-with-timer
+         81,520   0%                              - run-at-time
+         43,824   0%                               - timer-activate
+         43,824   0%                                - timer--activate
+         43,824   0%                                   timer--time-less-p
+         23,104   0%                                 timer-relative-time
+         14,592   0%                               - timer-set-time
+         14,592   0%                                  timer--time-setter
+         37,632   0%                               re-search-backward
+         12,432   0%                             - seed7-inside-string-p
+          8,288   0%                              - syntax-ppss
+          8,288   0%                                 make-closure
+          4,144   0%                               make-closure
+         53,648   0%                           - seed7-re-search-backward
+         45,360   0%                            - run-with-timer
+         45,360   0%                             - run-at-time
+         23,360   0%                              - timer-activate
+         23,360   0%                               - timer--activate
+         23,360   0%                                  timer--time-less-p
+         10,944   0%                                timer-relative-time
+          6,912   0%                              - timer-set-time
+          6,912   0%                                 timer--time-setter
+          4,144   0%                                timer-create
+          8,288   0%                            - seed7-inside-string-p
+          8,288   0%                             - syntax-ppss
+          8,288   0%                                make-closure
+          6,192   0%                           - seed7-move-to-line
+          6,192   0%                              seed7-to-previous-non-empty-line
+        510,263   0%                          - seed7-comment-column
+        420,023   0%                           - seed7-calc-indent
+         55,327   0%                            - seed7-line-inside-a-block-cached
+         55,327   0%                             - seed7-line-inside-a-block
+         25,960   0%                              - seed7-re-search-backward
+         20,840   0%                               - run-with-timer
+         20,840   0%                                - run-at-time
+          8,440   0%                                 - timer-activate
+          8,440   0%                                  - timer--activate
+          8,440   0%                                     timer--time-less-p
+          7,600   0%                                   timer-relative-time
+          4,800   0%                                 - timer-set-time
+          4,800   0%                                    timer--time-setter
+          5,120   0%                                 re-search-backward
+         24,223   0%                              - seed7--safe-enclosing-block-bounds
+         15,455   0%                               - seed7--block-end-pos-for
+         15,455   0%                                - seed7-to-block-forward
+         15,455   0%                                   seed7-re-search-forward
+          8,768   0%                               - seed7-to-block-backward
+          8,768   0%                                - seed7-re-search-backward
+          7,744   0%                                 - run-with-timer
+          7,744   0%                                  - run-at-time
+          3,776   0%                                   - timer-activate
+          3,776   0%                                    - timer--activate
+          3,776   0%                                       timer--time-less-p
+          2,432   0%                                     timer-relative-time
+          1,536   0%                                   - timer-set-time
+          1,536   0%                                      timer--time-setter
+          1,024   0%                                   re-search-backward
+          4,096   0%                                replace-regexp-in-string
+         47,648   0%                            - seed7-line-inside-parens-pair-column
+         47,648   0%                             - seed7-line-inside-parens-pair
+         47,648   0%                              - seed7-re-search-backward
+         21,808   0%                               - run-with-timer
+         21,808   0%                                - run-at-time
+          8,912   0%                                 - timer-activate
+          8,912   0%                                  - timer--activate
+          8,912   0%                                     timer--time-less-p
+          7,904   0%                                   timer-relative-time
+          4,992   0%                                 - timer-set-time
+          4,992   0%                                    timer--time-setter
+         20,720   0%                               - seed7-inside-comment-p
+          8,288   0%                                - syntax-ppss
+          8,288   0%                                   make-closure
+          5,120   0%                                 re-search-backward
+         38,560   0%                            - seed7-line-inside-array-definition-block
+         32,416   0%                             - seed7-re-search-backward
+         25,952   0%                              - run-with-timer
+         25,952   0%                               - run-at-time
+          8,912   0%                                - timer-activate
+          8,912   0%                                 - timer--activate
+          8,912   0%                                    timer--time-less-p
+          7,904   0%                                  timer-relative-time
+          4,992   0%                                - timer-set-time
+          4,992   0%                                   timer--time-setter
+          4,144   0%                                  timer-create
+          6,464   0%                                re-search-backward
+          6,144   0%                             - forward-sexp
+          6,144   0%                                seed7--forward-sexp-function
+         32,096   0%                            - seed7-line-inside-set-definition-block
+         27,952   0%                             - seed7-re-search-backward
+         21,808   0%                              - run-with-timer
+         21,808   0%                               - run-at-time
+          8,912   0%                                - timer-activate
+          8,912   0%                                 - timer--activate
+          8,912   0%                                    timer--time-less-p
+          7,904   0%                                  timer-relative-time
+          4,992   0%                                - timer-set-time
+          4,992   0%                                   timer--time-setter
+          6,144   0%                                re-search-backward
+         32,096   0%                            - seed7-line-inside-assign-statement-continuation
+         32,096   0%                             - seed7-assign-op-pos
+         27,952   0%                              - seed7-re-search-backward
+         21,808   0%                               - run-with-timer
+         21,808   0%                                - run-at-time
+          8,912   0%                                 - timer-activate
+          8,912   0%                                  - timer--activate
+          8,912   0%                                     timer--time-less-p
+          7,904   0%                                   timer-relative-time
+          4,992   0%                                 - timer-set-time
+          4,992   0%                                    timer--time-setter
+          6,144   0%                                 re-search-backward
+         29,008   0%                            - seed7-line-at-endof-set-definition-block
+         29,008   0%                             - seed7-move-to-line
+         29,008   0%                              - seed7-to-previous-non-empty-line
+         20,720   0%                               - seed7-inside-comment-p
+         12,432   0%                                - syntax-ppss
+         12,432   0%                                   make-closure
+         28,960   0%                            - seed7-line-after-func-return-logic-operator-column
+         24,864   0%                             - seed7-move-to-line
+         24,864   0%                              - seed7-to-previous-non-empty-line
+         12,432   0%                                 seed7-inside-comment-p
+         27,928   0%                            - seed7-line-is-defun-end
+         20,720   0%                             - seed7-move-to-line
+         20,720   0%                              - seed7-to-previous-non-empty-line
+         16,576   0%                               - seed7-inside-comment-p
+         16,576   0%                                - syntax-ppss
+         16,576   0%                                   make-closure
+          3,144   0%                             - seed7--current-line-nth-word
+          3,144   0%                              - thing-at-point
+          3,144   0%                               - bounds-of-thing-at-point
+          2,096   0%                                - #<byte-code-function 16B>
+          2,096   0%                                 - forward-thing
+          2,096   0%                                    format
+          1,048   0%                                - #<byte-code-function F7F>
+          1,048   0%                                 - forward-thing
+          1,048   0%                                    format
+          3,040   0%                             - seed7--safe-current-line-defun-start-indent
+          3,040   0%                              - seed7-to-block-backward
+          1,992   0%                               - seed7-re-search-backward
+          1,024   0%                                  re-search-backward
+            968   0%                                - run-with-timer
+            968   0%                                 - run-at-time
+            472   0%                                  - timer-activate
+            472   0%                                   - timer--activate
+            472   0%                                      timer--time-less-p
+            304   0%                                    timer-relative-time
+            192   0%                                  - timer-set-time
+            192   0%                                     timer--time-setter
+          1,048   0%                               - seed7--current-line-nth-word
+          1,048   0%                                - thing-at-point
+          1,048   0%                                 - bounds-of-thing-at-point
+          1,048   0%                                  - #<byte-code-function A38>
+          1,048   0%                                   - forward-thing
+          1,048   0%                                      format
+          1,024   0%                             - seed7-line-starts-with-any
+          1,024   0%                                seed7-line-starts-with
+         26,936   0%                            - seed7-line-starts-with-open-paren-after-logic-operator
+         24,864   0%                             - seed7-move-to-line
+         24,864   0%                              - seed7-to-previous-non-empty-line
+          8,288   0%                               - seed7-inside-comment-p
+          8,288   0%                                - syntax-ppss
+          8,288   0%                                   make-closure
+          2,072   0%                               seed7-line-starts-with
+         20,720   0%                            - seed7-line-at-endof-array-definition-block
+         20,720   0%                             - seed7-move-to-line
+         20,720   0%                              - seed7-to-previous-non-empty-line
+         16,576   0%                               - seed7-inside-comment-p
+         16,576   0%                                - syntax-ppss
+         16,576   0%                                   make-closure
+         20,720   0%                            - seed7-line-after-short-func-end
+         20,720   0%                             - seed7-move-to-line
+         20,720   0%                              - seed7-to-previous-non-empty-line
+         20,720   0%                               - seed7-inside-comment-p
+         12,432   0%                                - syntax-ppss
+         12,432   0%                                   make-closure
+         14,448   0%                            - seed7-line-inside-argument-list-section
+         10,352   0%                             - seed7-re-search-backward
+          6,480   0%                                re-search-backward
+          3,872   0%                              - run-with-timer
+          3,872   0%                               - run-at-time
+          1,888   0%                                - timer-activate
+          1,888   0%                                 - timer--activate
+          1,888   0%                                    timer--time-less-p
+          1,216   0%                                  timer-relative-time
+            768   0%                                - timer-set-time
+            768   0%                                   timer--time-setter
+          4,096   0%                             - seed7-line-is-procfunc-beg-of-decl
+          4,096   0%                                seed7-line-starts-with
+          7,968   0%                            - seed7-line-inside-logic-check-expression
+          7,968   0%                             - seed7-to-previous-line-starts-with
+          7,968   0%                              - seed7-re-search-backward
+          4,096   0%                                 re-search-backward
+          3,872   0%                               - run-with-timer
+          3,872   0%                                - run-at-time
+          1,888   0%                                 - timer-activate
+          1,888   0%                                  - timer--activate
+          1,888   0%                                     timer--time-less-p
+          1,216   0%                                   timer-relative-time
+            768   0%                                 - timer-set-time
+            768   0%                                    timer--time-setter
+          7,968   0%                            - seed7-line-inside-until-logic-expression
+          7,968   0%                             - seed7-re-search-backward
+          4,096   0%                                re-search-backward
+          3,872   0%                              - run-with-timer
+          3,872   0%                               - run-at-time
+          1,888   0%                                - timer-activate
+          1,888   0%                                 - timer--activate
+          1,888   0%                                    timer--time-less-p
+          1,216   0%                                  timer-relative-time
+            768   0%                                - timer-set-time
+            768   0%                                   timer--time-setter
+          7,968   0%                            - seed7-line-inside-func-return-statement
+          7,968   0%                             - seed7-re-search-backward
+          4,096   0%                                re-search-backward
+          3,872   0%                              - run-with-timer
+          3,872   0%                               - run-at-time
+          1,888   0%                                - timer-activate
+          1,888   0%                                 - timer--activate
+          1,888   0%                                    timer--time-less-p
+          1,216   0%                                  timer-relative-time
+            768   0%                                - timer-set-time
+            768   0%                                   timer--time-setter
+          7,288   0%                            - seed7--current-line-nth-word
+          7,288   0%                             - thing-at-point
+          7,288   0%                              - bounds-of-thing-at-point
+          2,096   0%                               - #<byte-code-function EE5>
+          2,096   0%                                - forward-thing
+          2,096   0%                                   format
+          1,048   0%                               - #<byte-code-function D04>
+          1,048   0%                                - forward-thing
+          1,048   0%                                   format
+          7,192   0%                              seed7-line-starts-with
+          6,144   0%                            - seed7-line-isa-string
+          6,144   0%                               seed7-line-starts-with
+          1,048   0%                            - error
+          1,048   0%                               format-message
+         40,688   0%                           - seed7-line-code-ends-with
+         25,888   0%                            - seed7-move-to-line
+         25,888   0%                             - seed7-to-previous-non-empty-line
+         20,720   0%                                seed7-inside-comment-p
+         14,800   0%                            - seed7-re-search-backward
+          9,680   0%                             - run-with-timer
+          9,680   0%                              - run-at-time
+          4,720   0%                               - timer-activate
+          4,720   0%                                - timer--activate
+          4,720   0%                                   timer--time-less-p
+          3,040   0%                                 timer-relative-time
+          1,920   0%                               - timer-set-time
+          1,920   0%                                  timer--time-setter
+          5,120   0%                               re-search-backward
+         40,240   0%                             seed7-line-starts-with
+          4,144   0%                           - seed7-inside-comment-p
+          4,144   0%                            - syntax-ppss
+          4,144   0%                               make-closure
+          1,024   0%                             looking-at
+        350,280   0%                          - seed7-line-indent-step
+         62,160   0%                           - seed7-move-to-line
+         62,160   0%                            - seed7-to-previous-non-empty-line
+         33,152   0%                             - seed7-inside-comment-p
+         20,720   0%                              - syntax-ppss
+         20,720   0%                                 make-closure
+        118,336   0%                          - seed7-line-inside-nested-parens-pairs-column
+        118,336   0%                           - seed7-line-inside-nested-parens-pairs
+        114,192   0%                            - seed7-line-inside-parens-pair
+        110,048   0%                             - seed7-re-search-backward
+         93,472   0%                              - run-with-timer
+         93,472   0%                               - run-at-time
+         45,680   0%                                - timer-activate
+         45,680   0%                                 - timer--activate
+         45,680   0%                                    timer--time-less-p
+         26,752   0%                                  timer-relative-time
+         16,896   0%                                - timer-set-time
+         16,896   0%                                   timer--time-setter
+          4,144   0%                                  timer-create
+          8,288   0%                              - seed7-inside-comment-p
+          8,288   0%                               - syntax-ppss
+          8,288   0%                                  make-closure
+          4,144   0%                                seed7-inside-string-p
+          4,144   0%                                make-closure
+          4,144   0%                               seed7-line-inside-syntax-parens-pair
+         98,096   0%                          - seed7-line-at-endof-set-definition-block
+         89,808   0%                           - seed7-line-code-ends-with
+         89,808   0%                            - seed7-re-search-backward
+         81,520   0%                             - run-with-timer
+         81,520   0%                              - run-at-time
+         43,824   0%                               - timer-activate
+         43,824   0%                                - timer--activate
+         43,824   0%                                   timer--time-less-p
+         23,104   0%                                 timer-relative-time
+         14,592   0%                               - timer-set-time
+         14,592   0%                                  timer--time-setter
+          8,288   0%                               seed7-inside-string-p
+          8,288   0%                           - seed7-move-to-line
+          8,288   0%                            - seed7-to-previous-non-empty-line
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+         40,192   0%                          - seed7-line-starts-with-open-paren-after-logic-operator
+         40,192   0%                             seed7-line-starts-with
+         10,976   0%                          - seed7-position-of-end-of-statement
+         10,976   0%                           - seed7-line-code-ends-with
+         10,976   0%                            - seed7-re-search-backward
+          5,808   0%                             - run-with-timer
+          5,808   0%                              - run-at-time
+          2,832   0%                               - timer-activate
+          2,832   0%                                - timer--activate
+          2,832   0%                                   timer--time-less-p
+          1,824   0%                                 timer-relative-time
+          1,152   0%                               - timer-set-time
+          1,152   0%                                  timer--time-setter
+          4,144   0%                             - seed7-inside-string-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+          1,024   0%                               re-search-backward
+         10,760   0%                          - seed7-line-ends-with
+          9,736   0%                           - seed7-re-search-backward
+          8,712   0%                            - run-with-timer
+          8,712   0%                             - run-at-time
+          4,248   0%                              - timer-activate
+          4,248   0%                               - timer--activate
+          4,248   0%                                  timer--time-less-p
+          2,736   0%                                timer-relative-time
+          1,728   0%                              - timer-set-time
+          1,728   0%                                 timer--time-setter
+          1,024   0%                              re-search-backward
+          1,024   0%                           - seed7-move-to-line
+          1,024   0%                              seed7-to-previous-non-empty-line
+          4,144   0%                            seed7-bol-position
+      3,617,688   0%                         - #<byte-code-function EAE>
+      3,617,688   0%                          - filter-buffer-substring
+      3,617,688   0%                           - buffer-substring--filter
+      3,617,688   0%                            - #<byte-code-function BD8>
+      3,617,688   0%                             - apply
+      3,617,688   0%                                #<byte-code-function 954>
+        683,400   0%                         - jit-lock-after-change
+        302,512   0%                            font-lock-extend-jit-lock-region-after-change
+      1,640,620   0%                   profiler-stop
+      5,604,984   0%   Automatic GC

--- a/reports/19.1/timing.txt
+++ b/reports/19.1/timing.txt
@@ -1,0 +1,5 @@
+Time of the execution of seed7-complete-statement-or-indent to indent the complete files:
+
+castle.sd7:   79.3977 seconds
+chkarr.sd7:  840.4272 seconds
+bas7.sd7:   1109.2559 seconds

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260703.1053
+;; Package-Version: 20260703.1117
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-03T14:53:31+0000 W27-5"
+(defconst seed7-mode-version-timestamp "2026-07-03T15:17:19+0000 W27-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5644,25 +5644,27 @@ N is: - :previous-non-empty for the previous non-empty line,
   "Return position of end of block starting with HEADER.
 Move point."
   (cond
+   ;;
    ((member header '("const func " "const func\t"))
-    (save-excursion
-      (forward-line 0)
+    (let ((long-body
+           (save-excursion
+             (forward-line 0)
+             (re-search-forward "\\_<is[[:blank:]]+func\\_>" (line-end-position) t)))
+          (bare-is
+           (save-excursion
+             (forward-line 0)
+             (re-search-forward "\\_<is[[:blank:]]*$" (line-end-position) t))))
       (cond
-       ;; Long-body function: `... is func`
-       ((re-search-forward "\\_<is[[:blank:]]+func\\_>" (line-end-position) t)
+       (long-body
         (seed7-to-block-forward :dont-push-mark)
         (point))
-
-       ;; Short function: declaration line ends with bare `is`
-       ((re-search-forward "\\_<is[[:blank:]]*\\'" (line-end-position) t)
+       (bare-is
         (seed7-re-search-forward seed7-short-func-end-regexp)
         (point))
-
-       ;; Fallback to existing behavior
        (t
         (seed7-to-block-forward :dont-push-mark)
         (point)))))
-
+   ;;
    ((member header '("const proc: "
                      "const type: "
                      "local"
@@ -5686,11 +5688,11 @@ Move point."
                      "case\t"))
     (seed7-to-block-forward :dont-push-mark)
     (point))
-
+   ;;
    ((member header '("exception" "catch " "catch\t"))
     (seed7-to-next-line-starts-with "end block")
     (point))
-
+   ;;
    (t
     (error "Unsupported block header: %s" header))))
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260703.1342
+;; Package-Version: 20260703.1418
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -284,6 +284,7 @@
 ;;       . `seed7--pos-msg'
 ;;       . `seed7--show-info'
 ;;       . `seed7--no-defun-found-msg-for'
+;;       . `seed7-line-after-short-func-end'
 ;;     - Seed7 Procedure/Function Navigation Commands
 ;;       * `seed7-beg-of-defun'
 ;;       * `seed7-beg-of-next-defun'
@@ -542,7 +543,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-03T17:42:23+0000 W27-5"
+(defconst seed7-mode-version-timestamp "2026-07-03T18:18:14+0000 W27-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3442,6 +3443,29 @@ Arguments:
           (seed7--plural-s n)
           (if (eq direction 'forward) "below" "above")))
 
+(defun seed7-line-after-short-func-end (n &optional dont-skip-comment-start)
+  "Return the sibling indentation column for a line following a short function.
+
+A Seed7 short function (`const func ... is' immediately followed by a
+single `return ...;' statement, with no `end func;') leaves no explicit
+block-end marker.  A statement that follows such a function (skipping
+blank lines) is therefore reported as being outside of any block by
+`seed7-line-inside-a-block-cached', but it must still be dedented back to
+the column of the `const func' header that started that short function,
+rather than inheriting the `return' line's own indent step.
+
+Return the indentation column of the corresponding `const func' header
+when N's predecessor is exactly a short-function-terminating `return'
+statement.  Return nil otherwise."
+  (save-excursion
+    (when (and (seed7-move-to-line n dont-skip-comment-start)
+               (seed7-move-to-line :previous-non-empty dont-skip-comment-start))
+      (when (save-excursion
+              (forward-line 0)
+              (looking-at-p seed7-short-func-end-regexp))
+        (when (seed7-to-block-backward nil :dont-push-mark)
+          (skip-chars-forward " \t")
+          (current-column))))))
 
 ;;*** Seed7 Procedure/Function Navigation Commands
 ;;    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -5674,7 +5698,7 @@ Move point."
                        (save-excursion
                          (goto-char (match-beginning 0))
                          (looking-at-p seed7-short-func-end-regexp)))
-            (error "Unsupported incomplete short function header: %s" header)))
+            (user-error "Unsupported incomplete short function header: %s" header)))
         (point))
        (t
         (seed7-to-block-forward :dont-push-mark)
@@ -5875,7 +5899,7 @@ just return nil so the caller can continue searching farther upward."
               (start-pos (seed7-to-block-backward nil :dont-push-mark)))
           (when (and start-pos end-pos)
             (cons start-pos end-pos))))
-    (error nil)))
+    (user-error nil)))
 
 (defun seed7-line-inside-a-block (n &optional dont-skip-comment-start beg-bound)
   "Check if line N is inside a Seed7 block.
@@ -7400,6 +7424,12 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                          :previous-non-empty)
                         indent-column))
         (setq indent-column (- indent-column seed7-indent-width)))
+
+       ;; Just after the terminating `return ...;' of a short function
+       ;; (no `end func;'), align with the `const func' header rather than
+       ;; inheriting the return statement's own indent step.
+       ((seed7--set (seed7-line-after-short-func-end 0)
+                    indent-column))
 
        ;; When inside a paren block, adjust indent to the column
        ;; following the open paren; any of: ( { [

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260703.1126
+;; Package-Version: 20260703.1156
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-03T15:26:17+0000 W27-5"
+(defconst seed7-mode-version-timestamp "2026-07-03T15:56:16+0000 W27-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1947,8 +1947,10 @@ Group 4: - \"func\" for proc or function that ends with \"end func\".
   "Regexp to detect end of procedure or long function.  No group.")
 
 (defconst seed7-short-func-end-regexp
-  "^[[:blank:]]+return[^;]*;"
+  "^[[:blank:]]*return[^;]*;"
   "Regexp to detect end of short function.  No group.
+Allow return to not be indented; it should be but in case it's not
+it is still a valid end of a function block.
 Uses `[^;]*' (negated character class) instead of nested lazy quantifiers
 to prevent catastrophic backtracking on large files.
 Matches a return statement starting on a line beginning with whitespace,
@@ -5659,8 +5661,14 @@ Move point."
         (seed7-to-block-forward :dont-push-mark)
         (point))
        (bare-is
-        (or (seed7-re-search-forward seed7-short-func-end-regexp)
-            (error "Unsupported incomplete short function header: %s" header))
+        (let ((closest (seed7-re-search-forward-closest
+                        (list seed7-short-func-end-regexp
+                              seed7-block-line-start-regexp))))
+          (unless (and closest
+                       (save-excursion
+                         (goto-char (match-beginning 0))
+                         (looking-at-p seed7-short-func-end-regexp)))
+            (error "Unsupported incomplete short function header: %s" header)))
         (point))
        (t
         (seed7-to-block-forward :dont-push-mark)
@@ -5861,7 +5869,7 @@ just return nil so the caller can continue searching farther upward."
               (start-pos (seed7-to-block-backward nil :dont-push-mark)))
           (when (and start-pos end-pos)
             (cons start-pos end-pos))))
-    (user-error nil)))
+    (error nil)))
 
 (defun seed7-line-inside-a-block (n &optional dont-skip-comment-start beg-bound)
   "Check if line N is inside a Seed7 block.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260703.1156
+;; Package-Version: 20260703.1342
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-03T15:56:16+0000 W27-5"
+(defconst seed7-mode-version-timestamp "2026-07-03T17:42:23+0000 W27-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5661,9 +5661,15 @@ Move point."
         (seed7-to-block-forward :dont-push-mark)
         (point))
        (bare-is
-        (let ((closest (seed7-re-search-forward-closest
-                        (list seed7-short-func-end-regexp
-                              seed7-block-line-start-regexp))))
+        ;; Do not search from the header line itself, otherwise
+        ;; `seed7-block-line-start-regexp' can match the current
+        ;; `const func ... is' header and incorrectly win as the
+        ;; "closest" match.
+        (forward-line 1)
+        (let ((closest
+               (seed7-re-search-forward-closest
+                (list seed7-short-func-end-regexp
+                      seed7-block-line-start-regexp))))
           (unless (and closest
                        (save-excursion
                          (goto-char (match-beginning 0))

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260703.1117
+;; Package-Version: 20260703.1126
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-03T15:17:19+0000 W27-5"
+(defconst seed7-mode-version-timestamp "2026-07-03T15:26:17+0000 W27-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5659,7 +5659,8 @@ Move point."
         (seed7-to-block-forward :dont-push-mark)
         (point))
        (bare-is
-        (seed7-re-search-forward seed7-short-func-end-regexp)
+        (or (seed7-re-search-forward seed7-short-func-end-regexp)
+            (error "Unsupported incomplete short function header: %s" header))
         (point))
        (t
         (seed7-to-block-forward :dont-push-mark)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260701.1344
+;; Package-Version: 20260703.1053
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -542,7 +542,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-01T17:44:07+0000 W27-3"
+(defconst seed7-mode-version-timestamp "2026-07-03T14:53:31+0000 W27-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5642,10 +5642,28 @@ N is: - :previous-non-empty for the previous non-empty line,
 
 (defun seed7--block-end-pos-for (header)
   "Return position of end of block starting with HEADER.
- Move point."
+Move point."
   (cond
+   ((member header '("const func " "const func\t"))
+    (save-excursion
+      (forward-line 0)
+      (cond
+       ;; Long-body function: `... is func`
+       ((re-search-forward "\\_<is[[:blank:]]+func\\_>" (line-end-position) t)
+        (seed7-to-block-forward :dont-push-mark)
+        (point))
+
+       ;; Short function: declaration line ends with bare `is`
+       ((re-search-forward "\\_<is[[:blank:]]*\\'" (line-end-position) t)
+        (seed7-re-search-forward seed7-short-func-end-regexp)
+        (point))
+
+       ;; Fallback to existing behavior
+       (t
+        (seed7-to-block-forward :dont-push-mark)
+        (point)))))
+
    ((member header '("const proc: "
-                     "const func "
                      "const type: "
                      "local"
                      "repeat"
@@ -5659,9 +5677,7 @@ N is: - :previous-non-empty for the previous non-empty line,
                      "while "
                      "for "
                      "case "
-                     ;; ... also support tabs when caller did not normalize them.
                      "const proc:\t"
-                     "const func\t"
                      "const type:\t"
                      "if\t"
                      "elsif\t"
@@ -5670,12 +5686,13 @@ N is: - :previous-non-empty for the previous non-empty line,
                      "case\t"))
     (seed7-to-block-forward :dont-push-mark)
     (point))
-   ;;
+
    ((member header '("exception" "catch " "catch\t"))
     (seed7-to-next-line-starts-with "end block")
     (point))
-   ;;
-   (t (error "Unsupported block header: %s" header))))
+
+   (t
+    (error "Unsupported block header: %s" header))))
 
 (defun seed7--indent-offset-for (header first-text)
   "Return indentation offset (in columns) for the inside of a block.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260703.1418
+;; Package-Version: 20260703.1439
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -543,7 +543,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-03T18:18:14+0000 W27-5"
+(defconst seed7-mode-version-timestamp "2026-07-03T18:39:23+0000 W27-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -7469,9 +7469,10 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
         (error "No rule yet to indent line %d" (seed7-current-line-number)))))
     (if indent-column
         indent-column
-      (* (or indent-step
-             (seed7-line-indent-step :previous-non-empty))
-         seed7-indent-width))))
+      (or (seed7-line-after-short-func-end 0)
+          (* (or indent-step
+                 (seed7-line-indent-step :previous-non-empty))
+             seed7-indent-width)))))
 
 
 (defun seed7--indent-one-line ()

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260703.1439
+;; Package-Version: 20260703.1444
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -543,7 +543,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-03T18:39:23+0000 W27-5"
+(defconst seed7-mode-version-timestamp "2026-07-03T18:44:12+0000 W27-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5718,6 +5718,7 @@ Move point."
                      "while "
                      "for "
                      "case "
+                     ;; ... also support tabs when caller did not normalize them.
                      "const proc:\t"
                      "const type:\t"
                      "if\t"

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-25 16:15:53 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-03 10:55:38 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -249,7 +249,7 @@
 (defconst seed7-test-indent-02--is-return-misaligned
   (concat
    "const func boolean: alwaysTrue is\n"
-   "  return TRUE;\n")
+   "return TRUE;\n")
   "Misaligned `is return' function.")
 
 (ert-deftest seed7-indent/is-return-keeps-correct-layout ()
@@ -919,6 +919,99 @@
     (should (= (seed7-test-indent-02--line-indentation 4) 2))
     (should (string= (buffer-string)
                      seed7-test-indent-02--set-def-correct))))
+;; ---------------------------------------------------------------------------
+;; Regression: adjacent short `is return' functions (prg/chkarr.sd7, lines 50-87)
+;; -------------------------------------------------------------------------
+;;
+;; Several consecutive `const func ... is' / `return ...;' declarations,
+;; separated by blank lines, must each have their `return' line indented
+;; to column 2.  This reproduces the bug where `seed7--block-end-pos-for'
+;; misidentifies the end of a short function's enclosing block, so
+;; `seed7-line-inside-a-block' fails to recognize the first `return' line
+;; as belonging to the preceding `const func ... is' declaration.
+
+(defconst seed7-test-indent-02--adjacent-is-return-correct
+  (concat
+   "const func boolean: boolExpr (ref boolean: value) is\n"
+   "  return value and str(rand(1, 9))[2 ..] = \"\";\n"
+   "\n"
+   "\n"
+   "const func integer: intExpr (in integer: number) is\n"
+   "  return number + length(str(rand(1, 9))[2 ..]);\n"
+   "\n"
+   "\n"
+   "const func float: floatExpr (in float: number) is\n"
+   "  return number;\n")
+  "Correctly-indented adjacent `is return' functions, as in prg/chkarr.sd7.")
+
+(defconst seed7-test-indent-02--adjacent-is-return-misaligned
+  (concat
+   "const func boolean: boolExpr (ref boolean: value) is\n"
+   "return value and str(rand(1, 9))[2 ..] = \"\";\n"
+   "\n"
+   "\n"
+   "const func integer: intExpr (in integer: number) is\n"
+   "return number + length(str(rand(1, 9))[2 ..]);\n"
+   "\n"
+   "\n"
+   "const func float: floatExpr (in float: number) is\n"
+   "return number;\n")
+  "Misaligned adjacent `is return' functions, matching prg/chkarr.sd7 as-is.")
+
+(ert-deftest seed7-indent/adjacent-is-return-keeps-correct-layout ()
+  "Indenting already-correct adjacent `is return' functions keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--adjacent-is-return-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 0))
+    (should (= (seed7-test-indent-02--line-indentation 6) 2))
+    (should (= (seed7-test-indent-02--line-indentation 9) 0))
+    (should (= (seed7-test-indent-02--line-indentation 10) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--adjacent-is-return-correct))))
+
+(ert-deftest seed7-indent/adjacent-is-return-fixes-misaligned-layout ()
+  "Indenting misaligned adjacent `is return' functions restores the layout.
+
+Regression test for the bug reported against `prg/chkarr.sd7' lines 51, 55,
+67, 71, 75, 79, 83: `seed7--block-end-pos-for' treats a short
+`const func ... is' declaration like a long-body function ending in
+`end func;', so the first `return' line of the short function is never
+recognized as being inside the enclosing block and is left at column 0
+by both `indent-region' and interactive `TAB'."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--adjacent-is-return-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))
+    (should (= (seed7-test-indent-02--line-indentation 5) 0))
+    (should (= (seed7-test-indent-02--line-indentation 6) 2))
+    (should (= (seed7-test-indent-02--line-indentation 9) 0))
+    (should (= (seed7-test-indent-02--line-indentation 10) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--adjacent-is-return-correct))))
+;; ---------------------------------------------------------------------------
+
+(ert-deftest seed7-indent/adjacent-is-return-tab-indents-return-line ()
+  "Pressing TAB on an unindented short-function `return' line must indent it.
+
+This exercises `seed7-indent-line' directly (the interactive TAB path),
+as opposed to `indent-region', to catch the reported failure where TAB
+on line 2 (`return value and ...;') does nothing."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--adjacent-is-return-misaligned)
+    (seed7-mode)
+    (goto-char (point-min))
+    (forward-line 1)                    ; move to the first `return' line
+    (seed7-indent-line)
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-02)

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-02 13:22:33 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-02 13:41:24 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -194,6 +194,25 @@ the RST report.")
     (format "first %d file(s)" sd7-indent-perf--profile))
    (t "unknown")))
 
+(defun sd7-indent-perf--format-profiler-entry (entry)
+  "Return a human-readable string for the profiler ENTRY.
+ENTRY is the raw entry object stored in a `profiler-calltree' node's
+`entry' slot (see `profiler-calltree-entry').  This avoids depending on
+private/internal `profiler.el' helpers (such as `profiler-calltree-name'
+or `profiler-format-entry'), whose availability differs across Emacs
+versions."
+  (cond
+   ((eq entry t) "Others")
+   ((stringp entry) entry)
+   ((symbolp entry) (symbol-name entry))
+   ((and (fboundp 'help-fns-function-name)
+         (or (subrp entry) (functionp entry)))
+    (condition-case nil
+        (help-fns-function-name entry)
+      (error (format "%S" entry))))
+   ((byte-code-function-p entry) (format "#<compiled %#x>" (sxhash entry)))
+   (t (format "%S" entry))))
+
 (defun sd7-indent-perf--profile-report-text ()
   "Return the Emacs CPU profiler results as a plain-text string.
 Uses `profiler-cpu-log' and `profiler-calltree-build' to build a call tree,
@@ -214,7 +233,8 @@ count.  Works in both interactive and batch mode."
          (lambda (node)
            (when (profiler-calltree-leaf-p node)
              (push (cons (profiler-calltree-count node)
-                         (profiler-calltree-name  node))
+                         (sd7-indent-perf--format-profiler-entry
+                          (profiler-calltree-entry node)))
                    entries))))
         (setq entries (sort entries (lambda (a b) (> (car a) (car b)))))
         (let ((total (apply #'+ (mapcar #'car entries))))

--- a/tools/sd7-indent-perf.el
+++ b/tools/sd7-indent-perf.el
@@ -2,7 +2,7 @@
 
 ;; Created   : Tuesday, June 24 2026.
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-25 12:06:59 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-02 13:22:33 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -50,6 +50,22 @@
 ;; this PR.  This benchmark is therefore the correct tool for measuring the
 ;; impact of changes to indentation-path regexps.
 ;;
+;; Emacs Profiler Integration
+;; --------------------------
+;;
+;; When profiling is requested, the built-in Emacs sampling profiler
+;; (`profiler' package) is activated around the `indent-region' calls so
+;; that CPU hot-spots in seed7-mode indentation logic are identified.
+;;
+;; Profiling can cover the whole run (all files) or be limited to only the
+;; first N files (useful when the full corpus is too large and you only want
+;; to sample a representative subset).
+;;
+;; The profiler report is written as plain text to:
+;;   REPORT_DIR/seed7mode-indent-perf-ID-profile.txt
+;;
+;; and a summary is appended to the RST report as well.
+;;
 ;; Usage
 ;; -----
 ;;
@@ -59,26 +75,44 @@
 ;;      M-x sd7-indent-perf-run
 ;;
 ;;    Prompts for INPUT-DIR, OUTPUT-DIR, REPORT-DIR, and ID.
+;;    Answer the profiling question to enable CPU profiling.
 ;;
-;; 2. Batch:
+;; 2. Interactive — profiling only (shorter run over first N files):
+;;
+;;      M-x sd7-indent-perf-run-with-profile
+;;
+;; 3. Batch (no profiling):
 ;;
 ;;      emacs -Q --batch --load tools/sd7-indent-perf.el \
 ;;            -- INPUT_DIR OUTPUT_DIR REPORT_DIR ID
 ;;
-;; 3. Makefile:
+;; 4. Batch with profiling (all files):
+;;
+;;      emacs -Q --batch --load tools/sd7-indent-perf.el \
+;;            -- INPUT_DIR OUTPUT_DIR REPORT_DIR ID --profile
+;;
+;; 5. Batch with profiling (first N files only):
+;;
+;;      emacs -Q --batch --load tools/sd7-indent-perf.el \
+;;            -- INPUT_DIR OUTPUT_DIR REPORT_DIR ID --profile N
+;;
+;; 6. Makefile:
 ;;
 ;;      $(EMACS) -Q --batch --load tools/sd7-indent-perf.el \
-;;               -- $(INPUT_DIR) $(OUTPUT_DIR) $(REPORT_DIR) $(ID)
+;;               -- $(INPUT_DIR) $(OUTPUT_DIR) $(REPORT_DIR) $(ID) --profile
 ;;
 ;; Arguments:
 ;;   INPUT_DIR  : root of the input directory tree (read-only)
 ;;   OUTPUT_DIR : root of the output directory tree (created/overwritten)
 ;;   REPORT_DIR : directory where the RST report is written (created if absent)
 ;;   ID         : free-form report identifier (e.g. "01", "before-simplify")
+;;   --profile  : optional flag; activates the Emacs CPU profiler
+;;   N          : optional integer after --profile; limit profiling to first N files
 ;;
 ;; Output:
 ;;   OUTPUT_DIR/  — mirrored tree with re-indented .sd7 / .s7i files
 ;;   REPORT_DIR/seed7mode-indent-perf-ID.rst
+;;   REPORT_DIR/seed7mode-indent-perf-ID-profile.txt  (only when --profile)
 
 ;;; --------------------------------------------------------------------------
 ;;; Load-path bootstrap
@@ -98,6 +132,7 @@
 
 (require 'seed7-mode)
 (require 'cl-lib)
+(require 'profiler)
 
 ;;; --------------------------------------------------------------------------
 ;;; Repository root
@@ -132,6 +167,108 @@
 
 (defvar sd7-indent-perf--last-id "01"
   "Last report ID used.  Offered as default in `sd7-indent-perf-run'.")
+
+;;; --------------------------------------------------------------------------
+;;; Profiler support
+
+(defvar sd7-indent-perf--profile nil
+  "When non-nil, activate the Emacs CPU profiler around `indent-region' calls.
+Set to t to profile all files, or to a positive integer to profile only the
+first N files in the corpus.  After the run the profiler report is written to
+REPORT-DIR/seed7mode-indent-perf-ID-profile.txt and a summary is included in
+the RST report.")
+
+(defun sd7-indent-perf--profile-active-p (file-index)
+  "Return non-nil if profiling should be active for FILE-INDEX (1-based)."
+  (and sd7-indent-perf--profile
+       (or (eq sd7-indent-perf--profile t)
+           (and (integerp sd7-indent-perf--profile)
+                (<= file-index sd7-indent-perf--profile)))))
+
+(defun sd7-indent-perf--profile-limit-string ()
+  "Return a human-readable string describing the profiling scope."
+  (cond
+   ((null sd7-indent-perf--profile) "disabled")
+   ((eq sd7-indent-perf--profile t) "all files")
+   ((integerp sd7-indent-perf--profile)
+    (format "first %d file(s)" sd7-indent-perf--profile))
+   (t "unknown")))
+
+(defun sd7-indent-perf--profile-report-text ()
+  "Return the Emacs CPU profiler results as a plain-text string.
+Uses `profiler-cpu-log' and `profiler-calltree-build' to build a call tree,
+then `profiler-calltree-walk' to collect leaf-node (self-time) sample counts
+per function.  Leaf nodes represent functions where CPU time was actually
+spent (as opposed to intermediate callers), making them the best candidates
+for optimisation.  The result is a flat table sorted by descending sample
+count.  Works in both interactive and batch mode."
+  (let ((log (profiler-cpu-log)))
+    (if (null log)
+        "(no profiler CPU data — was profiler-start called?)\n"
+      ;; Build a descending call tree (roots = top-level callers, leaves =
+      ;; innermost callees where time is actually spent).
+      (let ((tree    (profiler-calltree-build log 'descending))
+            (entries '()))
+        (profiler-calltree-walk
+         tree
+         (lambda (node)
+           (when (profiler-calltree-leaf-p node)
+             (push (cons (profiler-calltree-count node)
+                         (profiler-calltree-name  node))
+                   entries))))
+        (setq entries (sort entries (lambda (a b) (> (car a) (car b)))))
+        (let ((total (apply #'+ (mapcar #'car entries))))
+          (with-temp-buffer
+            (insert (format "%-8s  %6s  %s\n" "Samples" "%" "Function"))
+            (insert (make-string 72 ?-))
+            (insert "\n")
+            (dolist (e entries)
+              (insert (format "%-8d  %5.1f%%  %s\n"
+                              (car e)
+                              (if (> total 0)
+                                  (* 100.0 (/ (float (car e)) total))
+                                0.0)
+                              (cdr e))))
+            (buffer-string)))))))
+
+(defun sd7-indent-perf--write-profile-report (report-dir id)
+  "Write the Emacs profiler CPU report.
+Write report to REPORT-DIR/seed7mode-indent-perf-ID-profile.txt.
+Returns the path of the written file, or nil if profiler data is unavailable."
+  (let ((profile-file (expand-file-name
+                       (format "seed7mode-indent-perf-%s-profile.txt" id)
+                       report-dir)))
+    (condition-case err
+        (progn
+          (make-directory report-dir t)
+          (with-temp-file profile-file
+            (insert "Seed7 Mode — Indentation Hot-Spot Profile\n")
+            (insert (make-string 60 ?=))
+            (insert "\n\n")
+            (insert (format "seed7-mode version : %s\n" seed7-mode-version-timestamp))
+            (insert (format "Generated on       : %s\n"
+                            (format-time-string "%Y-%m-%dT%H:%M:%S%z")))
+            (insert (format "Profiling scope    : %s\n\n"
+                            (sd7-indent-perf--profile-limit-string)))
+            (insert "CPU Hot-Spots (sampled during indent-region)\n")
+            (insert "---------------------------------------------\n\n")
+            (insert (sd7-indent-perf--profile-report-text))
+            (insert "\n")
+            (insert "Notes\n")
+            (insert "-----\n\n")
+            (insert "Each row is a leaf call-tree node from the Emacs sampling profiler.\n")
+            (insert "\"Samples\" is the raw sample count; \"%\" is the fraction of total\n")
+            (insert "CPU samples attributed to that function.  Functions near the top\n")
+            (insert "are the hottest spots in the indentation path and are the best\n")
+            (insert "candidates for optimisation.\n\n")
+            (insert "To get an interactive call-tree, run with profiling from a live\n")
+            (insert "Emacs session via `M-x sd7-indent-perf-run-with-profile' and then\n")
+            (insert "inspect the result with `M-x profiler-report'.\n"))
+          profile-file)
+      (error
+       (sd7-indent-perf--message "WARNING: could not write profile report: %s"
+                                 (error-message-string err))
+       nil))))
 
 ;;; --------------------------------------------------------------------------
 ;;; Warning capture
@@ -224,30 +361,42 @@ and sd7-nav-index.el."
 ;;; --------------------------------------------------------------------------
 ;;; Per-file processing
 
-(defun sd7-indent-perf--process-file (input-file input-dir output-dir)
+(defun sd7-indent-perf--process-file (input-file input-dir output-dir
+                                                  &optional file-index)
   "Re-indent INPUT-FILE with seed7-mode and write result to the output tree.
 
 The original INPUT-FILE is never modified.  The re-indented content is
 written to OUTPUT-DIR/<relative-path-from-INPUT-DIR> **immediately** after
 indentation completes, before any subsequent file is processed.
 
+FILE-INDEX (1-based integer) is used to decide whether the Emacs CPU profiler
+should be active for this file.  When `sd7-indent-perf--profile' is non-nil
+and FILE-INDEX falls within the configured profiling scope, `profiler-start'
+is called before `indent-region' and `profiler-stop' is called after.  The
+profiler accumulates data across all profiled files; call
+`sd7-indent-perf--write-profile-report' once after the full run to retrieve
+the combined results.
+
 Returns a plist:
   :file        abbreviated file name (relative to INPUT-DIR)
   :lines       line count of the file
   :file-start  wall-clock time (float) when indentation started
   :indent-time elapsed time in seconds for `indent-region'
+  :profiled    t if the Emacs profiler was active for this file, else nil
   :warnings    list of captured indentation-warning strings (may be nil)
   :error       error message string if processing failed, or nil"
   (let* ((rel        (file-relative-name input-file input-dir))
          (out-file   (sd7-indent-perf--output-path input-file input-dir output-dir))
          (out-parent (file-name-directory out-file))
+         (profile-this (sd7-indent-perf--profile-active-p (or file-index 0)))
          line-count
          indent-time
          file-start
          warnings
          err-msg)
     ;; Announce the start of this file with a wall-clock timestamp.
-    (sd7-indent-perf--message "  indenting %s …" rel)
+    (sd7-indent-perf--message "  indenting %s …%s" rel
+                              (if profile-this " [profiling]" ""))
     (condition-case err
         (progn
           ;; Install warning capture BEFORE with-temp-buffer so that
@@ -264,14 +413,22 @@ Returns a plist:
                 (setq line-count (line-number-at-pos (point-max)))
                 (let ((t0 (current-time)))
                   (setq file-start (float-time t0))
+                  ;; Start the CPU profiler for this file if requested.
+                  (when profile-this
+                    (profiler-start 'cpu))
                   (indent-region (point-min) (point-max))
+                  ;; Stop the profiler immediately after indent-region returns.
+                  (when profile-this
+                    (profiler-stop))
                   (setq indent-time
                         (float-time (time-subtract (current-time) t0))))
                 (make-directory out-parent t)
                 (let ((coding-system-for-write 'undecided))
                   (write-region (point-min) (point-max) out-file nil :silent)))
-            ;; Always remove the advice.
+            ;; Always remove the advice; stop profiler if still running.
             (advice-remove 'message #'sd7-indent-perf--capture-advice)
+            (when (and profile-this (profiler-running-p))
+              (profiler-stop))
             (setq warnings (nreverse sd7-indent-perf--current-warnings))))
       (error
        (setq err-msg (format "%s" (cadr err)))))
@@ -290,6 +447,7 @@ Returns a plist:
           :lines       (or line-count 0)
           :file-start  (or file-start 0.0)
           :indent-time (or indent-time 0.0)
+          :profiled    profile-this
           :warnings    warnings
           :error       err-msg)))
 
@@ -309,10 +467,13 @@ Returns a plist:
 
 (defun sd7-indent-perf--write-report (results input-dir output-dir
                                                report-dir id
-                                               total-elapsed)
+                                               total-elapsed
+                                               &optional profile-file)
   "Write the RST indentation benchmark report.
 
 RESULTS is a list of plists as returned by `sd7-indent-perf--process-file'.
+PROFILE-FILE, if non-nil, is the path to the written CPU profile text file;
+its path is referenced in the RST report.
 Returns the path of the written report file."
   (let* ((report-file (expand-file-name
                        (format "seed7mode-indent-perf-%s.rst" id)
@@ -323,6 +484,7 @@ Returns the path of the written report file."
          (times       (mapcar (lambda (r) (plist-get r :indent-time)) ok-results))
          (n           (length results))
          (n-ok        (length ok-results))
+         (n-profiled  (cl-count-if (lambda (r) (plist-get r :profiled)) results))
          (avg         (if (> n-ok 0) (/ (apply #'+ times) (float n-ok)) 0.0))
          (mn          (if (> n-ok 0) (apply #'min times) 0.0))
          (mx          (if (> n-ok 0) (apply #'max times) 0.0))
@@ -350,8 +512,17 @@ Returns the path of the written report file."
       (when errors
         (insert (format ":Files with errors: %d\n" (length errors))))
       (insert (format ":Total indent time: %.3f s\n" total-time))
-      (insert (format ":Wall-clock time   : %s\n\n"
+      (insert (format ":Wall-clock time   : %s\n"
                       (sd7-indent-perf--format-duration total-elapsed)))
+      (if sd7-indent-perf--profile
+          (progn
+            (insert (format ":Profiling scope   : %s (%d file(s) profiled)\n"
+                            (sd7-indent-perf--profile-limit-string)
+                            n-profiled))
+            (when profile-file
+              (insert (format ":CPU profile report: %s\n" profile-file))))
+        (insert ":Profiling         : disabled\n"))
+      (insert "\n")
       ;; Correctness note
       (insert "Correctness Check\n")
       (insert "=================\n\n")
@@ -468,6 +639,10 @@ Returns the absolute path of the written report file."
   (sd7-indent-perf--message "Report dir: %s" report-dir)
   (sd7-indent-perf--message "Report ID : %s" id)
 
+  (when sd7-indent-perf--profile
+    (sd7-indent-perf--message "Profiling: %s"
+                              (sd7-indent-perf--profile-limit-string)))
+
   (let* ((files       (sd7-indent-perf--seed7-files input-dir))
          (total-files (length files))
          (_ (sd7-indent-perf--message "Files found: %d" total-files))
@@ -482,53 +657,118 @@ Returns the absolute path of the written report file."
        "[%d/%d]  started %s"
        n total-files
        (format-time-string "%H:%M:%S"))
-      (push (sd7-indent-perf--process-file f input-dir output-dir)
+      (push (sd7-indent-perf--process-file f input-dir output-dir n)
             results))
 
     (let* ((total-elapsed (- (float-time) total-start))
            (results-fwd   (nreverse results))
+           ;; Write the CPU profile report (if profiling was requested).
+           (profile-file  (when sd7-indent-perf--profile
+                            (sd7-indent-perf--message
+                             "Writing CPU profile report…")
+                            (sd7-indent-perf--write-profile-report
+                             report-dir id)))
            (report        (sd7-indent-perf--write-report
                            results-fwd input-dir output-dir
-                           report-dir id total-elapsed)))
+                           report-dir id total-elapsed
+                           profile-file)))
       (sd7-indent-perf--message
        "Done.  Wall clock: %s"
        (sd7-indent-perf--format-duration total-elapsed))
       (sd7-indent-perf--message "Report: %s" report)
+      (when profile-file
+        (sd7-indent-perf--message "CPU profile: %s" profile-file))
       report)))
 
 ;;; --------------------------------------------------------------------------
 ;;; Interactive entry point
 
 ;;;###autoload
-(defun sd7-indent-perf-run (input-dir output-dir report-dir id)
+(defun sd7-indent-perf-run (input-dir output-dir report-dir id &optional profile)
   "Interactively run the Seed7 indentation benchmark.
 
-Prompts for INPUT-DIR, OUTPUT-DIR, REPORT-DIR, and ID.
-Previous values are offered as defaults and remembered within the session.
+Prompts for INPUT-DIR, OUTPUT-DIR, REPORT-DIR, ID, and whether to enable CPU
+profiling.  Previous values are offered as defaults and remembered within the
+session.
 
 OUTPUT-DIR will mirror INPUT-DIR with re-indented file content; it is
 created if absent.  The original files in INPUT-DIR are never modified.
 
-The RST report is written to REPORT-DIR/seed7mode-indent-perf-ID.rst."
+The RST report is written to REPORT-DIR/seed7mode-indent-perf-ID.rst.
+When PROFILE is non-nil the Emacs CPU profiler is active during `indent-region'
+and the report is also written to
+REPORT-DIR/seed7mode-indent-perf-ID-profile.txt."
   (interactive
-   (list
-    (read-directory-name "Input directory (Seed7 source tree): "
-                         sd7-indent-perf--last-input-dir)
-    (read-directory-name "Output directory (re-indented tree): "
-                         sd7-indent-perf--last-output-dir)
-    (read-directory-name "Report directory: "
-                         sd7-indent-perf--last-report-dir)
-    (read-string (format "Report ID (default %S): "
-                         sd7-indent-perf--last-id)
-                 nil nil sd7-indent-perf--last-id)))
+   (let* ((in-dir  (read-directory-name "Input directory (Seed7 source tree): "
+                                        sd7-indent-perf--last-input-dir))
+          (out-dir (read-directory-name "Output directory (re-indented tree): "
+                                        sd7-indent-perf--last-output-dir))
+          (rep-dir (read-directory-name "Report directory: "
+                                        sd7-indent-perf--last-report-dir))
+          (rep-id  (read-string (format "Report ID (default %S): "
+                                        sd7-indent-perf--last-id)
+                                nil nil sd7-indent-perf--last-id))
+          (prof-ans (read-string
+                     "Enable CPU profiler? [no / yes / N (first N files)]: "
+                     "no"))
+          (prof-val (cond
+                     ((member prof-ans '("no" "n" ""))     nil)
+                     ((member prof-ans '("yes" "y" "all")) t)
+                     ((string-match-p "\\`[0-9]+\\'" prof-ans)
+                      (string-to-number prof-ans))
+                     (t nil))))
+     (list in-dir out-dir rep-dir rep-id prof-val)))
   (setq sd7-indent-perf--last-input-dir  (directory-file-name
                                           (expand-file-name input-dir))
         sd7-indent-perf--last-output-dir (directory-file-name
                                           (expand-file-name output-dir))
         sd7-indent-perf--last-report-dir (directory-file-name
                                           (expand-file-name report-dir))
-        sd7-indent-perf--last-id         id)
+        sd7-indent-perf--last-id         id
+        sd7-indent-perf--profile         profile)
   ;; Show the live progress buffer in another window before starting.
+  (with-current-buffer (get-buffer-create sd7-indent-perf--progress-buffer)
+    (erase-buffer))
+  (display-buffer sd7-indent-perf--progress-buffer
+                  '((display-buffer-pop-up-window) (inhibit-same-window . t)))
+  (sd7-indent-perf-run-core input-dir output-dir report-dir id))
+
+;;;###autoload
+(defun sd7-indent-perf-run-with-profile (input-dir output-dir report-dir id
+                                                    &optional n-files)
+  "Run the Seed7 indentation benchmark with the Emacs CPU profiler enabled.
+
+Like `sd7-indent-perf-run' but always enables profiling.  If N-FILES is a
+positive integer, only the first N-FILES files are profiled (the rest are still
+re-indented and timed, but without profiler overhead).  Useful when the full
+corpus is too large and a representative sample suffices.
+
+The CPU profile is written to REPORT-DIR/seed7mode-indent-perf-ID-profile.txt."
+  (interactive
+   (let* ((in-dir  (read-directory-name "Input directory (Seed7 source tree): "
+                                        sd7-indent-perf--last-input-dir))
+          (out-dir (read-directory-name "Output directory (re-indented tree): "
+                                        sd7-indent-perf--last-output-dir))
+          (rep-dir (read-directory-name "Report directory: "
+                                        sd7-indent-perf--last-report-dir))
+          (rep-id  (read-string (format "Report ID (default %S): "
+                                        sd7-indent-perf--last-id)
+                                nil nil sd7-indent-perf--last-id))
+          (n-str   (read-string
+                    "Limit profiling to first N files (RET = all files): "
+                    ""))
+          (n-val   (if (string-match-p "\\`[0-9]+\\'" n-str)
+                       (string-to-number n-str)
+                     t)))
+     (list in-dir out-dir rep-dir rep-id n-val)))
+  (setq sd7-indent-perf--last-input-dir  (directory-file-name
+                                          (expand-file-name input-dir))
+        sd7-indent-perf--last-output-dir (directory-file-name
+                                          (expand-file-name output-dir))
+        sd7-indent-perf--last-report-dir (directory-file-name
+                                          (expand-file-name report-dir))
+        sd7-indent-perf--last-id         id
+        sd7-indent-perf--profile         (or n-files t))
   (with-current-buffer (get-buffer-create sd7-indent-perf--progress-buffer)
     (erase-buffer))
   (display-buffer sd7-indent-perf--progress-buffer
@@ -543,7 +783,12 @@ The RST report is written to REPORT-DIR/seed7mode-indent-perf-ID.rst."
 
 Expected positional arguments (after --)::
 
-  INPUT_DIR OUTPUT_DIR REPORT_DIR ID
+  INPUT_DIR OUTPUT_DIR REPORT_DIR ID [--profile [N]]
+
+The optional --profile flag activates the Emacs CPU profiler around
+`indent-region' calls and writes the hot-spot report alongside the RST report.
+An optional integer N immediately after --profile limits profiling to the
+first N files.
 
 Exits Emacs with 0 on success or 1 on error."
   (let ((args command-line-args-left))
@@ -551,8 +796,16 @@ Exits Emacs with 0 on success or 1 on error."
     (when (equal (car args) "--")
       (setq args (cdr args)))
     (when (< (length args) 4)
-      (message "Usage: -- INPUT_DIR OUTPUT_DIR REPORT_DIR ID")
+      (message "Usage: -- INPUT_DIR OUTPUT_DIR REPORT_DIR ID [--profile [N]]")
       (kill-emacs 1))
+    ;; Parse optional --profile [N] from position 4 onward.
+    (let ((tail (nthcdr 4 args)))
+      (when (equal (car tail) "--profile")
+        (let ((n-str (cadr tail)))
+          (setq sd7-indent-perf--profile
+                (if (and n-str (string-match-p "\\`[0-9]+\\'" n-str))
+                    (string-to-number n-str)
+                  t)))))
     (condition-case err
         (progn
           (sd7-indent-perf-run-core


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional CPU profiling to the indentation benchmark (profile all files or the first N), including a new interactive profiling command and a `--profile [N]` CLI flag.
* **Bug Fixes**
  * Improved short-function and block-end detection for `const func`/`const proc` header variants (including tab forms), fixing indentation after short functions.
* **Tests**
  * Added regression coverage for adjacent short `const func ... is` cases.
* **Documentation**
  * Updated benchmark/help text and refreshed generated profiling output reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->