### PR TITLE
Cleanup- prepare to fix struct indentation issue

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -175,6 +175,8 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
   code.  I started accumulating regression test code to create a complete
   regression test suite to add and activate later.
 
+- Fix *indentation of new and sub struct and enums*.
+
 - Fix *indentation of the definitions of arrays and sets*.
 
 - Fix *excessive indentation of sibling catch and error statements*.  Issue reported by /barankegnu/

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260711.1012
+;; Package-Version: 20260712.0925
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-11T14:12:02+0000 W28-6"
+(defconst seed7-mode-version-timestamp "2026-07-12T13:25:52+0000 W28-7"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -5814,6 +5814,12 @@ deciding: if a `;' is reached before a bare `is' at end of line or
          ;; can be silently skipped over (e.g. "is func" appearing before
          ;; any parenthesis/bracket/semicolon is ever seen).
          ((looking-at "is[[:blank:]]+func\\_>")
+          (setq done t))
+         ;; `const type: X is new struct'/`is new enum', and inheritance-style
+         ;; `const type: X is sub BaseType struct'/`is sub BaseType enum', all
+         ;; open a struct/enum member-list block (closed by `end struct;'/
+         ;; `end enum;'), not a one-liner.
+         ((looking-at "\\_<is[[:blank:]]+\\(?:new\\|sub\\)\\(?:[[:blank:]]+[[:alpha:]][[:alnum:]_]*\\)?[[:blank:]]+\\(?:struct\\|enum\\)\\_>")
           (setq done t))
          ((looking-at "is[[:blank:]]*$")
           (setq done t))

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260711.0850
+;; Package-Version: 20260711.1012
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-11T12:50:05+0000 W28-6"
+(defconst seed7-mode-version-timestamp "2026-07-11T14:12:02+0000 W28-6"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6058,16 +6058,7 @@ Move point."
         ;; relative to the const type
         seed7-indent-width
       ;; struct/enum member definitions are indented twice.
-      (* 2 seed7-indent-width))
-    ;; ---------------------------------------------------------------------------
-    ;; (if (or (string-prefix-p "end struct;" first-text)
-    ;;         (string-prefix-p "end enum;"   first-text))
-    ;;     ;; end struct/enum is indented once relative to the const type
-    ;;     seed7-indent-width
-    ;;   ;; the definitions are indented twice.
-    ;;   (* 2 seed7-indent-width))
-
-    )
+      (* 2 seed7-indent-width)))
    ((string= header "const type: ")
     (if (or (string-prefix-p "end struct;" first-text)
             (string-prefix-p "end enum;"   first-text)

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260712.0925
+;; Package-Version: 20260712.0959
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-12T13:25:52+0000 W28-7"
+(defconst seed7-mode-version-timestamp "2026-07-12T13:59:30+0000 W28-7"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6049,22 +6049,6 @@ Move point."
    ((string= header "const proc: ")
     seed7-indent-width)
 
-   ((string= header "const type: ")
-    (if (or (string-prefix-p "end struct;" first-text)
-            (string-prefix-p "end enum;"   first-text)
-            ;; A `const type: X is func ... end func;' declaration is a
-            ;; func-style body (like `const proc:'/`const func'), not a
-            ;; struct/enum member list -- its `local'/`begin' section
-            ;; markers and closing `end func;' get a single indent level,
-            ;; not the double indent used for struct/enum members.
-            (string-prefix-p "local"     first-text)
-            (string-prefix-p "begin"     first-text)
-            (string-prefix-p "end func;" first-text))
-        ;; end struct/enum/func, local, and begin are indented once
-        ;; relative to the const type
-        seed7-indent-width
-      ;; struct/enum member definitions are indented twice.
-      (* 2 seed7-indent-width)))
    ((string= header "const type: ")
     (if (or (string-prefix-p "end struct;" first-text)
             (string-prefix-p "end enum;"   first-text)

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-11 08:50:29 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-12 09:27:03 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -89,6 +89,8 @@
 ;; 13. One-line action/primitive declarations must not accumulate indentation.
 ;;
 ;; 14. Nested block-opening callable inside `begin', followed by `end func;'.
+;;
+;; 15. Struct member-list definition: `const type: X is new struct ... end struct;'
 
 ;; ---------------------------------------------------------------------------
 ;;; Code:
@@ -1716,6 +1718,103 @@ indentation of declarations that follow it."
     (should (= (seed7-test-indent-02--line-indentation 4) 24)) ; continuation, adjust if a different rule applies
     (should (= (seed7-test-indent-02--line-indentation 6) 4))
     (should (= (seed7-test-indent-02--line-indentation 7) 2))))
+
+;; ---------------------------------------------------------------------------
+;; 15. Struct member-list definition: `const type: X is new struct ... end struct;'
+;; ----------------------------------------------------------------------------
+;;
+;;   const type: defFnType is new struct     ; col 0
+;;     var string: name is "";                ; col 4
+;;     var string: params is "";               ; col 4
+;;     var string: expression is "";           ; col 4
+;;   end struct;                               ; col 2
+
+(defconst seed7-test-indent-02--struct-correct
+  (concat
+   "const type: defFnType is new struct\n"
+   "    var string: name is \"\";\n"
+   "    var string: params is \"\";\n"
+   "    var string: expression is \"\";\n"
+   "  end struct;\n")
+  "Correctly-indented struct member-list fixture.")
+
+(defconst seed7-test-indent-02--struct-misaligned
+  (concat
+   "const type: defFnType is new struct\n"
+   "var string: name is \"\";\n"
+   "var string: params is \"\";\n"
+   "var string: expression is \"\";\n"
+   "end struct;\n")
+  "Misaligned struct member-list fixture.")
+
+(ert-deftest seed7-indent/struct-keeps-correct-layout ()
+  "Indenting an already-correct struct definition keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--struct-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 4))
+    (should (= (seed7-test-indent-02--line-indentation 5) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--struct-correct))))
+
+(ert-deftest seed7-indent/struct-fixes-misaligned-layout ()
+  "Indenting a misaligned struct definition (via `indent-region') restores
+the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--struct-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 4))
+    (should (= (seed7-test-indent-02--line-indentation 5) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--struct-correct))))
+
+(ert-deftest seed7-indent/struct-fixes-misaligned-layout-line-by-line ()
+  "Calling `seed7-indent-line' on each line of a misaligned struct
+definition (simulating manual <TAB> on each line) restores the
+expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--struct-misaligned)
+    (seed7-mode)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (seed7-indent-line)
+      (forward-line 1))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))
+    (should (= (seed7-test-indent-02--line-indentation 4) 4))
+    (should (= (seed7-test-indent-02--line-indentation 5) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--struct-correct))))
+
+(defconst seed7-test-indent-02--struct-sub-correct
+  (concat
+   "const type: aesState is sub noCipherState struct\n"
+   "    var array bin32: encryptionSubKey is 0 times bin32.value;\n"
+   "    var array bin32: decryptionSubKey is 0 times bin32.value;\n"
+   "    var integer: rounds is 0;\n"
+   "    var string: cipherBlock is \"\";\n"
+   "  end struct;\n"))
+
+(defconst seed7-test-indent-02--struct-sub-misaligned
+  (concat
+   "const type: aesState is sub noCipherState struct\n"
+   "var array bin32: encryptionSubKey is 0 times bin32.value;\n"
+   "var array bin32: decryptionSubKey is 0 times bin32.value;\n"
+   "var integer: rounds is 0;\n"
+   "var string: cipherBlock is \"\";\n"
+   "end struct;\n"))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-02)

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-12 09:40:41 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-12 09:55:08 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -91,6 +91,10 @@
 ;; 14. Nested block-opening callable inside `begin', followed by `end func;'.
 ;;
 ;; 15. Struct member-list definition: `const type: X is new struct ... end struct;'
+;;
+;; 16. Enum member-list definition: `const type: X is new enum ... end enum;'
+;;
+;; 17. Enum inheritance-style member-list definition:
 
 ;; ---------------------------------------------------------------------------
 ;;; Code:
