### PR TITLE
A better docstring is required

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -124,6 +124,15 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
   - *seed7-line-inside-a-block-cached* added to reduce repeated calls
     from *seed7-indent-line* on multi-line statements.
 
+- *Indentation correctness*: Improved the indentation logic to support more
+  Seed7 code constructions that were previously not handled properly,
+  including:
+
+  - =const type: ... is func= declarations.
+  - Short functions definitions with just a return statement.
+  - Nested function definitions.
+  - Action declarations.
+
 - *Xref support*:
   - Cache is now invalidated when the Seed7 buffer is saved or reverted.
   - *seed7-xref* =~= expansion, space-in-path handling, and failing

--- a/reports/21.1/array.s7i-perf-cpu-3.txt
+++ b/reports/21.1/array.s7i-perf-cpu-3.txt
@@ -1,0 +1,767 @@
+        2448  88% - ...
+        2448  88%  - #<native-comp-function execute-extended-command>
+        2448  88%   - command-execute
+        2448  88%    - call-interactively
+        2448  88%     - apply
+        2448  88%      - call-interactively@ido-cr+-record-current-command
+        2448  88%       - #<primitive-function call-interactively>
+        2448  88%        - funcall-interactively
+        2448  88%         - pel-profile
+        2448  88%          - call-interactively
+        2448  88%           - apply
+        2448  88%            - call-interactively@ido-cr+-record-current-command
+        2448  88%             - #<primitive-function call-interactively>
+        2448  88%              - funcall-interactively
+        2448  88%               - seed7-complete-statement-or-indent
+        2448  88%                - seed7-indent-region
+        2448  88%                 - seed7--indent-one-line
+        2447  88%                  - seed7-calc-indent
+         839  30%                   - seed7-line-inside-a-block-cached
+         839  30%                    - seed7-line-inside-a-block
+         400  14%                     - seed7-calc-indent
+         143   5%                      - seed7-line-is-defun-end
+         115   4%                       - seed7-end-of-defun
+          83   2%                        - seed7-top-block-name
+          83   2%                         - seed7--to-top
+          81   2%                          - seed7-re-search-backward
+          69   2%                           - seed7-inside-comment-p
+          69   2%                            - syntax-ppss
+          68   2%                               parse-partial-sexp
+           1   0%                               syntax-ppss--data
+           6   0%                             re-search-backward
+           4   0%                           - run-with-timer
+           4   0%                            - run-at-time
+           2   0%                             - timer-set-time
+           2   0%                                timer--time-setter
+           1   0%                             - timer-activate
+           1   0%                              - timer--activate
+           1   0%                                 timer--time-less-p
+           2   0%                           - seed7-inside-string-p
+           1   0%                              match-data
+           1   0%                            - syntax-ppss
+           1   0%                               syntax-ppss--update-stats
+          29   1%                        - seed7-re-search-forward
+          14   0%                         - seed7-inside-comment-p
+          14   0%                          - syntax-ppss
+          14   0%                             parse-partial-sexp
+          10   0%                         - seed7-inside-string-p
+          10   0%                          - syntax-ppss
+          10   0%                             parse-partial-sexp
+           5   0%                           re-search-forward
+           3   0%                        - seed7-re-search-backward
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           1   0%                         - seed7-inside-string-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+          26   0%                       - seed7-beg-of-defun
+          22   0%                        - seed7-re-search-backward
+          21   0%                         - seed7-inside-comment-p
+          21   0%                          - syntax-ppss
+          21   0%                             parse-partial-sexp
+           1   0%                           re-search-backward
+           2   0%                        - seed7-re-search-backward-closest
+           2   0%                         - seed7-re-search-backward
+           1   0%                            re-search-backward
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           1   0%                        - seed7-top-block-name
+           1   0%                         - seed7--block-name
+           1   0%                          - seed7-re-search-forward
+           1   0%                             re-search-forward
+           1   0%                          looking-at
+           1   0%                       - seed7-move-to-line
+           1   0%                        - seed7-to-previous-non-empty-line
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                       - seed7-line-starts-with-any
+           1   0%                        - seed7-line-starts-with
+           1   0%                           looking-at
+          94   3%                      - seed7--indent-search-boundary
+          94   3%                       - seed7--indent-search-boundary-uncached
+          90   3%                        - syntax-ppss
+          89   3%                           parse-partial-sexp
+           1   0%                           make-closure
+           3   0%                          seed7-to-indent
+          76   2%                      - seed7-line-inside-parens-pair-column
+          76   2%                       - seed7-line-inside-parens-pair
+          69   2%                        - seed7-re-search-backward
+          64   2%                         - seed7-inside-comment-p
+          64   2%                          - syntax-ppss
+          63   2%                             parse-partial-sexp
+           4   0%                         - run-with-timer
+           4   0%                          - run-at-time
+           2   0%                           - timer-set-time
+           2   0%                              timer--time-setter
+           2   0%                           - timer-activate
+           2   0%                            - timer--activate
+           2   0%                               timer--time-less-p
+           4   0%                        - forward-sexp
+           4   0%                         - seed7--forward-sexp-function
+           1   0%                            scan-sexps
+           1   0%                          seed7--paren-pair-string
+          74   2%                      - seed7-line-inside-a-block-cached
+          74   2%                       - seed7-line-inside-a-block
+          60   2%                        - seed7--safe-enclosing-block-bounds
+          60   2%                         - seed7--block-end-pos-for
+          49   1%                          - seed7-to-block-forward
+          41   1%                           - seed7-end-of-defun
+          32   1%                            - seed7-top-block-name
+          32   1%                             - seed7--to-top
+          32   1%                              - seed7-re-search-backward
+          30   1%                               - seed7-inside-comment-p
+          30   1%                                - syntax-ppss
+          30   1%                                   parse-partial-sexp
+           1   0%                               - run-with-timer
+           1   0%                                - run-at-time
+           1   0%                                   timer-create
+           1   0%                               - seed7-inside-string-p
+           1   0%                                  make-closure
+           9   0%                            - seed7-re-search-forward
+           6   0%                             - seed7-inside-string-p
+           3   0%                                match-data
+           3   0%                              - syntax-ppss
+           3   0%                                 parse-partial-sexp
+           2   0%                             - seed7-inside-comment-p
+           2   0%                              - syntax-ppss
+           2   0%                                 parse-partial-sexp
+           1   0%                               re-search-forward
+           6   0%                           - seed7-re-search-forward
+           3   0%                              re-search-forward
+           2   0%                            - seed7-inside-comment-p
+           1   0%                             - syntax-ppss
+           1   0%                                parse-partial-sexp
+           1   0%                            - seed7-inside-string-p
+           1   0%                               make-closure
+           2   0%                           - seed7--current-line-nth-word
+           1   0%                            - thing-at-point
+           1   0%                             - bounds-of-thing-at-point
+           1   0%                              - seq-some
+           1   0%                                 make-closure
+          10   0%                          - seed7--line-ends-a-statement-p
+           6   0%                             looking-at
+           2   0%                           - forward-sexp
+           2   0%                              seed7--forward-sexp-function
+           1   0%                            re-search-forward
+          13   0%                        - seed7-re-search-backward
+           8   0%                         - seed7-inside-comment-p
+           8   0%                          - syntax-ppss
+           8   0%                             parse-partial-sexp
+           2   0%                         - seed7-inside-string-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                            match-data
+           2   0%                           re-search-backward
+           1   0%                         - run-with-timer
+           1   0%                          - run-at-time
+           1   0%                           - timer-activate
+           1   0%                            - timer--activate
+           1   0%                               timer--time-less-p
+           3   0%                      - seed7-line-inside-set-definition-block
+           3   0%                       - seed7-re-search-backward
+           3   0%                          re-search-backward
+           2   0%                      - seed7-line-after-func-return-logic-operator-column
+           2   0%                       - seed7-move-to-line
+           2   0%                        - seed7-to-previous-non-empty-line
+           2   0%                         - seed7-inside-comment-p
+           2   0%                          - syntax-ppss
+           2   0%                             parse-partial-sexp
+           2   0%                      - seed7-line-inside-func-return-statement
+           2   0%                       - seed7-re-search-backward
+           2   0%                          re-search-backward
+           1   0%                      - seed7-line-at-endof-set-definition-block
+           1   0%                       - seed7-move-to-line
+           1   0%                        - seed7-to-previous-non-empty-line
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                      - seed7-line-inside-argument-list-section
+           1   0%                       - seed7-re-search-backward
+           1   0%                        - seed7-inside-string-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+           1   0%                      - seed7-line-inside-until-logic-expression
+           1   0%                       - seed7-re-search-backward
+           1   0%                          re-search-backward
+           1   0%                      - seed7-line-after-short-func-end
+           1   0%                       - seed7-move-to-line
+           1   0%                        - seed7-to-previous-non-empty-line
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+           1   0%                      - seed7-line-inside-array-definition-block
+           1   0%                       - seed7-re-search-backward
+           1   0%                          re-search-backward
+           1   0%                      - seed7-line-inside-assign-statement-continuation
+           1   0%                       - seed7-assign-op-pos
+           1   0%                        - seed7-re-search-backward
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+         399  14%                     - seed7--safe-enclosing-block-bounds
+         399  14%                      - seed7--block-end-pos-for
+         390  14%                       - seed7-to-block-forward
+         370  13%                        - seed7-end-of-defun
+         318  11%                         - seed7-top-block-name
+         313  11%                          - seed7--to-top
+         308  11%                           - seed7-re-search-backward
+         244   8%                            - seed7-inside-comment-p
+         244   8%                             - syntax-ppss
+         242   8%                                parse-partial-sexp
+           1   0%                                make-closure
+          42   1%                            - run-with-timer
+          42   1%                             - run-at-time
+          14   0%                              - timer-activate
+          14   0%                               - timer--activate
+          14   0%                                - timer--time-less-p
+           1   0%                                   timer--time
+          12   0%                              - timer-set-time
+          12   0%                                 timer--time-setter
+          11   0%                                timer-relative-time
+           5   0%                                timer-create
+          12   0%                            - seed7-inside-string-p
+           7   0%                               match-data
+           3   0%                             - syntax-ppss
+           1   0%                                make-closure
+           1   0%                                #<byte-code-function 102>
+           1   0%                                parse-partial-sexp
+           1   0%                             - #<byte-code-function 190>
+           1   0%                                set-match-data
+           7   0%                              re-search-backward
+           3   0%                           - run-with-timer
+           3   0%                            - run-at-time
+           3   0%                             - timer-activate
+           3   0%                              - timer--activate
+           3   0%                                 timer--time-less-p
+           1   0%                             make-closure
+           4   0%                          - seed7--block-name
+           4   0%                           - seed7-re-search-forward
+           2   0%                            - seed7-inside-string-p
+           2   0%                             - syntax-ppss
+           1   0%                                make-closure
+           1   0%                                parse-partial-sexp
+           1   0%                            - seed7-inside-comment-p
+           1   0%                             - syntax-ppss
+           1   0%                                parse-partial-sexp
+          45   1%                         - seed7-re-search-forward
+          29   1%                          - re-search-forward
+           2   0%                           - internal--syntax-propertize
+           2   0%                            - syntax-propertize
+           1   0%                             - seed7-mode-syntax-propertize
+           1   0%                                re-search-forward
+          10   0%                          - seed7-inside-string-p
+           9   0%                           - syntax-ppss
+           9   0%                              parse-partial-sexp
+           1   0%                             make-closure
+           6   0%                          - seed7-inside-comment-p
+           6   0%                           - syntax-ppss
+           6   0%                              parse-partial-sexp
+           5   0%                         - seed7-re-search-backward
+           3   0%                          - seed7-inside-comment-p
+           3   0%                           - syntax-ppss
+           3   0%                              parse-partial-sexp
+           1   0%                          - seed7-inside-string-p
+           1   0%                             match-data
+           1   0%                          - run-with-timer
+           1   0%                           - run-at-time
+           1   0%                              timer-relative-time
+           1   0%                           looking-at
+          16   0%                        - seed7-re-search-forward
+           9   0%                         - seed7-inside-comment-p
+           9   0%                          - syntax-ppss
+           8   0%                             parse-partial-sexp
+           1   0%                           - syntax-propertize
+           1   0%                            - seed7-mode-syntax-propertize
+           1   0%                               re-search-forward
+           5   0%                         - seed7-inside-string-p
+           5   0%                          - syntax-ppss
+           4   0%                             parse-partial-sexp
+           2   0%                           re-search-forward
+           4   0%                        - seed7--current-line-nth-word
+           2   0%                         - thing-at-point
+           2   0%                          - bounds-of-thing-at-point
+           2   0%                           - #<byte-code-function 7F2>
+           2   0%                            - forward-thing
+           1   0%                               forward-word
+           1   0%                           line-beginning-position
+           8   0%                       - seed7--line-ends-a-statement-p
+           5   0%                          looking-at
+           1   0%                       - seed7-re-search-forward-closest
+           1   0%                        - seed7-re-search-forward
+           1   0%                         - seed7-inside-comment-p
+           1   0%                          - syntax-ppss
+           1   0%                             parse-partial-sexp
+          35   1%                     - seed7-re-search-backward
+          29   1%                      - seed7-inside-comment-p
+          29   1%                       - syntax-ppss
+          29   1%                          parse-partial-sexp
+           5   0%                      - run-with-timer
+           5   0%                       - run-at-time
+           2   0%                        - timer-activate
+           2   0%                         - timer--activate
+           2   0%                            timer--time-less-p
+           2   0%                          timer-relative-time
+           1   0%                        - timer-set-time
+           1   0%                           timer--time-setter
+           1   0%                        re-search-backward
+           1   0%                       replace-regexp-in-string
+           1   0%                       make-closure
+         669  24%                   - seed7-line-is-defun-end
+         560  20%                    - seed7-end-of-defun
+         447  16%                     - seed7-top-block-name
+         442  15%                      - seed7--to-top
+         439  15%                       - seed7-re-search-backward
+         398  14%                        - seed7-inside-comment-p
+         398  14%                         - syntax-ppss
+         390  14%                            parse-partial-sexp
+           3   0%                            make-closure
+           2   0%                          - syntax-propertize
+           1   0%                           - seed7-mode-syntax-propertize
+           1   0%                              re-search-forward
+           1   0%                           - #<byte-code-function 125>
+           1   0%                              syntax-propertize-wholelines
+           1   0%                          - #<byte-code-function 525>
+           1   0%                             set-syntax-table
+          28   1%                        - run-with-timer
+          28   1%                         - run-at-time
+          16   0%                          - timer-activate
+          16   0%                           - timer--activate
+          16   0%                            - timer--time-less-p
+           1   0%                               timer--time
+           7   0%                            timer-relative-time
+           3   0%                          - timer-set-time
+           3   0%                             timer--time-setter
+           2   0%                            timer-create
+           7   0%                        - seed7-inside-string-p
+           5   0%                           match-data
+           2   0%                         - syntax-ppss
+           1   0%                            make-closure
+           1   0%                            parse-partial-sexp
+           3   0%                          re-search-backward
+           1   0%                          make-closure
+           2   0%                       - run-with-timer
+           2   0%                        - run-at-time
+           2   0%                         - timer-set-time
+           2   0%                            timer--time-setter
+           5   0%                      - seed7--block-name
+           5   0%                       - seed7-re-search-forward
+           2   0%                          re-search-forward
+           2   0%                        - seed7-inside-comment-p
+           2   0%                         - syntax-ppss
+           2   0%                            parse-partial-sexp
+           1   0%                        - seed7-inside-string-p
+           1   0%                           match-data
+         105   3%                     - seed7-re-search-forward
+          59   2%                      - seed7-inside-comment-p
+          56   2%                       - syntax-ppss
+          47   1%                          parse-partial-sexp
+           8   0%                        - syntax-propertize
+           5   0%                         - seed7-mode-syntax-propertize
+           3   0%                            re-search-forward
+           1   0%                            match-data
+           1   0%                            put-text-property
+           1   0%                          make-closure
+          26   0%                      - seed7-inside-string-p
+          24   0%                       - syntax-ppss
+          24   0%                          parse-partial-sexp
+           1   0%                         match-data
+           1   0%                         make-closure
+          19   0%                        re-search-forward
+           7   0%                     - seed7-re-search-backward
+           3   0%                      - seed7-inside-string-p
+           2   0%                         match-data
+           1   0%                       - syntax-ppss
+           1   0%                          parse-partial-sexp
+           2   0%                      - seed7-inside-comment-p
+           2   0%                       - syntax-ppss
+           2   0%                          parse-partial-sexp
+           1   0%                        re-search-backward
+           1   0%                      - run-with-timer
+           1   0%                       - run-at-time
+           1   0%                        - timer-activate
+           1   0%                         - timer--activate
+           1   0%                            timer--time-less-p
+           1   0%                       match-string
+          80   2%                    - seed7-beg-of-defun
+          57   2%                     - seed7-re-search-backward
+          42   1%                      - seed7-inside-comment-p
+          41   1%                       - syntax-ppss
+          41   1%                          parse-partial-sexp
+           7   0%                        re-search-backward
+           6   0%                      - run-with-timer
+           6   0%                       - run-at-time
+           3   0%                        - timer-set-time
+           3   0%                           timer--time-setter
+           2   0%                        - timer-activate
+           2   0%                         - timer--activate
+           2   0%                            timer--time-less-p
+           1   0%                          timer-relative-time
+           2   0%                      - seed7-inside-string-p
+           2   0%                         match-data
+          17   0%                     - seed7-re-search-backward-closest
+          17   0%                      - seed7-re-search-backward
+           9   0%                         re-search-backward
+           5   0%                       - seed7-inside-comment-p
+           5   0%                        - syntax-ppss
+           5   0%                           parse-partial-sexp
+           1   0%                       - run-with-timer
+           1   0%                        - run-at-time
+           1   0%                           timer-relative-time
+           1   0%                       - seed7-inside-string-p
+           1   0%                          match-data
+           5   0%                     - seed7-top-block-name
+           4   0%                      - seed7--to-top
+           3   0%                       - seed7-re-search-backward
+           2   0%                          re-search-backward
+           1   0%                        - seed7-inside-comment-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+           1   0%                       - run-with-timer
+           1   0%                        - run-at-time
+           1   0%                         - timer-set-time
+           1   0%                            timer--time-setter
+           1   0%                      - seed7--block-name
+           1   0%                       - seed7-re-search-forward
+           1   0%                          re-search-forward
+           1   0%                       looking-at
+          10   0%                    - seed7--safe-current-line-defun-start-indent
+          10   0%                     - seed7-to-block-backward
+          10   0%                      - seed7-re-search-backward
+           9   0%                       - seed7-inside-comment-p
+           9   0%                        - syntax-ppss
+           9   0%                           parse-partial-sexp
+           1   0%                         re-search-backward
+           8   0%                    - seed7-move-to-line
+           8   0%                     - seed7-to-previous-non-empty-line
+           7   0%                      - seed7-inside-comment-p
+           7   0%                       - syntax-ppss
+           7   0%                          parse-partial-sexp
+           4   0%                    - seed7--current-line-nth-word
+           3   0%                     - thing-at-point
+           3   0%                      - bounds-of-thing-at-point
+           1   0%                       - #<byte-code-function 0C9>
+           1   0%                        - forward-thing
+           1   0%                           forward-word
+           1   0%                       - #<byte-code-function 123>
+           1   0%                        - forward-thing
+           1   0%                           forward-word
+           3   0%                    - seed7--indent-search-boundary-uncached
+           2   0%                     - syntax-ppss
+           2   0%                        parse-partial-sexp
+           2   0%                    - seed7-line-starts-with-any
+           2   0%                     - seed7-line-starts-with
+           2   0%                        looking-at
+           1   0%                      looking-back
+           1   0%                      line-beginning-position
+         571  20%                   - seed7--indent-search-boundary
+         571  20%                    - seed7--indent-search-boundary-uncached
+         549  19%                     - syntax-ppss
+         539  19%                        parse-partial-sexp
+           6   0%                        make-closure
+           1   0%                        syntax-ppss--data
+           1   0%                        #<byte-code-function 1E7>
+           1   0%                        syntax-ppss--update-stats
+           2   0%                       seed7-to-indent
+         243   8%                   - seed7-comment-column
+         238   8%                    - seed7-calc-indent
+         105   3%                     - seed7-line-is-defun-end
+          89   3%                      - seed7-end-of-defun
+          68   2%                       - seed7-top-block-name
+          67   2%                        - seed7--to-top
+          66   2%                         - seed7-re-search-backward
+          59   2%                          - seed7-inside-comment-p
+          59   2%                           - syntax-ppss
+          59   2%                              parse-partial-sexp
+           4   0%                          - run-with-timer
+           4   0%                           - run-at-time
+           2   0%                            - timer-activate
+           2   0%                             - timer--activate
+           2   0%                                timer--time-less-p
+           2   0%                              timer-relative-time
+           2   0%                          - seed7-inside-string-p
+           2   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+           1   0%                         - run-with-timer
+           1   0%                          - run-at-time
+           1   0%                             timer-relative-time
+           1   0%                        - seed7--block-name
+           1   0%                         - seed7-re-search-forward
+           1   0%                          - seed7-inside-comment-p
+           1   0%                           - syntax-ppss
+           1   0%                              parse-partial-sexp
+          21   0%                       - seed7-re-search-forward
+           9   0%                        - seed7-inside-comment-p
+           9   0%                         - syntax-ppss
+           7   0%                            parse-partial-sexp
+           1   0%                            make-closure
+           1   0%                            syntax-propertize
+           9   0%                        - seed7-inside-string-p
+           9   0%                         - syntax-ppss
+           9   0%                            parse-partial-sexp
+           3   0%                          re-search-forward
+          10   0%                      - seed7-beg-of-defun
+          10   0%                       - seed7-re-search-backward
+           5   0%                        - seed7-inside-comment-p
+           5   0%                         - syntax-ppss
+           5   0%                            parse-partial-sexp
+           3   0%                        - run-with-timer
+           3   0%                         - run-at-time
+           1   0%                            timer-relative-time
+           1   0%                          - timer-activate
+           1   0%                           - timer--activate
+           1   0%                              timer--time-less-p
+           1   0%                          - timer-set-time
+           1   0%                             timer--time-setter
+           2   0%                          re-search-backward
+           3   0%                      - seed7-move-to-line
+           3   0%                       - seed7-to-previous-non-empty-line
+           3   0%                        - seed7-inside-comment-p
+           3   0%                         - syntax-ppss
+           3   0%                            parse-partial-sexp
+           1   0%                        looking-back
+           1   0%                      - seed7--safe-current-line-defun-start-indent
+           1   0%                       - seed7-to-block-backward
+           1   0%                        - seed7-inside-comment-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+           1   0%                      - seed7--indent-search-boundary-uncached
+           1   0%                       - syntax-ppss
+           1   0%                          parse-partial-sexp
+          54   1%                     - seed7--indent-search-boundary
+          54   1%                      - seed7--indent-search-boundary-uncached
+          52   1%                       - syntax-ppss
+          52   1%                          parse-partial-sexp
+           1   0%                         seed7-to-indent
+          32   1%                     - seed7-line-inside-parens-pair-column
+          32   1%                      - seed7-line-inside-parens-pair
+          32   1%                       - seed7-re-search-backward
+          28   1%                        - seed7-inside-comment-p
+          28   1%                         - syntax-ppss
+          28   1%                            parse-partial-sexp
+           2   0%                        - run-with-timer
+           2   0%                         - run-at-time
+           1   0%                          - timer-set-time
+           1   0%                             timer--time-setter
+           1   0%                            timer-relative-time
+           1   0%                          re-search-backward
+           1   0%                        - seed7-inside-string-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+          30   1%                     - seed7-line-inside-a-block-cached
+          30   1%                      - seed7-line-inside-a-block
+          20   0%                       - seed7--safe-enclosing-block-bounds
+          20   0%                        - seed7--block-end-pos-for
+          16   0%                         - seed7-to-block-forward
+          13   0%                          - seed7-end-of-defun
+          10   0%                           - seed7-top-block-name
+          10   0%                            - seed7--to-top
+          10   0%                             - seed7-re-search-backward
+           8   0%                              - seed7-inside-comment-p
+           8   0%                               - syntax-ppss
+           8   0%                                  parse-partial-sexp
+           2   0%                              - run-with-timer
+           2   0%                               - run-at-time
+           1   0%                                - timer-activate
+           1   0%                                 - timer--activate
+           1   0%                                    timer--time-less-p
+           1   0%                                  timer-relative-time
+           3   0%                           - seed7-re-search-forward
+           2   0%                            - seed7-inside-comment-p
+           2   0%                             - syntax-ppss
+           2   0%                                parse-partial-sexp
+           1   0%                              re-search-forward
+           2   0%                          - seed7-re-search-forward
+           2   0%                           - seed7-inside-comment-p
+           2   0%                            - syntax-ppss
+           1   0%                             - syntax-propertize
+           1   0%                              - seed7-mode-syntax-propertize
+           1   0%                                 put-text-property
+           1   0%                               parse-partial-sexp
+           1   0%                          - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+           1   0%                             looking-at
+           4   0%                         - seed7--line-ends-a-statement-p
+           2   0%                            looking-at
+          10   0%                       - seed7-re-search-backward
+           7   0%                        - seed7-inside-comment-p
+           7   0%                         - syntax-ppss
+           7   0%                            parse-partial-sexp
+           2   0%                        - run-with-timer
+           2   0%                         - run-at-time
+           2   0%                            timer-relative-time
+           1   0%                          re-search-backward
+           4   0%                     - seed7-line-starts-with-open-paren-after-logic-operator
+           4   0%                      - seed7-move-to-line
+           4   0%                       - seed7-to-previous-non-empty-line
+           4   0%                        - seed7-inside-comment-p
+           4   0%                         - syntax-ppss
+           4   0%                            parse-partial-sexp
+           3   0%                     - seed7-line-after-short-func-end
+           3   0%                      - seed7-move-to-line
+           3   0%                       - seed7-to-previous-non-empty-line
+           3   0%                        - seed7-inside-comment-p
+           3   0%                         - syntax-ppss
+           3   0%                            parse-partial-sexp
+           2   0%                     - seed7-line-at-endof-set-definition-block
+           2   0%                      - seed7-move-to-line
+           2   0%                       - seed7-to-previous-non-empty-line
+           2   0%                        - seed7-inside-comment-p
+           2   0%                         - syntax-ppss
+           2   0%                            parse-partial-sexp
+           2   0%                     - seed7-line-at-endof-array-definition-block
+           2   0%                      - seed7-move-to-line
+           2   0%                       - seed7-to-previous-non-empty-line
+           2   0%                        - seed7-inside-comment-p
+           2   0%                         - syntax-ppss
+           2   0%                            parse-partial-sexp
+           2   0%                     - seed7-line-inside-assign-statement-continuation
+           2   0%                      - seed7-assign-op-pos
+           2   0%                       - seed7-re-search-backward
+           1   0%                        - seed7-inside-comment-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+           1   0%                        - run-with-timer
+           1   0%                         - run-at-time
+           1   0%                          - timer-set-time
+           1   0%                             timer--time-setter
+           1   0%                     - seed7-line-inside-array-definition-block
+           1   0%                      - seed7-re-search-backward
+           1   0%                       - run-with-timer
+           1   0%                        - run-at-time
+           1   0%                           timer-relative-time
+           1   0%                     - seed7-line-after-func-return-logic-operator-column
+           1   0%                      - seed7-move-to-line
+           1   0%                       - seed7-to-previous-non-empty-line
+           1   0%                        - seed7-inside-comment-p
+           1   0%                         - syntax-ppss
+           1   0%                            parse-partial-sexp
+           1   0%                     - seed7-line-inside-argument-list-section
+           1   0%                      - seed7-re-search-backward
+           1   0%                       - seed7-inside-comment-p
+           1   0%                        - syntax-ppss
+           1   0%                           parse-partial-sexp
+           1   0%                     - seed7--current-line-nth-word
+           1   0%                      - thing-at-point
+           1   0%                       - bounds-of-thing-at-point
+           1   0%                          make-closure
+           3   0%                    - seed7-line-code-ends-with
+           2   0%                     - seed7-move-to-line
+           2   0%                      - seed7-to-previous-non-empty-line
+           2   0%                       - seed7-inside-comment-p
+           2   0%                        - syntax-ppss
+           2   0%                           parse-partial-sexp
+           1   0%                     - seed7-re-search-backward
+           1   0%                      - seed7-inside-comment-p
+           1   0%                       - syntax-ppss
+           1   0%                          parse-partial-sexp
+           1   0%                    - seed7-line-starts-with
+           1   0%                     - seed7-move-to-line
+           1   0%                        seed7-to-previous-non-empty-line
+          59   2%                   - seed7-line-inside-parens-pair-column
+          59   2%                    - seed7-line-inside-parens-pair
+          56   2%                     - seed7-re-search-backward
+          47   1%                      - seed7-inside-comment-p
+          47   1%                       - syntax-ppss
+          43   1%                          parse-partial-sexp
+           3   0%                          make-closure
+           1   0%                          set-syntax-table
+           6   0%                      - run-with-timer
+           6   0%                       - run-at-time
+           3   0%                        - timer-activate
+           3   0%                         - timer--activate
+           3   0%                            timer--time-less-p
+           2   0%                        - timer-set-time
+           2   0%                           timer--time-setter
+           1   0%                          timer-relative-time
+           1   0%                        #<byte-code-function 455>
+           1   0%                     - seed7-line-inside-syntax-parens-pair
+           1   0%                      - syntax-ppss
+           1   0%                         parse-partial-sexp
+           1   0%                     - forward-sexp
+           1   0%                      - seed7--forward-sexp-function
+           1   0%                         looking-at
+          19   0%                   - seed7--current-line-nth-word
+          19   0%                    - thing-at-point
+          19   0%                     - bounds-of-thing-at-point
+          18   0%                      - #<byte-code-function 37F>
+          18   0%                       - forward-thing
+          18   0%                        - forward-word
+          16   0%                         - internal--syntax-propertize
+          15   0%                          - syntax-propertize
+          12   0%                           - seed7-mode-syntax-propertize
+          10   0%                              re-search-forward
+           1   0%                              put-text-property
+           1   0%                      - #<byte-code-function B44>
+           1   0%                       - forward-thing
+           1   0%                          forward-word
+          13   0%                   - seed7-line-inside-set-definition-block
+          13   0%                    - seed7-re-search-backward
+           9   0%                       re-search-backward
+           4   0%                     - run-with-timer
+           4   0%                      - run-at-time
+           2   0%                       - timer-activate
+           2   0%                        - timer--activate
+           2   0%                           timer--time-less-p
+           1   0%                         timer-relative-time
+           1   0%                       - timer-set-time
+           1   0%                          timer--time-setter
+          10   0%                   - seed7-line-inside-array-definition-block
+          10   0%                    - seed7-re-search-backward
+           7   0%                       re-search-backward
+           2   0%                       make-closure
+           1   0%                     - run-with-timer
+           1   0%                      - run-at-time
+           1   0%                       - timer-activate
+           1   0%                        - timer--activate
+           1   0%                           timer--time-less-p
+           9   0%                   - seed7-line-inside-assign-statement-continuation
+           8   0%                    - seed7-assign-op-pos
+           8   0%                     - seed7-re-search-backward
+           5   0%                      - seed7-inside-comment-p
+           5   0%                       - syntax-ppss
+           5   0%                          parse-partial-sexp
+           2   0%                      - run-with-timer
+           2   0%                       - run-at-time
+           1   0%                          timer-relative-time
+           1   0%                          timer-create
+           1   0%                        re-search-backward
+           1   0%                    - seed7-statement-end-pos
+           1   0%                     - seed7-forward-char-pos
+           1   0%                      - seed7-re-search-forward
+           1   0%                       - seed7-inside-string-p
+           1   0%                        - syntax-ppss
+           1   0%                           #<byte-code-function 95B>
+           7   0%                   - seed7-line-inside-argument-list-section
+           7   0%                    - seed7-re-search-backward
+           3   0%                     - seed7-inside-comment-p
+           3   0%                      - syntax-ppss
+           3   0%                         parse-partial-sexp
+           2   0%                     - run-with-timer
+           2   0%                      - run-at-time
+           2   0%                       - timer-activate
+           2   0%                        - timer--activate
+           2   0%                           timer--time-less-p
+           1   0%                     - seed7-inside-string-p
+           1   0%                        match-data
+           4   0%                   - seed7-line-after-func-return-logic-operator-column
+           4   0%                    - seed7-move-to-line
+           4   0%                     - seed7-to-previous-non-empty-line
+           3   0%                      - seed7-inside-comment-p
+           3   0%                       - syntax-ppss
+           3   0%                          parse-partial-sexp
+           2   0%                   - seed7-line-inside-until-logic-expression
+           2   0%                    - seed7-re-search-backward
+           2   0%                     - run-with-timer
+           2   0%                      - run-at-time
+           1   0%                         timer-relative-time
+           1   0%                       - timer-activate
+           1   0%                        - timer--activate
+           1   0%                           timer--time-less-p
+           1   0%                     seed7-line-inside-func-return-statement
+           1   0%                   - seed7-current-line-start-inside-comment-p
+           1   0%                    - seed7-inside-comment-p
+           1   0%                     - syntax-ppss
+           1   0%                        parse-partial-sexp
+         327  11%   Automatic GC

