### PR TITLE
Add test for the indentation of code similar to asn1.s7i

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ ERT_TEST_EL_FILES := tests/ert-tests/seed7-test-arrays-01.el \
                   tests/ert-tests/seed7-test-font-lock-02b.el \
                   tests/ert-tests/seed7-test-indent-01.el \
                   tests/ert-tests/seed7-test-indent-02.el \
+                  tests/ert-tests/seed7-test-indent-03.el \
                   tests/ert-tests/seed7-test-mark-defun-01.el \
                   tests/ert-tests/seed7-test-nav-array-01.el \
                   tests/ert-tests/seed7-test-nav-final-pos-01.el \
@@ -269,6 +270,7 @@ tests/ert-tests/seed7-test-font-lock-02.el.test-passed:            seed7-mode.el
 tests/ert-tests/seed7-test-font-lock-02b.el.test-passed:           seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-font-lock-02b.elc
 tests/ert-tests/seed7-test-indent-01.el.test-passed:               seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-01.elc
 tests/ert-tests/seed7-test-indent-02.el.test-passed:               seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-02.elc
+tests/ert-tests/seed7-test-indent-03.el.test-passed:               seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-indent-03.elc
 tests/ert-tests/seed7-test-mark-defun-01.el.test-passed:           seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-mark-defun-01.el
 tests/ert-tests/seed7-test-nav-array-01.el.test-passed:            seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-array-01.elc
 tests/ert-tests/seed7-test-nav-final-pos-01.el.test-passed:        seed7-mode.elc tests/ert-tests/pel-ert.elc tests/ert-tests/seed7-test-nav-final-pos-01.elc

--- a/NEWS
+++ b/NEWS
@@ -196,6 +196,9 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
 - Fix *seed7-line-inside-parens-pair*: was using the wrong variable for
   the line-beginning position.
 