@@ -1858,6 +1862,142 @@ expected layout."
       (forward-line 1))
     (should (string= (buffer-string)
                      seed7-test-indent-02--struct-sub-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 16. Enum member-list definition: `const type: X is new enum ... end enum;'
+;; ----------------------------------------------------------------------------
+;;
+;;   const type: color is new enum      ; col 0
+;;     red, green, blue                  ; col 4
+;;   end enum;                           ; col 2
+
+(defconst seed7-test-indent-02--enum-correct
+  (concat
+   "const type: color is new enum\n"
+   "    red, green, blue\n"
+   "  end enum;\n")
+  "Correctly-indented enum member-list fixture.")
+
+(defconst seed7-test-indent-02--enum-misaligned
+  (concat
+   "const type: color is new enum\n"
+   "red, green, blue\n"
+   "end enum;\n")
+  "Misaligned enum member-list fixture.")
+
+(ert-deftest seed7-indent/enum-keeps-correct-layout ()
+  "Indenting an already-correct enum definition keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--enum-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--enum-correct))))
+
+(ert-deftest seed7-indent/enum-fixes-misaligned-layout ()
+  "Indenting a misaligned enum definition (via `indent-region') restores
+the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--enum-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--enum-correct))))
+
+(ert-deftest seed7-indent/enum-fixes-misaligned-layout-line-by-line ()
+  "Calling `seed7-indent-line' on each line of a misaligned enum
+definition (simulating manual <TAB> on each line) restores the
+expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--enum-misaligned)
+    (seed7-mode)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (seed7-indent-line)
+      (forward-line 1))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--enum-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 17. Enum inheritance-style member-list definition:
+;;     `const type: X is sub BaseType enum ... end enum;'
+;; ----------------------------------------------------------------------------
+;;
+;;   const type: extendedColor is sub color enum   ; col 0
+;;     yellow, orange, purple                       ; col 4
+;;   end enum;                                       ; col 2
+
+(defconst seed7-test-indent-02--enum-sub-correct
+  (concat
+   "const type: extendedColor is sub color enum\n"
+   "    yellow, orange, purple\n"
+   "  end enum;\n")
+  "Correctly-indented inheritance-style enum member-list fixture.")
+
+(defconst seed7-test-indent-02--enum-sub-misaligned
+  (concat
+   "const type: extendedColor is sub color enum\n"
+   "yellow, orange, purple\n"
+   "end enum;\n")
+  "Misaligned inheritance-style enum member-list fixture.")
+
+(ert-deftest seed7-indent/enum-sub-keeps-correct-layout ()
+  "Indenting an already-correct inheritance-style enum definition keeps
+the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--enum-sub-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--enum-sub-correct))))
+
+(ert-deftest seed7-indent/enum-sub-fixes-misaligned-layout ()
+  "Indenting a misaligned inheritance-style enum definition (via
+`indent-region') restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--enum-sub-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--enum-sub-correct))))
+
+(ert-deftest seed7-indent/enum-sub-fixes-misaligned-layout-line-by-line ()
+  "Calling `seed7-indent-line' on each line of a misaligned
+inheritance-style enum definition (simulating manual <TAB> on each
+line) restores the expected layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--enum-sub-misaligned)
+    (seed7-mode)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (seed7-indent-line)
+      (forward-line 1))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 3) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--enum-sub-correct))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-02)

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-12 09:27:03 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-12 09:40:41 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -1798,6 +1798,8 @@ expected layout."
     (should (string= (buffer-string)
                      seed7-test-indent-02--struct-correct))))
 
