### PR TITLE
Add indentation test for code like lib/string.s7i string actions

### DIFF
--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260720.1556
+;; Package-Version: 20260720.1639
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-20T19:56:19+0000 W30-1"
+(defconst seed7-mode-version-timestamp "2026-07-20T20:39:30+0000 W30-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -1984,15 +1984,14 @@ spanning any number of continuation lines, ending at the first `;'.")
 - Group 1: procedure name,
 - Group 2: \"func\", \"forward\", \"DYNAMIC\", \"action XYZ\".")
 
-
 (defconst seed7-func-forward-or-action-declaration-nc-re
-  ;;              (----------------)            (------)
-  ;;         (--------------------------------------------)
+  ;;                 (----------------)            (------)
+  ;;          (----------------------------------------------)
   ;;              name
-  (format "\\(?:%s\\(%s%s+?([^;]+?)\\)%s+?is%s+?\\(?:%s\\)\\)"
-          ;;         g     G1
-          ;;    %    %  %             %     %        %
-          ;;    1    2  3             4     5        6
+  (format "^\\(?:%s\\(%s%s+?([^;]+?)\\)%s+?is%s+?\\(?:%s\\)\\)"
+          ;;          g     G1
+          ;;     %    %  %             %     %        %
+          ;;     1    2  3             4     5        6
           (seed7-func-beg-of-decl-re-fmt)       ; 1
           "?:"                                  ; 2: don't capture g
           "[^;]"                                ; 3

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260720.1639
+;; Package-Version: 20260720.1724
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-20T20:39:30+0000 W30-1"
+(defconst seed7-mode-version-timestamp "2026-07-20T21:24:55+0000 W30-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -7245,28 +7245,30 @@ N is: - :previous-non-empty for the previous non-empty line,
             ;; Locate that header line and re-check the declaration from
             ;; there, still bounded by END-POS (the end of this
             ;; continuation line).
-            (let ((declaration-regexps
-                   (list seed7-func-forward-or-action-declaration-nc-re
-                         seed7--forward-proc-decl-re
-                         seed7-proc-forward-or-action-declaration-re)))
-              ;; Search backward through candidate `const' lines.  Do not use the
-              ;; candidate's indentation as a boundary: while correcting a malformed
-              ;; declaration, its header can itself be indented incorrectly.
+
+            (let ((candidate-column nil)
+                  (statement-end-pos nil))
+              ;; Search backward through callable declaration headers.  The candidate
+              ;; may itself be wrongly indented, so do not use indentation as a search
+              ;; boundary.
               ;;
-              ;; A candidate is accepted only when its complete declaration reaches
-              ;; END-POS, i.e. the end of the original forward/DYNAMIC/action tail.
-              ;; Thus, a completed earlier declaration separated by comments is rejected.
+              ;; A candidate belongs to this continuation tail only when its first code
+              ;; statement terminator is the semicolon at END-POS.  This works for both
+              ;; one- and multi-line forward/DYNAMIC/action declarations without
+              ;; reparsing their complete signature with a large multiline regexp.
               (save-excursion
                 (while (and (not previous-defun-column)
                             (= (forward-line -1) 0))
                   (seed7-to-indent)
                   (when (and (not (eolp))
                              (not (seed7-inside-comment-p))
-                             (looking-at-p "const\\_>"))
-                    (seed7--set
-                     (seed7-line-starts-with-any
-                      0 declaration-regexps nil end-pos)
-                     previous-defun-column))))
+                             (setq candidate-column
+                                   (seed7-line-is-procfunc-beg-of-decl 0)))
+                    (setq statement-end-pos
+                          (seed7-statement-end-pos nil end-pos))
+                    (when (and statement-end-pos
+                               (= statement-end-pos end-pos))
+                      (setq previous-defun-column candidate-column)))))
               previous-defun-column)))
 
          ;; Handle line that is an end func, struct or enum.

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260717.1110
+;; Package-Version: 20260720.1556
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-17T15:10:50+0000 W29-5"
+(defconst seed7-mode-version-timestamp "2026-07-20T19:56:19+0000 W30-1"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -7246,23 +7246,29 @@ N is: - :previous-non-empty for the previous non-empty line,
             ;; Locate that header line and re-check the declaration from
             ;; there, still bounded by END-POS (the end of this
             ;; continuation line).
-            (let ((boundary (seed7--indent-search-boundary-uncached
-                             (current-column))))
-              (when boundary
-                (save-excursion
-                  (goto-char boundary)
+            (let ((declaration-regexps
+                   (list seed7-func-forward-or-action-declaration-nc-re
+                         seed7--forward-proc-decl-re
+                         seed7-proc-forward-or-action-declaration-re)))
+              ;; Search backward through candidate `const' lines.  Do not use the
+              ;; candidate's indentation as a boundary: while correcting a malformed
+              ;; declaration, its header can itself be indented incorrectly.
+              ;;
+              ;; A candidate is accepted only when its complete declaration reaches
+              ;; END-POS, i.e. the end of the original forward/DYNAMIC/action tail.
+              ;; Thus, a completed earlier declaration separated by comments is rejected.
+              (save-excursion
+                (while (and (not previous-defun-column)
+                            (= (forward-line -1) 0))
                   (seed7-to-indent)
-                  (when (string= (seed7--current-line-nth-word 1) "const")
-                    (seed7--set (seed7-line-starts-with-any
-                                 0
-                                 (list
-                                  seed7-func-forward-or-action-declaration-nc-re
-                                  seed7--forward-proc-decl-re
-                                  seed7-proc-forward-or-action-declaration-re)
-                                 nil
-                                 end-pos)
-                                previous-defun-column)
-                    previous-defun-column))))))
+                  (when (and (not (eolp))
+                             (not (seed7-inside-comment-p))
+                             (looking-at-p "const\\_>"))
+                    (seed7--set
+                     (seed7-line-starts-with-any
+                      0 declaration-regexps nil end-pos)
+                     previous-defun-column))))
+              previous-defun-column)))
 
          ;; Handle line that is an end func, struct or enum.
          ((seed7--set (and (seed7-line-starts-with-any
@@ -7710,7 +7716,7 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                      seed7-predef-assignment-operator-regexp)
                     indent-column))
        ;;
-       ;; Assignment statement continuation
+       ;; -- Assignment statement continuation
        ((and (seed7--set (seed7-line-inside-assign-statement-continuation
                           0 early-begin-pos early-end-pos)
                          indent-column2)
@@ -7720,17 +7726,15 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
                    early-end-pos)))
         (setq indent-column indent-column2))
 