--- a/reports/21.1/array.s7i-perf-mem-3.txt
+++ b/reports/21.1/array.s7i-perf-mem-3.txt
@@ -1,0 +1,1801 @@
+     78,248,888  99% - ...
+     78,248,888  99%  - #<primitive-function call-interactively>
+     78,248,888  99%   - funcall-interactively
+     78,248,888  99%    - smex
+     78,248,888  99%     - smex-read-and-run
+     78,248,888  99%      - execute-extended-command
+     78,248,888  99%       - apply
+     78,248,888  99%        - ad-Advice-execute-extended-command
+     78,248,888  99%         - #<native-comp-function execute-extended-command>
+     78,248,888  99%          - command-execute
+     78,248,888  99%           - call-interactively
+     78,248,888  99%            - apply
+     78,248,888  99%             - call-interactively@ido-cr+-record-current-command
+     78,248,888  99%              - #<primitive-function call-interactively>
+     78,248,888  99%               - funcall-interactively
+     78,248,888  99%                - pel-profile
+     76,622,508  97%                 - call-interactively
+     76,622,508  97%                  - apply
+     76,622,508  97%                   - call-interactively@ido-cr+-record-current-command
+     76,622,508  97%                    - #<primitive-function call-interactively>
+     76,622,508  97%                     - funcall-interactively
+     76,622,492  97%                      - seed7-complete-statement-or-indent
+     76,622,492  97%                       - seed7-indent-region
+     76,622,492  97%                        - seed7--indent-one-line
+     76,427,452  97%                         - seed7-calc-indent
+     32,017,685  40%                          - seed7-line-inside-a-block-cached
+     32,009,397  40%                           - seed7-line-inside-a-block
+     17,361,360  22%                            - seed7--safe-enclosing-block-bounds
+     17,340,640  22%                             - seed7--block-end-pos-for
+     16,611,240  21%                              - seed7-to-block-forward
+     14,606,184  18%                               - seed7-end-of-defun
+     12,817,484  16%                                - seed7-top-block-name
+     12,482,469  15%                                 - seed7--to-top
+     11,825,277  15%                                  - seed7-re-search-backward
+      8,460,928  10%                                   - run-with-timer
+      8,460,928  10%                                    - run-at-time
+      3,307,136   4%                                     - timer-activate
+      3,307,136   4%                                      - timer--activate
+      3,307,136   4%                                         timer--time-less-p
+      2,681,280   3%                                       timer-relative-time
+      1,842,624   2%                                     - timer-set-time
+      1,842,624   2%                                        timer--time-setter
+        629,888   0%                                       timer-create
+      2,021,552   2%                                   - seed7-inside-string-p
+      1,139,600   1%                                      match-data
+        517,280   0%                                    - syntax-ppss
+        443,408   0%                                       make-closure
+         73,872   0%                                     - parse-partial-sexp
+          8,288   0%                                        internal--syntax-propertize
+        364,672   0%                                      make-closure
+        833,469   1%                                   - seed7-inside-comment-p
+        588,973   0%                                    - syntax-ppss
+        497,280   0%                                       make-closure
+         58,901   0%                                     - syntax-propertize
+         54,757   0%                                      - seed7-mode-syntax-propertize
+         46,469   0%                                         re-search-forward
+          8,288   0%                                         match-data
+         32,792   0%                                       parse-partial-sexp
+        476,560   0%                                     make-closure
+         32,768   0%                                     re-search-backward
+        595,392   0%                                  - run-with-timer
+        595,392   0%                                   - run-at-time
+        273,856   0%                                    - timer-activate
+        273,856   0%                                     - timer--activate
+        273,856   0%                                      - timer--time-less-p
+         65,584   0%                                         timer--time
+        166,592   0%                                      timer-relative-time
+        109,360   0%                                    - timer-set-time
+        109,360   0%                                       timer--time-setter
+         45,584   0%                                      timer-create
+         29,008   0%                                    make-closure
+        306,007   0%                                 - seed7--block-name
+        281,143   0%                                  - seed7-re-search-forward
+        194,768   0%                                   - seed7-inside-string-p
+        153,328   0%                                      match-data
+         20,720   0%                                      make-closure
+         20,720   0%                                    - syntax-ppss
+         20,720   0%                                       make-closure
+         45,584   0%                                   - seed7-inside-comment-p
+         24,864   0%                                    - syntax-ppss
+         24,864   0%                                       make-closure
+         40,791   0%                                     re-search-forward
+        840,608   1%                                - seed7-re-search-backward
+        504,944   0%                                 - run-with-timer
+        504,944   0%                                  - run-at-time
+        199,984   0%                                   - timer-activate
+        199,984   0%                                    - timer--activate
+        199,984   0%                                       timer--time-less-p
+        166,592   0%                                     timer-relative-time
+        109,360   0%                                   - timer-set-time
+        109,360   0%                                      timer--time-setter
+         29,008   0%                                     timer-create
+        269,360   0%                                 - seed7-inside-string-p
+        198,912   0%                                    match-data
+         37,296   0%                                    make-closure
+         33,152   0%                                  - syntax-ppss
+         33,152   0%                                     make-closure
+         41,440   0%                                   make-closure
+         24,864   0%                                 - seed7-inside-comment-p
+         12,432   0%                                  - syntax-ppss
+         12,432   0%                                     make-closure
+        673,468   0%                                - seed7-re-search-forward
+        291,612   0%                                 - re-search-forward
+         29,858   0%                                  - internal--syntax-propertize
+         29,858   0%                                   - syntax-propertize
+         25,714   0%                                    - seed7-mode-syntax-propertize
+         25,714   0%                                       re-search-forward
+        244,496   0%                                 - seed7-inside-string-p
+        194,768   0%                                    match-data
+         29,008   0%                                    make-closure
+         20,720   0%                                  - syntax-ppss
+         20,720   0%                                     make-closure
+        137,360   0%                                 - seed7-inside-comment-p
+        108,352   0%                                  - syntax-ppss
+         66,304   0%                                     make-closure
+         42,048   0%                                   - syntax-propertize
+         33,760   0%                                    - seed7-mode-syntax-propertize
+         17,184   0%                                       re-search-forward
+         12,432   0%                                       match-data
+         71,408   0%                                  looking-at
+         67,712   0%                                  string-match
+         40,920   0%                                  match-string-no-properties
+         40,920   0%                                  substring-no-properties
+         16,368   0%                                  match-string
+        768,456   0%                               - seed7--current-line-nth-word
+        677,288   0%                                - thing-at-point
+        644,552   0%                                 - bounds-of-thing-at-point
+        261,072   0%                                    make-closure
+         95,312   0%                                  - seq-some
+         95,312   0%                                     make-closure
+         90,024   0%                                  - #<byte-code-function C70>
+         90,024   0%                                   - forward-thing
+         90,024   0%                                      format
+         41,088   0%                                    re-search-forward
+         32,736   0%                                  - #<byte-code-function 09B>
+         32,736   0%                                   - forward-thing
+         32,736   0%                                      format
+        671,400   0%                               - seed7-re-search-forward
+        380,515   0%                                  re-search-forward
+        186,480   0%                                - seed7-inside-string-p
+        107,744   0%                                   match-data
+         45,584   0%                                 - syntax-ppss
+         45,584   0%                                    make-closure
+         33,152   0%                                   make-closure
+        104,405   0%                                - seed7-inside-comment-p
+         91,973   0%                                 - syntax-ppss
+         46,389   0%                                  - syntax-propertize
+         46,389   0%                                   - seed7-mode-syntax-propertize
+         42,245   0%                                      re-search-forward
+          4,144   0%                                      make-closure
+         45,584   0%                                    make-closure
+        404,152   0%                               - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+        254,968   0%                                  looking-at
+         82,880   0%                                - seed7-inside-line-indent-before-comment-p
+          8,288   0%                                 - seed7-inside-comment-p
+          8,288   0%                                  - syntax-ppss
+          8,288   0%                                     make-closure
+         41,440   0%                                - seed7-inside-comment-p
+         16,576   0%                                 - syntax-ppss
+         16,576   0%                                    make-closure
+         61,800   0%                               - seed7-inside-comment-p
+         41,080   0%                                - syntax-ppss
+         32,792   0%                                   parse-partial-sexp
+          8,288   0%                                   make-closure
+         49,728   0%                               - seed7-inside-line-indent-before-comment-p
+          8,288   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         16,368   0%                               - seed7--end-regexp-for
+         16,368   0%                                  format
+        458,184   0%                              - seed7--line-ends-a-statement-p
+        215,160   0%                               - forward-sexp
+        215,160   0%                                - seed7--forward-sexp-function
+        215,160   0%                                   looking-at
+        214,016   0%                                 looking-at
+        161,784   0%                                re-search-forward
+         57,968   0%                              - seed7-re-search-forward-closest
+         37,248   0%                               - seed7-re-search-forward
+         33,152   0%                                - seed7-inside-string-p
+         16,576   0%                                   match-data
+         12,432   0%                                 - syntax-ppss
+         12,432   0%                                    make-closure
+          4,144   0%                                   make-closure
+          4,096   0%                                  re-search-forward
+         20,720   0%                                 match-data
+         39,032   0%                                looking-at
+     12,058,357  15%                            - seed7-calc-indent
+      5,014,768   6%                             - seed7-line-is-defun-end
+      3,362,130   4%                              - seed7-end-of-defun
+      2,547,704   3%                               - seed7-top-block-name
+      2,497,976   3%                                - seed7--to-top
+      2,380,192   3%                                 - seed7-re-search-backward
+      1,746,880   2%                                  - run-with-timer
+      1,746,880   2%                                   - run-at-time
+        699,648   0%                                    - timer-activate
+        699,648   0%                                     - timer--activate
+        699,648   0%                                        timer--time-less-p
+        560,576   0%                                      timer-relative-time
+        366,480   0%                                    - timer-set-time
+        366,480   0%                                       timer--time-setter
+        120,176   0%                                      timer-create
+        327,376   0%                                  - seed7-inside-string-p
+        174,048   0%                                     match-data
+         78,736   0%                                   - syntax-ppss
+         78,736   0%                                      make-closure
+         74,592   0%                                     make-closure
+        198,552   0%                                  - seed7-inside-comment-p
+        144,680   0%                                   - syntax-ppss
+        111,888   0%                                      make-closure
+         32,792   0%                                      parse-partial-sexp
+         74,592   0%                                    make-closure
+        109,496   0%                                 - run-with-timer
+        109,496   0%                                  - run-at-time
+         40,024   0%                                   - timer-activate
+         40,024   0%                                    - timer--activate
+         40,024   0%                                       timer--time-less-p
+         34,960   0%                                     timer-relative-time
+         22,080   0%                                   - timer-set-time
+         22,080   0%                                      timer--time-setter
+         12,432   0%                                     timer-create
+          8,288   0%                                   make-closure
+         45,584   0%                                - seed7--block-name
+         41,440   0%                                 - seed7-re-search-forward
+         33,152   0%                                  - seed7-inside-string-p
+         24,864   0%                                     match-data
+          8,288   0%                                     make-closure
+          8,288   0%                                    seed7-inside-comment-p
+        454,226   0%                               - seed7-re-search-forward
+        277,648   0%                                - seed7-inside-string-p
+        203,056   0%                                   match-data
+         41,440   0%                                   make-closure
+         33,152   0%                                 - syntax-ppss
+         33,152   0%                                    make-closure
+        116,930   0%                                - seed7-inside-comment-p
+         83,778   0%                                 - syntax-ppss
+         58,016   0%                                    make-closure
+         25,762   0%                                  - syntax-propertize
+         25,762   0%                                   - seed7-mode-syntax-propertize
+         21,618   0%                                      re-search-forward
+         59,648   0%                                  re-search-forward
+        171,656   0%                               - seed7-re-search-backward
+        117,784   0%                                - run-with-timer
+        117,784   0%                                 - run-at-time
+         44,168   0%                                  - timer-activate
+         44,168   0%                                   - timer--activate
+         44,168   0%                                      timer--time-less-p
+         34,960   0%                                    timer-relative-time
+         22,080   0%                                  - timer-set-time
+         22,080   0%                                     timer--time-setter
+         16,576   0%                                    timer-create
+         45,584   0%                                - seed7-inside-string-p
+         29,008   0%                                   match-data
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+          8,288   0%                                   make-closure
+          4,144   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          4,144   0%                                  make-closure
+         61,688   0%                                 string-match
+         32,736   0%                                 match-string-no-properties
+         32,736   0%                                 match-string
+         32,688   0%                                 looking-at
+         24,552   0%                                 substring-no-properties
+      1,033,973   1%                              - seed7-beg-of-defun
+        519,755   0%                               - seed7-re-search-backward
+        372,224   0%                                - run-with-timer
+        372,224   0%                                 - run-at-time
+        160,224   0%                                  - timer-activate
+        160,224   0%                                   - timer--activate
+        160,224   0%                                      timer--time-less-p
+        119,776   0%                                    timer-relative-time
+         79,792   0%                                  - timer-set-time
+         79,792   0%                                     timer--time-setter
+         12,432   0%                                    timer-create
+         62,160   0%                                - seed7-inside-string-p
+         41,440   0%                                   match-data
+         12,432   0%                                   make-closure
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+         56,363   0%                                  re-search-backward
+         16,576   0%                                - seed7-inside-comment-p
+         12,432   0%                                 - syntax-ppss
+         12,432   0%                                    make-closure
+         12,432   0%                                  make-closure
+        156,746   0%                               - seed7-top-block-name
+         98,112   0%                                - seed7--to-top
+         70,536   0%                                 - seed7-re-search-backward
+         30,528   0%                                    re-search-backward
+         23,432   0%                                  - run-with-timer
+         23,432   0%                                   - run-at-time
+          9,048   0%                                    - timer-activate
+          9,048   0%                                     - timer--activate
+          9,048   0%                                        timer--time-less-p
+          8,816   0%                                      timer-relative-time
+          5,568   0%                                    - timer-set-time
+          5,568   0%                                       timer--time-setter
+          8,288   0%                                  - seed7-inside-string-p
+          4,144   0%                                   - syntax-ppss
+          4,144   0%                                      make-closure
+          4,144   0%                                     match-data
+          4,144   0%                                    make-closure
+          4,144   0%                                    seed7-inside-comment-p
+         27,576   0%                                 - run-with-timer
+         27,576   0%                                  - run-at-time
+         13,192   0%                                   - timer-activate
+         13,192   0%                                    - timer--activate
+         13,192   0%                                       timer--time-less-p
+          8,816   0%                                     timer-relative-time
+          5,568   0%                                   - timer-set-time
+          5,568   0%                                      timer--time-setter
+         58,634   0%                                - seed7--block-name
+         58,634   0%                                 - seed7-re-search-forward
+         58,634   0%                                    re-search-forward
+        154,537   0%                               - seed7-re-search-backward-closest
+        150,393   0%                                - seed7-re-search-backward
+         74,521   0%                                   re-search-backward
+         55,152   0%                                 - run-with-timer
+         55,152   0%                                  - run-at-time
+         18,096   0%                                   - timer-activate
+         18,096   0%                                    - timer--activate
+         18,096   0%                                       timer--time-less-p
+         17,632   0%                                     timer-relative-time
+         11,136   0%                                   - timer-set-time
+         11,136   0%                                      timer--time-setter
+          8,288   0%                                     timer-create
+         16,576   0%                                 - seed7-inside-string-p
+         12,432   0%                                    match-data
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+          4,144   0%                                   make-closure
+          4,144   0%                                - seq-filter
+          4,144   0%                                   make-closure
+        146,199   0%                                 looking-at
+         36,224   0%                                 string-match
+          8,184   0%                                 match-string
+          8,184   0%                                 match-string-no-properties
+        427,649   0%                              - seed7-line-starts-with-any
+        427,649   0%                               - seed7-line-starts-with
+        402,889   0%                                  looking-at
+        127,064   0%                                looking-back
+         41,232   0%                              - seed7--current-line-nth-word
+         41,232   0%                               - thing-at-point
+         33,048   0%                                - bounds-of-thing-at-point
+         12,432   0%                                   make-closure
+          8,288   0%                                 - seq-some
+          8,288   0%                                    make-closure
+          8,184   0%                                 - #<byte-code-function 943>
+          8,184   0%                                  - forward-thing
+          8,184   0%                                     format
+         18,576   0%                              - seed7-move-to-line
+         18,576   0%                               - seed7-to-previous-non-empty-line
+         12,432   0%                                - seed7-inside-comment-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+          6,144   0%                                  looking-at
+      3,008,757   3%                             - seed7-line-inside-a-block-cached
+      3,008,757   3%                              - seed7-line-inside-a-block
+      2,078,853   2%                               - seed7--safe-enclosing-block-bounds
+      2,058,133   2%                                - seed7--block-end-pos-for
+      1,811,405   2%                                 - seed7-to-block-forward
+      1,331,932   1%                                  - seed7-end-of-defun
+      1,100,096   1%                                   - seed7-top-block-name
+      1,043,456   1%                                    - seed7--to-top
+        993,856   1%                                     - seed7-re-search-backward
+        721,328   0%                                      - run-with-timer
+        721,328   0%                                       - run-at-time
+        286,000   0%                                        - timer-activate
+        286,000   0%                                         - timer--activate
+        286,000   0%                                            timer--time-less-p
+        226,176   0%                                          timer-relative-time
+        155,280   0%                                        - timer-set-time
+        155,280   0%                                           timer--time-setter
+         53,872   0%                                          timer-create
+        161,616   0%                                      - seed7-inside-string-p
+         82,880   0%                                         match-data
+         49,728   0%                                         make-closure
+         29,008   0%                                       - syntax-ppss
+         29,008   0%                                          make-closure
+         74,592   0%                                      - seed7-inside-comment-p
+         45,584   0%                                       - syntax-ppss
+         45,584   0%                                          make-closure
+         24,864   0%                                        make-closure
+         11,456   0%                                        re-search-backward
+         45,456   0%                                     - run-with-timer
+         45,456   0%                                      - run-at-time
+         22,640   0%                                       - timer-activate
+         22,640   0%                                        - timer--activate
+         22,640   0%                                           timer--time-less-p
+         13,984   0%                                         timer-relative-time
+          8,832   0%                                       - timer-set-time
+          8,832   0%                                          timer--time-setter
+          4,144   0%                                       make-closure
+         52,496   0%                                    - seed7--block-name
+         52,496   0%                                     - seed7-re-search-forward
+         27,632   0%                                        re-search-forward
+         16,576   0%                                      - seed7-inside-string-p
+         12,432   0%                                         match-data
+          4,144   0%                                         make-closure
+          8,288   0%                                        seed7-inside-comment-p
+        115,636   0%                                   - seed7-re-search-forward
+         62,160   0%                                    - seed7-inside-string-p
+         49,728   0%                                       match-data
+          8,288   0%                                     - syntax-ppss
+          8,288   0%                                        make-closure
+          4,144   0%                                       make-closure
+         32,756   0%                                      re-search-forward
+         20,720   0%                                    - seed7-inside-comment-p
+          8,288   0%                                     - syntax-ppss
+          8,288   0%                                        make-closure
+         70,320   0%                                   - seed7-re-search-backward
+         41,312   0%                                    - run-with-timer
+         41,312   0%                                     - run-at-time
+         14,352   0%                                      - timer-activate
+         14,352   0%                                       - timer--activate
+         14,352   0%                                          timer--time-less-p
+         13,984   0%                                        timer-relative-time
+          8,832   0%                                      - timer-set-time
+          8,832   0%                                         timer--time-setter
+          4,144   0%                                        timer-create
+         24,864   0%                                    - seed7-inside-string-p
+         20,720   0%                                       match-data
+          4,144   0%                                       make-closure
+          4,144   0%                                    - seed7-inside-comment-p
+          4,144   0%                                     - syntax-ppss
+          4,144   0%                                        make-closure
+         15,360   0%                                     string-match
+         14,048   0%                                     looking-at
+          8,184   0%                                     match-string-no-properties
+        249,753   0%                                  - seed7-re-search-forward
+        119,241   0%                                     re-search-forward
+         99,456   0%                                   - seed7-inside-string-p
+         53,872   0%                                      match-data
+         24,864   0%                                      make-closure
+         20,720   0%                                    - syntax-ppss
+         20,720   0%                                       make-closure
+         31,056   0%                                   - seed7-inside-comment-p
+         14,480   0%                                    - syntax-ppss
+         12,432   0%                                       make-closure
+          2,048   0%                                     - syntax-propertize
+          2,048   0%                                      - seed7-mode-syntax-propertize
+          2,048   0%                                         re-search-forward
+        134,160   0%                                  - seed7--current-line-nth-word
+        117,584   0%                                   - thing-at-point
+        109,400   0%                                    - bounds-of-thing-at-point
+         41,440   0%                                       make-closure
+         26,624   0%                                       re-search-forward
+         16,576   0%                                     - seq-some
+         16,576   0%                                        make-closure
+          8,184   0%                                     - #<byte-code-function 8C3>
+          8,184   0%                                      - forward-thing
+          8,184   0%                                         format
+         56,512   0%                                  - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+         39,936   0%                                     looking-at
+          8,288   0%                                   - seed7-inside-comment-p
+          8,288   0%                                    - syntax-ppss
+          8,288   0%                                       make-closure
+          8,288   0%                                     seed7-inside-line-indent-before-comment-p
+         12,432   0%                                    seed7-inside-line-indent-before-comment-p
+          8,288   0%                                  - seed7-inside-comment-p
+          4,144   0%                                   - syntax-ppss
+          4,144   0%                                      make-closure
+          8,184   0%                                  - seed7--end-regexp-for
+          8,184   0%                                     format
+          6,000   0%                                  - user-error
+          6,000   0%                                     format-message
+        135,416   0%                                 - seed7--line-ends-a-statement-p
+         71,800   0%                                    looking-at
+         63,616   0%                                  - forward-sexp
+         63,616   0%                                   - seed7--forward-sexp-function
+         63,616   0%                                      looking-at
+         47,104   0%                                   re-search-forward
+         33,152   0%                                 - seed7-re-search-forward-closest
+         12,432   0%                                  - seed7-re-search-forward
+          8,288   0%                                   - seed7-inside-string-p
+          4,144   0%                                      make-closure
+          4,144   0%                                      match-data
+          4,144   0%                                   - seed7-inside-comment-p
+          4,144   0%                                    - syntax-ppss
+          4,144   0%                                       make-closure
+         12,432   0%                                    match-data
+          2,048   0%                                   looking-at
+        729,240   0%                               - seed7-re-search-backward
+        497,592   0%                                - run-with-timer
+        497,592   0%                                 - run-at-time
+        194,232   0%                                  - timer-activate
+        194,232   0%                                   - timer--activate
+        194,232   0%                                      timer--time-less-p
+        152,912   0%                                    timer-relative-time
+        100,720   0%                                  - timer-set-time
+        100,720   0%                                     timer--time-setter
+         49,728   0%                                    timer-create
+        148,824   0%                                - seed7-inside-string-p
+         70,448   0%                                   match-data
+         49,368   0%                                 - syntax-ppss
+         32,792   0%                                    parse-partial-sexp
+         16,576   0%                                    make-closure
+         29,008   0%                                   make-closure
+         45,528   0%                                  re-search-backward
+         20,720   0%                                - seed7-inside-comment-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+         16,576   0%                                  make-closure
+        151,352   0%                               - replace-regexp-in-string
+         16,368   0%                                  concat
+         32,736   0%                                 substring-no-properties
+          4,144   0%                                 seed7--on-lineof
+      2,484,384   3%                             - seed7-line-inside-parens-pair-column
+      2,484,384   3%                              - seed7-line-inside-parens-pair
+      2,447,520   3%                               - seed7-re-search-backward
+      1,777,744   2%                                - run-with-timer
+      1,777,744   2%                                 - run-at-time
+        696,672   0%                                  - timer-activate
+        696,672   0%                                   - timer--activate
+        696,672   0%                                      timer--time-less-p
+        594,016   0%                                    timer-relative-time
+        408,320   0%                                  - timer-set-time
+        408,320   0%                                     timer--time-setter
+         78,736   0%                                    timer-create
+        285,936   0%                                - seed7-inside-comment-p
+        190,624   0%                                 - syntax-ppss
+        190,624   0%                                    make-closure
+        252,784   0%                                - seed7-inside-string-p
+        103,600   0%                                   make-closure
+         74,592   0%                                   match-data
+         74,592   0%                                 - syntax-ppss
+         74,592   0%                                    make-closure
+         87,024   0%                                  make-closure
+         44,032   0%                                  re-search-backward
+         36,864   0%                               - forward-sexp
+         36,864   0%                                - seed7--forward-sexp-function
+         36,864   0%                                   looking-at
+        529,352   0%                             - seed7--indent-search-boundary
+        525,208   0%                              - seed7--indent-search-boundary-uncached
+        525,208   0%                               - syntax-ppss
+        426,832   0%                                  make-closure
+         98,376   0%                                  parse-partial-sexp
+        157,280   0%                             - seed7-line-inside-assign-statement-continuation
+        112,056   0%                              - seed7-assign-op-pos
+        112,056   0%                               - seed7-re-search-backward
+         44,160   0%                                  re-search-backward
+         43,032   0%                                - run-with-timer
+         43,032   0%                                 - run-at-time
+         17,560   0%                                  - timer-activate
+         17,560   0%                                   - timer--activate
+         17,560   0%                                      timer--time-less-p
+         13,072   0%                                    timer-relative-time
+          8,256   0%                                  - timer-set-time
+          8,256   0%                                     timer--time-setter
+          4,144   0%                                    timer-create
+         16,576   0%                                - seed7-inside-string-p
+          8,288   0%                                   match-data
+          4,144   0%                                   make-closure
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          8,288   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         45,224   0%                              - seed7-statement-end-pos
+         45,224   0%                               - seed7-forward-char-pos
+         41,080   0%                                - seed7-re-search-forward
+         32,792   0%                                 - seed7-inside-string-p
+         32,792   0%                                    match-data
+          8,288   0%                                   seed7-inside-comment-p
+        144,120   0%                             - seed7-line-inside-argument-list-section
+        103,016   0%                              - seed7-re-search-backward
+         51,592   0%                                 re-search-backward
+         34,848   0%                               - run-with-timer
+         34,848   0%                                - run-at-time
+         11,856   0%                                 - timer-activate
+         11,856   0%                                  - timer--activate
+         11,856   0%                                     timer--time-less-p
+         11,552   0%                                   timer-relative-time
+          7,296   0%                                 - timer-set-time
+          7,296   0%                                    timer--time-setter
+          4,144   0%                                   timer-create
+          8,288   0%                               - seed7-inside-string-p
+          8,288   0%                                  match-data
+          8,288   0%                                 seed7-inside-comment-p
+         28,672   0%                              - seed7-line-is-procfunc-beg-of-decl
+         28,672   0%                               - seed7-line-starts-with
+         28,672   0%                                  looking-at
+          8,288   0%                              - seed7-forward-char-pos
+          8,288   0%                               - seed7-re-search-forward
+          8,288   0%                                  seed7-inside-comment-p
+         91,488   0%                             - seed7-line-inside-array-definition-block
+         91,488   0%                              - seed7-re-search-backward
+         52,600   0%                                 re-search-backward
+         38,888   0%                               - run-with-timer
+         38,888   0%                                - run-at-time
+         17,560   0%                                 - timer-activate
+         17,560   0%                                  - timer--activate
+         17,560   0%                                     timer--time-less-p
+         13,072   0%                                   timer-relative-time
+          8,256   0%                                 - timer-set-time
+          8,256   0%                                    timer--time-setter
+         91,400   0%                             - seed7-line-inside-set-definition-block
+         91,400   0%                              - seed7-re-search-backward
+         47,176   0%                               - run-with-timer
+         47,176   0%                                - run-at-time
+         13,416   0%                                 - timer-activate
+         13,416   0%                                  - timer--activate
+         13,416   0%                                     timer--time-less-p
+         13,072   0%                                   timer-relative-time
+         12,432   0%                                   timer-create
+          8,256   0%                                 - timer-set-time
+          8,256   0%                                    timer--time-setter
+         44,224   0%                                 re-search-backward
+         88,272   0%                             - seed7-line-inside-func-return-statement
+         78,032   0%                              - seed7-re-search-backward
+         39,040   0%                                 re-search-backward
+         34,848   0%                               - run-with-timer
+         34,848   0%                                - run-at-time
+         16,000   0%                                 - timer-activate
+         16,000   0%                                  - timer--activate
+         16,000   0%                                     timer--time-less-p
+         11,552   0%                                   timer-relative-time
+          7,296   0%                                 - timer-set-time
+          7,296   0%                                    timer--time-setter
+          4,144   0%                               - seed7-inside-string-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+         10,240   0%                                re-search-forward
+         82,368   0%                             - seed7-line-after-func-return-logic-operator-column
+         42,128   0%                              - seed7-move-to-line
+         42,128   0%                               - seed7-to-previous-non-empty-line
+         29,696   0%                                  looking-at
+         12,432   0%                                - seed7-inside-comment-p
+          8,288   0%                                 - syntax-ppss
+          8,288   0%                                    make-closure
+         36,096   0%                                re-search-forward
+         82,176   0%                             - seed7-line-inside-logic-check-expression
+         73,888   0%                              - seed7-to-previous-line-starts-with
+         73,888   0%                               - seed7-re-search-backward
+         39,040   0%                                  re-search-backward
+         30,704   0%                                - run-with-timer
+         30,704   0%                                 - run-at-time
+         11,856   0%                                  - timer-activate
+         11,856   0%                                   - timer--activate
+         11,856   0%                                      timer--time-less-p
+         11,552   0%                                    timer-relative-time
+          7,296   0%                                  - timer-set-time
+          7,296   0%                                     timer--time-setter
+          4,144   0%                                  make-closure
+          4,144   0%                              - seed7--current-line-nth-word
+          4,144   0%                               - thing-at-point
+          4,144   0%                                - bounds-of-thing-at-point
+          4,144   0%                                 - seq-some
+          4,144   0%                                    make-closure
+          4,144   0%                              - seed7-re-search-forward
+          4,144   0%                               - seed7-inside-string-p
+          4,144   0%                                  match-data
+         78,032   0%                             - seed7-line-inside-until-logic-expression
+         78,032   0%                              - seed7-re-search-backward
+         39,040   0%                                 re-search-backward
+         34,848   0%                               - run-with-timer
+         34,848   0%                                - run-at-time
+         16,000   0%                                 - timer-activate
+         16,000   0%                                  - timer--activate
+         16,000   0%                                     timer--time-less-p
+         11,552   0%                                   timer-relative-time
+          7,296   0%                                 - timer-set-time
+          7,296   0%                                    timer--time-setter
+          4,144   0%                                 make-closure
+         52,216   0%                             - seed7-line-isa-string
+         52,216   0%                              - seed7-line-starts-with
+         44,032   0%                                 looking-at
+         48,176   0%                             - seed7-line-starts-with
+         44,032   0%                                looking-at
+         41,104   0%                             - seed7--current-line-nth-word
+         41,104   0%                              - thing-at-point
+         41,104   0%                               - bounds-of-thing-at-point
+         28,672   0%                                  re-search-forward
+          4,144   0%                                - seq-some
+          4,144   0%                                   make-closure
+         19,872   0%                             - seed7-line-at-endof-array-definition-block
+         14,704   0%                              - seed7-line-code-ends-with
+         10,560   0%                               - seed7-re-search-backward
+          6,464   0%                                - run-with-timer
+          6,464   0%                                 - run-at-time
+          2,496   0%                                  - timer-activate
+          2,496   0%                                   - timer--activate
+          2,496   0%                                      timer--time-less-p
+          2,432   0%                                    timer-relative-time
+          1,536   0%                                  - timer-set-time
+          1,536   0%                                     timer--time-setter
+          4,096   0%                                  re-search-backward
+          5,168   0%                              - seed7-move-to-line
+          5,168   0%                               - seed7-to-previous-non-empty-line
+          1,024   0%                                  looking-at
+         12,384   0%                             - seed7-line-indent-step
+          8,288   0%                              - seed7-move-to-line
+          8,288   0%                                 seed7-to-previous-non-empty-line
+          4,096   0%                                looking-at
+         12,336   0%                             - seed7-line-after-short-func-end
+          8,192   0%                                looking-at
+         10,608   0%                             - seed7-line-at-endof-set-definition-block
+         10,608   0%                              - seed7-line-code-ends-with
+         10,608   0%                               - seed7-re-search-backward
+         10,608   0%                                - run-with-timer
+         10,608   0%                                 - run-at-time
+          6,640   0%                                  - timer-activate
+          6,640   0%                                   - timer--activate
+          6,640   0%                                      timer--time-less-p
+          2,432   0%                                    timer-relative-time
+          1,536   0%                                  - timer-set-time
+          1,536   0%                                     timer--time-setter
+          5,120   0%                             - seed7-line-starts-with-open-paren-after-logic-operator
+          5,120   0%                              - seed7-line-starts-with
+          5,120   0%                                 looking-at
+          4,144   0%                             - seed7-current-line-start-inside-comment-p
+          4,144   0%                              - seed7-inside-comment-p
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+      1,803,688   2%                            - seed7-re-search-backward
+      1,018,072   1%                             - run-with-timer
+      1,018,072   1%                              - run-at-time
+        393,240   0%                               - timer-activate
+        393,240   0%                                - timer--activate
+        393,240   0%                                   timer--time-less-p
+        334,704   0%                                 timer-relative-time
+        215,536   0%                               - timer-set-time
+        215,536   0%                                  timer--time-setter
+         74,592   0%                                 timer-create
+        387,792   0%                               re-search-backward
+        261,072   0%                             - seed7-inside-string-p
+        169,904   0%                                match-data
+         53,872   0%                              - syntax-ppss
+         53,872   0%                                 make-closure
+         37,296   0%                                make-closure
+         87,024   0%                             - seed7-inside-comment-p
+         49,728   0%                              - syntax-ppss
+         49,728   0%                                 make-closure
+         49,728   0%                               make-closure
+        652,968   0%                            - replace-regexp-in-string
+         32,736   0%                               concat
+         33,152   0%                              seed7--on-lineof
+         27,640   0%                            - seed7--indent-offset-for
+         27,640   0%                               string-match
+         24,552   0%                              match-string
+         24,552   0%                              substring-no-properties
+          8,960   0%                              #<byte-code-function C6C>
+          4,144   0%                              make-closure
+          8,288   0%                           - seed7--cache-block-spec
+          8,288   0%                              copy-marker
+     24,043,875  30%                          - seed7-line-is-defun-end
+     15,827,977  20%                           - seed7-end-of-defun
+     11,835,620  15%                            - seed7-top-block-name
+     11,587,396  14%                             - seed7--to-top
+     11,046,148  14%                              - seed7-re-search-backward
+      7,976,632  10%                               - run-with-timer
+      7,976,632  10%                                - run-at-time
+      3,218,504   4%                                 - timer-activate
+      3,218,504   4%                                  - timer--activate
+      3,218,504   4%                                   - timer--time-less-p
+         32,792   0%                                      timer--time
+      2,522,592   3%                                   timer-relative-time
+      1,696,816   2%                                 - timer-set-time
+      1,696,816   2%                                    timer--time-setter
+        538,720   0%                                   timer-create
+      1,864,800   2%                               - seed7-inside-string-p
+      1,073,296   1%                                  match-data
+        426,832   0%                                - syntax-ppss
+        414,400   0%                                   make-closure
+         12,432   0%                                 - parse-partial-sexp
+         12,432   0%                                  - internal--syntax-propertize
+          4,144   0%                                   - syntax-propertize
+          4,144   0%                                    - seed7-mode-syntax-propertize
+          4,144   0%                                       match-data
+        364,672   0%                                  make-closure
+        786,172   1%                               - seed7-inside-comment-p
+        525,100   0%                                - syntax-ppss
+        406,112   0%                                   make-closure
+         86,196   0%                                 - syntax-propertize
+         69,620   0%                                  - seed7-mode-syntax-propertize
+         48,900   0%                                     re-search-forward
+         12,432   0%                                     match-data
+          8,288   0%                                     make-closure
+         32,792   0%                                   parse-partial-sexp
+        418,544   0%                                 make-closure
+        528,816   0%                              - run-with-timer
+        528,816   0%                               - run-at-time
+        219,008   0%                                - timer-activate
+        219,008   0%                                 - timer--activate
+        219,008   0%                                    timer--time-less-p
+        156,864   0%                                  timer-relative-time
+        103,216   0%                                - timer-set-time
+        103,216   0%                                   timer--time-setter
+         49,728   0%                                  timer-create
+         12,432   0%                                make-closure
+        235,792   0%                             - seed7--block-name
+        198,912   0%                              - seed7-re-search-forward
+        174,048   0%                               - seed7-inside-string-p
+        140,896   0%                                  match-data
+         20,720   0%                                  make-closure
+         12,432   0%                                - syntax-ppss
+         12,432   0%                                   make-closure
+         24,864   0%                               - seed7-inside-comment-p
+         12,432   0%                                - syntax-ppss
+         12,432   0%                                   make-closure
+         32,736   0%                                substring-no-properties
+      2,596,634   3%                            - seed7-re-search-forward
+      1,197,919   1%                             - seed7-inside-comment-p
+        953,423   1%                              - syntax-ppss
+        737,935   0%                               - syntax-propertize
+        539,023   0%                                - seed7-mode-syntax-propertize
+        344,255   0%                                   re-search-forward
+         87,024   0%                                   make-closure
+         82,880   0%                                   match-data
+        215,488   0%                                 make-closure
+      1,060,864   1%                             - seed7-inside-string-p
+        576,016   0%                                match-data
+        244,496   0%                                make-closure
+        240,352   0%                              - syntax-ppss
+        240,352   0%                                 make-closure
+        337,851   0%                             - re-search-forward
+         65,347   0%                              - internal--syntax-propertize
+         65,347   0%                               - syntax-propertize
+         61,203   0%                                - seed7-mode-syntax-propertize
+         57,059   0%                                   re-search-forward
+          4,144   0%                                   match-data
+        756,736   0%                            - seed7-re-search-backward
+        470,800   0%                             - run-with-timer
+        470,800   0%                              - run-at-time
+        185,856   0%                               - timer-activate
+        185,856   0%                                - timer--activate
+        185,856   0%                                   timer--time-less-p
+        156,864   0%                                 timer-relative-time
+        103,216   0%                               - timer-set-time
+        103,216   0%                                  timer--time-setter
+         24,864   0%                                 timer-create
+        215,488   0%                             - seed7-inside-string-p
+        149,184   0%                                match-data
+         41,440   0%                              - syntax-ppss
+         41,440   0%                                 make-closure
+         24,864   0%                                make-closure
+         53,872   0%                             - seed7-inside-comment-p
+         16,576   0%                              - syntax-ppss
+         16,576   0%                                 make-closure
+         16,576   0%                               make-closure
+        192,504   0%                              string-match
+        180,243   0%                              looking-at
+        155,496   0%                              match-string-no-properties
+         81,840   0%                              match-string
+          8,184   0%                              substring-no-properties
+      4,389,113   5%                           - seed7-beg-of-defun
+      1,868,095   2%                            - seed7-re-search-backward
+      1,245,744   1%                             - run-with-timer
+      1,245,744   1%                              - run-at-time
+        504,704   0%                               - timer-activate
+        504,704   0%                                - timer--activate
+        504,704   0%                                   timer--time-less-p
+        411,008   0%                                 timer-relative-time
+        276,160   0%                               - timer-set-time
+        276,160   0%                                  timer--time-setter
+         53,872   0%                                 timer-create
+        266,300   0%                             - seed7-inside-string-p
+        145,040   0%                                match-data
+         74,592   0%                                make-closure
+         46,668   0%                              - syntax-ppss
+         45,584   0%                                 make-closure
+        235,875   0%                               re-search-backward
+         78,736   0%                             - seed7-inside-comment-p
+         37,296   0%                              - syntax-ppss
+         37,296   0%                                 make-closure
+         41,440   0%                               make-closure
+        847,206   1%                            - seed7-re-search-backward-closest
+        789,190   1%                             - seed7-re-search-backward
+        468,342   0%                                re-search-backward
+        250,400   0%                              - run-with-timer
+        250,400   0%                               - run-at-time
+        106,208   0%                                - timer-activate
+        106,208   0%                                 - timer--activate
+        106,208   0%                                    timer--time-less-p
+         83,296   0%                                  timer-relative-time
+         56,752   0%                                - timer-set-time
+         56,752   0%                                   timer--time-setter
+          4,144   0%                                  timer-create
+         45,584   0%                              - seed7-inside-string-p
+         20,720   0%                                 match-data
+         16,576   0%                                 make-closure
+          8,288   0%                               - syntax-ppss
+          8,288   0%                                  make-closure
+         20,720   0%                              - seed7-inside-comment-p
+         12,432   0%                               - syntax-ppss
+         12,432   0%                                  make-closure
+          4,144   0%                                make-closure
+         29,008   0%                               match-data
+          8,288   0%                             - seq-filter
+          8,288   0%                                make-closure
+        720,473   0%                            - seed7-top-block-name
+        442,664   0%                             - seed7--to-top
+        305,280   0%                              - seed7-re-search-backward
+        143,032   0%                                 re-search-backward
+        137,384   0%                               - run-with-timer
+        137,384   0%                                - run-at-time
+         56,824   0%                                 - timer-activate
+         56,824   0%                                  - timer--activate
+         56,824   0%                                     timer--time-less-p
+         39,216   0%                                   timer-relative-time
+         28,912   0%                                 - timer-set-time
+         28,912   0%                                    timer--time-setter
+         12,432   0%                                   timer-create
+         24,864   0%                               - seed7-inside-string-p
+         16,576   0%                                  match-data
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+          4,144   0%                                  make-closure
+        124,952   0%                              - run-with-timer
+        124,952   0%                               - run-at-time
+         48,536   0%                                - timer-activate
+         48,536   0%                                 - timer--activate
+         48,536   0%                                    timer--time-less-p
+         39,216   0%                                  timer-relative-time
+         28,912   0%                                - timer-set-time
+         28,912   0%                                   timer--time-setter
+          8,288   0%                                  timer-create
+         12,432   0%                                make-closure
+        277,809   0%                             - seed7--block-name
+        261,337   0%                              - seed7-re-search-forward
+        261,337   0%                                 re-search-forward
+          8,184   0%                                substring-no-properties
+        655,115   0%                              looking-at
+        216,176   0%                              string-match
+         49,104   0%                              match-string-no-properties
+          8,184   0%                              format
+          8,184   0%                              match-string
+      2,087,109   2%                           - seed7-line-starts-with-any
+      2,087,109   2%                            - seed7-line-starts-with
+      2,025,261   2%                               looking-at
+        816,480   1%                             looking-back
+        314,800   0%                           - seed7-move-to-line
+        314,800   0%                            - seed7-to-previous-non-empty-line
+        277,504   0%                               looking-at
+         20,720   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+        276,456   0%                           - seed7--current-line-nth-word
+        264,024   0%                            - thing-at-point
+        255,840   0%                             - bounds-of-thing-at-point
+         82,880   0%                                make-closure
+         57,344   0%                                re-search-forward
+         37,296   0%                              - seq-some
+         37,296   0%                                 make-closure
+         32,736   0%                              - #<byte-code-function E21>
+         32,736   0%                               - forward-thing
+         32,736   0%                                  format
+        257,348   0%                           - seed7--safe-current-line-defun-start-indent
+        257,348   0%                            - seed7-to-block-backward
+        220,156   0%                             - seed7-re-search-backward
+        148,176   0%                              - run-with-timer
+        148,176   0%                               - run-at-time
+         56,560   0%                                - timer-activate
+         56,560   0%                                 - timer--activate
+         56,560   0%                                    timer--time-less-p
+         51,072   0%                                  timer-relative-time
+         32,256   0%                                - timer-set-time
+         32,256   0%                                   timer--time-setter
+          8,288   0%                                  timer-create
+         26,396   0%                                re-search-backward
+         24,864   0%                              - seed7-inside-string-p
+         12,432   0%                                 match-data
+          8,288   0%                               - syntax-ppss
+          8,288   0%                                  make-closure
+          4,144   0%                                 make-closure
+         12,432   0%                                make-closure
+          8,288   0%                              - seed7-inside-comment-p
+          8,288   0%                               - syntax-ppss
+          8,288   0%                                  make-closure
+         28,904   0%                             - seed7--current-line-nth-word
+         24,760   0%                              - thing-at-point
+         24,760   0%                               - bounds-of-thing-at-point
+         12,432   0%                                  make-closure
+          8,184   0%                                - #<byte-code-function 202>
+          8,184   0%                                 - forward-thing
+          8,184   0%                                    format
+          4,144   0%                                - seq-some
+          4,144   0%                                   make-closure
+          4,144   0%                               seed7-inside-line-indent-before-comment-p
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+         29,008   0%                           - seed7--indent-search-boundary-uncached
+         29,008   0%                            - syntax-ppss
+         29,008   0%                               make-closure
+      6,752,293   8%                          - seed7-comment-column
+      6,495,317   8%                           - seed7-calc-indent
+      2,925,611   3%                            - seed7-line-is-defun-end
+      1,994,170   2%                             - seed7-end-of-defun
+      1,303,792   1%                              - seed7-top-block-name
+      1,262,352   1%                               - seed7--to-top
+      1,200,528   1%                                - seed7-re-search-backward
+        869,008   1%                                 - run-with-timer
+        869,008   1%                                  - run-at-time
+        341,712   0%                                   - timer-activate
+        341,712   0%                                    - timer--activate
+        341,712   0%                                       timer--time-less-p
+        272,384   0%                                     timer-relative-time
+        188,608   0%                                   - timer-set-time
+        188,608   0%                                      timer--time-setter
+         66,304   0%                                     timer-create
+        194,768   0%                                 - seed7-inside-string-p
+        116,032   0%                                    match-data
+         49,728   0%                                    make-closure
+         29,008   0%                                  - syntax-ppss
+         29,008   0%                                     make-closure
+        107,744   0%                                 - seed7-inside-comment-p
+         62,160   0%                                  - syntax-ppss
+         53,872   0%                                     make-closure
+          8,288   0%                                   - syntax-propertize
+          4,144   0%                                    - seed7-mode-syntax-propertize
+          4,144   0%                                       match-data
+         29,008   0%                                   make-closure
+         57,680   0%                                - run-with-timer
+         57,680   0%                                 - run-at-time
+         21,616   0%                                  - timer-activate
+         21,616   0%                                   - timer--activate
+         21,616   0%                                      timer--time-less-p
+         17,024   0%                                    timer-relative-time
+         14,896   0%                                  - timer-set-time
+         14,896   0%                                     timer--time-setter
+          4,144   0%                                    timer-create
+          4,144   0%                                  make-closure
+         37,296   0%                               - seed7--block-name
+         33,152   0%                                - seed7-re-search-forward
+         29,008   0%                                 - seed7-inside-string-p
+         20,720   0%                                    match-data
+          4,144   0%                                  - syntax-ppss
+          4,144   0%                                     make-closure
+          4,144   0%                                    make-closure
+          4,144   0%                                   seed7-inside-comment-p
+        513,730   0%                              - seed7-re-search-forward
+        286,018   0%                               - seed7-inside-comment-p
+        228,002   0%                                - syntax-ppss
+        203,138   0%                                 - syntax-propertize
+        136,834   0%                                  - seed7-mode-syntax-propertize
+         62,242   0%                                     re-search-forward
+         41,440   0%                                     match-data
+         16,576   0%                                     make-closure
+         24,864   0%                                   make-closure
+        198,912   0%                               - seed7-inside-string-p
+        128,464   0%                                  match-data
+         41,440   0%                                - syntax-ppss
+         41,440   0%                                   make-closure
+         29,008   0%                                  make-closure
+         28,800   0%                                 re-search-forward
+         74,256   0%                              - seed7-re-search-backward
+         53,536   0%                               - run-with-timer
+         53,536   0%                                - run-at-time
+         17,472   0%                                 - timer-activate
+         17,472   0%                                  - timer--activate
+         17,472   0%                                     timer--time-less-p
+         17,024   0%                                   timer-relative-time
+         10,752   0%                                 - timer-set-time
+         10,752   0%                                    timer--time-setter
+          8,288   0%                                   timer-create
+         12,432   0%                               - seed7-inside-string-p
+         12,432   0%                                  match-data
+          4,144   0%                               - seed7-inside-comment-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+          4,144   0%                                 make-closure
+         26,624   0%                                string-match
+         22,520   0%                                looking-at
+         16,368   0%                                match-string-no-properties
+         16,368   0%                                match-string
+         16,368   0%                                substring-no-properties
+        544,886   0%                             - seed7-beg-of-defun
+        302,900   0%                              - seed7-re-search-backward
+        182,528   0%                               - run-with-timer
+        182,528   0%                                - run-at-time
+         75,856   0%                                 - timer-activate
+         75,856   0%                                  - timer--activate
+         75,856   0%                                     timer--time-less-p
+         57,760   0%                                   timer-relative-time
+         36,480   0%                                 - timer-set-time
+         36,480   0%                                    timer--time-setter
+         12,432   0%                                   timer-create
+         62,160   0%                               - seed7-inside-string-p
+         29,008   0%                                  match-data
+         24,864   0%                                  make-closure
+          8,288   0%                                - syntax-ppss
+          8,288   0%                                   make-closure
+         29,204   0%                                 re-search-backward
+         20,720   0%                               - seed7-inside-comment-p
+          8,288   0%                                - syntax-ppss
+          8,288   0%                                   make-closure
+          8,288   0%                                 make-closure
+         73,614   0%                              - seed7-re-search-backward-closest
+         73,614   0%                               - seed7-re-search-backward
+         38,558   0%                                  re-search-backward
+         22,624   0%                                - run-with-timer
+         22,624   0%                                 - run-at-time
+          8,736   0%                                  - timer-activate
+          8,736   0%                                   - timer--activate
+          8,736   0%                                      timer--time-less-p
+          8,512   0%                                    timer-relative-time
+          5,376   0%                                  - timer-set-time
+          5,376   0%                                     timer--time-setter
+          8,288   0%                                - seed7-inside-comment-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+          4,144   0%                                - seed7-inside-string-p
+          4,144   0%                                   match-data
+         70,360   0%                              - seed7-top-block-name
+         45,248   0%                               - seed7--to-top
+         33,936   0%                                - seed7-re-search-backward
+         14,336   0%                                   re-search-backward
+         11,312   0%                                 - run-with-timer
+         11,312   0%                                  - run-at-time
+          4,368   0%                                   - timer-activate
+          4,368   0%                                    - timer--activate
+          4,368   0%                                       timer--time-less-p
+          4,256   0%                                     timer-relative-time
+          2,688   0%                                   - timer-set-time
+          2,688   0%                                      timer--time-setter
+          8,288   0%                                 - seed7-inside-string-p
+          4,144   0%                                    make-closure
+          4,144   0%                                    match-data
+         11,312   0%                                - run-with-timer
+         11,312   0%                                 - run-at-time
+          4,368   0%                                  - timer-activate
+          4,368   0%                                   - timer--activate
+          4,368   0%                                      timer--time-less-p
+          4,256   0%                                    timer-relative-time
+          2,688   0%                                  - timer-set-time
+          2,688   0%                                     timer--time-setter
+         25,112   0%                               - seed7--block-name
+         25,112   0%                                - seed7-re-search-forward
+         25,112   0%                                   re-search-forward
+         57,076   0%                                looking-at
+         16,384   0%                                string-match
+         16,368   0%                                substring-no-properties
+          8,184   0%                                match-string-no-properties
+        217,579   0%                             - seed7-line-starts-with-any
+        217,579   0%                              - seed7-line-starts-with
+        201,003   0%                                 looking-at
+        110,568   0%                               looking-back
+         29,008   0%                             - seed7--current-line-nth-word
+         29,008   0%                              - thing-at-point
+         29,008   0%                               - bounds-of-thing-at-point
+         12,432   0%                                  make-closure
+          4,144   0%                                - seq-some
+          4,144   0%                                   make-closure
+         16,968   0%                             - seed7--safe-current-line-defun-start-indent
+         16,968   0%                              - seed7-to-block-backward
+         12,824   0%                               - seed7-re-search-backward
+          7,168   0%                                  re-search-backward
+          5,656   0%                                - run-with-timer
+          5,656   0%                                 - run-at-time
+          2,184   0%                                  - timer-activate
+          2,184   0%                                   - timer--activate
+          2,184   0%                                      timer--time-less-p
+          2,128   0%                                    timer-relative-time
+          1,344   0%                                  - timer-set-time
+          1,344   0%                                     timer--time-setter
+          4,144   0%                               - seed7--current-line-nth-word
+          4,144   0%                                - thing-at-point
+          4,144   0%                                 - bounds-of-thing-at-point
+          4,144   0%                                    make-closure
+          8,288   0%                             - seed7-move-to-line
+          8,288   0%                              - seed7-to-previous-non-empty-line
+          4,144   0%                               - seed7-inside-comment-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+      1,383,592   1%                            - seed7-line-inside-parens-pair-column
+      1,383,592   1%                             - seed7-line-inside-parens-pair
+      1,377,448   1%                              - seed7-re-search-backward
+        959,504   1%                               - run-with-timer
+        959,504   1%                                - run-at-time
+        372,512   0%                                 - timer-activate
+        372,512   0%                                  - timer--activate
+        372,512   0%                                     timer--time-less-p
+        306,432   0%                                   timer-relative-time
+        205,968   0%                                 - timer-set-time
+        205,968   0%                                    timer--time-setter
+         74,592   0%                                   timer-create
+        210,984   0%                               - seed7-inside-comment-p
+        136,392   0%                                - syntax-ppss
+        103,600   0%                                   make-closure
+         32,792   0%                                   parse-partial-sexp
+        140,896   0%                               - seed7-inside-string-p
+         66,304   0%                                  match-data
+         41,440   0%                                  make-closure
+         33,152   0%                                - syntax-ppss
+         33,152   0%                                   make-closure
+         45,584   0%                                 make-closure
+         20,480   0%                                 re-search-backward
+          6,144   0%                              - forward-sexp
+          6,144   0%                               - seed7--forward-sexp-function
+          6,144   0%                                  looking-at
+      1,188,482   1%                            - seed7-line-inside-a-block-cached
+      1,184,338   1%                             - seed7-line-inside-a-block
+        681,146   0%                              - seed7--safe-enclosing-block-bounds
+        677,002   0%                               - seed7--block-end-pos-for
+        529,034   0%                                - seed7-to-block-forward
+        365,252   0%                                 - seed7-end-of-defun
+        280,236   0%                                  - seed7-top-block-name
+        259,072   0%                                   - seed7--to-top
+        249,376   0%                                    - seed7-re-search-backward
+        171,712   0%                                     - run-with-timer
+        171,712   0%                                      - run-at-time
+         68,192   0%                                       - timer-activate
+         68,192   0%                                        - timer--activate
+         68,192   0%                                           timer--time-less-p
+         58,368   0%                                         timer-relative-time
+         41,008   0%                                       - timer-set-time
+         41,008   0%                                          timer--time-setter
+          4,144   0%                                         timer-create
+         41,440   0%                                     - seed7-inside-string-p
+         20,720   0%                                        match-data
+         12,432   0%                                      - syntax-ppss
+         12,432   0%                                         make-closure
+          8,288   0%                                        make-closure
+         24,864   0%                                     - seed7-inside-comment-p
+         16,576   0%                                      - syntax-ppss
+         16,576   0%                                         make-closure
+          8,288   0%                                       make-closure
+          3,072   0%                                       re-search-backward
+          9,696   0%                                    - run-with-timer
+          9,696   0%                                     - run-at-time
+          3,744   0%                                      - timer-activate
+          3,744   0%                                       - timer--activate
+          3,744   0%                                          timer--time-less-p
+          3,648   0%                                        timer-relative-time
+          2,304   0%                                      - timer-set-time
+          2,304   0%                                         timer--time-setter
+         21,164   0%                                   - seed7--block-name
+         21,164   0%                                    - seed7-re-search-forward
+         12,876   0%                                       re-search-forward
+          8,288   0%                                     - seed7-inside-string-p
+          8,288   0%                                        match-data
+         51,680   0%                                  - seed7-re-search-forward
+         29,008   0%                                   - seed7-inside-string-p
+         12,432   0%                                      make-closure
+         12,432   0%                                      match-data
+          4,144   0%                                    - syntax-ppss
+          4,144   0%                                       make-closure
+         14,480   0%                                   - seed7-inside-comment-p
+         10,336   0%                                    - syntax-ppss
+          6,192   0%                                     - syntax-propertize
+          2,048   0%                                      - seed7-mode-syntax-propertize
+          2,048   0%                                         re-search-forward
+          4,144   0%                                       make-closure
+          8,192   0%                                     re-search-forward
+         17,984   0%                                  - seed7-re-search-backward
+         13,840   0%                                   - run-with-timer
+         13,840   0%                                    - run-at-time
+          6,448   0%                                     - timer-set-time
+          6,448   0%                                        timer--time-setter
+          3,744   0%                                     - timer-activate
+          3,744   0%                                      - timer--activate
+          3,744   0%                                         timer--time-less-p
+          3,648   0%                                       timer-relative-time
+          4,144   0%                                   - seed7-inside-string-p
+          4,144   0%                                      match-data
+          8,184   0%                                    match-string
+          4,096   0%                                    string-match
+          3,072   0%                                    looking-at
+         72,040   0%                                 - seed7--current-line-nth-word
+         63,752   0%                                  - thing-at-point
+         47,384   0%                                   - bounds-of-thing-at-point
+         14,336   0%                                      re-search-forward
+         12,432   0%                                      make-closure
+          8,288   0%                                    - seq-some
+          8,288   0%                                       make-closure
+          8,184   0%                                    - #<byte-code-function 7A9>
+          8,184   0%                                     - forward-thing
+          8,184   0%                                        format
+         63,998   0%                                 - seed7-re-search-forward
+         30,852   0%                                    re-search-forward
+         29,002   0%                                  - seed7-inside-comment-p
+         29,002   0%                                   - syntax-ppss
+         24,858   0%                                    - syntax-propertize
+         24,858   0%                                     - seed7-mode-syntax-propertize
+         24,858   0%                                        re-search-forward
+          4,144   0%                                      make-closure
+          4,144   0%                                  - seed7-inside-string-p
+          4,144   0%                                     make-closure
+         27,744   0%                                 - seed7-inside-line-trailing-whitespace-before-line-end-comment-p
+         19,456   0%                                    looking-at
+          4,144   0%                                    seed7-inside-line-indent-before-comment-p
+         93,376   0%                                - seed7--line-ends-a-statement-p
+         38,912   0%                                   looking-at
+         37,888   0%                                 - forward-sexp
+         37,888   0%                                  - seed7--forward-sexp-function
+         37,888   0%                                     looking-at
+         34,944   0%                                  re-search-forward
+          5,168   0%                                - seed7-re-search-forward-closest
+          5,168   0%                                 - seed7-re-search-forward
+          4,144   0%                                  - seed7-inside-string-p
+          4,144   0%                                     match-data
+          1,024   0%                                    re-search-forward
+          2,048   0%                                  looking-at
+        425,008   0%                              - seed7-re-search-backward
+        307,584   0%                               - run-with-timer
+        307,584   0%                                - run-at-time
+        126,976   0%                                 - timer-activate
+        126,976   0%                                  - timer--activate
+        126,976   0%                                     timer--time-less-p
+         95,456   0%                                   timer-relative-time
+         68,576   0%                                 - timer-set-time
+         68,576   0%                                    timer--time-setter
+         16,576   0%                                   timer-create
+         66,304   0%                               - seed7-inside-string-p
+         33,152   0%                                  match-data
+         16,576   0%                                - syntax-ppss
+         16,576   0%                                   make-closure
+         16,576   0%                                  make-closure
+         22,112   0%                                 re-search-backward
+         16,576   0%                               - seed7-inside-comment-p
+          8,288   0%                                - syntax-ppss
+          8,288   0%                                   make-closure
+         12,432   0%                                 make-closure
+         70,000   0%                                replace-regexp-in-string
+          8,184   0%                                match-string
+          4,144   0%                             - seed7--cache-block-spec
+          4,144   0%                                copy-marker
+        224,800   0%                            - seed7--indent-search-boundary
+        219,632   0%                             - seed7--indent-search-boundary-uncached
+        219,632   0%                              - syntax-ppss
+        219,632   0%                                 make-closure
+          1,024   0%                               looking-at
+        100,528   0%                            - seed7-line-after-func-return-logic-operator-column
+         79,920   0%                             - seed7-move-to-line
+         79,920   0%                              - seed7-to-previous-non-empty-line
+         65,584   0%                               - seed7-inside-comment-p
+         65,584   0%                                - syntax-ppss
+         65,584   0%                                   parse-partial-sexp
+         14,336   0%                                 looking-at
+         20,608   0%                               re-search-forward
+         93,240   0%                            - seed7-line-inside-assign-statement-continuation
+         80,808   0%                             - seed7-assign-op-pos
+         76,664   0%                              - seed7-re-search-backward
+         46,968   0%                               - run-with-timer
+         46,968   0%                                - run-at-time
+         16,536   0%                                 - timer-activate
+         16,536   0%                                  - timer--activate
+         16,536   0%                                     timer--time-less-p
+         16,112   0%                                   timer-relative-time
+         10,176   0%                                 - timer-set-time
+         10,176   0%                                    timer--time-setter
+          4,144   0%                                   timer-create
+         29,696   0%                                 re-search-backward
+         12,432   0%                             - seed7-statement-end-pos
+         12,432   0%                              - seed7-forward-char-pos
+         12,432   0%                               - seed7-re-search-forward
+          8,288   0%                                  seed7-inside-comment-p
+          4,144   0%                                - seed7-inside-string-p
+          4,144   0%                                 - syntax-ppss
+          4,144   0%                                    make-closure
+         84,848   0%                            - seed7-line-inside-array-definition-block
+         84,848   0%                             - seed7-re-search-backward
+         46,968   0%                              - run-with-timer
+         46,968   0%                               - run-at-time
+         16,536   0%                                - timer-activate
+         16,536   0%                                 - timer--activate
+         16,536   0%                                    timer--time-less-p
+         16,112   0%                                  timer-relative-time
+         14,320   0%                                - timer-set-time
+         14,320   0%                                   timer--time-setter
+         37,880   0%                                re-search-backward
+         72,520   0%                            - seed7-line-inside-set-definition-block
+         72,520   0%                             - seed7-re-search-backward
+         42,824   0%                              - run-with-timer
+         42,824   0%                               - run-at-time
+         16,536   0%                                - timer-activate
+         16,536   0%                                 - timer--activate
+         16,536   0%                                    timer--time-less-p
+         16,112   0%                                  timer-relative-time
+         10,176   0%                                - timer-set-time
+         10,176   0%                                   timer--time-setter
+         29,696   0%                                re-search-backward
+         71,344   0%                            - seed7-line-at-endof-set-definition-block
+         69,728   0%                             - seed7-move-to-line
+         69,728   0%                              - seed7-to-previous-non-empty-line
+         69,728   0%                               - seed7-inside-comment-p
+         65,584   0%                                - syntax-ppss
+         65,584   0%                                   parse-partial-sexp
+          1,616   0%                             - seed7-line-code-ends-with
+          1,616   0%                              - seed7-re-search-backward
+          1,616   0%                               - run-with-timer
+          1,616   0%                                - run-at-time
+            624   0%                                 - timer-activate
+            624   0%                                  - timer--activate
+            624   0%                                     timer--time-less-p
+            608   0%                                   timer-relative-time
+            384   0%                                 - timer-set-time
+            384   0%                                    timer--time-setter
+         65,504   0%                            - seed7-line-inside-argument-list-section
+         34,608   0%                             - seed7-re-search-backward
+         20,064   0%                                re-search-backward
+         14,544   0%                              - run-with-timer
+         14,544   0%                               - run-at-time
+          5,616   0%                                - timer-activate
+          5,616   0%                                 - timer--activate
+          5,616   0%                                    timer--time-less-p
+          5,472   0%                                  timer-relative-time
+          3,456   0%                                - timer-set-time
+          3,456   0%                                   timer--time-setter
+         18,464   0%                             - seed7-line-is-procfunc-beg-of-decl
+         18,464   0%                              - seed7-line-starts-with
+         18,464   0%                                 looking-at
+         12,432   0%                             - seed7-forward-char-pos
+         12,432   0%                              - seed7-re-search-forward
+          8,288   0%                               - seed7-inside-string-p
+          4,144   0%                                  make-closure
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+          4,144   0%                               - seed7-inside-comment-p
+          4,144   0%                                - syntax-ppss
+          4,144   0%                                   make-closure
+         44,464   0%                            - seed7-line-inside-func-return-statement
+         41,392   0%                             - seed7-re-search-backward
+         22,832   0%                              - run-with-timer
+         22,832   0%                               - run-at-time
+          9,760   0%                                - timer-activate
+          9,760   0%                                 - timer--activate
+          9,760   0%                                    timer--time-less-p
+          5,472   0%                                  timer-relative-time
+          4,144   0%                                  timer-create
+          3,456   0%                                - timer-set-time
+          3,456   0%                                   timer--time-setter
+         18,560   0%                                re-search-backward
+          3,072   0%                               re-search-forward
+         40,008   0%                            - seed7-line-starts-with-open-paren-after-logic-operator
+         36,936   0%                             - seed7-move-to-line
+         36,936   0%                              - seed7-to-previous-non-empty-line
+         36,936   0%                               - seed7-inside-comment-p
+         36,936   0%                                - syntax-ppss
+         32,792   0%                                   parse-partial-sexp
+          4,144   0%                                   make-closure
+          2,048   0%                             - seed7-line-starts-with
+          2,048   0%                                looking-at
+          1,024   0%                               re-search-forward
+         37,248   0%                            - seed7-line-inside-logic-check-expression
+         37,248   0%                             - seed7-to-previous-line-starts-with
+         37,248   0%                              - seed7-re-search-backward
+         18,560   0%                                 re-search-backward
+         14,544   0%                               - run-with-timer
+         14,544   0%                                - run-at-time
+          5,616   0%                                 - timer-activate
+          5,616   0%                                  - timer--activate
+          5,616   0%                                     timer--time-less-p
+          5,472   0%                                   timer-relative-time
+          3,456   0%                                 - timer-set-time
+          3,456   0%                                    timer--time-setter
+          4,144   0%                                 make-closure
+         34,840   0%                            - seed7-line-after-short-func-end
+         32,792   0%                             - seed7-move-to-line
+         32,792   0%                              - seed7-to-previous-non-empty-line
+         32,792   0%                               - seed7-inside-comment-p
+         32,792   0%                                - syntax-ppss
+         32,792   0%                                   parse-partial-sexp
+          2,048   0%                               looking-at
+         33,104   0%                            - seed7-line-inside-until-logic-expression
+         33,104   0%                             - seed7-re-search-backward
+         18,560   0%                                re-search-backward
+         14,544   0%                              - run-with-timer
+         14,544   0%                               - run-at-time
+          5,616   0%                                - timer-activate
+          5,616   0%                                 - timer--activate
+          5,616   0%                                    timer--time-less-p
+          5,472   0%                                  timer-relative-time
+          3,456   0%                                - timer-set-time
+          3,456   0%                                   timer--time-setter
+         29,696   0%                            - seed7-line-isa-string
+         29,696   0%                             - seed7-line-starts-with
+         29,696   0%                                looking-at
+         29,696   0%                            - seed7-line-starts-with
+         29,696   0%                               looking-at
+         29,008   0%                            - seed7--current-line-nth-word
+         29,008   0%                             - thing-at-point
+         29,008   0%                              - bounds-of-thing-at-point
+         16,576   0%                                 make-closure
+          8,288   0%                               - seq-some
+          8,288   0%                                  make-closure
+          4,144   0%                            - seed7-current-line-start-inside-comment-p
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+          2,640   0%                            - seed7-line-at-endof-array-definition-block
+          2,640   0%                             - seed7-line-code-ends-with
+          2,640   0%                              - seed7-re-search-backward
+          1,616   0%                               - run-with-timer
+          1,616   0%                                - run-at-time
+            624   0%                                 - timer-activate
+            624   0%                                  - timer--activate
+            624   0%                                     timer--time-less-p
+            608   0%                                   timer-relative-time
+            384   0%                                 - timer-set-time
+            384   0%                                    timer--time-setter
+          1,024   0%                                 re-search-backward
+        146,984   0%                           - seed7-line-code-ends-with
+         97,760   0%                            - seed7-re-search-backward
+         61,824   0%                             - run-with-timer
+         61,824   0%                              - run-at-time
+         25,760   0%                               - timer-activate
+         25,760   0%                                - timer--activate
+         25,760   0%                                   timer--time-less-p
+         17,024   0%                                 timer-relative-time
+         10,752   0%                               - timer-set-time
+         10,752   0%                                  timer--time-setter
+          8,288   0%                                 timer-create
+         27,648   0%                               re-search-backward
+          8,288   0%                             - seed7-inside-string-p
+          4,144   0%                                match-data
+          4,144   0%                                make-closure
+         49,224   0%                            - seed7-move-to-line
+         49,224   0%                             - seed7-to-previous-non-empty-line
+         36,936   0%                              - seed7-inside-comment-p
+         36,936   0%                               - syntax-ppss
+         32,792   0%                                  parse-partial-sexp
+          4,144   0%                                  make-closure
+         12,288   0%                                looking-at
+         95,512   0%                           - seed7-line-starts-with
+         62,464   0%                              looking-at
+          8,288   0%                           - seed7-inside-comment-p
+          4,144   0%                            - syntax-ppss
+          4,144   0%                               make-closure
+          2,048   0%                             looking-at
+      3,092,536   3%                          - seed7-line-inside-parens-pair-column
+      3,092,536   3%                           - seed7-line-inside-parens-pair
+      2,858,920   3%                            - seed7-re-search-backward
+      1,943,928   2%                             - run-with-timer
+      1,943,928   2%                              - run-at-time
+        752,472   0%                               - timer-activate
+        752,472   0%                                - timer--activate
+        752,472   0%                                   timer--time-less-p
+        636,272   0%                                 timer-relative-time
+        447,440   0%                               - timer-set-time
+        447,440   0%                                  timer--time-setter
+        107,744   0%                                 timer-create
+        298,368   0%                             - seed7-inside-comment-p
+        174,048   0%                              - syntax-ppss
+        174,048   0%                                 make-closure
+        273,504   0%                             - seed7-inside-string-p
+         95,312   0%                                make-closure
+         91,168   0%                                match-data
+         87,024   0%                              - syntax-ppss
+         87,024   0%                                 make-closure
+        247,808   0%                               re-search-backward
+         95,312   0%                               make-closure
+        221,184   0%                            - forward-sexp
+        221,184   0%                             - seed7--forward-sexp-function
+        221,184   0%                                looking-at
+          8,288   0%                            - seed7-line-inside-syntax-parens-pair
+          4,144   0%                             - syntax-ppss
+          4,144   0%                                make-closure
+      2,700,891   3%                          - seed7--indent-search-boundary
+      2,408,928   3%                           - seed7--indent-search-boundary-uncached
+      2,376,136   3%                            - syntax-ppss
+      2,146,592   2%                               make-closure
+        229,544   0%                               parse-partial-sexp
+        271,243   0%                             looking-at
+      1,953,250   2%                          - seed7--current-line-nth-word
+      1,932,530   2%                           - thing-at-point
+      1,932,530   2%                            - bounds-of-thing-at-point
+      1,790,194   2%                             - #<byte-code-function 521>
+      1,790,194   2%                              - forward-thing
+      1,757,458   2%                               - forward-word
+      1,757,458   2%                                - internal--syntax-propertize
+      1,720,162   2%                                 - syntax-propertize
+      1,579,266   2%                                  - seed7-mode-syntax-propertize
+      1,471,522   1%                                     re-search-forward
+         78,736   0%                                     make-closure
+         20,720   0%                                     match-data
+         32,736   0%                                 format
+         62,160   0%                               make-closure
+         32,736   0%                             - #<byte-code-function C7D>
+         32,736   0%                              - forward-thing
+         32,736   0%                                 format
+         18,432   0%                               re-search-forward
+         16,576   0%                             - seq-some
+         16,576   0%                                make-closure
+        791,173   1%                          - seed7-line-inside-argument-list-section
+        551,364   0%                           - seed7-re-search-backward
+        302,764   0%                              re-search-backward
+        232,024   0%                            - run-with-timer
+        232,024   0%                             - run-at-time
+         91,768   0%                              - timer-activate
+         91,768   0%                               - timer--activate
+         91,768   0%                                  timer--time-less-p
+         73,264   0%                                timer-relative-time
+         46,272   0%                              - timer-set-time
+         46,272   0%                                 timer--time-setter
+         20,720   0%                                timer-create
+         16,576   0%                            - seed7-inside-string-p
+         12,432   0%                               match-data
+          4,144   0%                               make-closure
+        214,945   0%                           - seed7-line-is-procfunc-beg-of-decl
+        214,945   0%                            - seed7-line-starts-with
+        206,761   0%                               looking-at
+         16,576   0%                           - seed7-forward-char-pos
+         16,576   0%                            - seed7-re-search-forward
+         12,432   0%                             - seed7-inside-string-p
+          8,288   0%                                match-data
+          4,144   0%                                make-closure
+          4,144   0%                             - seed7-inside-comment-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+        749,704   0%                          - seed7-line-inside-assign-statement-continuation
+        687,544   0%                           - seed7-assign-op-pos
+        687,544   0%                            - seed7-re-search-backward
+        329,320   0%                               re-search-backward
+        283,632   0%                             - run-with-timer
+        283,632   0%                              - run-at-time
+        113,296   0%                               - timer-activate
+        113,296   0%                                - timer--activate
+        113,296   0%                                   timer--time-less-p
+         94,240   0%                                 timer-relative-time
+         59,520   0%                               - timer-set-time
+         59,520   0%                                  timer--time-setter
+         16,576   0%                                 timer-create
+         37,296   0%                             - seed7-inside-comment-p
+         24,864   0%                              - syntax-ppss
+         24,864   0%                                 make-closure
+         24,864   0%                             - seed7-inside-string-p
+         16,576   0%                                match-data
+          8,288   0%                              - syntax-ppss
+          8,288   0%                                 make-closure
+         12,432   0%                               make-closure
+         53,872   0%                           - seed7-statement-end-pos
+         53,872   0%                            - seed7-forward-char-pos
+         45,584   0%                             - seed7-re-search-forward
+         37,296   0%                              - seed7-inside-string-p
+         16,576   0%                                 match-data
+         12,432   0%                               - syntax-ppss
+         12,432   0%                                  make-closure
+          8,288   0%                                 make-closure
+          8,288   0%                              - seed7-inside-comment-p
+          4,144   0%                               - syntax-ppss
+          4,144   0%                                  make-closure
+        651,080   0%                          - seed7-line-inside-logic-check-expression
+        605,496   0%                           - seed7-to-previous-line-starts-with
+        531,736   0%                            - seed7-re-search-backward
+        261,008   0%                             - run-with-timer
+        261,008   0%                              - run-at-time
+        100,416   0%                               - timer-activate
+        100,416   0%                                - timer--activate
+        100,416   0%                                   timer--time-less-p
+         85,728   0%                                 timer-relative-time
+         62,432   0%                               - timer-set-time
+         62,432   0%                                  timer--time-setter
+         12,432   0%                                 timer-create
+        258,296   0%                               re-search-backward
+          8,288   0%                             - seed7-inside-string-p
+          4,144   0%                              - syntax-ppss
+          4,144   0%                                 make-closure
+          4,144   0%                                make-closure
+          4,144   0%                               make-closure
+         20,720   0%                           - seed7-re-search-forward
+         12,432   0%                            - seed7-inside-comment-p
+          8,288   0%                             - syntax-ppss
+          8,288   0%                                make-closure
+          8,288   0%                            - seed7-inside-string-p
+          4,144   0%                               match-data
+          4,144   0%                             - syntax-ppss
+          4,144   0%                                make-closure
+         12,432   0%                           - seed7--current-line-nth-word
+         12,432   0%                            - thing-at-point
+         12,432   0%                             - bounds-of-thing-at-point
+          4,144   0%                                make-closure
+        636,856   0%                          - seed7-line-inside-until-logic-expression
+        556,920   0%                           - seed7-re-search-backward
+        289,240   0%                              re-search-backward
+        255,248   0%                            - run-with-timer
+        255,248   0%                             - run-at-time
+         95,648   0%                              - timer-activate
+         95,648   0%                               - timer--activate
+         95,648   0%                                  timer--time-less-p
+         85,120   0%                                timer-relative-time
+         53,760   0%                              - timer-set-time
+         53,760   0%                                 timer--time-setter
+         20,720   0%                                timer-create
+         12,432   0%                              make-closure
+         75,792   0%                           - seed7-line-code-ends-with
+         71,648   0%                            - seed7-re-search-backward
+         38,784   0%                             - run-with-timer
+         38,784   0%                              - run-at-time
+         14,976   0%                               - timer-activate
+         14,976   0%                                - timer--activate
+         14,976   0%                                   timer--time-less-p
+         14,592   0%                                 timer-relative-time
+          9,216   0%                               - timer-set-time
+          9,216   0%                                  timer--time-setter
+         24,576   0%                               re-search-backward
+          4,144   0%                               make-closure
+          4,144   0%                             - seed7-inside-string-p
+          4,144   0%                                match-data
+          4,144   0%                           - seed7-statement-end-pos
+          4,144   0%                            - seed7-forward-char-pos
+          4,144   0%                             - seed7-re-search-forward
+          4,144   0%                              - seed7-inside-string-p
+          4,144   0%                                 match-data
+        631,832   0%                          - seed7-line-inside-array-definition-block
+        627,688   0%                           - seed7-re-search-backward
+        331,624   0%                              re-search-backward
+        275,344   0%                            - run-with-timer
+        275,344   0%                             - run-at-time
+        105,008   0%                              - timer-activate
+        105,008   0%                               - timer--activate
+        105,008   0%                                  timer--time-less-p
+         94,240   0%                                timer-relative-time
+         63,664   0%                              - timer-set-time
+         63,664   0%                                 timer--time-setter
+         12,432   0%                                timer-create
+         20,720   0%                              make-closure
+        616,229   0%                          - seed7-line-inside-set-definition-block
+        603,797   0%                           - seed7-re-search-backward
+        324,309   0%                              re-search-backward
+        271,200   0%                            - run-with-timer
+        271,200   0%                             - run-at-time
+        109,152   0%                              - timer-activate
+        109,152   0%                               - timer--activate
+        109,152   0%                                  timer--time-less-p
+         94,240   0%                                timer-relative-time
+         59,520   0%                              - timer-set-time
+         59,520   0%                                 timer--time-setter
+          8,288   0%                                timer-create
+          8,288   0%                              make-closure
+        532,960   0%                          - seed7-line-inside-func-return-statement
+        503,024   0%                           - seed7-re-search-backward
+        245,744   0%                              re-search-backward
+        232,416   0%                            - run-with-timer
+        232,416   0%                             - run-at-time
+         81,744   0%                              - timer-activate
+         81,744   0%                               - timer--activate
+         81,744   0%                                  timer--time-less-p
+         79,648   0%                                timer-relative-time
+         54,448   0%                              - timer-set-time
+         54,448   0%                                 timer--time-setter
+         16,576   0%                                timer-create
+         16,576   0%                              make-closure
+          8,288   0%                            - seed7-inside-string-p
+          8,288   0%                               match-data
+          9,216   0%                             re-search-forward
+        487,944   0%                          - seed7-line-after-func-return-logic-operator-column
+        308,736   0%                             re-search-forward
+        175,064   0%                           - seed7-move-to-line
+        175,064   0%                            - seed7-to-previous-non-empty-line
+        100,472   0%                               looking-at
+         62,160   0%                             - seed7-inside-comment-p
+         37,296   0%                              - syntax-ppss
+         37,296   0%                                 make-closure
+        324,744   0%                          - seed7-line-isa-string
+        324,744   0%                           - seed7-line-starts-with
+        304,128   0%                              looking-at
+        314,744   0%                          - seed7-line-starts-with
+        306,560   0%                             looking-at
+        103,240   0%                          - seed7-current-line-start-inside-comment-p
+         78,376   0%                           - seed7-inside-comment-p
+         65,944   0%                            - syntax-ppss
+         33,152   0%                               make-closure
+         32,792   0%                               parse-partial-sexp
+          7,920   0%                          - seed7-line-at-endof-array-definition-block
+          7,920   0%                           - seed7-line-code-ends-with
+          7,920   0%                            - seed7-re-search-backward
+          4,848   0%                             - run-with-timer
+          4,848   0%                              - run-at-time
+          1,872   0%                               - timer-activate
+          1,872   0%                                - timer--activate
+          1,872   0%                                   timer--time-less-p
+          1,824   0%                                 timer-relative-time
+          1,152   0%                               - timer-set-time
+          1,152   0%                                  timer--time-setter
+          3,072   0%                               re-search-backward
+          4,848   0%                          - seed7-line-at-endof-set-definition-block
+          4,848   0%                           - seed7-line-code-ends-with
+          4,848   0%                            - seed7-re-search-backward
+          4,848   0%                             - run-with-timer
+          4,848   0%                              - run-at-time
+          1,872   0%                               - timer-activate
+          1,872   0%                                - timer--activate
+          1,872   0%                                   timer--time-less-p
+          1,824   0%                                 timer-relative-time
+          1,152   0%                               - timer-set-time
+          1,152   0%                                  timer--time-setter
+          4,736   0%                          - seed7-line-after-short-func-end
+          4,736   0%                             looking-at
+          3,072   0%                          - seed7-line-starts-with-open-paren-after-logic-operator
+          3,072   0%                           - seed7-line-starts-with
+          3,072   0%                              looking-at
+          3,072   0%                          - seed7-line-indent-step
+          3,072   0%                             looking-at
+          2,768   0%                          - seed7-line-is-procfunc-beg-of-decl
+          2,768   0%                           - seed7-line-starts-with
+          2,768   0%                              looking-at
+         37,296   0%                         - jit-lock-after-change
+         20,720   0%                            font-lock-extend-jit-lock-region-after-change
+         19,928   0%                         - #<advice 96D>
+         19,928   0%                          - apply
+         19,928   0%                           - rectangle--extract-region
+         19,928   0%                            - #<byte-code-function AAE>
+         19,928   0%                             - filter-buffer-substring
+         19,928   0%                              - buffer-substring--filter
+         19,928   0%                               - #<byte-code-function 597>
+         19,928   0%                                - apply
+         19,928   0%                                   #<byte-code-function D54>
+      1,626,380   2%                   profiler-stop
+         49,353   0%   Automatic GC