+;; ---------------------------------------------------------------------------
+
 (defconst seed7-test-indent-02--struct-sub-correct
   (concat
    "const type: aesState is sub noCipherState struct\n"
@@ -1815,6 +1817,47 @@ expected layout."
    "var integer: rounds is 0;\n"
    "var string: cipherBlock is \"\";\n"
    "end struct;\n"))
+
+(ert-deftest seed7-indent/struct-sub-keeps-correct-layout ()
+  "Indenting an already-correct `is sub ... struct' definition keeps the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--struct-sub-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--struct-sub-correct))))
+
+(ert-deftest seed7-indent/struct-sub-fixes-misaligned-layout ()
+  "Indenting a misaligned `is sub ... struct' definition restores the layout."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--struct-sub-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))
+    (should (= (seed7-test-indent-02--line-indentation 2) 4))
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))
+    (should (= (seed7-test-indent-02--line-indentation 6) 2))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--struct-sub-correct))))
+
+(ert-deftest seed7-indent/struct-sub-fixes-misaligned-layout-line-by-line ()
+  "`seed7-indent-line' on each line restores a misaligned `is sub ... struct'."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--struct-sub-misaligned)
+    (seed7-mode)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (seed7-indent-line)
+      (forward-line 1))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--struct-sub-correct))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-02)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indentation for Seed7 `new`/`sub` struct and enum declarations, ensuring member-list blocks indent correctly (including nested member definitions).

* **Tests**
  * Added ERT coverage to validate correct indentation and automatic recovery for both aligned and misaligned struct member layouts.

* **Chores**
  * Updated package version and release metadata.
  * Added a NEWS entry describing the indentation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->