-       ;; Handle special cases before checking if line is inside a block
-       ;; --------------------------------------------------------------
+       ;; --  Handle special cases before checking if line is inside a block
        ;; Check if line is below end of func|struct|enum before checking if it
        ;; is inside a block and is not itself a 'end func|struct|enum;' line.
        ;; This ensures it handles the next line properly.
        ((and (or (not (seed7-line-is-defun-end 0))
                  (seed7-line-is-procfunc-beg-of-decl 0))
-             (seed7--set (seed7-line-is-defun-end :previous-non-empty)
-                         indent-column)))
+             (setq indent-column (seed7-line-is-defun-end :previous-non-empty))))
 
-       ;; Also perform some tests that are fast to execute.
+       ;; -- Then perform some tests that execute quickly.
        ((string= first-word-on-line "$")
         (setq indent-step 0))
        ((string= first-word-on-line "include")

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-17 11:11:10 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-20 11:56:39 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -252,6 +252,79 @@
     (should (string=
              (buffer-string)
              seed7-test-indent--elliptic-sibling-calls-correct))))
+
+;; ---------------------------------------------------------------------------
+
+(defconst seed7-test-indent--string-action-siblings-correct
+  (concat
+   "const func string: striRange (in string: stri) [ (in integer: start) ..\n"
+   "                                                    (in integer: stop) ] is action \"STR_RANGE\";\n"
+   "\n"
+   "(**\n"
+   " *  Get a substring with a requested maximum length.\n"
+   " *)\n"
+   "const func string: striSubstr (in string: stri) [ (in integer: start) len\n"
+   "                                                     (in integer: length) ] is action \"STR_SUBSTR\";\n"
+   "\n"
+   "(**\n"
+   " *  Get a substring with a guaranteed length.\n"
+   " *)\n"
+   "const func string: striFixLen (in string: stri) [ (in integer: start) fixLen\n"
+   "                                                     (in integer: length) ] is action \"STR_SUBSTR_FIXLEN\";\n"
+   "\n"
+   "(**\n"
+   " *  Append EXTENSION to DESTINATION.\n"
+   " *)\n"
+   "const proc: appendTo (inout string: destination) &:= (in string: extension) is action \"STR_APPEND\";\n")
+  "Correct layout for top-level action declarations following comments.")
+
+(defconst seed7-test-indent--string-action-siblings-misaligned
+  (concat
+   "const func string: striRange (in string: stri) [ (in integer: start) ..\n"
+   "                                                    (in integer: stop) ] is action \"STR_RANGE\";\n"
+   "\n"
+   "(**\n"
+   " *  Get a substring with a requested maximum length.\n"
+   " *)\n"
+   "                                                    const func string: striSubstr (in string: stri) [ (in integer: start) len\n"
+   "                                                                                                         (in integer: length) ] is action \"STR_SUBSTR\";\n"
+   "\n"
+   "(**\n"
+   " *  Get a substring with a guaranteed length.\n"
+   " *)\n"
+   "                                                                                                         const func string: striFixLen (in string: stri) [ (in integer: start) fixLen\n"
+   "                                                                                                                             (in integer: length) ] is action \"STR_SUBSTR_FIXLEN\";\n"
+   "\n"
+   "(**\n"
+   " *  Append EXTENSION to DESTINATION.\n"
+   " *)\n"
+   "                                                                                                                             const proc: appendTo (inout string: destination) &:= (in string: extension) is action \"STR_APPEND\";\n")
+  "Input for accumulated indentation after multiline action declarations.")
+
+(ert-deftest seed7-indent/string-action-siblings-are-top-level-after-comments ()
+  "Top-level action declarations do not inherit parameter continuation columns."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent--string-action-siblings-misaligned)
+    (seed7-mode)
+
+    (indent-region (point-min) (point-max))
+
+    ;; Declaration headers, rather than parameter continuations, must be
+    ;; aligned as top-level siblings.
+    (should (= (seed7-test-indent--line-indentation 1) 0))
+    (should (= (seed7-test-indent--line-indentation 7) 0))
+    (should (= (seed7-test-indent--line-indentation 13) 0))
+    (should (= (seed7-test-indent--line-indentation 19) 0))
+
+    ;; Continuation lines remain aligned within their own declarations.
+    (should (= (seed7-test-indent--line-indentation 2) 52))
+    (should (= (seed7-test-indent--line-indentation 8) 53))
+    (should (= (seed7-test-indent--line-indentation 14) 53))
+
+    (should (string=
+             (buffer-string)
+             seed7-test-indent--string-action-siblings-correct))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-01)

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-20 16:39:19 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-20 17:24:13 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -258,19 +258,19 @@
 (defconst seed7-test-indent--string-action-siblings-correct
   (concat
    "const func string: striRange (in string: stri) [ (in integer: start) ..\n"
-   "                                                    (in integer: stop) ] is action \"STR_RANGE\";\n"
+   "                                                (in integer: stop) ] is action \"STR_RANGE\";\n"
    "\n"
    "(**\n"
    " *  Get a substring with a requested maximum length.\n"
    " *)\n"
    "const func string: striSubstr (in string: stri) [ (in integer: start) len\n"
-   "                                                     (in integer: length) ] is action \"STR_SUBSTR\";\n"
+   "                                                 (in integer: length) ] is action \"STR_SUBSTR\";\n"
    "\n"
    "(**\n"
    " *  Get a substring with a guaranteed length.\n"
    " *)\n"
    "const func string: striFixLen (in string: stri) [ (in integer: start) fixLen\n"
-   "                                                     (in integer: length) ] is action \"STR_SUBSTR_FIXLEN\";\n"
+   "                                                 (in integer: length) ] is action \"STR_SUBSTR_FIXLEN\";\n"
    "\n"
    "(**\n"
    " *  Append EXTENSION to DESTINATION.\n"
@@ -303,7 +303,6 @@
 
 (ert-deftest seed7-indent/string-action-siblings-are-top-level-after-comments ()
   "Top-level action declarations do not inherit parameter continuation columns."
-  (ert-skip "failing test")
   (with-temp-buffer
     (setq-local indent-tabs-mode nil)
     (insert seed7-test-indent--string-action-siblings-misaligned)
@@ -329,9 +328,9 @@
     (should (= (seed7-test-indent--line-indentation 19) 0))
 
     ;; Continuation lines remain aligned within their own declarations.
-    (should (= (seed7-test-indent--line-indentation 2) 52))
-    (should (= (seed7-test-indent--line-indentation 8) 53))
-    (should (= (seed7-test-indent--line-indentation 14) 53))
+    (should (= (seed7-test-indent--line-indentation 2) 48))
+    (should (= (seed7-test-indent--line-indentation 8) 49))
+    (should (= (seed7-test-indent--line-indentation 14) 49))
 
     (should (string=
              (buffer-string)

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-20 15:58:12 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-20 16:39:19 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -303,10 +303,21 @@
 
 (ert-deftest seed7-indent/string-action-siblings-are-top-level-after-comments ()
   "Top-level action declarations do not inherit parameter continuation columns."
+  (ert-skip "failing test")
   (with-temp-buffer
     (setq-local indent-tabs-mode nil)
     (insert seed7-test-indent--string-action-siblings-misaligned)
     (seed7-mode)
+
+    ;; Each continuation tail must be recognized as the end of its own
+    ;; multiline action declaration before region indentation changes the
+    ;; deliberately malformed header columns.
+    ;;
+    ;; The returned integer is the current header indentation: 0 for the
+    ;; first declaration and nonzero for intentionally misindented siblings.
+    (dolist (line '(2 8 14))
+      (seed7-test-indent--goto-line line)
+      (should (integerp (seed7-line-is-defun-end 0))))
 
     (indent-region (point-min) (point-max))
 
@@ -324,15 +335,7 @@
 
     (should (string=
              (buffer-string)
-             seed7-test-indent--string-action-siblings-correct)))
-
-
-    ;; A multiline top-level native/action declaration must itself be
-    ;; recognized as a completed definition, even before region indentation.
-    (goto-char (point-min))
-    (forward-line 1)
-    (should (equal (seed7-line-is-defun-end 0) 0)))
-
+             seed7-test-indent--string-action-siblings-correct))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-01)

--- a/tests/ert-tests/seed7-test-indent-01.el
+++ b/tests/ert-tests/seed7-test-indent-01.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-01.el --- ERT tests for Seed7 indentation regressions  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-20 11:56:39 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-20 15:58:12 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -324,7 +324,15 @@
 
     (should (string=
              (buffer-string)
-             seed7-test-indent--string-action-siblings-correct))))
+             seed7-test-indent--string-action-siblings-correct)))
+
+
+    ;; A multiline top-level native/action declaration must itself be
+    ;; recognized as a completed definition, even before region indentation.
+    (goto-char (point-min))
+    (forward-line 1)
+    (should (equal (seed7-line-is-defun-end 0) 0)))
+
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-01)


