### PR TITLE
Add tests to check indentation and navigation of `is func` space code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ ERT_TEST_EL_FILES := tests/ert-tests/seed7-test-arrays-01.el \
                   tests/ert-tests/seed7-test-nav-array-01.el \
                   tests/ert-tests/seed7-test-nav-final-pos-01.el \
                   tests/ert-tests/seed7-test-nav-nested-01.el \
+                  tests/ert-tests/seed7-test-nav-trailing-comment-01.el	\
                   tests/ert-tests/seed7-test-syntax-propertize-01.el
 
 ALL_ERT_TEST_PASSED := $(ERT_TEST_EL_FILES:.el=.el.test-passed)
@@ -262,18 +263,20 @@ tools/sd7-indent-perf.elc:        seed7-mode.elc
 
 # See ERT_TEST_EL_FILES
 
-tests/ert-tests/seed7-test-arrays-01.el.test-passed:             seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-arrays-01.elc
-tests/ert-tests/seed7-test-font-lock-01.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-01.elc
-tests/ert-tests/seed7-test-font-lock-02.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02.elc
-tests/ert-tests/seed7-test-font-lock-02b.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02b.elc
-tests/ert-tests/seed7-test-indent-01.el.test-passed:             seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-01.elc
-tests/ert-tests/seed7-test-indent-02.el.test-passed:             seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-02.elc
-tests/ert-tests/seed7-test-mark-defun-01.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-mark-defun-01.el
-tests/ert-tests/seed7-test-nav-array-01.el.test-passed:          seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-array-01.elc
-tests/ert-tests/seed7-test-nav-final-pos-01.el.test-passed:      seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-final-pos-01.elc
-tests/ert-tests/seed7-test-nav-nested-01.el.test-passed:         seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-nested-01.elc
-tests/ert-tests/seed7-test-syntax-propertize-01.el.test-passed:  seed7-mode.elc tests/ert-tests/pel-ert.elc  tests/ert-tests/seed7-test-syntax-propertize-01.el
+tests/ert-tests/seed7-test-arrays-01.el.test-passed:               seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-arrays-01.elc
+tests/ert-tests/seed7-test-font-lock-01.el.test-passed:            seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-01.elc
+tests/ert-tests/seed7-test-font-lock-02.el.test-passed:            seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02.elc
+tests/ert-tests/seed7-test-font-lock-02b.el.test-passed:           seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02b.elc
+tests/ert-tests/seed7-test-indent-01.el.test-passed:               seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-01.elc
+tests/ert-tests/seed7-test-indent-02.el.test-passed:               seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-02.elc
+tests/ert-tests/seed7-test-mark-defun-01.el.test-passed:           seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-mark-defun-01.el
+tests/ert-tests/seed7-test-nav-array-01.el.test-passed:            seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-array-01.elc
+tests/ert-tests/seed7-test-nav-final-pos-01.el.test-passed:        seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-final-pos-01.elc
+tests/ert-tests/seed7-test-nav-nested-01.el.test-passed:           seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-nested-01.elc
+tests/ert-tests/seed7-test-nav-trailing-comment-01.el.test-passed: seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-trailing-comment-01.elc
+tests/ert-tests/seed7-test-syntax-propertize-01.el.test-passed:    seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-syntax-propertize-01.el
 #tests/ert-tests/seed7-test-sets-01.el.test-passed:          seed7-mode.elc tests/ert-tests/seed7-test-sets-01.elc
+
 
 # ----------------------------------------------------------------------------
 # RULE - execute ERT tests

--- a/NEWS
+++ b/NEWS
@@ -179,6 +179,9 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
 
 - Fix *indentation of the definitions of arrays and sets*.
 
