### PR TITLE
Add test to check indentation after multiline parenthesized declarations

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -199,6 +199,10 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
 - Fix *indentation of declarations (e.g. ~new enum~) immediately following
   a closing array/set literal line*, as seen in Seed7's =lib/asn1.s7i line 71=.
 
+- Fix *incorrect inherited indentation after completed multiline
+  parenthesized declarations* (for example, consecutive ellipticCurve
+  constants in lib/elliptic.s7i).
+
 - Fix *seed7-symbol-at-point*: was using *looking-at-p* (does not
   update match data) instead of *looking-at* in one branch.
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260715.1141
+;; Package-Version: 20260717.1110
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-15T15:41:55+0000 W29-3"
+(defconst seed7-mode-version-timestamp "2026-07-17T15:10:50+0000 W29-5"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -6688,6 +6688,47 @@ N is: - :previous-non-empty for the previous non-empty line,
                  ;; step below the header (see `Te'/`Td' in aes.s7i).
                  (current-column))))))))))
 
+(defun seed7-line-at-endof-parenthesized-statement
+    (n &optional dont-skip-comment-start)
+  "Check if line N ends a completed parenthesized statement.
+
+Return the indentation column of the line containing the matching opening
+parenthesis when line N ends with `);'.  Return nil otherwise.
+
+N is: - :previous-non-empty for the previous non-empty line,
+        skipping lines with starting comments unless DONT-SKIP-COMMENT-START
+        is non-nil,
+      - 0 for the current line,
+      - A negative number for previous lines: -1 previous, -2 line before..."
+  (save-excursion
+    (when (seed7-move-to-line n dont-skip-comment-start)
+      (let ((line-start-pos (point))
+            (line-end-pos (line-end-position))
+            (opening-paren-pos nil)
+            (closing-paren-pos nil))
+        ;; This helper deliberately handles only a completed `);' expression.
+        ;; Array and set definition blocks retain their dedicated handlers.
+        (when (seed7-line-code-ends-with 0 ");")
+          (goto-char line-end-pos)
+          ;; Keep the search on this line: the terminator must belong to the
+          ;; previous non-empty code line selected above.
+          (when (seed7-re-search-backward ");" line-start-pos)
+            (setq closing-paren-pos (point))
+            ;; `seed7-re-search-backward' leaves point at the `)'.  Move past
+            ;; it so `backward-sexp' reaches its matching opening `('.
+            (goto-char (1+ closing-paren-pos))
+            (seed7--with-backward-sexp
+              (setq opening-paren-pos (point))
+              ;; Do not accept an opener on the closing line itself.  A
+              ;; multiline completed expression must start on an earlier line.
+              (when (and (< opening-paren-pos line-start-pos)
+                         (<= line-start-pos closing-paren-pos)
+                         (< closing-paren-pos line-end-pos))
+                ;; The statement/declaration following the completed call must
+                ;; align with the line that introduced that call.
+                (seed7-to-indent)
+                (current-column)))))))))
+
 (defun seed7-line-inside-set-definition-block (n &optional
                                                  scope-begin-pos
                                                  scope-end-pos
@@ -7805,6 +7846,14 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
        ;; 697          not symbol[length(symbol)] in numeric_var_suffix);
        ((seed7--set
          (seed7-line-starts-with-open-paren-after-logic-operator 0)
+         indent-column))
+
+       ;; A sibling declaration/statement after a completed multiline call
+       ;; aligns with the call's header, rather than with the continuation
+       ;; column of its closing `);' line.
+       ((seed7--set
+         (seed7-line-at-endof-parenthesized-statement
+          :previous-non-empty)
          indent-column))
 
        ((seed7-line-starts-with 0 "(")

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-06-25 22:55:18 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-17 11:11:10 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -196,6 +196,62 @@
         (seed7-indent-line)
         (forward-line 1))
       (should (string= region-result (buffer-string))))))
+
+;; ---------------------------------------------------------------------------
+
+(defconst seed7-test-indent--elliptic-sibling-calls-correct
+  (concat
+   "const ellipticCurve: secp192k1 is ellipticCurve(\n"
+   "                                                192, \"secp192k1\",\n"
+   "                                                3_);\n"
+   "\n"
+   "(**\n"
+   " *  The elliptical curve secp192r1.\n"
+   " *)\n"
+   "const ellipticCurve: secp192r1 is ellipticCurve(\n"
+   "                                                192, \"secp192r1\",\n"
+   "                                                4_);\n")
+  "Correct layout for consecutive top-level multiline calls.")
+
+(defconst seed7-test-indent--elliptic-sibling-calls-misaligned
+  (concat
+   "const ellipticCurve: secp192k1 is ellipticCurve(\n"
+   "                                                192, \"secp192k1\",\n"
+   "                                                3_);\n"
+   "\n"
+   "(**\n"
+   " *  The elliptical curve secp192r1.\n"
+   " *)\n"
+   "                                                const ellipticCurve: secp192r1 is ellipticCurve(\n"
+   "                                                192, \"secp192r1\",\n"
+   "                                                4_);\n")
+  "Regression input: sibling declaration inherits the prior `);' column.")
+
+(ert-deftest seed7-indent/elliptic-sibling-call-layout-is-stable ()
+  "A declaration after a completed multiline call remains top-level."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent--elliptic-sibling-calls-correct)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    ;; Line 8 is the second top-level `const ellipticCurve:' declaration.
+    (should (= (seed7-test-indent--line-indentation 8) 0))
+    (should (string=
+             (buffer-string)
+             seed7-test-indent--elliptic-sibling-calls-correct))))
+
+(ert-deftest seed7-indent/elliptic-sibling-call-layout-is-corrected ()
+  "A sibling declaration must not inherit the preceding `);' indentation."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent--elliptic-sibling-calls-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    ;; Line 8 must align with Line 1, not with the closing `);' on Line 3.
+    (should (= (seed7-test-indent--line-indentation 8) 0))
+    (should (string=
+             (buffer-string)
+             seed7-test-indent--elliptic-sibling-calls-correct))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-01)


