### PR TITLE
Investigate indentation bug

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -187,6 +187,12 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
 
 - Fix *indentation issue caused by ~:=~ inside a function call parameter list*
 
+- Fix *indentation of continuation lines of a multi-line function-call
+  argument list on the RHS of a top-level ~:=~ assignment* (e.g. Seed7's
+  =lib/x509cert.s7i= ~aTime := time(year, ...)~ statement).  Such lines were
+  incorrectly aligned under the assignment operator instead of under the
+  still-open call's opening paren.
+
 - Fix *seed7-line-inside-parens-pair*: was using the wrong variable for
   the line-beginning position.
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260713.0650
+;; Package-Version: 20260713.0954
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-13T10:50:24+0000 W29-1"
+(defconst seed7-mode-version-timestamp "2026-07-13T13:54:29+0000 W29-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6809,6 +6809,8 @@ search boundaries for the assignment operator and statement-end searches."
         (when (and assignment-pos
                    statement-end-pos
                    (< assignment-pos current-pos statement-end-pos)
+                   ;; [:todo 2026-07-13, by Pierre Rouleau:
+                   ;;    Also reject when line is inside function argument list]
                    ;; Reject assignment operators nested inside an open
                    ;; paren/bracket/brace (e.g. a local declare-and-assign
                    ;; sub-expression used as a function argument, such as

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260713.0954
+;; Package-Version: 20260713.1010
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-13T13:54:29+0000 W29-1"
+(defconst seed7-mode-version-timestamp "2026-07-13T14:10:19+0000 W29-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6809,8 +6809,6 @@ search boundaries for the assignment operator and statement-end searches."
         (when (and assignment-pos
                    statement-end-pos
                    (< assignment-pos current-pos statement-end-pos)
-                   ;; [:todo 2026-07-13, by Pierre Rouleau:
-                   ;;    Also reject when line is inside function argument list]
                    ;; Reject assignment operators nested inside an open
                    ;; paren/bracket/brace (e.g. a local declare-and-assign
                    ;; sub-expression used as a function argument, such as
@@ -7668,8 +7666,8 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                          indent-column2)
              (not (seed7-line-inside-parens-pair-column
                    0
-                   (seed7-bol-position -1)
-                   (seed7-position-of-end-of-statement -1))))
+                   early-begin-pos
+                   early-end-pos)))
         (setq indent-column indent-column2))
 
        ;; Handle special cases before checking if line is inside a block

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-13 07:15:25 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-13 10:15:49 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -2287,6 +2287,96 @@ also restore correct indentation for this pattern."
       (forward-line 1))
     (should (string= (buffer-string)
                      seed7-test-indent-02--slice-compare-eq-correct))))