+- Fix *backward-sexp navigation of function where is func line has trailing whitespace*.
+  This also fixes the indentation problem of code following such function.
+
 - Fix *excessive indentation of sibling catch and error statements*.  Issue reported by /barankegnu/
   in [[https://github.com/pierre-rouleau/seed7-mode/issues/79][bug-79] .
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260712.0959
+;; Package-Version: 20260712.1221
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-12T13:59:30+0000 W28-7"
+(defconst seed7-mode-version-timestamp "2026-07-12T16:21:20+0000 W28-7"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -3547,10 +3547,10 @@ statement.  Return nil otherwise."
 ;;    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (defconst seed7---func/proc/type-decl-start-re
-  ;;          (---------------------)                (----------)
-  ;;                                            (--------------------)
-  ;; (------------------------------------------------------------------)
-  "\\(const \\(?:func\\|proc\\|type\\)[^;]+?is\\(?:\\(?: +func\\)?$\\)\\)"
+  ;;          (---------------------)                (----------)               (-------)
+  ;;                                            (---------------------------------------------)
+  ;; (-------------------------------------------------------------------------------------------)
+  "\\(const \\(?:func\\|proc\\|type\\)[^;]+?is\\(?:\\(?: +func\\)?[[:blank:]]*\\(?:#.*?\\)?$\\)\\)"
   "Func/Proc declaration start. Group 1: complete text.")
 
 (defconst seed7---func/proc-decl-end-re
@@ -3695,7 +3695,7 @@ Group 2: the end of the enclosing local section: `end func;', `end proc;',
                          ((match-beginning 1)
                           (let ((is-long-body
                                  (string-match-p
-                                  "\\bis[[:blank:]]+\\(?:func\\|proc\\)[[:blank:]]*\\'"
+                                  "\\bis[[:blank:]]+\\(?:func\\|proc\\)[[:blank:]]*\\(?:#.*?\\)?\\'"
                                   (match-string-no-properties 1))))
                             (if (eq nesting 0)
                                 ;; At nesting=0: stop only when this declaration
@@ -3940,8 +3940,8 @@ Move inside the current if inside one, to the next if outside one.
                        ;; callable for this scan.  Short functions ending in plain "is"
                        ;; are handled by the short-function candidate search below.
                        ((match-beginning 1)
-                        (when (string-match-p "\\bis[[:blank:]]+func[[:blank:]]*\\'"
-                                              (match-string-no-properties 1))
+                        (when (string-match-p "\\bis[[:blank:]]+func[[:blank:]]*\\(?:#.*?\\)?\\'"
+                               (match-string-no-properties 1))
                           (setq nesting (1+ nesting))))
                        ;; Group 2: end func/proc; or return ...;
                        ((match-beginning 2)
@@ -4846,7 +4846,7 @@ Returns nil when no adjustment is needed:
      ;; (Only when point is exactly at line-end-position is re-search-backward
      ;; already able to find the match; for any earlier position it cannot.)
      ((looking-at
-       "^[[:blank:]]*[^;]*?is\\(?: +func\\)?[[:blank:]]*$")
+       "^[[:blank:]]*[^;]*?is\\(?: +func\\)?[[:blank:]]*\\(?:#.*?\\)?$")
       (line-end-position))
      ;; Otherwise — whether this is the opening `const proc/func' line of a
      ;; multi-line header or a continuation line — scan forward for the
@@ -4858,7 +4858,7 @@ Returns nil when no adjustment is needed:
           (cond
            ;; Found the `is func' / `is' terminator.
            ((looking-at
-             "^[[:blank:]]*[^;]*?is\\(?: +func\\)?[[:blank:]]*$")
+             "^[[:blank:]]*[^;]*?is\\(?: +func\\)?[[:blank:]]*\\(?:#.*?\\)?$")
             (setq found (line-end-position)))
            ;; Hit a body start, a new declaration, or a complete statement
            ;; (ends with `;'): no terminator in this direction.

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-12 09:55:08 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-12 11:51:29 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -1998,6 +1998,102 @@ line) restores the expected layout."
     (should (= (seed7-test-indent-02--line-indentation 3) 2))
     (should (string= (buffer-string)
                      seed7-test-indent-02--enum-sub-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 18. Func declaration with trailing whitespace + comment after `is func',
+;;     and indentation of the declaration that follows the closing `end func;'
+;; ----------------------------------------------------------------------------
+;;
+;; NOTE: line 1 below intentionally ends with `is func <SPACE>#' — trailing
+;; whitespace followed by a `#' comment.  This must be preserved verbatim
+;; (many editors strip trailing whitespace on save; the `#' after the space
+;; keeps it non-trailing in the source, so it survives such cleanups).
+
+(defconst seed7-test-indent-02--func-trailing-comment-correct
+  (concat
+   "const func string: gcmMult (in string: factor1, in factorHType: factorH) is func #\n"
+   "  result\n"
+   "    var string: product is \"\";\n"
+   "  local\n"
+   "    var integer: index is 0;\n"
+   "  begin\n"
+   "    index := 1;\n"
+   "  end func;\n"
+   "\n"
+   "const proc: main is func\n"
+   "  begin\n"
+   "    writeln(\"done\");\n"
+   "  end func;\n")
+  "Correctly-indented fixture: `is func' line has trailing ` #' comment.
+The second declaration (`const proc: main is func') must be indented at
+column 0, verifying that the following declaration is not corrupted by
+the preceding trailing-whitespace/comment `is func' line.")
+
+(defconst seed7-test-indent-02--func-trailing-comment-misaligned
+  (concat
+   "const func string: gcmMult (in string: factor1, in factorHType: factorH) is func #\n"
+   "result\n"
+   "var string: product is \"\";\n"
+   "local\n"
+   "var integer: index is 0;\n"
+   "begin\n"
+   "index := 1;\n"
+   "end func;\n"
+   "\n"
+   "const proc: main is func\n"
+   "begin\n"
+   "writeln(\"done\");\n"
+   "end func;\n")
+  "Misaligned counterpart of `seed7-test-indent-02--func-trailing-comment-correct'.")
+
+(ert-deftest seed7-indent/func-trailing-comment-keeps-correct-layout ()
+  "A `is func' line followed by trailing whitespace and a `#' comment must
+not break indentation of its own body nor of the declaration that follows."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--func-trailing-comment-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 1) 0))   ; declaration
+    (should (= (seed7-test-indent-02--line-indentation 2) 2))   ; result
+    (should (= (seed7-test-indent-02--line-indentation 3) 4))   ; var string
+    (should (= (seed7-test-indent-02--line-indentation 4) 2))   ; local
+    (should (= (seed7-test-indent-02--line-indentation 5) 4))   ; var integer
+    (should (= (seed7-test-indent-02--line-indentation 6) 2))   ; begin
+    (should (= (seed7-test-indent-02--line-indentation 7) 4))   ; index := 1;
+    (should (= (seed7-test-indent-02--line-indentation 8) 2))   ; end func;
+    (should (= (seed7-test-indent-02--line-indentation 10) 0))  ; const proc: main
+    (should (= (seed7-test-indent-02--line-indentation 11) 2))  ; begin
+    (should (= (seed7-test-indent-02--line-indentation 12) 4))  ; writeln(...)
+    (should (= (seed7-test-indent-02--line-indentation 13) 2))  ; end func;
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--func-trailing-comment-correct))))
+
+(ert-deftest seed7-indent/func-trailing-comment-fixes-misaligned-layout ()
+  "`indent-region' must restore correct indentation even when the earlier
+`is func' line has trailing whitespace + a `#' comment."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--func-trailing-comment-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--func-trailing-comment-correct))))
+
+(ert-deftest seed7-indent/func-trailing-comment-fixes-misaligned-layout-line-by-line ()
+  "Calling `seed7-indent-line' on each line (simulating manual <TAB>) must
+also restore correct indentation, including for the declaration following
+`end func;'."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--func-trailing-comment-misaligned)
+    (seed7-mode)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (seed7-indent-line)
+      (forward-line 1))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--func-trailing-comment-correct))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-02)

--- a/tests/ert-tests/seed7-test-nav-trailing-comment-01.el
+++ b/tests/ert-tests/seed7-test-nav-trailing-comment-01.el
@@ -1,0 +1,106 @@
+;;; seed7-test-nav-trailing-comment-01.el --- Regression: backward-sexp with trailing whitespace/comment after `is func'.  -*- lexical-binding: t; -*-
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Regression test for a `backward-sexp' failure when the declaration's
+;; `is func' line ends with trailing whitespace followed by a `#' comment
+;; (e.g. `is func #').  `seed7---func/proc/type-decl-start-re' anchors the
+;; declaration-start match to `$' right after `is func', with no tolerance
+;; for trailing whitespace/comment, so the nesting-aware backward scan in
+;; `seed7-beg-of-defun' (invoked from `seed7--forward-sexp-function' when
+;; `backward-sexp' is issued from `end func;') fails to recognize the
+;; declaration line and cannot find it.
+;;
+;; NOTE: line 2 below intentionally ends with `is func <SPACE>#'.  This must
+;; be preserved verbatim; the trailing `#' after the space prevents editors
+;; from silently stripping the trailing whitespace on save.
+;;
+;; Fixture line layout (1-based):
+;;
+;;   1   blank
+;;   2   const func string: gcmMult (in string: factor1, in factorHType: factorH) is func #
+;;   3     result
+;;   4       var string: product is "";
+;;   5     local
+;;   6       var integer: index is 0;
+;;   7     begin
+;;   8       index := 1;
+;;   9     end func;
+;;  10   blank
+
+;;; --------------------------------------------------------------------------
+;;; Dependencies:
+;;
+(require 'ert)
+(require 'seed7-mode)
+
+;;; --------------------------------------------------------------------------
+;;; Fixture
+;;
+
+(defconst seed7-test--trailing-comment-nav-code
+  (concat
+   "\n"
+   "const func string: gcmMult (in string: factor1, in factorHType: factorH) is func #\n"
+   "  result\n"
+   "    var string: product is \"\";\n"
+   "  local\n"
+   "    var integer: index is 0;\n"
+   "  begin\n"
+   "    index := 1;\n"
+   "  end func;\n"
+   "\n"))
+
+(defmacro seed7-test--with-trailing-comment-nav-buffer (&rest body)
+  "Run BODY in a temp buffer holding `seed7-test--trailing-comment-nav-code'."
+  `(with-temp-buffer
+     (seed7-mode)
+     (insert seed7-test--trailing-comment-nav-code)
+     ,@body))
+
+(defun seed7-test--trailing-comment-nav-goto-eol (line)
+  "Move point to the end of LINE (1-based)."
+  (goto-char (point-min))
+  (forward-line (1- line))
+  (end-of-line))
+
+(defun seed7-test--trailing-comment-nav-current-line ()
+  "Return the current line number (1-based)."
+  (line-number-at-pos))
+
+;;; --------------------------------------------------------------------------
+;;; Tests
+;;
+
+(ert-deftest seed7-nav-trailing-comment/beginning-of-defun-reaches-decl ()
+  "`beginning-of-defun' from `end func;' (line 9) must reach the declaration
+start on line 2, even though line 2 ends with trailing whitespace + `#'."
+  (seed7-test--with-trailing-comment-nav-buffer
+    (seed7-test--trailing-comment-nav-goto-eol 9)
+    (beginning-of-defun)
+    (should (= (seed7-test--trailing-comment-nav-current-line) 2))))
+
+(ert-deftest seed7-nav-trailing-comment/backward-sexp-from-end-func-reaches-decl ()
+  "`seed7--forward-sexp-function' called with -1 from EOL of `end func;'
+(line 9) must reach the declaration start on line 2, not fail or land at
+some intermediate position, when line 2 ends with trailing whitespace + `#'."
+  (seed7-test--with-trailing-comment-nav-buffer
+    (seed7-test--trailing-comment-nav-goto-eol 9)
+    (seed7--forward-sexp-function -1)
+    (should (= (seed7-test--trailing-comment-nav-current-line) 2))))
+
+(ert-deftest seed7-nav-trailing-comment/end-of-defun-reaches-end-func ()
+  "`end-of-defun' from the declaration (line 2, with trailing whitespace +
+`#') must reach `end func;' on line 9, confirming the forward direction is
+also unaffected once the fix generalizes the regex."
+  (seed7-test--with-trailing-comment-nav-buffer
+    (goto-char (point-min))
+    (forward-line 1)                    ; line 2
+    (seed7-end-of-defun)
+    (should (= (seed7-test--trailing-comment-nav-current-line) 9))))
+
+;; ---------------------------------------------------------------------------
+(provide 'seed7-test-nav-trailing-comment-01)
+
+;;; seed7-test-nav-trailing-comment-01.el ends here


### PR DESCRIPTION
Add test to check that indentation and navigation of code where the `is func` is followed by whitespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved indentation for Seed7 function declarations followed by trailing comments.
  - Improved navigation to function declarations and their closing statements when trailing comments are present.

- **Tests**
  - Added regression coverage for indentation and navigation with trailing comments.
  - Included interactive line-by-line indentation scenarios.
  - Integrated the new navigation tests into the automated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->