### PR DESCRIPTION
A top-level declaration following a completed multiline parenthesized call could be incorrectly indented to the continuation column of the preceding closing `);` line.

This happened when the declarations were separated by blank lines and/or a Seed7 documentation comment.  No dedicated indentation rule handled the new sibling declaration, so the generic fallback reused the indentation of the previous non-empty code line.  When that line was an indented `);`, the following top-level declaration inherited its indentation.  Repeating this pattern caused indentation to grow progressively.

The regression test covers consecutive top-level `const ellipticCurve:` declarations, modelled after lib/elliptic.s7i.  It verifies that a declaration following a multiline `ellipticCurve(...)` expression is aligned with the preceding declaration header at column zero, rather than with the closing delimiter's continuation indentation.

The failing code was first detected in lib/elliptic.s7i lines 153, 164, 174, etc..

~~~
 136     curve.n := n;
 137   end func;
 138
 139
 140 (**
 141  *  The elliptical curve secp192k1.
 142  *)
 143 const ellipticCurve: secp192k1 is ellipticCurve(
 144                                                 192, "secp192k1",
 145                                                 16#fffffffffffffffffffffffffffffffffffffffeffffee37_, 0_, 3_,
 146                                                 ecPoint(16#db4ff10ec057e9ae26b07d0280b7f4341da5d1b1eae06c7d_,
 147                                                         16#9b2f2f6d9c5628a7844163d015be86344082aa88d95e2f9d_),
 148                                                 16#fffffffffffffffffffffffe26f2fc170f69466a74defd8d_);
 149
 150 (**
 151  *  The elliptical curve secp192r1.
 152  *)
 153                                                 const ellipticCurve: secp192r1 is ellipticCurve(
 154                                                                                                 192, "secp192r1",
 155                                                                                                 16#fffffffffffffffffffffffffffffffeffffffffffffffff_, -3_,
 156                                                                                                 16#64210519e59c80e70fa7e9ab72243049feb8deecc146b9b1_,
 157                                                                                                 ecPoint(16#188da80eb03090f67cbf20eb43a18800f4ff0afd82ff1012_,
 158                                                                                                         16#07192b95ffc8da78631011ed6b24cdd573f977a11e794811_),
 159                                                                                                 16#ffffffffffffffffffffffff99def836146bc9b1b4d22831_);
 160
 161 (**
 162  *  The elliptical curve secp224k1.
 163  *)
 164                                                                                                 const ellipticCurve: secp224k1 is ellipticCurve(
 165                                                                                                                                                 224, "secp224k1",
 166                                                                                                                                                 16#fffffffffffffffffffffffffffffffffffffffffffffffeffffe56d_, 0_, 5_,
 167                                                                                                                                                 ecPoint(16#a1455b334df099df30fc28a169a467e9e47075a90f7e650eb6b7a45c_,
 168                                                                                                                                                         16#7e089fed7fba344282cafbd6f7e319f7c0b0bd59e2ca4bdb556d61a5_),
 169                                                                                                                                                 16#0000000000000000000000000001dce8d2ec6184caf0a971769fb1f7_);
 170
 171 (**
 172  *  The elliptical curve secp224r1.
 173  *)
 174                                                                                                                                                 const ellipticCurve: secp224r1 is ellipticCurve(
 175                                                                                                                                                                                                 224, "secp224r1",
 176                                                                                                                                                                                                 16#ffffffffffffffffffffffffffffffff000000000000000000000001_, -3_,
 177                                                                                                                                                                                                 16#b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4_,
 178                                                                                                                                                                                                 ecPoint(16#b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21_,
 179                                                                                                                                                                                                         16#bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34_),
 180                                                                                                                                                                                                 16#ffffffffffffffffffffffffffff16a2e0b8f03e13dd29455c5c2a3d_);
 181
 ~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved indentation stability for consecutive multiline top-level calls, ensuring following declarations align correctly.

- **Tests**
  - Added regression coverage for correctly indented and misaligned multiline call layouts.
  - Added checks confirming both targeted indentation and complete buffer formatting are corrected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->