### PR TITLE
Fix indentation of begin that follows the end of a func/proc/struct

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -209,6 +209,12 @@ seed7-mode -- Seed7 Classic Emacs Mode -- NEWS     -*- org -*-
   parenthesized declarations* (for example, consecutive ellipticCurve
   constants in lib/elliptic.s7i).
 
+- Fix *indentation of =begin= after a nested function, procedure, or
+  structure declaration*.  When such a =begin= closes an enclosing
+  =local= or =result= section, it now aligns with that section rather
+  than inheriting the indentation of the preceding =end func;=,
+  =end proc;=, or =end struct;=.
+
 - Fix *seed7-symbol-at-point*: was using *looking-at-p* (does not
   update match data) instead of *looking-at* in one branch.
 

--- a/seed7-mode.el
+++ b/seed7-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/pierre-rouleau/seed7-mode
 ;; Created   : Wednesday, March 26 2025.
 ;; Version: 0.1
-;; Package-Version: 20260720.1724
+;; Package-Version: 20260721.1143
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1"))
 
@@ -544,7 +544,7 @@
 ;;* Version Info
 ;;  ============
 
-(defconst seed7-mode-version-timestamp "2026-07-20T21:24:55+0000 W30-1"
+(defconst seed7-mode-version-timestamp "2026-07-21T15:43:05+0000 W30-2"
   "Version UTC timestamp of the `seed7-mode' file.
 Automatically updated when saved during development.
 Please do not modify.")
@@ -7730,8 +7730,11 @@ The RECURSE-COUNT should be nil on the first call, 1 on the first recursive
        ;; --  Handle special cases before checking if line is inside a block
        ;; Check if line is below end of func|struct|enum before checking if it
        ;; is inside a block and is not itself a 'end func|struct|enum;' line.
-       ;; This ensures it handles the next line properly.
-       ((and (or (not (seed7-line-is-defun-end 0))
+       ;; Handle ordinary siblings below `end func|struct|enum;' before checking
+       ;; enclosing blocks.  A `begin' may instead close an enclosing `local' or
+       ;; `result' declaration section, so it must use the block-structure logic.
+       ((and (not (string= first-word-on-line "begin"))
+             (or (not (seed7-line-is-defun-end 0))
                  (seed7-line-is-procfunc-beg-of-decl 0))
              (setq indent-column (seed7-line-is-defun-end :previous-non-empty))))
 

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-13 10:15:49 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-21 12:24:22 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -2377,6 +2377,80 @@ also restore correct indentation for this pattern."
       (forward-line 1))
     (should (string= (buffer-string)
                      seed7-test-indent-02--multiline-call-arg-in-assign-correct))))
+
+;; ---------------------------------------------------------------------------
+;; Regression: `begin' following a nested callable's `end func;' inside an
+;; enclosing `local' section must align with that enclosing `local'.
+
+(defconst seed7-test-indent-02--begin-after-nested-func-end-correct
+  (concat
+   "const proc: XX is func\n"
+   "  local\n"
+   "    const proc: YY is func\n"
+   "      local\n"
+   "        const proc: WW is func\n"
+   "          begin\n"
+   "            WW;\n"
+   "          end func;\n"
+   "        const proc: ZZ is func\n"
+   "          begin\n"
+   "            ZZ;\n"
+   "          end func;\n"
+   "      begin\n"
+   "        YY;\n"
+   "      end func;\n"
+   "  begin\n"
+   "    XX;\n"
+   "  end func;\n")
+  "Nested-callable fixture with `begin' aligned to its enclosing `local'.")
+
+(defconst seed7-test-indent-02--begin-after-nested-func-end-misaligned
+  (concat
+   "const proc: XX is func\n"
+   "  local\n"
+   "    const proc: YY is func\n"
+   "      local\n"
+   "        const proc: WW is func\n"
+   "          begin\n"
+   "            WW;\n"
+   "          end func;\n"
+   "        const proc: ZZ is func\n"
+   "          begin\n"
+   "            ZZ;\n"
+   "          end func;\n"
+   "        begin\n"
+   "          YY;\n"
+   "      end func;\n"
+   "  begin\n"
+   "    XX;\n"
+   "  end func;\n")
+  "Same fixture with YY's `begin' wrongly indented at column 8, rather
+than the column-6 indentation of YY's `local'.")
+
+(ert-deftest seed7-indent/begin-after-nested-func-end-fixes-region-layout ()
+  "A `begin' after a nested callable's `end func;' must align with its
+enclosing callable's `local', not inherit the nested callable's indentation."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--begin-after-nested-func-end-misaligned)
+    (seed7-mode)
+    (indent-region (point-min) (point-max))
+    ;; Line 14 is YY's `begin': it must align with YY's `local' on line 4.
+    (should (= (seed7-test-indent-02--line-indentation 4) 6))
+    (should (= (seed7-test-indent-02--line-indentation 13) 6))
+    (should (= (seed7-test-indent-02--line-indentation 14) 8))
+    (should (string= (buffer-string)
+                     seed7-test-indent-02--begin-after-nested-func-end-correct))))
+
+(ert-deftest seed7-indent/begin-after-nested-func-end-tab-dedents ()
+  "TAB on the affected `begin' restores its enclosing `local' indentation."
+  (with-temp-buffer
+    (setq-local indent-tabs-mode nil)
+    (insert seed7-test-indent-02--begin-after-nested-func-end-misaligned)
+    (seed7-mode)
+    (seed7-test-indent-02--goto-line 13)
+    (seed7-indent-line)
+    (should (= (seed7-test-indent-02--line-indentation 13) 6))))
 
 ;; ---------------------------------------------------------------------------
 (provide 'seed7-test-indent-02)

--- a/tests/ert-tests/seed7-test-indent-02.el
+++ b/tests/ert-tests/seed7-test-indent-02.el
@@ -1,7 +1,7 @@
 ;;; seed7-test-indent-02.el --- Comprehensive ERT tests for Seed7 indentation  -*- lexical-binding: t; -*-
 
 ;; Author    : Pierre Rouleau <prouleau001@gmail.com>
-;; Time-stamp: <2026-07-21 12:24:22 EDT, updated by Pierre Rouleau>
+;; Time-stamp: <2026-07-21 12:30:39 EDT, updated by Pierre Rouleau>
 
 ;; This file is part of the SEED7-MODE package.
 ;; This file is not part of GNU Emacs.
@@ -2435,7 +2435,7 @@ enclosing callable's `local', not inherit the nested callable's indentation."
     (insert seed7-test-indent-02--begin-after-nested-func-end-misaligned)
     (seed7-mode)
     (indent-region (point-min) (point-max))
-    ;; Line 14 is YY's `begin': it must align with YY's `local' on line 4.
+    ;; Line 13 is YY's `begin': it must align with YY's `local' on line 4.
     (should (= (seed7-test-indent-02--line-indentation 4) 6))
     (should (= (seed7-test-indent-02--line-indentation 13) 6))
     (should (= (seed7-test-indent-02--line-indentation 14) 8))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected indentation for `begin` blocks following nested function or structure endings.
  * Ensured indentation commands align these blocks with the surrounding `local` section.

* **Tests**
  * Added regression coverage for region indentation and Tab-based indentation.
  * Updated package version metadata and test timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->