--- a/reports/21.1/timing.txt
+++ b/reports/21.1/timing.txt
@@ -1,6 +1,15 @@
-Time of the execution of seed7-complete-statement-or-indent to indent the complete files:
+# Time of the execution of seed7-complete-statement-or-indent to indent the complete files:
 
-aes.s7i:       9.2734 seconds : test 1 in session 1.  1143 lines.
-array.s7i:     5.3291 seconds : test 1 in session 2.   610 lines.
-array.s7i:     6.1219 seconds : test 2 in session 2.   610 lines.
-array.s7i:     8.1122 seconds : test 1 in session 3.   610 lines.  All indented properly.
+1: aes.s7i:       9.2734 seconds : test 1 in session 1.  1143 lines.
+2: array.s7i:     5.3291 seconds : test 1 in session 2.   610 lines.
+3: array.s7i:     6.1219 seconds : test 2 in session 2.   610 lines.
+4: array.s7i:     8.1122 seconds : test 1 in session 3.   610 lines.  All indented properly.
+
+# Notes
+#
+# #4: The 8.1122 s run uses commit 6ba8b5e, which correctly recognizes
+#        const type: ... is func
+# declarations as callable blocks and fixes all observed array.s7i
+# indentation errors. It is slower than the two earlier session-2 single
+# runs. Since these measurements were taken in separate sessions with no
+# repeated-run statistics, the comparison is indicative only.