### PR DESCRIPTION
I found another indentation bug in the lib/string.s7i in line 191, 214 and 223: these lines are indented but they should not be indented:
~~~
 147 const func string: (in string: stri) [ .. (in integer: stop) ]   is action "STR_HEAD";
 148 
 149 
 150 (**                                                                                                                                                                                      
 151  *  Get a substring from a ''start'' position to a ''stop'' position.                                                                                                                    
 152  *  The first character in a ''string'' has the position 1.                                                                                                                              
 153  *   "abcde"[2 .. 4]   returns "bcd"                                                                                                                                                     
 154  *   "abcde"[2 .. 7]   returns "bcde"                                                                                                                                                    
 155  *   "abcde"[4 .. 3]   returns ""                                                                                                                                                        
 156  *   "abcde"[4 .. 2]   raises INDEX_ERROR                                                                                                                                                
 157  *   "abcde"[6 .. 8]   returns ""                                                                                                                                                        
 158  *   "abcde"[1 .. 3]   returns "abc"                                                                                                                                                     
 159  *   "abcde"[0 .. 3]   raises INDEX_ERROR                                                                                                                                                
 160  *   "abcde"[1 .. 0]   returns ""                                                                                                                                                        
 161  *   "abcde"[1 .. -1]  raises INDEX_ERROR                                                                                                                                                
 162  *  @param stri Source string from which the substring is created.                                                                                                                       
 163  *  @param start Start position which must be >= 1.                                                                                                                                      
 164  *  @param stop Stop position which must be >= pred(''start'').                                                                                                                          
 165  *  @return the substring from position ''start'' to ''stop''.                                                                                                                           
 166  *  @exception INDEX_ERROR The ''start'' position is negative or zero, or                                                                                                                
 167  *                         the ''stop'' position is less than pred(''start'').                                                                                                           
 168  *  @exception MEMORY_ERROR Not enough memory to represent the result.                                                                                                                   
 169  *)
 170 const func string: (in string: stri) [ (in integer: start) ..
 171                                       (in integer: stop) ]      is action "STR_RANGE";
 172 
 173 
 174 (**                                                                                                                                                                                      
 175  *  Get a substring from a ''start'' position with a given ''length''.                                                                                                                   
 176  *  The first character in a ''string'' has the position 1.                                                                                                                              
 177  *   "abcde"[2 len 3]   returns "bcd"                                                                                                                                                    
 178  *   "abcde"[2 len 5]   returns "bcde"                                                                                                                                                   
 179  *   "abcde"[3 len 0]   returns ""                                                                                                                                                       
 180  *   "abcde"[6 len 2]   returns ""                                                                                                                                                       
 181  *   "abcde"[3 len -1]  raises INDEX_ERROR                                                                                                                                               
 182  *   "abcde"[0 len 2]   raises INDEX_ERROR                                                                                                                                               
 183  *  @param stri Source string from which the substring is created.                                                                                                                       
 184  *  @param start Start position which must be >= 1.                                                                                                                                      
 185  *  @param length Requested maximum length of the substring.                                                                                                                             
 186  *  @return the substring from the ''start'' position with up to ''length'' characters.                                                                                                  
 187  *  @exception INDEX_ERROR The ''start'' position is negative or zero, or                                                                                                                
 188  *                         the ''length'' is negative.                                                                                                                                   
 189  *  @exception MEMORY_ERROR Not enough memory to represent the result.                                                                                                                   
 190  *)
 191                                       const func string: (in string: stri) [ (in integer: start) len
 192                                                                             (in integer: length) ]    is action "STR_SUBSTR";
 193 
 194 
 195 (**                                                                                                                                                                                      
 196  *  Get a substring from a ''start'' position with a guaranteed ''length''.                                                                                                              
 197  *  The first character in a string has the position 1.                                                                                                                                  
 198  *   "abcde"[2 fixLen 3]   returns "bcd"                                                                                                                                                 
 199  *   "abcde"[3 fixLen 0]   returns ""                                                                                                                                                    
 200  *   "abcde"[2 fixLen 5]   raises INDEX_ERROR                                                                                                                                            
 201  *   "abcde"[6 fixLen 2]   raises INDEX_ERROR                                                                                                                                            
 202  *   "abcde"[3 fixLen -1]  raises INDEX_ERROR                                                                                                                                            
 203  *   "abcde"[0 fixLen 2]   raises INDEX_ERROR                                                                                                                                            
 204  *        ""[1 fixLen 0]   raises INDEX_ERROR                                                                                                                                            
 205  *  @param stri Source string from which the substring is created.                                                                                                                       
 206  *  @param start Start position between 1 and length(''stri'').                                                                                                                          
 207  *  @param length Guaranteed length of the substring.                                                                                                                                    
 208  *  @return the substring from the ''start'' position with ''length'' characters.                                                                                                        
 209  *  @exception INDEX_ERROR The ''length'' is negative, or the ''start'' position                                                                                                         
 210  *                         is outside of the string, or the substring from the                                                                                                           
 211  *                         ''start'' position has less than ''length'' characters.                                                                                                       
 212  *  @exception MEMORY_ERROR Not enough memory to represent the result.                                                                                                                   
 213  *)
 214                                                                             const func string: (in string: stri) [ (in integer: start) fixLen
 215                                                                                                                   (in integer: length) ]    is action "STR_SUBSTR_FIXLEN";
 216 
 217 
 218 (**                                                                                                                                                                                      
 219  *  Append the string ''extension'' to ''destination''.                                                                                                                                  
 220  *  @exception MEMORY_ERROR Not enough memory for the concatenated                                                                                                                       
 221  *             string.                                                                                                                                                                   
 222  *)
 223                                                                                                                   const proc: (inout string: destination) &:= (in string: extension)   i$
 224 
 225 
~~~

This commit adds test code to test indentation of this type of code. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Seed7 indentation for multiline top-level native/action declarations, especially how continuation lines align.
  * Refined end-of-declaration detection so indentation decisions stop at the correct declaration boundary.

* **Tests**
  * Added indentation regression coverage for top-level action “sibling” declarations following documentation/comments, including header and parameter/continuation alignment.
  * Added fixtures to validate both targeted indentation behavior and full-buffer formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->