+- Fix *indentation of declarations (e.g. ~new enum~) immediately following
+  a closing array/set literal line*, as seen in Seed7's =lib/asn1.s7i line 71=.
+
 - Fix *seed7-symbol-at-point*: was using *looking-at-p* (does not
   update match data) instead of *looking-at* in one branch.
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260713.1010
+;; Package-Version: 20260715.1141
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-13T14:10:19+0000 W29-1"
+(defconst seed7-mode-version-timestamp "2026-07-15T15:41:55+0000 W29-3"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6679,7 +6679,9 @@ N is: - :previous-non-empty for the previous non-empty line,
              (seed7-to-indent)
              (when (looking-at-p seed7--array-definition-start-regexp)
                (setq block-start-pos (point))
-               (when (< block-start-pos line-start-pos enclosing-block-end-pos line-end-pos)
+               (when (and (< block-start-pos line-start-pos)
+                          (<= line-start-pos enclosing-block-end-pos)
+                          (< enclosing-block-end-pos line-end-pos))
                  ;; Return the header's own column — the closing line of a
                  ;; nested array literal is aligned with its innermost
                  ;; open paren, not necessarily one `seed7-indent-width'
@@ -6852,11 +6854,18 @@ N is: - :previous-non-empty for the previous non-empty line,
           ;; backward without a bound, which could scan far above line N.
           (when (seed7-re-search-backward "};" line-start-pos)
             (setq enclosing-block-end-pos (point))
+            ;; `seed7-re-search-backward' leaves point just *before* the
+            ;; closing brace; `backward-sexp' needs point *after* it to
+            ;; jump to the beginning of the whole (possibly deeply nested)
+            ;; set literal. (Mirrors the array-definition-block twin.)
+            (goto-char (1+ enclosing-block-end-pos))
             (seed7--with-backward-sexp
               (seed7-to-indent)
               (when (looking-at-p seed7--set-definition-start-regexp)
                 (setq block-start-pos (point))
-                (when (< block-start-pos line-start-pos enclosing-block-end-pos line-end-pos)
+                (when (and (< block-start-pos line-start-pos)
+                           (<= line-start-pos enclosing-block-end-pos)
+                           (< enclosing-block-end-pos line-end-pos))
                   ;; return header's own column
                   (current-column))))))))))
 

--- a/tests/ert-tests/seed7-test-indent-03.el
+++ b/tests/ert-tests/seed7-test-indent-03.el
@@ -1,0 +1,178 @@
+;;; seed7-test-indent-03.el --- ERT tests for array/set-block-end indentation regressions  -*- lexical-binding: t; -*-
+
+;; Author    : Pierre Rouleau <prouleau001@gmail.com>
+
+;; This file is part of the SEED7-MODE package.
+;; This file is not part of GNU Emacs.
+
+;;; --------------------------------------------------------------------------
+;;; Commentary:
+;;
+;; Regression tests for the case where an array/set-literal definition ends
+;; on a line that contains *only* the closing delimiter (e.g. `  );' or
+;; `  };'), immediately followed (after blank lines and/or a block comment)
+;; by another top-level declaration.
+;;
+;; Before the fix to `seed7-line-at-endof-array-definition-block' and
+;; `seed7-line-at-endof-set-definition-block', the strict chained inequality
+;;
+;;   (< block-start-pos line-start-pos enclosing-block-end-pos line-end-pos)
+;;
+;; failed whenever `line-start-pos' and `enclosing-block-end-pos' were equal
+;; (i.e. the closing delimiter is the very first thing on the line), causing
+;; the "just after end of array/set definition block" clause in
+;; `seed7-calc-indent' to be skipped.  Control then fell through to the
+;; generic indent-step fallback, which incorrectly re-used the raw column of
+;; the previous line (the position of the closing delimiter) instead of the
+;; array/set header's own column.
+;;
+;; Real-world case: lib/asn1.s7i, around line 71 --
+;;
+;; 33 const array string: classTagName is [0] (
+;; ...
+;; 65   "(use long-form)"
+;; 66   );
+;; 67
+;; 68 (**
+;; 69  *  Tag type used by ASN.1/BER data elements.
+;; 70  *)
+;; 71 const type: asn1TagType is new enum
+;; ...
+;;
+;; Line 71 must be indented at column 0 (same as the `const array string:
+;; classTagName' header on line 33), not column 2 (the column of the `)' on
+;; line 66).
+
+;; ---------------------------------------------------------------------------
+;;; Code:
+
+(require 'ert)
+(require 'seed7-mode)
+
+(defconst seed7-test-indent-03--array-end-then-decl-correct
+  (concat
+   "const array string: classTagName is [0] (\n"
+   "  \"EOC (End-of-Content)\",\n"
+   "  \"BOOLEAN\",\n"
+   "  \"(use long-form)\"\n"
+   "  );\n"
+   "\n"
+   "(**\n"
+   " *  Tag type used by ASN.1/BER data elements.\n"
+   " *)\n"
+   "const type: asn1TagType is new enum\n"
+   "    tagEndOfContent,\n"
+   "    tagBoolean,\n"
+   "    tagUseLongForm\n"
+   "  end enum;\n")
+  "Correctly indented reproduction of the lib/asn1.s7i Line 71 shape.")
+
+(defconst seed7-test-indent-03--array-end-then-decl-misaligned
+  (concat
+   "const array string: classTagName is [0] (\n"
+   "  \"EOC (End-of-Content)\",\n"
+   "  \"BOOLEAN\",\n"
+   "  \"(use long-form)\"\n"
+   "  );\n"
+   "\n"
+   "(**\n"
+   " *  Tag type used by ASN.1/BER data elements.\n"
+   " *)\n"
+   "  const type: asn1TagType is new enum\n"          ; <- wrongly indented at col 2
+   "    tagEndOfContent,\n"
+   "    tagBoolean,\n"
+   "    tagUseLongForm\n"
+   "  end enum;\n")
+  "Misindented version of `seed7-test-indent-03--array-end-then-decl-correct'.")
+
+(defconst seed7-test-indent-03--set-end-then-decl-correct
+  (concat
+   "const set of string: tagNameSet is {\n"
+   "  \"EOC\",\n"
+   "  \"BOOLEAN\"\n"
+   "  };\n"
+   "\n"
+   "(** doc comment *)\n"
+   "const type: asn1TagType is new enum\n"
+   "    tagEndOfContent\n"
+   "  end enum;\n")
+  "Correctly indented set-literal analogue of the array-block regression.")
+
+(defconst seed7-test-indent-03--set-end-then-decl-misaligned
+  (concat
+   "const set of string: tagNameSet is {\n"
+   "  \"EOC\",\n"
+   "  \"BOOLEAN\"\n"
+   "  };\n"
+   "\n"
+   "(** doc comment *)\n"
+   "  const type: asn1TagType is new enum\n"           ; <- wrongly indented at col 2
+   "    tagEndOfContent\n"
+   "  end enum;\n")
+  "Misindented version of `seed7-test-indent-03--set-end-then-decl-correct'.")
+
+(defun seed7-test-indent-03--goto-line (line)
+  "Move point to the beginning of LINE (1-based)."
+  (goto-char (point-min))
+  (forward-line (1- line)))
+
+(defun seed7-test-indent-03--line-indentation (line)
+  "Return indentation of LINE (1-based)."
+  (save-excursion
+    (seed7-test-indent-03--goto-line line)
+    (current-indentation)))
+
+(ert-deftest seed7-indent/array-block-end-then-decl-keeps-correct-layout ()
+  "Indenting an already-correct array-block-end-then-decl layout is stable."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-03--array-end-then-decl-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-03--line-indentation 1) 0))   ; const array string: ...
+    (should (= (seed7-test-indent-03--line-indentation 5) 2))   ; `  );'
+    (should (= (seed7-test-indent-03--line-indentation 7) 0))   ; `(**'
+    (should (= (seed7-test-indent-03--line-indentation 10) 0))  ; const type: ... is new enum
+    (should (string= (buffer-string)
+                      seed7-test-indent-03--array-end-then-decl-correct))))
+
+(ert-deftest seed7-indent/array-block-end-then-decl-fixes-misaligned-layout ()
+  "Indenting the misaligned layout restores column 0 for the declaration
+that follows the closing `);' of an array literal."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-03--array-end-then-decl-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-03--line-indentation 10) 0))  ; must NOT be 2
+    (should (string= (buffer-string)
+                      seed7-test-indent-03--array-end-then-decl-correct))))
+
+(ert-deftest seed7-indent/set-block-end-then-decl-keeps-correct-layout ()
+  "Indenting an already-correct set-block-end-then-decl layout is stable."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-03--set-end-then-decl-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-03--line-indentation 1) 0))
+    (should (= (seed7-test-indent-03--line-indentation 4) 2))   ; `  };'
+    (should (= (seed7-test-indent-03--line-indentation 7) 0))   ; const type: ...
+    (should (string= (buffer-string)
+                      seed7-test-indent-03--set-end-then-decl-correct))))
+
+(ert-deftest seed7-indent/set-block-end-then-decl-fixes-misaligned-layout ()
+  "Indenting the misaligned set-literal layout restores column 0."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-03--set-end-then-decl-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    (should (= (seed7-test-indent-03--line-indentation 7) 0))
+    (should (string= (buffer-string)
+                      seed7-test-indent-03--set-end-then-decl-correct))))
+
+;; ---------------------------------------------------------------------------
+(provide 'seed7-test-indent-03)
+
+;;; seed7-test-indent-03.el ends here


### PR DESCRIPTION
The lib.asn1.s7i has the following code that does not indent properly with the current seed7-mode.el code:
~~~
  32
  33 const array string: classTagName is [0] (
  34   "EOC (End-of-Content)",
  35   "BOOLEAN",
  36   "INTEGER",
  37   "BIT STRING",
 ....
  61   "GeneralString",
  62   "UniversalString",
  63   "CHARACTER STRING",
  64   "BMPString",
  65   "(use long-form)"
  66   );
  67
  68 (**
  69  *  Tag type used by ASN.1/BER data elements.
  70  *)
  71   const type: asn1TagType is new enum   # <===  This does not indent properly
  72       tagEndOfContent,
  73       tagBoolean,
  74       tagInteger,
  75       tagBitString,
 ....
 102       tagBMPString,
 103       tagUseLongForm
 104     end enum;
 105
 ~~~

This new test code test this type of indentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Seed7 indentation handling for array and set definitions when closing delimiters appear on their own line.
  * Prevented subsequent top-level declarations from receiving incorrect indentation after these blocks, including cases involving blank lines or comments.

* **Tests**
  * Added regression coverage for correctly indented and automatically re-indented array and set definitions.
  * Included the new indentation tests in the standard test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->