+
+;; ---------------------------------------------------------------------------
+;; 21. Top-level `:=' assignment whose RHS is a multi-line function call:
+;;     every continuation line remains inside the still-open parens of the
+;;     call and must align under the column following the open paren, not
+;;     under the column following `:='.  Based on the `aTime := time(...)'
+;;     statement in Seed7's lib/x509cert.s7i.
+;; ---------------------------------------------------------------------------
+
+(defconst seed7-test-indent-02--multiline-call-arg-in-assign-correct
+  (concat
+   "const proc: main is func\n"
+   "  local\n"
+   "    var string: stri is \"20260713100000Z\";\n"
+   "    var time: aTime is time.value;\n"
+   "  begin\n"
+   "    aTime := time(year,\n"
+   "                  integer(stri[ 3 fixLen 2]),  # month\n"
+   "                  integer(stri[ 5 fixLen 2]),  # day\n"
+   "                  integer(stri[ 7 fixLen 2]),  # hour\n"
+   "                  integer(stri[ 9 fixLen 2]),  # minute\n"
+   "                  integer(stri[11 fixLen 2])); # second\n"
+   "  end func;\n")
+  "Correctly-indented fixture: a top-level `:=' assignment whose RHS is a
+multi-line function call.  Every continuation line is inside the still-open
+parens of the `time(...)' call and must align under the column following
+`time(', not under the column following `:='.")
+
+(defconst seed7-test-indent-02--multiline-call-arg-in-assign-misaligned
+  (concat
+   "const proc: main is func\n"
+   "local\n"
+   "var string: stri is \"20260713100000Z\";\n"
+   "var time: aTime is time.value;\n"
+   "begin\n"
+   "aTime := time(year,\n"
+   "integer(stri[ 3 fixLen 2]),  # month\n"
+   "integer(stri[ 5 fixLen 2]),  # day\n"
+   "integer(stri[ 7 fixLen 2]),  # hour\n"
+   "integer(stri[ 9 fixLen 2]),  # minute\n"
+   "integer(stri[11 fixLen 2])); # second\n"
+   "end func;\n")
+  "Un-indented counterpart of
+`seed7-test-indent-02--multiline-call-arg-in-assign-correct'.")
+
+(ert-deftest seed7-indent/multiline-call-arg-in-assign-keeps-correct-layout ()
+  "Every continuation line of the multi-line `time(...)' call on the RHS of
+the top-level `aTime := ...' assignment must align under the column
+following the open paren of `time(', not under the column following `:='."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--multiline-call-arg-in-assign-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-02--line-indentation 6) 4))    ; aTime := time(year,
+    (should (= (seed7-test-indent-02--line-indentation 7) 18))   ; integer(...) # month
+    (should (= (seed7-test-indent-02--line-indentation 8) 18))   ; integer(...) # day
+    (should (= (seed7-test-indent-02--line-indentation 9) 18))   ; integer(...) # hour
+    (should (= (seed7-test-indent-02--line-indentation 10) 18))  ; integer(...) # minute
+    (should (= (seed7-test-indent-02--line-indentation 11) 18))  ; integer(...) # second
+    (should (= (seed7-test-indent-02--line-indentation 12) 2))   ; end func;
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--multiline-call-arg-in-assign-correct))))
+
+(ert-deftest seed7-indent/multiline-call-arg-in-assign-fixes-misaligned-layout ()
+  "`indent-region' must restore correct indentation for a multi-line
+function-call argument list appearing on the RHS of a top-level `:='
+assignment, without any continuation line drifting to the assignment
+operator's column."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--multiline-call-arg-in-assign-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--multiline-call-arg-in-assign-correct))))
+
+(ert-deftest seed7-indent/multiline-call-arg-in-assign-fixes-misaligned-layout-line-by-line ()
+  "Calling `seed7-indent-line' on each line (simulating manual <TAB>) must
+also restore correct indentation for this pattern."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--multiline-call-arg-in-assign-misaligned)
+    (seed7-mode)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (seed7-indent-line)
+      (forward-line 1))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--multiline-call-arg-in-assign-correct))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-02)


### PR DESCRIPTION
Given this, correctly indented piece of Seed7 code, taken from the lib/x509cert.s7i file:

~~~
 470     aTime := time(year,
 471                   integer(stri[ 3 fixLen 2]),  # month
 472                   integer(stri[ 5 fixLen 2]),  # day
 473                   integer(stri[ 7 fixLen 2]),  # hour
 474                   integer(stri[ 9 fixLen 2]),  # minute
 475                   integer(stri[11 fixLen 2])); # second
~~~

seed7-mode indents it like this, which is wrong:

~~~
 470     aTime := time(year,
 471                   integer(stri[ 3 fixLen 2]),  # month
 472              integer(stri[ 5 fixLen 2]),  # day
 473              integer(stri[ 7 fixLen 2]),  # hour
 474              integer(stri[ 9 fixLen 2]),  # minute
 475              integer(stri[11 fixLen 2])); # second
~~~

If we place the second line (line 471) at the end of the first line (line 470), see7-mode indents the next line properly but not the others and we end up with:

~~~
470     aTime := time(year, integer(stri[ 3 fixLen 2]),  # month
 471                   integer(stri[ 5 fixLen 2]),  # day
 472              integer(stri[ 7 fixLen 2]),  # hour
 473              integer(stri[ 9 fixLen 2]),  # minute
 474              integer(stri[11 fixLen 2])); # second
~~~

I debugged the execution of `<TAB>` on the line that is not indented properly and it enters `seed7-line-inside-assign-statement-continuation` which returns
the invalid indentation column.    I believe the solution is to change the
code in ``seed7-line-inside-assign-statement-continuation` to reject the line
because it is inside a function argument parens pair.