### PR TITLE
Investigate/Fix another indentation bug

### DIFF
--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260713.0650
+;; Package-Version: 20260713.0937
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-13T10:50:24+0000 W29-1"
+(defconst seed7-mode-version-timestamp "2026-07-13T13:37:30+0000 W29-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6809,6 +6809,8 @@ search boundaries for the assignment operator and statement-end searches."
         (when (and assignment-pos
                    statement-end-pos
                    (< assignment-pos current-pos statement-end-pos)
+                   ;; [:todo 2026-07-13, by Pierre Rouleau:
+                   ;;    Also reject when inside function argument]
                    ;; Reject assignment operators nested inside an open
                    ;; paren/bracket/brace (e.g. a local declare-and-assign
                    ;; sub-expression used as a function argument, such as


### PR DESCRIPTION
I found another indentation bug.

Given this, correctly indented piece of Seed7 code, taken from the lib/x509cert.s7i file:

~~~
 470     aTime := time(year,
 471                             integer(stri[ 3 fixLen 2]),  # month
 472                             integer(stri[ 5 fixLen 2]),  # day
 473                             integer(stri[ 7 fixLen 2]),  # hour
 474                             integer(stri[ 9 fixLen 2]),  # minute
 475                             integer(stri[11 fixLen 2])); # second
 476 # writeln("getTime_yymmddhhmmssZ(" <& literal(stri) <& ") -->
~~~

seed7-mode indents it like this, which is wrong:

~~~
 470     aTime := time(year,
 471                   integer(stri[ 3 fixLen 2]),  # month
 472              integer(stri[ 5 fixLen 2]),  # day
 473              integer(stri[ 7 fixLen 2]),  # hour
 474              integer(stri[ 9 fixLen 2]),  # minute
 475              integer(stri[11 fixLen 2])); # second
~~~

If we place the second line (line 471) at the end of the first line (line 470), see7-mode indents the next line properly but not the others and we end up with:

~~~
 470     aTime := time(year, integer(stri[ 3 fixLen 2]),  # month
 471                   integer(stri[ 5 fixLen 2]),  # day
 472              integer(stri[ 7 fixLen 2]),  # hour
 473              integer(stri[ 9 fixLen 2]),  # minute
 474              integer(stri[11 fixLen 2])); # second
~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development version metadata.
  * Added an internal note for a potential future indentation improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->