--- a/reports/21.1/timing.txt
+++ b/reports/21.1/timing.txt
@@ -3,3 +3,4 @@ Time of the execution of seed7-complete-statement-or-indent to indent the comple
 aes.s7i:       9.2734 seconds : test 1 in session 1.  1143 lines.
 array.s7i:     5.3291 seconds : test 1 in session 2.   610 lines.
 array.s7i:     6.1219 seconds : test 2 in session 2.   610 lines.
+array.s7i:     8.1122 seconds : test 1 in session 3.   610 lines.  All indented properly.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.2318
+;; Package-Version: 20260711.0850
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-11T03:18:22+0000 W28-6"
+(defconst seed7-mode-version-timestamp "2026-07-11T12:50:05+0000 W28-6"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3546,11 +3546,11 @@ statement.  Return nil otherwise."
 ;;*** Seed7 Procedure/Function Navigation Commands
 ;;    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-(defconst seed7---func/proc-decl-start-re
-  ;;          (---------------)               (----------)
-  ;;                                     (--------------------)
-  ;; (-----------------------------------------------------------)
-  "\\(const \\(?:func\\|proc\\)[^;]+?is\\(?:\\(?: +func\\)?$\\)\\)"
+(defconst seed7---func/proc/type-decl-start-re
+  ;;          (---------------------)                (----------)
+  ;;                                            (--------------------)
+  ;; (------------------------------------------------------------------)
+  "\\(const \\(?:func\\|proc\\|type\\)[^;]+?is\\(?:\\(?: +func\\)?$\\)\\)"
   "Func/Proc declaration start. Group 1: complete text.")
 
 (defconst seed7---func/proc-decl-end-re
@@ -3566,7 +3566,7 @@ statement.  Return nil otherwise."
 (defconst seed7--callable-decl-parts-re
   (format
    "^[[:blank:]]*?\\(?:%s\\|%s\\|\\(%s\\)\\)"
-   seed7---func/proc-decl-start-re                  ; G1
+   seed7---func/proc/type-decl-start-re             ; G1
    seed7---func/proc-decl-end-re                    ; G2
    seed7-func-forward-or-action-declaration-nc-re)  ; G3
   "A regexp with 3 groups:
@@ -3587,7 +3587,7 @@ statement.  Return nil otherwise."
 (defconst seed7--local-block-re
   (format
    "^[[:blank:]]*?\\(?:%s\\|\\(\\(?:end \\(?:func\\|proc\\);\\)\\|\\(?:return%s;\\)\\|begin\\_>\\)\\)"
-   seed7---func/proc-decl-start-re
+   seed7---func/proc/type-decl-start-re
    seed7--any-non-semicolon-re)
   "Regexp used to locate the end of a `local' declaration section.
 
@@ -3596,7 +3596,7 @@ local-variable-declaration section ends, so that indentation of the
 declarations inside it can be computed relative to it.
 
 Group 1: the start of a nested callable declaration
-  (`const func/proc ... is'), matched by `seed7---func/proc-decl-start-re'.
+  (`const func/proc ... is'), matched by `seed7---func/proc/type-decl-start-re'.
   A match here means nesting must increase — this is a *deeper* local
   block, not the end of the current one.
 Group 2: the end of the enclosing local section: `end func;', `end proc;',
@@ -4819,7 +4819,7 @@ navigation command."
 at the start of a multi-line callable declaration header, else return nil.
 
 When `re-search-backward' is used on a multi-line nested func/proc
-declaration pattern (via `seed7---func/proc-decl-start-re'), the
+declaration pattern (via `seed7---func/proc/type-decl-start-re'), the
 match ends on the `... is func' or `... is' line.  If point lies on or
 before that line (but before its end), the match-end is *after* point
 and `re-search-backward' cannot find the declaration.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.1557
+;; Package-Version: 20260710.1619
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-10T19:57:30+0000 W28-5"
+(defconst seed7-mode-version-timestamp "2026-07-10T20:19:23+0000 W28-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5786,25 +5786,25 @@ deciding: if a `;' is reached before a bare `is' at end of line or
   (save-excursion
     (forward-line 0)
     (skip-chars-forward " \t")
-    ;; Skip past "const func TYPE: " / "const proc: " / etc. up to the
-    ;; first paren/bracket group, then over any further adjoining groups.
-    (while (looking-at "[^([;\n]")
-      (forward-char 1))
     (let ((limit (save-excursion (forward-line 6) (line-end-position)))
           (result nil)
           (done nil))
       (while (and (not done) (< (point) limit))
         (cond
+         ;; Check block-opener signals FIRST, at the current position,
+         ;; before any generic forward movement — otherwise these tokens
+         ;; can be silently skipped over (e.g. "is func" appearing before
+         ;; any parenthesis/bracket/semicolon is ever seen).
+         ((looking-at "is[[:blank:]]+func\\_>")
+          (setq done t))
+         ((looking-at "is[[:blank:]]*$")
+          (setq done t))
          ((memq (char-after) '(?\( ?\[))
           (condition-case nil
               (forward-sexp)
             (scan-error (setq done t))))
          ((eq (char-after) ?\;)
           (setq result t done t))
-         ((looking-at "is[[:blank:]]+func\\_>")
-          (setq done t))
-         ((looking-at "is[[:blank:]]*$")
-          (setq done t))
          ((eq (char-after) ?\n)
           (forward-char 1))
          (t (forward-char 1))))

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.1742
+;; Package-Version: 20260710.1756
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-10T21:42:09+0000 W28-5"
+(defconst seed7-mode-version-timestamp "2026-07-10T21:56:58+0000 W28-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6185,33 +6185,45 @@ If it finds something it returns a list that holds the following information:
                        ;;
                        ;; Case 2: point is on an internal block start line.
                        ((seed7--on-lineof block-start-pos current-pos)
-                        ;; Look for the previous block and use info from it.
+                        ;; Look for the TRUE enclosing block. Keep walking
+                        ;; backward past any sibling candidate whose own
+                        ;; bounds do not actually contain CURRENT-POS (e.g.
+                        ;; a preceding one-line action/forward declaration
+                        ;; sibling at the same nesting level) instead of
+                        ;; accepting the first candidate found.
                         (goto-char block-start-pos)
-                        (when (seed7-re-search-backward
-                               seed7-block-line-start-regexp beg-bound)
-                          (setq match-text (replace-regexp-in-string
-                                            "[[:blank:]]+$" " "
-                                            (substring-no-properties (match-string 1))))
-                          (setq block-start-pos (point))
-                          (skip-chars-forward " \t")
-                          (setq block-start-indent-column (current-column))
-                          ;; Identify the end position and start position of the
-                          ;; currently enclosing block
-                          (let ((bounds (seed7--safe-enclosing-block-bounds
-                                         match-text block-start-pos)))
-                            (when bounds
-                              (setq enclosing-block-start-pos (car bounds)
-                                    enclosing-block-end-pos (cdr bounds))
-                              (when (<= block-start-pos current-pos enclosing-block-end-pos)
-                                (setq keep-searching nil
-                                      result (list (+ block-start-indent-column
-                                                      (seed7--indent-offset-for
+                        (let ((inner-searching t))
+                          (while (and inner-searching
+                                      (seed7-re-search-backward
+                                       seed7-block-line-start-regexp beg-bound))
+                            (setq match-text (replace-regexp-in-string
+                                              "[[:blank:]]+$" " "
+                                              (substring-no-properties (match-string 1))))
+                            (setq block-start-pos (point))
+                            (skip-chars-forward " \t")
+                            (setq block-start-indent-column (current-column))
+                            (let ((bounds (seed7--safe-enclosing-block-bounds
+                                           match-text block-start-pos)))
+                              (if (and bounds
+                                       (<= block-start-pos current-pos (cdr bounds)))
+                                  (progn
+                                    (setq enclosing-block-start-pos (car bounds)
+                                          enclosing-block-end-pos (cdr bounds))
+                                    (setq inner-searching nil
+                                          keep-searching nil
+                                          result (list (+ block-start-indent-column
+                                                          (seed7--indent-offset-for
+                                                           match-text
+                                                           line-n-first-text))
                                                        match-text
-                                                       line-n-first-text))
-                                                   match-text
-                                                   block-start-pos
-                                                   enclosing-block-end-pos
-                                                   block-start-indent-column)))))))
+                                                       block-start-pos
+                                                       enclosing-block-end-pos
+                                                       block-start-indent-column)))
+                                ;; Not a valid enclosing candidate (e.g. a
+                                ;; sibling one-liner): keep walking backward
+                                ;; from just before this candidate's start.
+                                (goto-char block-start-pos)
+                                (unless (bobp) (backward-char)))))))
                        ;;
                        ;; Case 3: point is on a line that is not on the block start,
                        ;;         but between the block start and the block end.
@@ -7468,8 +7480,9 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
       (error "seed7-calc-indent: recursion depth exceeded at line %d"
              (line-number-at-pos)))
     ;; don't indent blank lines
-    (unless (and (not first-word-on-line)
-                 (seed7-blank-line-p))
+    (if (and (not first-word-on-line)
+             (seed7-blank-line-p))
+        (setq indent-column 0)
       (cond
        ;; in comment
        ((and (seed7-current-line-start-inside-comment-p)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.1530
+;; Package-Version: 20260710.1557
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-10T19:30:01+0000 W28-5"
+(defconst seed7-mode-version-timestamp "2026-07-10T19:57:30+0000 W28-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3583,13 +3583,25 @@ statement.  Return nil otherwise."
   (format "return\\_>%s;"
           seed7--any-non-semicolon-re))
 
-;; [:todo 2026-07-10, by Pierre Rouleau: add better docstring ]
 (defconst seed7--local-block-re
   (format
    "^[[:blank:]]*?\\(?:%s\\|\\(\\(?:end \\(?:func\\|proc\\);\\)\\|\\(?:return%s;\\)\\|begin\\_>\\)\\)"
    seed7---func/proc-decl-start-re
    seed7--any-non-semicolon-re)
-  "Local block context regexp")
+  "Regexp used to locate the end of a `local' declaration section.
+
+Searched forward from a `local' keyword line to find where the
+local-variable-declaration section ends, so that indentation of the
+declarations inside it can be computed relative to it.
+
+Group 1: the start of a nested callable declaration
+  (`const func/proc ... is'), matched by `seed7---func/proc-decl-start-re'.
+  A match here means nesting must increase — this is a *deeper* local
+  block, not the end of the current one.
+Group 2: the end of the enclosing local section: `end func;', `end proc;',
+  a short-function `return ...;', or `begin' — whichever comes first.
+  A match here (at nesting 0) is the position where the `local' section
+  of the enclosing callable ends.")
 
 
 (defun seed7-beg-of-defun (&optional n silent dont-push-mark)
@@ -5761,22 +5773,42 @@ N is: - :previous-non-empty for the previous non-empty line,
   (seed7-line-starts-with n seed7-block-end-regexp dont-skip-comment-start))
 
 (defun seed7--line-ends-a-statement-p ()
-  "Return non-nil if the current line ends a Seed7 statement.
+  "Return non-nil if the Seed7 statement whose header starts at point
+is a complete one-liner/multi-line statement terminated by `;', rather
+than the opening of a compound block.
 
-A complete statement line ends with the statement-terminating semicolon
-`;' (ignoring trailing whitespace) and therefore does not open an
-indented compound block, even though its start matches
-`seed7-block-line-start-regexp' — e.g. one-line action/primitive
-declarations such as (code modified to fit the width):
- const proc: (inout arrayType: dst) := (in arrayType: src) is action \"ARR_CPY\";
- const func arrayType: SORT (in arrayType: arr) is action \"ARR_SORT\";
- const type: TEST_1 is array integer;
-Point can be anywhere; only `(line-end-position)' of the current line
-is inspected, never a continuation line."
+The declaration's parameter list — delimited by balanced parentheses
+or brackets — may continue onto following physical lines (e.g. the
+`insert' and `ARR_RANGE' declarations in array.s7i). This skips any
+such balanced group(s) that immediately follow the header text before
+deciding: if a `;' is reached before a bare `is' at end of line or
+`is func', the statement is a complete one-liner."
   (save-excursion
-    (goto-char (line-end-position))
-    (skip-chars-backward " \t")
-    (eq (char-before (point)) ?\;)))
+    (forward-line 0)
+    (skip-chars-forward " \t")
+    ;; Skip past "const func TYPE: " / "const proc: " / etc. up to the
+    ;; first paren/bracket group, then over any further adjoining groups.
+    (while (looking-at "[^([;\n]")
+      (forward-char 1))
+    (let ((limit (save-excursion (forward-line 6) (line-end-position)))
+          (result nil)
+          (done nil))
+      (while (and (not done) (< (point) limit))
+        (cond
+         ((memq (char-after) '(?\( ?\[))
+          (condition-case nil
+              (forward-sexp)
+            (scan-error (setq done t))))
+         ((eq (char-after) ?\;)
+          (setq result t done t))
+         ((looking-at "is[[:blank:]]+func\\_>")
+          (setq done t))
+         ((looking-at "is[[:blank:]]*$")
+          (setq done t))
+         ((eq (char-after) ?\n)
+          (forward-char 1))
+         (t (forward-char 1))))
+      result)))
 
 (defun seed7--block-end-pos-for (header)
   "Return position of end of block starting with HEADER.
@@ -6098,6 +6130,7 @@ If it finds something it returns a list that holds the following information:
                       (cond
                        ;; Case 1: point is on the start line of a top level block.
                        ((and (seed7--on-lineof block-start-pos current-pos)
+                             (= block-start-indent-column 0)
                              (member match-text '("const proc: "
                                                   "const func "
                                                   "const type: ")))

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.1647
+;; Package-Version: 20260710.1742
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-10T20:47:08+0000 W28-5"
+(defconst seed7-mode-version-timestamp "2026-07-10T21:42:09+0000 W28-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1815,20 +1815,20 @@ When optional CAPTURE is non-nil, The returned regexp captures
 Otherwise the returned regexp captures nothing."
   (declare (side-effect-free t))
   (format
-   ;;    const     (varfunc| func          )RT    :
-   ;;              (-----------------------)
-   ;;              G1                      G2
-   "^%s*?const%s+\\(%s\\(?:var\\)?func%s+\\)%s%s??:"
-   ;;%        %     %                 %     % %
-   ;;1        2     3                 4     5 6
+   ;;    const     proc  :  |  (varfunc| func          )RT    :
+   ;;              (--)     |  (-----------------------)
+   ;;              G1       |  G1'                     G2
+   "^%s*?const%s+\\(?:\\(%sproc\\)%s*?:\\|\\(%s\\(?:var\\)?func%s+\\)%s%s??:\\)"
    seed7--blank-re                      ; 1
    seed7--whitespace-re                 ; 2
-   (if capture "" "?:")                 ; 3
-   seed7--blank-re                      ; 4
+   (if capture "" "?:")                 ; 3: proc branch capture
+   seed7--whitespace-re                 ; 4: optional blank before ':'
+   (if capture "" "?:")                 ; 5: func branch capture
+   seed7--blank-re                      ; 6
    (if capture
-       seed7-type-identifier-re         ; 5 : RT : Return Type
+       seed7-type-identifier-re         ; 7 : RT : Return Type
      seed7-type-identifier-nc-re)
-   seed7--whitespace-re))               ; 6
+   seed7--whitespace-re))               ; 8
 
 (defconst seed7-proc-beg-of-decl-re
   (format

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.1756
+;; Package-Version: 20260710.2318
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-10T21:56:58+0000 W28-5"
+(defconst seed7-mode-version-timestamp "2026-07-11T03:18:22+0000 W28-6"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1819,6 +1819,7 @@ Otherwise the returned regexp captures nothing."
    ;;              (--)     |  (-----------------------)
    ;;              G1       |  G1'                     G2
    "^%s*?const%s+\\(?:\\(%sproc\\)%s*?:\\|\\(%s\\(?:var\\)?func%s+\\)%s%s??:\\)"
+   ;; 1        2          3        4          5                6     7 8
    seed7--blank-re                      ; 1
    seed7--whitespace-re                 ; 2
    (if capture "" "?:")                 ; 3: proc branch capture
@@ -5651,14 +5652,22 @@ N is: - :previous-non-empty for the previous non-empty line,
 If END-POS is non-nil, it identifies the limit for the string."
   (save-excursion
     (when (seed7-move-to-line n dont-skip-comment-start)
-      (if (string=  (substring regexp 0 1) "^")
-          (forward-line 0)
-        (skip-chars-forward " \t"))
-      (when (and (looking-at-p regexp)
-                 (or (not end-pos)
-                     (save-excursion
-                       (re-search-forward regexp end-pos :noerror))))
-        (current-column)))))
+      ;; Capture the line's actual indentation column BEFORE possibly
+      ;; repositioning to the true beginning of line for an anchored
+      ;; ("^"-prefixed) REGEXP match check. Anchored regexps need point
+      ;; at true column 0 to match correctly, but the column this
+      ;; function reports must always be the line's real indentation,
+      ;; not column 0 — otherwise callers that use the returned column
+      ;; as an indentation value (e.g. `seed7-line-is-defun-end') get 0
+      ;; for every anchored match on a non-top-level (indented) line.
+      (let ((indent-column (current-column)))
+        (when (string= (substring regexp 0 1) "^")
+          (forward-line 0))
+        (when (and (looking-at-p regexp)
+                   (or (not end-pos)
+                       (save-excursion
+                         (re-search-forward regexp end-pos :noerror))))
+          indent-column)))))
 
 (defun seed7-line-starts-with-any (n regexps
                                      &optional dont-skip-comment-start end-pos)
@@ -6036,10 +6045,44 @@ Move point."
 
    ((string= header "const type: ")
     (if (or (string-prefix-p "end struct;" first-text)
-            (string-prefix-p "end enum;"   first-text))
-        ;; end struct/enum is indented once relative to the const type
+            (string-prefix-p "end enum;"   first-text)
+            ;; A `const type: X is func ... end func;' declaration is a
+            ;; func-style body (like `const proc:'/`const func'), not a
+            ;; struct/enum member list -- its `local'/`begin' section
+            ;; markers and closing `end func;' get a single indent level,
+            ;; not the double indent used for struct/enum members.
+            (string-prefix-p "local"     first-text)
+            (string-prefix-p "begin"     first-text)
+            (string-prefix-p "end func;" first-text))
+        ;; end struct/enum/func, local, and begin are indented once
+        ;; relative to the const type
         seed7-indent-width
-      ;; the definitions are indented twice.
+      ;; struct/enum member definitions are indented twice.
+      (* 2 seed7-indent-width))
+    ;; ---------------------------------------------------------------------------
+    ;; (if (or (string-prefix-p "end struct;" first-text)
+    ;;         (string-prefix-p "end enum;"   first-text))
+    ;;     ;; end struct/enum is indented once relative to the const type
+    ;;     seed7-indent-width
+    ;;   ;; the definitions are indented twice.
+    ;;   (* 2 seed7-indent-width))
+
+    )
+   ((string= header "const type: ")
+    (if (or (string-prefix-p "end struct;" first-text)
+            (string-prefix-p "end enum;"   first-text)
+            ;; A `const type: X is func ... end func;' declaration is a
+            ;; func-style body (like `const proc:'/`const func'), not a
+            ;; struct/enum member list -- its `local'/`begin' section
+            ;; markers and closing `end func;' get a single indent level,
+            ;; not the double indent used for struct/enum members.
+            (string-prefix-p "local"     first-text)
+            (string-prefix-p "begin"     first-text)
+            (string-prefix-p "end func;" first-text))
+        ;; end struct/enum/func, local, and begin are indented once
+        ;; relative to the const type
+        seed7-indent-width
+      ;; struct/enum member definitions are indented twice.
       (* 2 seed7-indent-width)))
 
    ;; (error "Unsupported header %s" header)
@@ -6204,6 +6247,8 @@ If it finds something it returns a list that holds the following information:
                             (setq block-start-indent-column (current-column))
                             (let ((bounds (seed7--safe-enclosing-block-bounds
                                            match-text block-start-pos)))
+                              ;; (message "seed7-DEBUG Case2: candidate match-text=%S block-start-pos=%d bounds=%S current-pos=%d"
+                              ;;          match-text block-start-pos bounds current-pos)
                               (if (and bounds
                                        (<= block-start-pos current-pos (cdr bounds)))
                                   (progn

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.1334
+;; Package-Version: 20260710.1410
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -543,7 +543,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-10T17:34:02+0000 W28-5"
+(defconst seed7-mode-version-timestamp "2026-07-10T18:10:00+0000 W28-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3582,12 +3582,14 @@ statement.  Return nil otherwise."
   (format "return\\_>%s;"
           seed7--any-non-semicolon-re))
 
+;; [:todo 2026-07-10, by Pierre Rouleau: add better docstring ]
 (defconst seed7--local-block-re
   (format
    "^[[:blank:]]*?\\(?:%s\\|\\(\\(?:end \\(?:func\\|proc\\);\\)\\|\\(?:return%s;\\)\\|begin\\_>\\)\\)"
    seed7---func/proc-decl-start-re
    seed7--any-non-semicolon-re)
-  "regexp TODO: TO-IDENTIFY!!!!!")
+  "Local block context regexp")
+
 
 (defun seed7-beg-of-defun (&optional n silent dont-push-mark)
   "Move backward to the beginning of the current function or procedure.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.1410
+;; Package-Version: 20260710.1530
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -365,6 +365,7 @@
 ;;       . `seed7-line-inside-a-block'
 ;;         . `seed7--safe-enclosing-block-bounds'
 ;;         . `seed7--block-end-pos-for'
+;;           . `seed7--line-ends-a-statement-p'
 ;;         . `seed7--indent-offset-for'
 ;;         . `seed7--on-lineof'
 ;;     . `seed7-line-inside-until-logic-expression'
@@ -543,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-10T18:10:00+0000 W28-5"
+(defconst seed7-mode-version-timestamp "2026-07-10T19:30:01+0000 W28-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1533,11 +1534,11 @@ declaration without visiting every control-flow keyword on the way.
 
 Performance improvement (measured keyword match counts):
   chkarr.sd7 : 2,943 total keywords → ~150 declarations  (~20× fewer iters)
-  castle.sd7  :   706 total keywords →  ~50 declarations  (~14× fewer iters)
+  castle.sd7 :   706 total keywords →  ~50 declarations  (~14× fewer iters)
 
 The column check in `seed7--to-top' (< start-col) is still correct for
 indented `const func'/`const proc' in .s7i template bodies such as
-`ENABLE_SORT' in aarray.s7i, since those are either `is action \"...\"'
+`ENABLE_SORT' in array.s7i, since those are either `is action \"...\"'
 one-liners or short `return...;' functions — neither creates a
 `begin...end func' block you can be indenting code *inside*.")
 
@@ -5759,6 +5760,24 @@ N is: - :previous-non-empty for the previous non-empty line,
       - A negative number for previous lines: -1 previous, -2 line before..."
   (seed7-line-starts-with n seed7-block-end-regexp dont-skip-comment-start))
 
+(defun seed7--line-ends-a-statement-p ()
+  "Return non-nil if the current line ends a Seed7 statement.
+
+A complete statement line ends with the statement-terminating semicolon
+`;' (ignoring trailing whitespace) and therefore does not open an
+indented compound block, even though its start matches
+`seed7-block-line-start-regexp' — e.g. one-line action/primitive
+declarations such as (code modified to fit the width):
+ const proc: (inout arrayType: dst) := (in arrayType: src) is action \"ARR_CPY\";
+ const func arrayType: SORT (in arrayType: arr) is action \"ARR_SORT\";
+ const type: TEST_1 is array integer;
+Point can be anywhere; only `(line-end-position)' of the current line
+is inspected, never a continuation line."
+  (save-excursion
+    (goto-char (line-end-position))
+    (skip-chars-backward " \t")
+    (eq (char-before (point)) ?\;)))
+
 (defun seed7--block-end-pos-for (header)
   "Return position of end of block starting with HEADER.
 Move point."
@@ -5793,13 +5812,30 @@ Move point."
                          (looking-at-p seed7-short-func-end-regexp)))
             (user-error "Unsupported incomplete short function header: %s" header)))
         (point))
+       ;; One-line action/primitive declaration, e.g. ENABLE_SORT's
+       ;; `SORT' declaration: `is action "ARR_SORT";' on the same line.
+       ;; It is a complete statement, not an opening of a compound
+       ;; block; treat its own line end as the "block" end so it can
+       ;; never be mistaken for the enclosing block of a following
+       ;; sibling declaration.
+       ((seed7--line-ends-a-statement-p)
+        (line-end-position))
+       ;;
        (t
         (seed7-to-block-forward :dont-push-mark)
         (point)))))
    ;;
    ((member header '("const proc: "
                      "const type: "
-                     "local"
+                     "const proc:\t"
+                     "const type:\t"))
+    (if (seed7--line-ends-a-statement-p)
+        (line-end-position)
+      (seed7-to-block-forward :dont-push-mark)
+      (point)))
+   ;;
+   ;;
+   ((member header '("local"
                      "repeat"
                      "begin"
                      "block"
@@ -5812,8 +5848,6 @@ Move point."
                      "for "
                      "case "
                      ;; ... also support tabs when caller did not normalize them.
-                     "const proc:\t"
-                     "const type:\t"
                      "if\t"
                      "elsif\t"
                      "while\t"

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260710.1619
+;; Package-Version: 20260710.1647
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-10T20:19:23+0000 W28-5"
+(defconst seed7-mode-version-timestamp "2026-07-10T20:47:08+0000 W28-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -4399,10 +4399,19 @@ Return found position or nil if nothing found."
                                ;; Found a peer level clause: stop if at
                                ;; nesting level 0
                                ((match-beginning 3)
-                                (when (and (not (string= word2 "func"))
-                                           (eq nesting 0))
-                                  (setq searching nil)
-                                  (setq found-position (point))))
+                                ;; A complete one-line action/forward
+                                ;; declaration (e.g. `const func ... is
+                                ;; action "...";'). It has the same
+                                ;; textual shape as a block-opening
+                                ;; header, but it is a complete
+                                ;; statement that never opens a compound
+                                ;; block and never signals the end of
+                                ;; the enclosing `begin'/`local' section
+                                ;; either. Skip over it silently: do
+                                ;; not touch `nesting', do not stop the
+                                ;; search — keep looking for the real
+                                ;; end of the enclosing section.
+                                nil)
                                ;; found nothing
                                (t (user-error
                                    "seed7-to-block-forward: \

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-10 23:20:39 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-11 08:50:29 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -1700,7 +1700,6 @@ with `SORT' (col 4) and `begin' (col 2) respectively.")
 second physical line (e.g. array.s7i's `insert'/ARR_RANGE shape) must
 not be treated as opening a compound block, and must not corrupt the
 indentation of declarations that follow it."
-  (skip-unless nil)                     ; this test is currently failing.
   (with-temp-buffer
     (setq-local indent-tabs-mode nil)
     (insert (concat
@@ -1714,7 +1713,7 @@ indentation of declarations that follow it."
     (seed7-mode)
     (indent-region (point-min) (point-max))
     (should (= (seed7-test-indent-02--line-indentation 3) 4))
-    (should (= (seed7-test-indent-02--line-indentation 4) 4)) ; continuation, adjust if a different rule applies
+    (should (= (seed7-test-indent-02--line-indentation 4) 24)) ; continuation, adjust if a different rule applies
     (should (= (seed7-test-indent-02--line-indentation 6) 4))
     (should (= (seed7-test-indent-02--line-indentation 7) 2))))
 

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-10 06:09:04 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-10 23:20:39 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -85,6 +85,10 @@
 ;; 12. Set definition block
 ;;     - Declaration: column 0
 ;;     - Set elements: column 2
+;;
+;; 13. One-line action/primitive declarations must not accumulate indentation.
+;;
+;; 14. Nested block-opening callable inside `begin', followed by `end func;'.
 
 ;; ---------------------------------------------------------------------------
 ;;; Code:
@@ -1540,6 +1544,179 @@ unindented (column 0) code."
       (seed7-test-indent-02--check-keyword-prefixed-layout)
       (should (string= (buffer-string)
                        (seed7-test-indent-02--keyword-prefixed-fixture ident))))))
+
+;; ---------------------------------------------------------------------------
+;; 13. One-line action/primitive declarations must not accumulate indentation.
+;;    Reproduces the array.s7i defect: a run of `const proc:'/`const func'
+;;    one-liners (each terminated by `;'), interspersed with block comments,
+;;    must all stay at the SAME indentation column, and a nested block-
+;;    opening callable must indent relative to its true enclosing `begin',
+;;    not relative to a preceding one-liner sibling.
+
+(defconst seed7-test-indent-02--action-decls-correct
+  (concat
+   "const type: arrayType is func\n"
+   "  local\n"
+   "    ...\n"
+   "  begin\n"
+   "    const proc: (inout arrayType: dest) := (in arrayType: source) is action \"ARR_CPY\";\n"
+   "    const proc: (inout arrayType: dest) &:= (in arrayType: source) is action \"ARR_APPEND\";\n"
+   "\n"
+   "    (**\n"
+   "     *  A block comment between two one-line declarations.\n"
+   "     *)\n"
+   "    const proc: (inout arrayType: dest) &:= (in baseType: element) is action \"ARR_PUSH\";\n"
+   "\n"
+   "    const func arrayType: [] (in tupleType: aTuple) is action \"ARR_ARRLIT\";\n"
+   "  end func;\n")
+  "Correctly-indented run of one-line action declarations inside `begin'.")
+
+(defconst seed7-test-indent-02--action-decls-misaligned
+  (concat
+   "const type: arrayType is func\n"
+   "  local\n"
+   "    ...\n"
+   "  begin\n"
+   "    const proc: (inout arrayType: dest) := (in arrayType: source) is action \"ARR_CPY\";\n"
+   "      const proc: (inout arrayType: dest) &:= (in arrayType: source) is action \"ARR_APPEND\";\n"
+   "\n"
+   "        (**\n"
+   "         *  A block comment between two one-line declarations.\n"
+   "         *)\n"
+   "        const proc: (inout arrayType: dest) &:= (in baseType: element) is action \"ARR_PUSH\";\n"
+   "\n"
+   "          const func arrayType: [] (in tupleType: aTuple) is action \"ARR_ARRLIT\";\n"
+   "  end func;\n")
+  "Same declarations, but progressively over-indented, mirroring the
+array.s7i defect where each one-liner inherits an extra indent step
+from the previous sibling instead of staying aligned under `begin'.")
+
+(ert-deftest seed7-indent/action-decls-keep-correct-layout ()
+  "A run of one-line action declarations under `begin' keeps a flat layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--action-decls-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (dolist (line '(5 6 11 13))
+      (should (= (seed7-test-indent-02--line-indentation line) 4)))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--action-decls-correct))))
+
+(ert-deftest seed7-indent/action-decls-fix-misaligned-layout ()
+  "`indent-region' flattens a progressively over-indented run of one-line
+action declarations back to the `begin' body column."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--action-decls-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (dolist (line '(5 6 11 13))
+      (should (= (seed7-test-indent-02--line-indentation line) 4)))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--action-decls-correct))))
+
+(ert-deftest seed7-indent/action-decl-tab-does-not-inherit-drift ()
+  "`seed7-indent-line' (TAB) alone on a drifted one-liner restores it to
+the `begin' body column, without needing a full region pass."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--action-decls-misaligned)
+    (seed7-mode)
+    (seed7-test-indent-02--goto-line 6)
+    (seed7-indent-line)
+    (should (= (seed7-test-indent-02--line-indentation 6) 4))))
+
+;; ---------------------------------------------------------------------------
+;; 14. Nested block-opening callable inside `begin', followed by `end func;'.
+;; Reproduces the ENABLE_SORT defect at array.s7i Lines 602-610.
+
+(defconst seed7-test-indent-02--nested-callable-in-begin-correct
+  (concat
+   "const proc: ENABLE_SORT (in type: arrayType) is func\n"
+   "  begin\n"
+   "    const reference: (attr arrayType) . dataCompare is getobj(x);\n"
+   "\n"
+   "    const func arrayType: SORT (in arrayType: arr, in reference: dataCompare) is action \"ARR_SORT\";\n"
+   "\n"
+   "    const func arrayType: sort (in arrayType: arr_obj) is\n"
+   "      return SORT(arr_obj, arrayType.dataCompare);\n"
+   "  end func;\n")
+  "Correctly-indented ENABLE_SORT shape: nested `sort' aligns with `SORT'
+under `begin' (column 4); outer `end func;' dedents to `begin' level
+(column 2).")
+
+(defconst seed7-test-indent-02--nested-callable-in-begin-misaligned
+  (concat
+   "const proc: ENABLE_SORT (in type: arrayType) is func\n"
+   "  begin\n"
+   "    const reference: (attr arrayType) . dataCompare is getobj(x);\n"
+   "\n"
+   "    const func arrayType: SORT (in arrayType: arr, in reference: dataCompare) is action \"ARR_SORT\";\n"
+   "\n"
+   "             const func arrayType: sort (in arrayType: arr_obj) is\n"
+   "               return SORT(arr_obj, arrayType.dataCompare);\n"
+   "             end func;\n")
+  "Misaligned version reproducing the reported array.s7i Lines 608/610 defect:
+`sort' and its `end func;' drift far to the right instead of aligning
+with `SORT' (col 4) and `begin' (col 2) respectively.")
+
+(ert-deftest seed7-indent/nested-callable-in-begin-keeps-correct-layout ()
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--nested-callable-in-begin-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 6))
+    (should (= (seed7-test-indent-02--line-indentation 9) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--nested-callable-in-begin-correct))))
+
+(ert-deftest seed7-indent/nested-callable-in-begin-fixes-misaligned-layout ()
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--nested-callable-in-begin-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))
+    (should (= (seed7-test-indent-02--line-indentation 8) 6))
+    (should (= (seed7-test-indent-02--line-indentation 9) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--nested-callable-in-begin-correct))))
+
+(ert-deftest seed7-indent/nested-callable-end-func-tab-dedents ()
+  "TAB alone on the drifted `end func;' line dedents it to `begin' level."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--nested-callable-in-begin-misaligned)
+    (seed7-mode)
+    (seed7-test-indent-02--goto-line 9)
+    (seed7-indent-line)
+    (should (= (seed7-test-indent-02--line-indentation 9) 2))))
+
+(ert-deftest seed7-indent/multiline-one-liner-decl-does-not-open-block ()
+  "A one-line action declaration whose parameter list wraps onto a
+second physical line (e.g. array.s7i's `insert'/ARR_RANGE shape) must
+not be treated as opening a compound block, and must not corrupt the
+indentation of declarations that follow it."
+  (skip-unless nil)                     ; this test is currently failing.
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert (concat
+             "const type: arrayType is func\n"
+             "  begin\n"
+             "    const proc: insert (inout arrayType: arr, in integer: index,\n"
+             "                        in baseType: element) is action \"ARR_INSERT\";\n"
+             "\n"
+             "    const proc: append (inout arrayType: arr) is action \"ARR_APPEND\";\n"
+             "  end func;\n"))
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 4)) ; continuation, adjust if a different rule applies
+    (should (= (seed7-test-indent-02--line-indentation 6) 4))
+    (should (= (seed7-test-indent-02--line-indentation 7) 2))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-02)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indentation and block navigation for one-line `const ... is ...;` declarations and similar `const proc/func/type` header variants.
  * Refined enclosing-block detection so indentation no longer drifts across consecutive one-line action/primitive declarations.
  * Corrected indentation behavior for nested callable declarations inside `begin ... end func;`, including proper dedent for `end func;`.

* **Documentation**
  * Refreshed mode documentation/navigation and updated mode metadata.
  * Improved regex/doc coverage for declaration matching and nesting semantics.

* **Tests**
  * Added ERT coverage for the above indentation scenarios, including a regression case for wrapped parameters (currently marked as failing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->